### PR TITLE
Fix for using */INT in cron-expressions

### DIFF
--- a/src/Private/CronParser.ps1
+++ b/src/Private/CronParser.ps1
@@ -164,7 +164,9 @@ function ConvertFrom-PodeCronExpression
         }
 
         # replace * with min/max constraint
-        $_atom = $_atom -ireplace '\*', ($_constraint -join '-')
+        if ($_atom -ieq '*') {
+            $_atom = ($_constraint -join '-')
+        }
 
         # parse the atom for either a literal, range, array, or interval
         # literal
@@ -198,7 +200,7 @@ function ConvertFrom-PodeCronExpression
                 $interval = '1'
             }
 
-            if ([string]::IsNullOrWhiteSpace($start) -or $start -ieq '*') {
+            if ([string]::IsNullOrWhiteSpace($start) -or ($start -ieq '*')) {
                 $start = '0'
             }
 

--- a/tests/unit/CronParser.Tests.ps1
+++ b/tests/unit/CronParser.Tests.ps1
@@ -209,6 +209,47 @@ Describe 'ConvertFrom-PodeCronExpression' {
             $cron.DayOfMonth.Constraints[1] | Should Be 31
             $cron.DayOfMonth.Random | Should Be $false
         }
+
+        It 'Returns a valid cron object for expression using wildcard' {
+            $cron = ConvertFrom-PodeCronExpression -Expression '*/10 * * * 2'
+
+            $cron.Month.Values | Should Be $null
+            $cron.Month.Range.Min | Should Be 1
+            $cron.Month.Range.Max | Should Be 12
+            $cron.Month.Constraints[0] | Should Be 1
+            $cron.Month.Constraints[1] | Should Be 12
+            $cron.Month.Random | Should Be $false
+
+            $cron.DayOfWeek.Values | Should Be 2
+            $cron.DayOfWeek.Range.Min | Should Be $null
+            $cron.DayOfWeek.Range.Max | Should Be $null
+            $cron.DayOfWeek.Constraints[0] | Should Be 0
+            $cron.DayOfWeek.Constraints[1] | Should Be 6
+            $cron.DayOfWeek.Random | Should Be $false
+
+            $cron.Minute.Values | Should Be @(0, 10, 20, 30, 40, 50)
+            $cron.Minute.Range.Min | Should Be $null
+            $cron.Minute.Range.Max | Should Be $null
+            $cron.Minute.Constraints[0] | Should Be 0
+            $cron.Minute.Constraints[1] | Should Be 59
+            $cron.Minute.Random | Should Be $false
+
+            $cron.Hour.Values | Should Be $null
+            $cron.Hour.Range.Min | Should Be 0
+            $cron.Hour.Range.Max | Should Be 23
+            $cron.Hour.Constraints[0] | Should Be 0
+            $cron.Hour.Constraints[1] | Should Be 23
+            $cron.Hour.Random | Should Be $false
+
+            $cron.Random | Should Be $false
+
+            $cron.DayOfMonth.Values | Should Be $null
+            $cron.DayOfMonth.Range.Min | Should Be 1
+            $cron.DayOfMonth.Range.Max | Should Be 31
+            $cron.DayOfMonth.Constraints[0] | Should Be 1
+            $cron.DayOfMonth.Constraints[1] | Should Be 31
+            $cron.DayOfMonth.Random | Should Be $false
+        }
     }
 }
 


### PR DESCRIPTION
### Description of the Change
Adds a missing if-statement to fix using `*/INT` atoms in cron-expressions.

### Related Issue
Resolves #414 

### Examples
`*/10 * * * *` - for once every 10mins.
