### PR TITLE
#382: allow shift+c/r on unix

### DIFF
--- a/docs/Tutorials/Basics.md
+++ b/docs/Tutorials/Basics.md
@@ -21,3 +21,4 @@ The above server will start a basic HTTP listener on port 8080. To start the ser
 
 !!! tip
     Once Pode has started, you can exit out at any time using `Ctrl+C`. You can also restart the server by using `Ctrl+R`.
+    On Unix, you can also use `Shuft+C` and `Shift+R`

--- a/docs/Tutorials/Restarting/Overview.md
+++ b/docs/Tutorials/Restarting/Overview.md
@@ -3,6 +3,7 @@
 There are 3 ways to restart a running Pode server:
 
 1. **Ctrl+R**: If you press `Ctrl+R` on a running server, it will trigger a restart to take place.
+    1a. On Unix you can use `Shift+R`.
 2. [**File Monitoring**](../Types/FileMonitoring): This will watch for file changes, and if enabled will trigger the server to restart.
 3. [**Auto-Restarting**](../Types/AutoRestarting): Defined within the `server.psd1` configuration file, you can set schedules for the server to automatically restart.
 

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -727,7 +727,8 @@ function Test-PodeTerminationPressed
         $Key = Get-PodeConsoleKey
     }
 
-    return ($null -ne $Key -and $Key.Key -ieq 'c' -and $Key.Modifiers -band [ConsoleModifiers]::Control)
+    return (($null -ne $Key) -and ($Key.Key -ieq 'c') -and
+        (($Key.Modifiers -band [ConsoleModifiers]::Control) -or ((Test-IsUnix) -and ($Key.Modifiers -band [ConsoleModifiers]::Shift))))
 }
 
 function Test-PodeRestartPressed
@@ -741,7 +742,8 @@ function Test-PodeRestartPressed
         $Key = Get-PodeConsoleKey
     }
 
-    return ($null -ne $Key -and $Key.Key -ieq 'r' -and $Key.Modifiers -band [ConsoleModifiers]::Control)
+    return (($null -ne $Key) -and ($Key.Key -ieq 'r') -and
+        (($Key.Modifiers -band [ConsoleModifiers]::Control) -or ((Test-IsUnix) -and ($Key.Modifiers -band [ConsoleModifiers]::Shift))))
 }
 
 function Start-PodeTerminationListener


### PR DESCRIPTION
### Description of the Change
On most Unix platforms, Ctrl+C or Ctrl+R doesn't always work to exit/restart the server. For this reason, on Unix only, Shift+C/R should be allowed as well.

### Related Issue
Resolves #382
