### PR TITLE
Return a 405 if the route exists for a different method

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-16.04, windows-latest, windows-2016, macOS-latest]
+        os: [ubuntu-latest, ubuntu-16.04, windows-latest, windows-2016]
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
### Description of the Change
Currently if a route exists for a POST method, but you make a GET call then it will return a 404. This change makes it so that it instead returns a 405.

### Related Issue
* #383
