### PR TITLE
#418: Documentation\examples typo fixes

### DIFF
--- a/docs/Tutorials/ImportingModules.md
+++ b/docs/Tutorials/ImportingModules.md
@@ -1,6 +1,6 @@
 # Importing Modules/SnapIns
 
-Because Pode runs most things in isolated runspaces, importing and using modules or snap-ins can be quite bothersome. To overcome this, you can use the  [`Import-PodeModule`](../../Functions/Utilities/Import-PodeModule) or  [`Import-PodeModule`](../../Functions/Utilities/Import-PodeModule) functions to declare paths/names of modules or snap-ins that need to be imported into all of the runspaces.
+Because Pode runs most things in isolated runspaces, importing and using modules or snap-ins can be quite bothersome. To overcome this, you can use the  [`Import-PodeModule`](../../Functions/Utilities/Import-PodeModule) or [`Import-PodeSnapIn`](../../Functions/Utilities/Import-PodeSnapIn) functions to declare paths/names of modules or snap-ins that need to be imported into all of the runspaces.
 
 !!! important
     Snap-ins are only supported in Windows PowerShell.

--- a/docs/Tutorials/Restarting/Overview.md
+++ b/docs/Tutorials/Restarting/Overview.md
@@ -7,4 +7,4 @@ There are 3 ways to restart a running Pode server:
 2. [**File Monitoring**](../Types/FileMonitoring): This will watch for file changes, and if enabled will trigger the server to restart.
 3. [**Auto-Restarting**](../Types/AutoRestarting): Defined within the `server.psd1` configuration file, you can set schedules for the server to automatically restart.
 
-When the server restarts, it will re-invoke the `scripblock` supplied to the  [`Start-PodeServer`](../../../Functions/Core/Start-PodeServer) function. This means the best approach to reload new modules/scripts it to dot-source your scripts into your server, as any changes to the main `scriptblock` will **not** take place.
+When the server restarts, it will re-invoke the `-ScriptBlock` supplied to the [`Start-PodeServer`](../../../Functions/Core/Start-PodeServer) function. This means the best approach to reload new modules/scripts it to dot-source/[`Use-PodeScript`](../../../Functions/Utilities/Use-PodeScript) your scripts into your server, as any changes to the main `scriptblock` will **not** take place.

--- a/docs/Tutorials/SharedState.md
+++ b/docs/Tutorials/SharedState.md
@@ -124,7 +124,7 @@ Start-PodeServer {
             $hash = (Get-PodeState -Name 'hash')
 
             # add a random number
-            $hash['values'] += (Get-Random -Minimum 0 -Maximum 10)
+            $hash.values += (Get-Random -Minimum 0 -Maximum 10)
 
             # save the state to file
             Save-PodeState -Path './state.json'

--- a/examples/external-funcs.ps1
+++ b/examples/external-funcs.ps1
@@ -11,7 +11,7 @@ Start-PodeServer {
     Add-PodeEndpoint -Address * -Port 8085 -Protocol Http
 
     # include the external function module
-    Use-PodeScript -Path './modules/external-funcs.psm1'
+    Import-PodeModule -Path './modules/external-funcs.psm1'
 
     # GET request for "localhost:8085/"
     Add-PodeRoute -Method Get -Path '/' -ScriptBlock {


### PR DESCRIPTION
### Description of the Change
Fixes some documentation and examples typo issues.

* `external-funcs` example: fix `Use-PodeScript` to be `Import-PodeModule`
* SharedState: fix `$hash['value']` to be `$hash.value`
* ImportingModule: fix dupe reference of `Import-PodeModule`

### Related Issue
Resolves #418: 
