### PR TITLE
Support on Timers and Schedules for an -OnStart switch

### DIFF
--- a/examples/timers.ps1
+++ b/examples/timers.ps1
@@ -11,7 +11,7 @@ Start-PodeServer {
 
     # runs forever, looping every 5secs
     Add-PodeTimer -Name 'forever' -Interval 5 -ScriptBlock {
-        # logic
+        'Hello, world' | Out-PodeHost
     }
 
     # runs forever, but skips the first 3 "loops" - is paused for 15secs then loops every 5secs

--- a/src/Pode.psd1
+++ b/src/Pode.psd1
@@ -102,7 +102,7 @@
         'Test-IsWindows',
         'Test-IsPSCore',
         'Test-IsEmpty',
-        'Write-PodeHost',
+        'Out-PodeHost',
 
         # routes
         'Add-PodeRoute',

--- a/src/Private/Schedules.ps1
+++ b/src/Private/Schedules.ps1
@@ -17,6 +17,79 @@ function Start-PodeScheduleRunspace
     }
 
     $script = {
+        function Invoke-PodeInternalSchedule($Schedule, $Now)
+        {
+            $Schedule.OnStart = $false
+            $remove = $false
+
+            # increment total number of triggers for the schedule
+            if ($Schedule.Countable) {
+                $Schedule.Count++
+                $Schedule.Countable = ($Schedule.Count -lt $Schedule.Limit)
+            }
+
+            # check if we have hit the limit, and remove
+            if (($Schedule.Limit -ne 0) -and ($Schedule.Count -ge $Schedule.Limit)) {
+                $remove = $true
+            }
+
+            # trigger the schedules logic
+            try {
+                $parameters = @{
+                    Event = @{
+                        Lockable = $PodeContext.Lockable
+                    }
+                }
+
+                foreach ($key in $Schedule.Arguments.Keys) {
+                    $parameters[$key] = $Schedule.Arguments[$key]
+                }
+
+                Add-PodeRunspace -Type Schedules -ScriptBlock (($Schedule.Script).GetNewClosure()) -Parameters $parameters -Forget
+            }
+            catch {
+                $_ | Write-PodeErrorLog
+            }
+
+            # reset the cron if it's random
+            $Schedule.Crons = Reset-PodeRandomCronExpressions -Expressions $Schedule.Crons
+            return $remove
+        }
+
+        function Remove-PodeInternalSchedules([string[]] $Schedules)
+        {
+            # add any schedules to remove that have exceeded their end time
+            $Schedules += @($PodeContext.Schedules.Values |
+                Where-Object { (($null -ne $_.EndTime) -and ($_.EndTime -lt $_now)) }).Name
+
+            if (($null -eq $Schedules) -or ($Schedules.Length -eq 0)) {
+                return
+            }
+
+            # remove any schedules
+            foreach ($name in $Schedules) {
+                if ($PodeContext.Schedules.ContainsKey($name)) {
+                    $PodeContext.Schedules.Remove($name) | Out-Null
+                }
+            }
+        }
+
+        # select the schedules that trigger on-start
+        $_remove = @()
+        $_now = [DateTime]::Now
+
+        $PodeContext.Schedules.Values |
+            Where-Object {
+                $_.OnStart
+            } | ForEach-Object {
+                if (Invoke-PodeInternalSchedule -Schedule $_ -Now $_now) {
+                    $_remove += $_.Name
+                }
+            }
+
+        # remove any schedules
+        Remove-PodeInternalSchedules -Schedules $_remove
+
         # first, sleep for a period of time to get to 00 seconds (start of minute)
         Start-Sleep -Seconds (60 - [DateTime]::Now.Second)
 
@@ -32,50 +105,13 @@ function Start-PodeScheduleRunspace
                     (($null -eq $_.EndTime) -or ($_.EndTime -ge $_now)) -and
                     (Test-PodeCronExpressions -Expressions $_.Crons -DateTime $_now)
                 } | ForEach-Object {
-
-                # increment total number of triggers for the schedule
-                if ($_.Countable) {
-                    $_.Count++
-                    $_.Countable = ($_.Count -lt $_.Limit)
-                }
-
-                # check if we have hit the limit, and remove
-                if ($_.Limit -ne 0 -and $_.Count -ge $_.Limit) {
-                    $_remove += $_.Name
-                }
-
-                # trigger the schedules logic
-                try {
-                    $parameters = @{
-                        Event = @{
-                            Lockable = $PodeContext.Lockable
-                        }
+                    if (Invoke-PodeInternalSchedule -Schedule $_ -Now $_now) {
+                        $_remove += $_.Name
                     }
-
-                    foreach ($key in $_.Arguments.Keys) {
-                        $parameters[$key] = $_.Arguments[$key]
-                    }
-
-                    Add-PodeRunspace -Type 'Schedules' -ScriptBlock (($_.Script).GetNewClosure()) -Parameters $parameters -Forget
                 }
-                catch {
-                    $_ | Write-PodeErrorLog
-                }
-
-                # reset the cron if it's random
-                $_.Crons = Reset-PodeRandomCronExpressions -Expressions $_.Crons
-            }
-
-            # add any schedules to remove that have exceeded their end time
-            $_remove += @($PodeContext.Schedules.Values |
-                Where-Object { (($null -ne $_.EndTime) -and ($_.EndTime -lt $_now)) }).Name
 
             # remove any schedules
-            foreach ($name in $_remove) {
-                if ($PodeContext.Schedules.ContainsKey($name)) {
-                    $PodeContext.Schedules.Remove($name) | Out-Null
-                }
-            }
+            Remove-PodeInternalSchedules -Schedules $_remove
 
             # cron expression only goes down to the minute, so sleep for 1min
             Start-Sleep -Seconds (60 - [DateTime]::Now.Second)

--- a/src/Private/Timers.ps1
+++ b/src/Private/Timers.ps1
@@ -22,8 +22,9 @@ function Start-PodeTimerRunspace
             $_remove = @()
             $_now = [DateTime]::Now
 
-            $PodeContext.Timers.Values | Where-Object { $_.NextTick -le $_now } | ForEach-Object {
+            $PodeContext.Timers.Values | Where-Object { $_.OnStart -or ($_.NextTick -le $_now) } | ForEach-Object {
                 $run = $true
+                $_.OnStart = $false
 
                 # increment total number of runs for timer (do we still need to count?)
                 if ($_.Countable) {

--- a/src/Public/Core.ps1
+++ b/src/Public/Core.ps1
@@ -665,6 +665,9 @@ The number of "invokes" to skip before the Timer actually runs.
 .PARAMETER ArgumentList
 An array of arguments to supply to the Timer's ScriptBlock.
 
+.PARAMETER OnStart
+If supplied, the timer will trigger when the server starts.
+
 .EXAMPLE
 Add-PodeTimer -Name 'Hello' -Interval 10 -ScriptBlock { 'Hello, world!' | Out-Default }
 
@@ -703,7 +706,10 @@ function Add-PodeTimer
 
         [Parameter()]
         [object[]]
-        $ArgumentList
+        $ArgumentList,
+
+        [switch]
+        $OnStart
     )
 
     # error if serverless
@@ -746,6 +752,7 @@ function Add-PodeTimer
         NextTick = $NextTick
         Script = $ScriptBlock
         Arguments = $ArgumentList
+        OnStart = $OnStart
     }
 }
 
@@ -820,6 +827,9 @@ A DateTime for when the Schedule should stop triggering, and be removed.
 .PARAMETER ArgumentList
 A hashtable of arguments to supply to the Schedule's ScriptBlock.
 
+.PARAMETER OnStart
+If supplied, the schedule will trigger when the server starts, regardless if the cron-expression matches the current time.
+
 .EXAMPLE
 Add-PodeSchedule -Name 'RunEveryMinute' -Cron '@minutely' -ScriptBlock { /* logic */ }
 
@@ -862,7 +872,10 @@ function Add-PodeSchedule
 
         [Parameter()]
         [hashtable]
-        $ArgumentList
+        $ArgumentList,
+
+        [switch]
+        $OnStart
     )
 
     # error if serverless
@@ -898,6 +911,7 @@ function Add-PodeSchedule
         Countable = ($Limit -gt 0)
         Script = $ScriptBlock
         Arguments = (Protect-PodeValue -Value $ArgumentList -Default @{})
+        OnStart = $OnStart
     }
 }
 

--- a/src/Public/Utilities.ps1
+++ b/src/Public/Utilities.ps1
@@ -764,25 +764,28 @@ function Test-IsWindows
 
 <#
 .SYNOPSIS
-Writes a message to the main Host.
+Outputs an object to the main Host.
 
 .DESCRIPTION
-Due to Pode's use of runspaces, this will write a given message back to the main Host.
+Due to Pode's use of runspaces, this will output a given object back to the main Host.
 
-.PARAMETER Message
-The Message to write.
+.PARAMETER InputObject
+The object to output.
 
 .EXAMPLE
-'Hello, world!' | Write-PodeHost
+'Hello, world!' | Out-PodeHost
+
+.EXAMPLE
+@{ Name = 'Rick' } | Out-PodeHost
 #>
-function Write-PodeHost
+function Out-PodeHost
 {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
-        [string]
-        $Message
+        [object]
+        $InputObject
     )
 
-    $Message | Out-Default
+    $InputObject | Out-Default
 }

--- a/tests/unit/Helpers.Tests.ps1
+++ b/tests/unit/Helpers.Tests.ps1
@@ -1381,16 +1381,21 @@ Describe 'Convert-PodePathSeparators' {
     }
 }
 
-Describe 'Write-PodeHost' {
+Describe 'Out-PodeHost' {
     Mock Out-Default {}
 
     It 'Writes a message to the Host by parameters' {
-        Write-PodeHost -Message 'Hello'
+        Out-PodeHost -InputObject 'Hello'
         Assert-MockCalled Out-Default -Scope It -Times 1
     }
 
     It 'Writes a message to the Host by pipeline' {
-        'Hello' | Write-PodeHost
+        'Hello' | Out-PodeHost
+        Assert-MockCalled Out-Default -Scope It -Times 1
+    }
+
+    It 'Writes a hashtable to the Host by pipeline' {
+        @{ Name = 'Rick' } | Out-PodeHost
         Assert-MockCalled Out-Default -Scope It -Times 1
     }
 }


### PR DESCRIPTION
### Description of the Change
Adds a new `-OnStart` switch to Timers and Schedules, so that the ScriptBlock will be invoked once when you start/restart the server.

### Related Issue
Resovles #401

### Examples
Schedules:
```powershell
Add-PodeSchedule -Name 'predefined' -Cron '@minutely' -OnStart -ScriptBlock {}
```

Timers:
```powershell
Add-PodeTimer -Name 'forever' -Interval 5 -OnStart -ScriptBlock {}
```

