### PR TITLE
Ability to use WebSockets for Server-to-Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ Then navigate to `http://127.0.0.1:8000` in your browser.
 * Docker support, including images for ARM/Raspberry Pi
 * Azure Functions and AWS Lambda support
 * Listen on a single or multiple IP address/hostnames
-* Support for HTTP, HTTPS, TCP and SMTP (Experimental cross-platform support for HTTPS)
+* Cross-platform support for HTTP, HTTPS, TCP and SMTP
+* Cross-platform support for WebSockets, and secure WebSockets
 * Host REST APIs, Web Pages, and Static Content (with caching)
 * Support for custom error pages
 * Multi-thread support for incoming requests

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Then navigate to `http://127.0.0.1:8000` in your browser.
 * Azure Functions and AWS Lambda support
 * Listen on a single or multiple IP address/hostnames
 * Cross-platform support for HTTP, HTTPS, TCP and SMTP
-* Cross-platform support for WebSockets, and secure WebSockets
+* Cross-platform support for server-to-client WebSockets, including secure WebSockets
 * Host REST APIs, Web Pages, and Static Content (with caching)
 * Support for custom error pages
 * Multi-thread support for incoming requests

--- a/docs/Tutorials/WebSockets.md
+++ b/docs/Tutorials/WebSockets.md
@@ -1,0 +1,153 @@
+# Web Sockets
+
+Pode now has support for server-to-client communications using WebSockets, including secure WebSockets.
+
+!!! note
+    Currently only broadcasting messages to connected clients/browsers from the server is supported. Client-to-server communications is in the works!
+
+WebSockets allow you to send messages directly from your server to connected clients. This allows you to get real-time continuous updates for the frontend without having to constantly refresh the page, or by using async javascript!
+
+## Server Side
+
+### Listening
+
+On the server side, the only real work required is to register a new endpoint to listen on. To do this you can use the normal [`Add-PodeEndpoint`] function, but with a protocol of either `Ws` or `Wss`:
+
+```powershell
+Add-PodeEndpoint -Address * -Port 8091 -Protocol Ws
+
+# or for secure sockets:
+Add-PodeEndpoint -Address * -Port 8091 -CertificateFile './path/cert.pfx' -CertificatePassword 'dummy' -Protocol Wss
+```
+
+### Broadcasting
+
+To broadcast a message from the server to all connected clients you can use the [`Send-PodeSignal`] function. You can either send raw JSON data, or you can pass a HashTable/PSObject and it will be converted to JSON for you.
+
+To broadcast some data to all clients from a POST route, you could use the following. This will get some message from one of the clients, and then broadcast it to every other client:
+
+```powershell
+Add-PodeRoute -Method Post -Path '/broadcast' -ScriptBlock {
+    param($e)
+    Send-PodeSignal -Value @{ Message = $e.Data['message'] }
+}
+```
+
+Because you can register WebSockets on different paths, you can also broadcast messages to all clients connected using a certain path.
+
+For example, the below would send some response time data to all clients connected and listening for response times on the `/response-times` path:
+
+```powershell
+Send-PodeSignal -Value @{ ResponseTimes = @(123, 101, 104) } -Path '/response-times'
+```
+
+You can also broadcast messages from Timers, or from Schedules.
+
+## Client Side
+
+On the client side, you need to use javascript to register a WebSocket and then bind the `onmessage` event to do something when a broadcasted message is received.
+
+To create a WebSocket, you can do something like the following which will bind a WebSocket onto the root path '/':
+
+```javascript
+$(document).ready(() => {
+    // create the websocket
+    var ws = new WebSocket("ws://localhost:8091/");
+
+    // event for inbound messages to append them
+    ws.onmessage = function(evt) {
+        var data = JSON.parse(evt.data)
+        $('#messages').append(`<p>${data.Message}</p>`);
+    }
+})
+```
+
+## Full Example
+
+> This full example is a cut-down version of the one found in `/examples/web-signal.ps1` of the main repository.
+
+The file structure for these files is:
+
+```plain
+server.ps1
+/views
+    index.html
+/public
+    script.js
+```
+
+The following is the Pode server code, that will create two routes.
+
+* The first route will be for some home page, with a button/input for broadcasting messages.
+* The second route will be invoked when the button above is clicked. It will then broadcast some message to all clients.
+
+```powershell
+Start-PodeServer {
+
+    # listen
+    Add-PodeEndpoint -Address * -Port 8090 -Protocol Http
+    Add-PodeEndpoint -Address * -Port 8091 -Protocol Ws
+
+    # request for web page
+    Add-PodeRoute -Method Get -Path '/' -ScriptBlock {
+        Write-PodeViewResponse -Path 'index'
+    }
+
+    # broadcast a received message back out to ever connected client via websockets
+    Add-PodeRoute -Method Post -Path '/broadcast' -ScriptBlock {
+        param($e)
+        Send-PodeSignal -Value @{ Message = $e.Data['message'] }
+    }
+}
+```
+
+Next we have the HTML web page with a basic button/input for broadcasting messages. There's also a `<div>` to append received messages:
+
+```html
+<html>
+    <head>
+        <title>WebSockets</title>
+        <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
+        <script type="text/javascript" src="/script.js"></script>
+    </head>
+    <body>
+        <p>Clicking submit will broadcast the message to all connected clients</p>
+        <form id='bc-form'>
+            <input type='text' name='message' placeholder='Enter any random text' />
+            <input type='submit' value='Broadcast!' />
+        </form>
+
+        <div id='messages'></div>
+    </body>
+</html>
+```
+
+Finally, the following is the client-side javascript to register a WebSocket for the client. It will also invoke the `/broadcast` endpoint when the button is clicked:
+
+```javascript
+$(document).ready(() => {
+    // bind submit on the form to send message to the server
+    $('#bc-form').submit(function(e) {
+        e.preventDefault();
+
+        $.ajax({
+            url: '/broadcast',
+            type: 'post',
+            data: $('#bc-form').serialize()
+        })
+
+        $('input[name=message]').val('')
+    })
+
+    // create the websocket
+    var ws = new WebSocket("ws://localhost:8091/");
+
+    // event for inbound messages to append them
+    ws.onmessage = function(evt) {
+        var data = JSON.parse(evt.data)
+        $('#messages').append(`<p>${data.Message}</p>`);
+    }
+})
+```
+
+

--- a/docs/Tutorials/WebSockets.md
+++ b/docs/Tutorials/WebSockets.md
@@ -11,7 +11,7 @@ WebSockets allow you to send messages directly from your server to connected cli
 
 ### Listening
 
-On the server side, the only real work required is to register a new endpoint to listen on. To do this you can use the normal [`Add-PodeEndpoint`] function, but with a protocol of either `Ws` or `Wss`:
+On the server side, the only real work required is to register a new endpoint to listen on. To do this you can use the normal [`Add-PodeEndpoint`](../../Functions/Core/Add-PodeEndpoint) function, but with a protocol of either `Ws` or `Wss`:
 
 ```powershell
 Add-PodeEndpoint -Address * -Port 8091 -Protocol Ws
@@ -22,7 +22,7 @@ Add-PodeEndpoint -Address * -Port 8091 -CertificateFile './path/cert.pfx' -Certi
 
 ### Broadcasting
 
-To broadcast a message from the server to all connected clients you can use the [`Send-PodeSignal`] function. You can either send raw JSON data, or you can pass a HashTable/PSObject and it will be converted to JSON for you.
+To broadcast a message from the server to all connected clients you can use the [`Send-PodeSignal`](../../Functions/Responses/Send-PodeSignal) function. You can either send raw JSON data, or you can pass a HashTable/PSObject and it will be converted to JSON for you.
 
 To broadcast some data to all clients from a POST route, you could use the following. This will get some message from one of the clients, and then broadcast it to every other client:
 
@@ -65,6 +65,8 @@ $(document).ready(() => {
 ## Full Example
 
 > This full example is a cut-down version of the one found in `/examples/web-signal.ps1` of the main repository.
+
+If you open this example on multiple browsers, sending messages will be automatically received by all browsers without using async javascript!
 
 The file structure for these files is:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,7 +19,7 @@ Pode is a Cross-Platform framework, *completely written in PowerShell*, to creat
 * Azure Functions and AWS Lambda support
 * Listen on a single or multiple IP address/hostnames
 * Cross-platform support for HTTP, HTTPS, TCP and SMTP
-* Cross-platform support for WebSockets, and secure WebSockets
+* Cross-platform support for server-to-client WebSockets, including secure WebSockets
 * Host REST APIs, Web Pages, and Static Content (with caching)
 * Support for custom error pages
 * Multi-thread support for incoming requests

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,8 @@ Pode is a Cross-Platform framework, *completely written in PowerShell*, to creat
 * Docker support, including images for ARM/Raspberry Pi
 * Azure Functions and AWS Lambda support
 * Listen on a single or multiple IP address/hostnames
-* Support for HTTP, HTTPS, TCP and SMTP (Experimental cross-platform support for HTTPS)
+* Cross-platform support for HTTP, HTTPS, TCP and SMTP
+* Cross-platform support for WebSockets, and secure WebSockets
 * Host REST APIs, Web Pages, and Static Content (with caching)
 * Support for custom error pages
 * Multi-thread support for incoming requests

--- a/examples/public/scripts/websockets.js
+++ b/examples/public/scripts/websockets.js
@@ -1,0 +1,23 @@
+$(document).ready(() => {
+    // bind submit on the form to send message to the server
+    $('#bc-form').submit(function(e) {
+        e.preventDefault();
+
+        $.ajax({
+            url: '/broadcast',
+            type: 'post',
+            data: $('#bc-form').serialize()
+        })
+
+        $('input[name=message]').val('')
+    })
+
+    // create the websocket
+    var ws = new WebSocket("ws://localhost:8091/");
+
+    // event for inbound messages to append them
+    ws.onmessage = function(evt) {
+        var data = JSON.parse(evt.data)
+        $('#messages').append(`<p>${data.Message}</p>`);
+    }
+})

--- a/examples/public/styles/websockets.css
+++ b/examples/public/styles/websockets.css
@@ -1,0 +1,3 @@
+body {
+    background-color: cyan;
+}

--- a/examples/views/websockets.html
+++ b/examples/views/websockets.html
@@ -1,9 +1,18 @@
 <html>
     <head>
-        <title>HTML Page</title>
-        <link rel="stylesheet" type="text/css" href="/styles/simple.css">
+        <title>WebSockets</title>
+        <link rel="stylesheet" type="text/css" href="/styles/websockets.css">
+        <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
+        <script type="text/javascript" src="/scripts/websockets.js"></script>
     </head>
     <body>
-        Hello, world! This is an HTML page!
+        <h1>Example of using a WebSockets</h1>
+        <p>Clicking submit will broadcast the message to all connected clients - try opening this page on multiple, and different, browsers!</p>
+        <form id='bc-form'>
+            <input type='text' name='message' placeholder='Enter any random text' />
+            <input type='submit' value='Broadcast!' />
+        </form>
+
+        <div id='messages'></div>
     </body>
 </html>

--- a/examples/views/websockets.html
+++ b/examples/views/websockets.html
@@ -1,0 +1,9 @@
+<html>
+    <head>
+        <title>HTML Page</title>
+        <link rel="stylesheet" type="text/css" href="/styles/simple.css">
+    </head>
+    <body>
+        Hello, world! This is an HTML page!
+    </body>
+</html>

--- a/examples/web-signal.ps1
+++ b/examples/web-signal.ps1
@@ -1,0 +1,30 @@
+$path = Split-Path -Parent -Path (Split-Path -Parent -Path $MyInvocation.MyCommand.Path)
+Import-Module "$($path)/src/Pode.psm1" -Force -ErrorAction Stop
+
+# or just:
+# Import-Module Pode
+
+# create a server, and start listening
+Start-PodeServer -Type Pode -Threads 5 {
+
+    # listen
+    Add-PodeEndpoint -Address * -Port 8090 -Protocol Http
+    Add-PodeEndpoint -Address * -Port 8091 -Protocol Ws
+    #Add-PodeEndpoint -Address * -Port 8095 -Protocol Http
+    #Add-PodeEndpoint -Address * -Port 8090 -CertificateFile './certs/pode-cert.pfx' -CertificatePassword '1234' -Protocol Https
+
+    # log requests to the terminal
+    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+
+    # set view engine to pode renderer
+    Set-PodeViewEngine -Type Html
+
+    # GET request for web page
+    Add-PodeRoute -Method Get -Path '/' -ScriptBlock {
+        Write-PodeViewResponse -Path 'websockets'
+    }
+
+    Add-PodeRoute -Method Get -Path '/msg' -ScriptBlock {
+        Send-PodeSignal -Data @{ Message = 'Hello, there' }
+    }
+}

--- a/examples/web-signal.ps1
+++ b/examples/web-signal.ps1
@@ -8,10 +8,10 @@ Import-Module "$($path)/src/Pode.psm1" -Force -ErrorAction Stop
 Start-PodeServer -Type Pode -Threads 5 {
 
     # listen
-    Add-PodeEndpoint -Address * -Port 8090 -Protocol Http
-    Add-PodeEndpoint -Address * -Port 8091 -Protocol Ws
-    #Add-PodeEndpoint -Address * -Port 8095 -Protocol Http
-    #Add-PodeEndpoint -Address * -Port 8090 -CertificateFile './certs/pode-cert.pfx' -CertificatePassword '1234' -Protocol Https
+    #Add-PodeEndpoint -Address * -Port 8090 -Protocol Http
+    #Add-PodeEndpoint -Address * -Port 8091 -Protocol Ws
+    Add-PodeEndpoint -Address * -Port 8090 -CertificateFile './certs/pode-cert.pfx' -CertificatePassword '1234' -Protocol Https
+    Add-PodeEndpoint -Address * -Port 8091 -CertificateFile './certs/pode-cert.pfx' -CertificatePassword '1234' -Protocol Wss
 
     # log requests to the terminal
     New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging

--- a/examples/web-signal.ps1
+++ b/examples/web-signal.ps1
@@ -8,10 +8,10 @@ Import-Module "$($path)/src/Pode.psm1" -Force -ErrorAction Stop
 Start-PodeServer -Type Pode -Threads 5 {
 
     # listen
-    #Add-PodeEndpoint -Address * -Port 8090 -Protocol Http
-    #Add-PodeEndpoint -Address * -Port 8091 -Protocol Ws
-    Add-PodeEndpoint -Address * -Port 8090 -CertificateFile './certs/pode-cert.pfx' -CertificatePassword '1234' -Protocol Https
-    Add-PodeEndpoint -Address * -Port 8091 -CertificateFile './certs/pode-cert.pfx' -CertificatePassword '1234' -Protocol Wss
+    Add-PodeEndpoint -Address * -Port 8090 -Protocol Http
+    Add-PodeEndpoint -Address * -Port 8091 -Protocol Ws
+    #Add-PodeEndpoint -Address * -Port 8090 -CertificateFile './certs/pode-cert.pfx' -CertificatePassword '1234' -Protocol Https
+    #Add-PodeEndpoint -Address * -Port 8091 -CertificateFile './certs/pode-cert.pfx' -CertificatePassword '1234' -Protocol Wss
 
     # log requests to the terminal
     New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
@@ -24,7 +24,9 @@ Start-PodeServer -Type Pode -Threads 5 {
         Write-PodeViewResponse -Path 'websockets'
     }
 
-    Add-PodeRoute -Method Get -Path '/msg' -ScriptBlock {
-        Send-PodeSignal -Data @{ Message = 'Hello, there' }
+    # POST broadcast a received message back out to ever connected client via websockets
+    Add-PodeRoute -Method Post -Path '/broadcast' -ScriptBlock {
+        param($e)
+        Send-PodeSignal -Value @{ Message = $e.Data['message'] }
     }
 }

--- a/packers/choco/pode.nuspec
+++ b/packers/choco/pode.nuspec
@@ -18,7 +18,7 @@ Pode is a Cross-Platform framework, completely written in PowerShell, for creati
 * Azure Functions and AWS Lambda support
 * Listen on a single or multiple IP address/hostnames
 * Cross-platform support for HTTP, HTTPS, TCP and SMTP
-* Cross-platform support for WebSockets, and secure WebSockets
+* Cross-platform support for server-to-client WebSockets, including secure WebSockets
 * Host REST APIs, Web Pages, and Static Content (with caching)
 * Support for custom error pages
 * Multi-thread support for incoming requests

--- a/packers/choco/pode.nuspec
+++ b/packers/choco/pode.nuspec
@@ -17,7 +17,8 @@ Pode is a Cross-Platform framework, completely written in PowerShell, for creati
 * Docker support, including images for ARM/Raspberry Pi
 * Azure Functions and AWS Lambda support
 * Listen on a single or multiple IP address/hostnames
-* Support for HTTP, HTTPS, TCP and SMTP (Experimental cross-platform support for HTTPS)
+* Cross-platform support for HTTP, HTTPS, TCP and SMTP
+* Cross-platform support for WebSockets, and secure WebSockets
 * Host REST APIs, Web Pages, and Static Content (with caching)
 * Support for custom error pages
 * Multi-thread support for incoming requests
@@ -40,7 +41,7 @@ Pode is a Cross-Platform framework, completely written in PowerShell, for creati
     <packageSourceUrl>https://github.com/Badgerati/Pode/tree/master/packers</packageSourceUrl>
     <docsUrl>https://badgerati.github.io/Pode</docsUrl>
     <bugTrackerUrl>https://github.com/Badgerati/Pode/issues</bugTrackerUrl>
-    <tags>powershell web server rest api http tcp smtp listener webpages json html unix cross-platform file-monitoring multithreaded cron schedule middleware session authentication active-directory csrf lambda aws azure functions</tags>
+    <tags>powershell web server rest api http tcp smtp listener webpages json html unix cross-platform file-monitoring multithreaded cron schedule middleware session authentication active-directory csrf lambda aws azure functions websockets</tags>
     <copyright>Copyright 2017-2019</copyright>
     <licenseUrl>https://github.com/Badgerati/Pode/blob/master/LICENSE.txt</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/src/Pode.psd1
+++ b/src/Pode.psd1
@@ -82,6 +82,7 @@
         'Save-PodeRequestFile',
         'Set-PodeViewEngine',
         'Use-PodePartialView',
+        'Send-PodeSignal',
 
         # utility helpers
         'Wait-PodeTask',
@@ -176,7 +177,8 @@
             Tags = @('powershell', 'web', 'server', 'http', 'listener', 'rest', 'api', 'tcp', 'smtp', 'websites',
                 'powershell-core', 'windows', 'unix', 'linux', 'pode', 'PSEdition_Core', 'cross-platform', 'access-control',
                 'file-monitoring', 'multithreaded', 'rate-limiting', 'cron', 'schedule', 'middleware', 'session',
-                'authentication', 'active-directory', 'caching', 'csrf', 'arm', 'raspberry-pi', 'aws-lambda', 'azure-functions')
+                'authentication', 'active-directory', 'caching', 'csrf', 'arm', 'raspberry-pi', 'aws-lambda',
+                'azure-functions', 'websockets')
 
             # A URL to the license for this module.
             LicenseUri = 'https://raw.githubusercontent.com/Badgerati/Pode/master/LICENSE.txt'

--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -68,7 +68,22 @@ function New-PodeContext
         }
         ReceiveTimeout = 100
         Queues = @{
-            Contexts = [System.Collections.Generic.List[hashtable]]::new(100)
+            Connections = [System.Collections.Concurrent.ConcurrentQueue[System.Net.Sockets.SocketAsyncEventArgs]]::new()
+        }
+    }
+
+    $ctx.Server.WebSockets = @{
+        Enabled = $false
+        Listeners = @()
+        MaxConnections = 0
+        Ssl = @{
+            Callback = $null
+            Protocols = (ConvertTo-PodeSslProtocols -Protocols @('Ssl3', 'Tls12'))
+        }
+        ReceiveTimeout = 100
+        Queues = @{
+            Sockets = @{}
+            Messages = [System.Collections.Concurrent.ConcurrentQueue[hashtable]]::new()
             Connections = [System.Collections.Concurrent.ConcurrentQueue[System.Net.Sockets.SocketAsyncEventArgs]]::new()
         }
     }
@@ -179,6 +194,7 @@ function New-PodeContext
     # runspace pools
     $ctx.RunspacePools = @{
         Main = $null
+        Signals = $null
         Schedules = $null
         Gui = $null
     }
@@ -231,6 +247,10 @@ function New-PodeRunspacePools
     $totalThreadCount = ($threadsCounts.Values | Measure-Object -Sum).Sum + $PodeContext.Threads
     $PodeContext.RunspacePools.Main = [runspacefactory]::CreateRunspacePool(1, $totalThreadCount, $PodeContext.RunspaceState, $Host)
     $PodeContext.RunspacePools.Main.Open()
+
+    # setup signal runspace pool
+    $PodeContext.RunspacePools.Signals = [runspacefactory]::CreateRunspacePool(1, ($PodeContext.Threads + 2), $PodeContext.RunspaceState, $Host)
+    $PodeContext.RunspacePools.Signals.Open()
 
     # setup schedule runspace pool
     $PodeContext.RunspacePools.Schedules = [runspacefactory]::CreateRunspacePool(1, 2, $PodeContext.RunspaceState, $Host)
@@ -426,4 +446,28 @@ function New-PodeAutoRestartServer
             $PodeContext.Tokens.Restart.Cancel()
         }
     }
+}
+
+function Get-PodeEndpoints
+{
+    param(
+        [Parameter(Mandatory=$true)]
+        [ValidateSet('Http', 'Ws')]
+        [string]
+        $Type
+    )
+
+    $endpoints = $null
+
+    switch ($Type.ToLowerInvariant()) {
+        'http' {
+            $endpoints = @($PodeContext.Server.Endpoints | Where-Object { @('http', 'https') -icontains $_.Protocol })
+        }
+
+        'ws' {
+            $endpoints = @($PodeContext.Server.Endpoints | Where-Object { @('ws', 'wss') -icontains $_.Protocol })
+        }
+    }
+
+    return $endpoints
 }

--- a/src/Private/Cryptography.ps1
+++ b/src/Private/Cryptography.ps1
@@ -29,6 +29,19 @@ function Invoke-PodeSHA256Hash
     return [System.Convert]::ToBase64String($crypto.ComputeHash([System.Text.Encoding]::UTF8.GetBytes($Value)))
 }
 
+function Invoke-PodeSHA1Hash
+{
+    param (
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $Value
+    )
+
+    $crypto = [System.Security.Cryptography.SHA1]::Create()
+    return [System.Convert]::ToBase64String($crypto.ComputeHash([System.Text.Encoding]::UTF8.GetBytes($Value)))
+}
+
 function Get-PodeRandomBytes
 {
     param (

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -618,7 +618,7 @@ function Add-PodeRunspace
 {
     param (
         [Parameter(Mandatory=$true)]
-        [ValidateSet('Main', 'Schedules', 'Gui')]
+        [ValidateSet('Main', 'Signals', 'Schedules', 'Gui')]
         [string]
         $Type,
 

--- a/src/Private/PodeServer.ps1
+++ b/src/Private/PodeServer.ps1
@@ -60,7 +60,7 @@ function Start-PodeSocketServer
     catch {
         $_ | Write-PodeErrorLog
         $_.Exception | Write-PodeErrorLog -CheckInnerException
-        Close-PodeSocketListener -Type WebSockets
+        Close-PodeSocketListener -Type Sockets
         throw $_.Exception
     }
 
@@ -112,7 +112,7 @@ function Start-PodeSocketServer
             throw $_.Exception
         }
         finally {
-            Close-PodeSocketListener -Type WebSockets
+            Close-PodeSocketListener -Type Sockets
         }
     }
 

--- a/src/Private/PodeServer.ps1
+++ b/src/Private/PodeServer.ps1
@@ -6,33 +6,7 @@ function Start-PodeSocketServer
     )
 
     # setup the callback for sockets
-    $PodeContext.Server.Sockets.Ssl.Callback = [System.Net.Security.RemoteCertificateValidationCallback]{
-        param(
-            [Parameter()]
-            [object]
-            $Sender,
-
-            [Parameter()]
-            [X509Certificate]
-            $Certificate,
-
-            [Parameter()]
-            [System.Security.Cryptography.X509Certificates.X509Chain]
-            $Chain,
-
-            [Parameter()]
-            [System.Net.Security.SslPolicyErrors]
-            $SslPolicyErrors
-        )
-
-        # if there is no client cert, just allow it
-        if ($null -eq $Certificate) {
-            return $true
-        }
-
-        # if we have a cert, but there are errors, fail
-        return ($SslPolicyErrors -ne [System.Net.Security.SslPolicyErrors]::None)
-    }
+    $PodeContext.Server.Sockets.Ssl.Callback = Get-PodeSocketCertifcateCallback
 
     # setup any inbuilt middleware
     $inbuilt_middleware = @(
@@ -48,7 +22,7 @@ function Start-PodeSocketServer
 
     # work out which endpoints to listen on
     $endpoints = @()
-    $PodeContext.Server.Endpoints | ForEach-Object {
+    @(Get-PodeEndpoints -Type Http) | ForEach-Object {
         # get the protocol
         $_protocol = (Resolve-PodeValue -Check $_.Ssl -TrueValue 'https' -FalseValue 'http')
 
@@ -76,13 +50,17 @@ function Start-PodeSocketServer
     {
         # register endpoints on the listener
         $endpoints | ForEach-Object {
-            Initialize-PodeSocketListenerEndpoint -Address $_.Address -Port $_.Port -Certificate $_.Certificate
+            $PodeContext.Server.Sockets.Listeners += (Initialize-PodeSocketListenerEndpoint `
+                -Type Sockets `
+                -Address $_.Address `
+                -Port $_.Port `
+                -Certificate $_.Certificate)
         }
     }
     catch {
         $_ | Write-PodeErrorLog
         $_.Exception | Write-PodeErrorLog -CheckInnerException
-        Close-PodeSocketListener
+        Close-PodeSocketListener -Type WebSockets
         throw $_.Exception
     }
 
@@ -96,7 +74,7 @@ function Start-PodeSocketServer
 
         try
         {
-            Start-PodeSocketListener
+            Start-PodeSocketListener -Listeners $PodeContext.Server.Sockets.Listeners
 
             [System.Threading.Thread]::CurrentThread.IsBackground = $true
             [System.Threading.Thread]::CurrentThread.Priority = [System.Threading.ThreadPriority]::Lowest
@@ -134,7 +112,7 @@ function Start-PodeSocketServer
             throw $_.Exception
         }
         finally {
-            Close-PodeSocketListener
+            Close-PodeSocketListener -Type WebSockets
         }
     }
 
@@ -362,79 +340,4 @@ function Set-PodeServerResponseHeaders
 
     # state to close the connection (no support for keep-alive yet)
     Set-PodeHeader -Name 'Connection' -Value 'close'
-}
-
-function Get-PodeServerRequestDetails
-{
-    param(
-        [Parameter()]
-        [byte[]]
-        $Bytes,
-
-        [Parameter(Mandatory=$true)]
-        [string]
-        $Protocol
-    )
-
-    # convert array to string
-    $Content = $PodeContext.Server.Encoding.GetString($bytes, 0, $bytes.Length)
-
-    # parse the request headers
-    $newLine = "`r`n"
-    if (!$Content.Contains($newLine)) {
-        $newLine = "`n"
-    }
-
-    $req_lines = ($Content -isplit $newLine)
-
-    # first line is the request info
-    $req_line_info = ($req_lines[0].Trim() -isplit '\s+')
-    if ($req_line_info.Length -ne 3) {
-        throw [System.Net.Http.HttpRequestException]::new("Invalid request line: $($req_lines[0]) [$($req_line_info.Length)]")
-    }
-
-    $req_method = $req_line_info[0].Trim()
-    if (@('DELETE', 'GET', 'HEAD', 'MERGE', 'OPTIONS', 'PATCH', 'POST', 'PUT', 'TRACE') -inotcontains $req_method) {
-        throw [System.Net.Http.HttpRequestException]::new("Invalid request HTTP method: $($req_method)")
-    }
-
-    $req_query = $req_line_info[1].Trim()
-    $req_proto = $req_line_info[2].Trim()
-    if (!$req_proto.StartsWith('HTTP/')) {
-        throw [System.Net.Http.HttpRequestException]::new("Invalid request version: $($req_proto)")
-    }
-
-    # then, read the headers
-    $req_headers = @{}
-    $req_body_index = 0
-    for ($i = 1; $i -le $req_lines.Length -1; $i++) {
-        $line = $req_lines[$i].Trim()
-        if ([string]::IsNullOrWhiteSpace($line)) {
-            $req_body_index = $i + 1
-            break
-        }
-
-        $index = $line.IndexOf(':')
-        $name = $line.Substring(0, $index).Trim()
-        $value = $line.Substring($index + 1).Trim()
-        $req_headers[$name] = $value
-    }
-
-    # then set the request body
-    $req_body = ($req_lines[($req_body_index)..($req_lines.Length - 1)] -join $newLine)
-    $req_body_bytes = $bytes[($bytes.Length - $req_body.Length)..($bytes.Length - 1)]
-
-    # build required URI details
-    $req_uri = [uri]::new("$($Protocol)://$($req_headers['Host'])$($req_query)")
-
-    # return the details
-    return @{
-        Method = $req_method
-        Query = $req_query
-        Protocol = $req_proto
-        Headers = $req_headers
-        Body = $req_body
-        RawBody = $req_body_bytes
-        Uri = $req_uri
-    }
 }

--- a/src/Private/PodeServer.ps1
+++ b/src/Private/PodeServer.ps1
@@ -118,18 +118,12 @@ function Start-PodeSocketServer
 
     Add-PodeRunspace -Type 'Main' -ScriptBlock $waitScript
 
-    # state where we're running
-    Write-Host 'Note: This server type is experimental' -ForegroundColor Magenta
-    Write-Host "Listening on the following $($endpoints.Length) endpoint(s) [$($PodeContext.Threads) thread(s)]:" -ForegroundColor Yellow
-
-    $endpoints | ForEach-Object {
-        Write-Host "`t- $($_.HostName)" -ForegroundColor Yellow
-    }
-
     # browse to the first endpoint, if flagged
     if ($Browse) {
         Start-Process $endpoints[0].HostName
     }
+
+    return @($endpoints.HostName)
 }
 
 function Invoke-PodeSocketHandler

--- a/src/Private/Server.ps1
+++ b/src/Private/Server.ps1
@@ -68,6 +68,11 @@ function Start-PodeInternalServer
                 Start-PodeAwsLambdaServer -Data $Request
             }
         }
+
+        # start web sockets if enabled
+        if ($PodeContext.Server.WebSockets.Enabled) {
+            Start-PodeSignalServer
+        }
     }
     catch {
         throw $_.Exception
@@ -115,8 +120,12 @@ function Restart-PodeInternalServer
 
         # clear the sockets
         $PodeContext.Server.Sockets.Listeners = @()
-        $PodeContext.Server.Sockets.Queues.Contexts.Clear()
         $PodeContext.Server.Sockets.Queues.Connections = [System.Collections.Concurrent.ConcurrentQueue[System.Net.Sockets.SocketAsyncEventArgs]]::new()
+
+        # clear the websockets
+        $PodeContext.Server.WebSockets.Listeners = @()
+        $PodeContext.Server.WebSockets.Queues.Sockets.Clear()
+        $PodeContext.Server.WebSockets.Queues.Connections = [System.Collections.Concurrent.ConcurrentQueue[System.Net.Sockets.SocketAsyncEventArgs]]::new()
 
         # set view engine back to default
         $PodeContext.Server.ViewEngine = @{

--- a/src/Private/Server.ps1
+++ b/src/Private/Server.ps1
@@ -38,22 +38,24 @@ function Start-PodeInternalServer
         }
 
         # start the appropriate server
+        $endpoints = @()
+
         switch ($_type)
         {
             'SMTP' {
-                Start-PodeSmtpServer
+                $endpoints += (Start-PodeSmtpServer)
             }
 
             'TCP' {
-                Start-PodeTcpServer
+                $endpoints += (Start-PodeTcpServer)
             }
 
             { ($_ -ieq 'HTTP') -or ($_ -ieq 'HTTPS') } {
-                Start-PodeWebServer -Browse:$Browse
+                $endpoints += (Start-PodeWebServer -Browse:$Browse)
             }
 
             'PODE' {
-                Start-PodeSocketServer -Browse:$Browse
+                $endpoints += (Start-PodeSocketServer -Browse:$Browse)
             }
 
             'SERVICE' {
@@ -71,7 +73,15 @@ function Start-PodeInternalServer
 
         # start web sockets if enabled
         if ($PodeContext.Server.WebSockets.Enabled) {
-            Start-PodeSignalServer
+            $endpoints += (Start-PodeSignalServer)
+        }
+
+        # state what endpoints are being listened on
+        if ($endpoints.Length -gt 0) {
+            Write-Host "Listening on the following $($endpoints.Length) endpoint(s) [$($PodeContext.Threads) thread(s)]:" -ForegroundColor Yellow
+            $endpoints | ForEach-Object {
+                Write-Host "`t- $($_)" -ForegroundColor Yellow
+            }
         }
     }
     catch {

--- a/src/Private/SignalServer.ps1
+++ b/src/Private/SignalServer.ps1
@@ -209,9 +209,10 @@ function Invoke-PodeWebSocketHandler
         if ($null -ne $Context.Certificate) {
             try {
                 $stream = [System.Net.Security.SslStream]::new($stream, $false, $PodeContext.Server.WebSockets.Ssl.Callback)
-                $stream.AuthenticateAsServer($Context.Certificate, $true, $PodeContext.Server.WebSockets.Ssl.Protocols, $false)
+                $stream.AuthenticateAsServer($Context.Certificate, $false, $PodeContext.Server.WebSockets.Ssl.Protocols, $false)
             }
             catch {
+                $_.Exception | Out-Default
                 # immediately close http connections
                 Close-PodeSocket -Socket $Context.Socket -Shutdown
                 return

--- a/src/Private/SignalServer.ps1
+++ b/src/Private/SignalServer.ps1
@@ -184,13 +184,7 @@ function Start-PodeSignalServer
     }
 
     Add-PodeRunspace -Type 'Signals' -ScriptBlock $waitScript
-
-    # state where we're running
-    Write-Host "Listening on the following $($endpoints.Length) endpoint(s) [$($PodeContext.Threads) thread(s)]:" -ForegroundColor Yellow
-
-    $endpoints | ForEach-Object {
-        Write-Host "`t- $($_.HostName)" -ForegroundColor Yellow
-    }
+    return @($endpoints.HostName)
 }
 
 function Invoke-PodeWebSocketHandler
@@ -212,7 +206,6 @@ function Invoke-PodeWebSocketHandler
                 $stream.AuthenticateAsServer($Context.Certificate, $false, $PodeContext.Server.WebSockets.Ssl.Protocols, $false)
             }
             catch {
-                $_.Exception | Out-Default
                 # immediately close http connections
                 Close-PodeSocket -Socket $Context.Socket -Shutdown
                 return

--- a/src/Private/SignalServer.ps1
+++ b/src/Private/SignalServer.ps1
@@ -261,6 +261,7 @@ function Invoke-PodeWebSocketHandler
             'Connection' = 'Upgrade'
             'Upgrade' = 'websocket'
             'Sec-WebSocket-Accept' = Invoke-PodeSHA1Hash -Value "$($secSocketKey)$($magicGuid)"
+            'X-Pode-ClientId' = $clientId
         }
 
         # write the response line

--- a/src/Private/SignalServer.ps1
+++ b/src/Private/SignalServer.ps1
@@ -1,0 +1,301 @@
+function Start-PodeSignalServer
+{
+    # setup the callback for sockets
+    $PodeContext.Server.WebSockets.Ssl.Callback = Get-PodeSocketCertifcateCallback
+
+    # work out which endpoints to listen on
+    $endpoints = @()
+    @(Get-PodeEndpoints -Type Ws) | ForEach-Object {
+        # get the protocol
+        $_protocol = (Resolve-PodeValue -Check $_.Ssl -TrueValue 'wss' -FalseValue 'ws')
+
+        # get the ip address
+        $_ip = [string]($_.Address)
+        $_ip = (Get-PodeIPAddressesForHostname -Hostname $_ip -Type All | Select-Object -First 1)
+        $_ip = (Get-PodeIPAddress $_ip)
+
+        # get the port
+        $_port = [int]($_.Port)
+        if ($_port -eq 0) {
+            $_port = (Resolve-PodeValue $_.Ssl -TrueValue 9443 -FalseValue 9080)
+        }
+
+        # add endpoint to list
+        $endpoints += @{
+            Address = $_ip
+            Port = $_port
+            Certificate = $_.Certificate.Raw
+            HostName = "$($_protocol)://$($_.HostName):$($_port)/"
+        }
+    }
+
+    try
+    {
+        # register endpoints on the listener
+        $endpoints | ForEach-Object {
+            $PodeContext.Server.WebSockets.Listeners += (Initialize-PodeSocketListenerEndpoint `
+                -Type WebSockets `
+                -Address $_.Address `
+                -Port $_.Port `
+                -Certificate $_.Certificate)
+        }
+    }
+    catch {
+        $_ | Write-PodeErrorLog
+        $_.Exception | Write-PodeErrorLog -CheckInnerException
+        Close-PodeSocketListener -Type WebSockets
+        throw $_.Exception
+    }
+
+    # script for listening out for incoming requests
+    $listenScript = {
+        param (
+            [Parameter(Mandatory=$true)]
+            [int]
+            $ThreadId
+        )
+
+        try
+        {
+            Start-PodeSocketListener -Listeners $PodeContext.Server.WebSockets.Listeners
+
+            [System.Threading.Thread]::CurrentThread.IsBackground = $true
+            [System.Threading.Thread]::CurrentThread.Priority = [System.Threading.ThreadPriority]::Lowest
+
+            while (!$PodeContext.Tokens.Cancellation.IsCancellationRequested)
+            {
+                Wait-PodeTask ([System.Threading.Tasks.Task]::Delay(60))
+            }
+        }
+        catch [System.OperationCanceledException] {}
+        catch {
+            $_ | Write-PodeErrorLog
+            $_.Exception | Write-PodeErrorLog -CheckInnerException
+            throw $_.Exception
+        }
+    }
+
+    # start the runspace for listening on x-number of threads
+    1..$PodeContext.Threads | ForEach-Object {
+        Add-PodeRunspace -Type 'Signals' -ScriptBlock $listenScript `
+            -Parameters @{ 'ThreadId' = $_ }
+    }
+
+    # script to write messages back to the client(s)
+    $signalScript = {
+        try {
+            [System.Threading.Thread]::CurrentThread.IsBackground = $true
+            [System.Threading.Thread]::CurrentThread.Priority = [System.Threading.ThreadPriority]::Lowest
+
+            while (!$PodeContext.Tokens.Cancellation.IsCancellationRequested)
+            {
+                Wait-PodeTask ([System.Threading.Tasks.Task]::Delay(100))
+
+                # check if we have any messages to send
+                $message = $null
+                if (!$PodeContext.Server.WebSockets.Queues.Messages.TryDequeue([ref]$message)) {
+                    $message = $null
+                }
+
+                if ($null -eq $message) {
+                    continue
+                }
+
+                # get the sockets for the message
+                $sockets = @()
+
+                # by clientId
+                if (![string]::IsNullOrWhiteSpace($message.ClientId)) {
+                    $sockets = @($PodeContext.Server.WebSockets.Queues.Sockets[$message.ClientId])
+                }
+                else {
+                    $sockets = @($PodeContext.Server.WebSockets.Queues.Sockets.Values)
+
+                    # by path
+                    if (![string]::IsNullOrWhiteSpace($message.Path)) {
+                        $sockets = @(foreach ($socket in $sockets) {
+                            if ($socket.Path -ieq $message.Path) {
+                                $socket
+                                break
+                            }
+                        })
+                    }
+                }
+
+                # do nothing if no socket found
+                if (($null -eq $sockets) -or ($sockets.Length -eq 0)) {
+                    continue
+                }
+
+                # frame the message
+                $buffer = [byte[]]@()
+                $buffer += [byte]([byte]0x80 -bor [byte]1)
+
+                $payload = $PodeContext.Server.Encoding.GetBytes($message.Value)
+                if ($payload.Length -lt 126) {
+                    $buffer += [byte]([byte]0x00 -bor [byte]$payload.Length)
+                }
+                elseif ($payload.Length -le [uint16]::MaxValue) {
+                    $buffer += [byte]([byte]0x00 -bor [byte]126)
+                }
+                else {
+                    $buffer += [byte]([byte]0x00 -bor [byte]127)
+                }
+
+                $buffer += $payload
+
+                # send the message to all found sockets
+                foreach ($socket in $sockets) {
+                    try {
+                        Wait-PodeTask -Task $socket.Stream.WriteAsync($buffer, 0, $buffer.Length)
+                    }
+                    catch {
+                        $PodeContext.Server.WebSockets.Queues.Sockets.Remove($socket.ClientId) | Out-Null
+                    }
+                }
+            }
+        }
+        catch [System.OperationCanceledException] {}
+        catch {
+            $_ | Write-PodeErrorLog
+            $_.Exception | Write-PodeErrorLog -CheckInnerException
+            throw $_.Exception
+        }
+    }
+
+    Add-PodeRunspace -Type 'Signals' -ScriptBlock $signalScript
+
+    # script to keep web server listening until cancelled
+    $waitScript = {
+        try {
+            while (!$PodeContext.Tokens.Cancellation.IsCancellationRequested) {
+                Start-Sleep -Seconds 1
+            }
+        }
+        catch [System.OperationCanceledException] {}
+        catch {
+            $_ | Write-PodeErrorLog
+            $_.Exception | Write-PodeErrorLog -CheckInnerException
+            throw $_.Exception
+        }
+        finally {
+            Close-PodeSocketListener -Type WebSockets
+        }
+    }
+
+    Add-PodeRunspace -Type 'Signals' -ScriptBlock $waitScript
+
+    # state where we're running
+    Write-Host "Listening on the following $($endpoints.Length) endpoint(s) [$($PodeContext.Threads) thread(s)]:" -ForegroundColor Yellow
+
+    $endpoints | ForEach-Object {
+        Write-Host "`t- $($_.HostName)" -ForegroundColor Yellow
+    }
+}
+
+function Invoke-PodeWebSocketHandler
+{
+    param(
+        [Parameter(Mandatory)]
+        [hashtable]
+        $Context
+    )
+
+    try
+    {
+        # make the stream (use an ssl stream if we have a cert)
+        $stream = [System.Net.Sockets.NetworkStream]::new($Context.Socket, $true)
+
+        if ($null -ne $Context.Certificate) {
+            try {
+                $stream = [System.Net.Security.SslStream]::new($stream, $false, $PodeContext.Server.WebSockets.Ssl.Callback)
+                $stream.AuthenticateAsServer($Context.Certificate, $true, $PodeContext.Server.WebSockets.Ssl.Protocols, $false)
+            }
+            catch {
+                # immediately close http connections
+                Close-PodeSocket -Socket $Context.Socket -Shutdown
+                return
+            }
+        }
+
+        # read the request headers - once again, I apologise profusely.
+        try {
+            $bytes = New-Object byte[] 0
+            $Context.Socket.Receive($bytes) | Out-Null
+        }
+        catch {
+            $err = [System.Net.Http.HttpRequestException]::new()
+            $err.Data.Add('PodeStatusCode', 408)
+            throw $err
+        }
+
+        $bytes = New-Object byte[] $Context.Socket.Available
+        (Wait-PodeTask -Task $stream.ReadAsync($bytes, 0, $Context.Socket.Available)) | Out-Null
+        $req_info = Get-PodeServerRequestDetails -Bytes $bytes -Protocol $Context.Protocol
+
+        # if the method is not a GET, close immediately
+        if ($req_info.Method -ine 'GET') {
+            Close-PodeSocket -Socket $Context.Socket -Shutdown
+            return
+        }
+    }
+    catch [System.OperationCanceledException] {}
+    catch [System.Net.Http.HttpRequestException] {
+        $code = [int]($_.Exception.Data['PodeStatusCode'])
+        if ($code -le 0) {
+            $code = 400
+        }
+
+        Set-PodeResponseStatus -Code $code -Exception $_
+    }
+    catch {
+        $_ | Write-PodeErrorLog
+        $_.Exception | Write-PodeErrorLog -CheckInnerException
+        Set-PodeResponseStatus -Code 500 -Exception $_
+    }
+
+    try {
+        # get the path, and generate a clientId
+        $path = $req_info.Uri.AbsolutePath
+        $clientId = New-PodeGuid -Secure
+
+        # send back headers to upgrade the client to a websocket
+        $magicGuid = '258EAFA5-E914-47DA-95CA-C5AB0DC85B11'
+        $secSocketKey = $req_info.Headers['Sec-WebSocket-Key'].Trim()
+
+        $resHeaders = @{
+            'Connection' = 'Upgrade'
+            'Upgrade' = 'websocket'
+            'Sec-WebSocket-Accept' = Invoke-PodeSHA1Hash -Value "$($secSocketKey)$($magicGuid)"
+        }
+
+        # write the response line
+        $protocol = $req_info.Protocol
+        if ([string]::IsNullOrWhiteSpace($protocol)) {
+            $protocol = 'HTTP/1.1'
+        }
+
+        $newLine = "`r`n"
+        $res_msg = "$($protocol) 101 Switching Protocols$($newLine)"
+
+        # write the response headers
+        foreach ($key in $resHeaders.Keys) {
+            $res_msg += "$($key): $($resHeaders[$key])$($newLine)"
+        }
+
+        $res_msg += $newLine
+
+        # stream response output
+        $buffer = $PodeContext.Server.Encoding.GetBytes($res_msg)
+        Wait-PodeTask -Task $stream.WriteAsync($buffer, 0, $buffer.Length)
+
+        # add the socket/stream to all sockets, and path sockets (and clientId)
+        $PodeContext.Server.WebSockets.Queues.Sockets[$clientId] = @{
+            Socket = $Context.Socket
+            Stream = $stream
+            Path = $path
+            ClientId = $clientId
+        }
+    }
+    catch [System.Management.Automation.MethodInvocationException] { }
+}

--- a/src/Private/SmtpServer.ps1
+++ b/src/Private/SmtpServer.ps1
@@ -207,7 +207,7 @@ function Start-PodeSmtpServer
     Add-PodeRunspace -Type 'Main' -ScriptBlock $waitScript -Parameters @{ 'Listener' = $listener }
 
     # state where we're running
-    Write-Host "Listening on smtp://$($PodeContext.Server.Endpoints[0].HostName):$($port) [$($PodeContext.Threads) thread(s)]" -ForegroundColor Yellow
+    return @("smtp://$($PodeContext.Server.Endpoints[0].HostName):$($port)")
 }
 
 

--- a/src/Private/TcpServer.ps1
+++ b/src/Private/TcpServer.ps1
@@ -119,5 +119,5 @@ function Start-PodeTcpServer
     Add-PodeRunspace -Type 'Main' -ScriptBlock $waitScript -Parameters @{ 'Listener' = $listener }
 
     # state where we're running
-    Write-Host "Listening on tcp://$($PodeContext.Server.Endpoints[0].HostName):$($port) [$($PodeContext.Threads) thread(s)]" -ForegroundColor Yellow
+    return @("tcp://$($PodeContext.Server.Endpoints[0].HostName):$($port)")
 }

--- a/src/Private/WebServer.ps1
+++ b/src/Private/WebServer.ps1
@@ -198,15 +198,10 @@ function Start-PodeWebServer
 
     Add-PodeRunspace -Type 'Main' -ScriptBlock $waitScript -Parameters @{ 'Listener' = $listener }
 
-    # state where we're running
-    Write-Host "Listening on the following $($endpoints.Length) endpoint(s) [$($PodeContext.Threads) thread(s)]:" -ForegroundColor Yellow
-
-    $endpoints | ForEach-Object {
-        Write-Host "`t- $($_.HostName)" -ForegroundColor Yellow
-    }
-
     # browse to the first endpoint, if flagged
     if ($Browse) {
         Start-Process $endpoints[0].HostName
     }
+
+    return @($endpoints.HostName)
 }

--- a/src/Private/WebServer.ps1
+++ b/src/Private/WebServer.ps1
@@ -19,7 +19,7 @@ function Start-PodeWebServer
 
     # work out which endpoints to listen on
     $endpoints = @()
-    $PodeContext.Server.Endpoints | ForEach-Object {
+    @(Get-PodeEndpoints -Type Http) | ForEach-Object {
         # get the protocol
         $_protocol = (Resolve-PodeValue -Check $_.Ssl -TrueValue 'https' -FalseValue 'http')
 

--- a/src/Public/Core.ps1
+++ b/src/Public/Core.ps1
@@ -477,7 +477,7 @@ function Add-PodeEndpoint
         $Port = 0,
 
         [Parameter()]
-        [ValidateSet('Http', 'Https', 'Smtp', 'Tcp')]
+        [ValidateSet('Http', 'Https', 'Smtp', 'Tcp', 'Ws', 'Wss')]
         [string]
         $Protocol,
 
@@ -540,7 +540,7 @@ function Add-PodeEndpoint
         Port = $null
         IsIPAddress = $true
         HostName = 'localhost'
-        Ssl = ($Protocol -ieq 'https')
+        Ssl = (@('https', 'wss') -icontains $Protocol)
         Protocol = $Protocol
         Certificate = @{
             Name = $Certificate
@@ -574,8 +574,8 @@ function Add-PodeEndpoint
     # if we're dealing with a certificate file, attempt to import it
     if ($PSCmdlet.ParameterSetName -ieq 'certfile') {
         # fail if protocol is not https
-        if ($Protocol -ine 'https') {
-            throw "Certificate supplied for non-HTTPS endpoint"
+        if (@('https', 'wss') -inotcontains $Protocol) {
+            throw "Certificate supplied for non-HTTPS/WSS endpoint"
         }
 
         $_path = Get-PodeRelativePath -Path $CertificateFile -JoinRoot -Resolve
@@ -600,16 +600,21 @@ function Add-PodeEndpoint
         }
 
         # set server type, ensure we aren't trying to change the server's type
-        $_type = (Resolve-PodeValue -Check ($Protocol -ieq 'https') -TrueValue 'http' -FalseValue $Protocol)
-        if (($_type -ieq 'http') -and ($PodeContext.Server.Type -ieq 'pode')) {
-            $_type = 'pode'
+        if (@('ws', 'wss') -icontains $Protocol) {
+            $PodeContext.Server.WebSockets.Enabled = $true
         }
+        else {
+            $_type = (Resolve-PodeValue -Check ($Protocol -ieq 'https') -TrueValue 'http' -FalseValue $Protocol)
+            if (($_type -ieq 'http') -and ($PodeContext.Server.Type -ieq 'pode')) {
+                $_type = 'pode'
+            }
 
-        if ([string]::IsNullOrWhiteSpace($PodeContext.Server.Type)) {
-            $PodeContext.Server.Type = $_type
-        }
-        elseif ($PodeContext.Server.Type -ine $_type) {
-            throw "Cannot add $($Protocol.ToUpperInvariant()) endpoint when already listening to $($PodeContext.Server.Type.ToUpperInvariant()) endpoints"
+            if ([string]::IsNullOrWhiteSpace($PodeContext.Server.Type)) {
+                $PodeContext.Server.Type = $_type
+            }
+            elseif ($PodeContext.Server.Type -ine $_type) {
+                throw "Cannot add $($Protocol.ToUpperInvariant()) endpoint when already listening to $($PodeContext.Server.Type.ToUpperInvariant()) endpoints"
+            }
         }
 
         # add the new endpoint

--- a/src/Public/Responses.ps1
+++ b/src/Public/Responses.ps1
@@ -567,7 +567,7 @@ Writes JSON data to the Response.
 Writes JSON data to the Response, setting the content type accordingly.
 
 .PARAMETER Value
-A String, PSObject, or HashTable value.
+A String, PSObject, or HashTable value. For non-string values, they will be converted to JSON.
 
 .PARAMETER Path
 The path to a JSON file.
@@ -1213,13 +1213,37 @@ function Use-PodePartialView
     return (Get-PodeFileContentUsingViewEngine -Path $Path -Data $Data)
 }
 
+<#
+.SYNOPSIS
+Broadcasts a message to connected WebSocket clients.
+
+.DESCRIPTION
+Broadcasts a message to all, or some, connected WebSocket clients. You can specify a path to send messages to, or a specific ClientId.
+
+.PARAMETER Value
+A String, PSObject, or HashTable value. For non-string values, they will be converted to JSON.
+
+.PARAMETER Path
+The Path of connected clients to send the message.
+
+.PARAMETER ClientId
+A specific ClientId of a connected client to send a message. Not currently used.
+
+.PARAMETER Depth
+The Depth to generate the JSON document - the larger this value the worse performance gets.
+
+.EXAMPLE
+Send-PodeSignal -Value @{ Message = 'Hello, world!' }
+
+.EXAMPLE
+Send-PodeSignal -Value @{ Data = @(123, 100, 101) } -Path '/response-charts'
+#>
 function Send-PodeSignal
 {
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
-        [hashtable]
-        $Data,
+        [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
+        $Value,
 
         [Parameter()]
         [string]
@@ -1227,11 +1251,24 @@ function Send-PodeSignal
 
         [Parameter()]
         [string]
-        $ClientId
+        $ClientId,
+
+        [Parameter()]
+        [int]
+        $Depth = 10
     )
 
+    if ($Value -isnot [string]) {
+        if ($Depth -le 0) {
+            $Value = ($Value | ConvertTo-Json -Compress)
+        }
+        else {
+            $Value = ($Value | ConvertTo-Json -Depth $Depth -Compress)
+        }
+    }
+
     $PodeContext.Server.WebSockets.Queues.Messages.Enqueue(@{
-        Value = ($Data | ConvertTo-Json -Compress)
+        Value = $Value
         ClientId = $ClientId
         Path = $Path
     })

--- a/src/Public/Responses.ps1
+++ b/src/Public/Responses.ps1
@@ -1212,3 +1212,27 @@ function Use-PodePartialView
     # run any engine logic
     return (Get-PodeFileContentUsingViewEngine -Path $Path -Data $Data)
 }
+
+function Send-PodeSignal
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [hashtable]
+        $Data,
+
+        [Parameter()]
+        [string]
+        $Path,
+
+        [Parameter()]
+        [string]
+        $ClientId
+    )
+
+    $PodeContext.Server.WebSockets.Queues.Messages.Enqueue(@{
+        Value = ($Data | ConvertTo-Json -Compress)
+        ClientId = $ClientId
+        Path = $Path
+    })
+}

--- a/tests/unit/Server.Tests.ps1
+++ b/tests/unit/Server.Tests.ps1
@@ -134,7 +134,13 @@ Describe 'Restart-PodeInternalServer' {
                 Sockets = @{
                     Listeners = @()
                     Queues = @{
-                        Contexts = [System.Collections.Generic.List[hashtable]]::new()
+                        Connections = [System.Collections.Concurrent.ConcurrentQueue[System.Net.Sockets.SocketAsyncEventArgs]]::new()
+                    }
+                }
+                WebSockets = @{
+                    Listeners = @()
+                    Queues = @{
+                        Sockets = @{}
                         Connections = [System.Collections.Concurrent.ConcurrentQueue[System.Net.Sockets.SocketAsyncEventArgs]]::new()
                     }
                 }


### PR DESCRIPTION
### Description of the Change
A new internal server type has been created for connecting and accepting websocket requests. The server will perform the websocket handshake, and then accept connecting clients. Any clients that connect will be added into a list, so that messages can be later broadcast to them all.

### Related Issue
#395 

### Examples
* To enable a server to listen for incoming websockets:
```powershell
Start-PodeServer {
    Add-PodeEndpoint -Address * -Port 8081 -Protocol Ws
}
```

* To broadcast a message to all connected clients:
```powershell
Send-PodeSignal -Value @{ Message = 'Hello, world!' }
```
