### PR TITLE
Add -ContentType Parameter, helps #386

### DIFF
--- a/src/Public/Responses.ps1
+++ b/src/Public/Responses.ps1
@@ -37,7 +37,7 @@ function Set-PodeResponseAttachment
         [string]
         $Path,
 
-        [ValidatePattern('\w+\/[\w.-]+')]
+        [ValidatePattern('^\w+\/[\w\.\+-]+$')]
         [string]
         $ContentType
     )

--- a/src/Public/Responses.ps1
+++ b/src/Public/Responses.ps1
@@ -26,8 +26,6 @@ Set-PodeResponseAttachment -Path 'c:/content/accounts.xlsx'
 
 .EXAMPLE
 Set-PodeResponseAttachment -Path './data.txt' -ContentType 'application/json'
-
-This command specifies that the content stored in data.txt should be considered as JSON data rather than plain text.
 #>
 function Set-PodeResponseAttachment
 {

--- a/src/Public/Responses.ps1
+++ b/src/Public/Responses.ps1
@@ -11,6 +11,10 @@ The Path to a static file relative to the "/public" directory, or a static Route
 If the supplied Path doesn't match any custom static Route, then Pode will look in the "/public" directory.
 Failing this, if the file path exists as a literal/relative file, then this file is used as a fall back.
 
+.PARAMETER ContentType
+Manually specify the content type of the response rather than infering it from the attachment's file extension.
+The supplied value must match the valid ContentType format, e.g. application/json
+
 .EXAMPLE
 Set-PodeResponseAttachment -Path 'downloads/installer.exe'
 
@@ -19,6 +23,11 @@ Set-PodeResponseAttachment -Path './image.png'
 
 .EXAMPLE
 Set-PodeResponseAttachment -Path 'c:/content/accounts.xlsx'
+
+.EXAMPLE
+Set-PodeResponseAttachment -Path './data.txt' -ContentType 'application/json'
+
+This command specifies that the content stored in data.txt should be considered as JSON data rather than plain text.
 #>
 function Set-PodeResponseAttachment
 {
@@ -26,7 +35,11 @@ function Set-PodeResponseAttachment
     param (
         [Parameter(Mandatory=$true)]
         [string]
-        $Path
+        $Path,
+
+        [ValidatePattern('\w+\/[\w.-]+')]
+        [string]
+        $ContentType
     )
 
     # only attach files from public/static-route directories when path is relative
@@ -51,7 +64,12 @@ function Set-PodeResponseAttachment
 
     try {
         # setup the content type and disposition
-        $WebEvent.Response.ContentType = (Get-PodeContentType -Extension $ext)
+        if (!$ContentType) {
+            $WebEvent.Response.ContentType = (Get-PodeContentType -Extension $ext)
+        }
+        else {
+            $WebEvent.Response.ContentType = $ContentType
+        }
         Set-PodeHeader -Name 'Content-Disposition' -Value "attachment; filename=$($filename)"
 
         # if serverless, get the content raw and return
@@ -610,7 +628,7 @@ function Write-PodeXmlResponse
                 $Value = @(foreach ($v in $Value) {
                     New-Object psobject -Property $v
                 })
-        
+
                 $Value = ($Value | ConvertTo-Xml -Depth 10 -As String -NoTypeInformation)
             }
         }


### PR DESCRIPTION
### Description of the Change

This PR adds a `ContentType` parameter to `Set-PodeResponseAttachment`.

I initially wanted to validate the input based on a full set of valid options... but there's way more than is tidy/practical to include.

Instead I've used a regex pattern to make sure it matches the format of "category/type". When this check fails the output isn't pretty, a follow up PR could be to move this over to ValidateScript with a nicer custom error message.

### Related Issue

#386 

### Examples

```powershell
Set-PodeResponseAttachment -Path './data.txt' -ContentType 'application/json'
```

This command specifies that the content stored in data.txt should be considered as JSON data rather than plain text.
