### PR TITLE
Adds -FilePath to Add-PodeSchedule and Timer

### DIFF
--- a/examples/schedules.ps1
+++ b/examples/schedules.ps1
@@ -15,6 +15,8 @@ Start-PodeServer {
         'hello, world!' | Out-Default
     }
 
+    Add-PodeSchedule -Name 'from-file' -Cron '@minutely' -FilePath './scripts/schedule.ps1'
+
     # schedule defined using two cron expressions
     Add-PodeSchedule -Name 'two-crons' -Cron @('0/3 * * * *', '0/5 * * * *') -ScriptBlock {
         'double cron' | Out-Default

--- a/examples/scripts/schedule.ps1
+++ b/examples/scripts/schedule.ps1
@@ -1,0 +1,3 @@
+{
+    'Hello, there!' | Out-PodeHost
+}

--- a/examples/scripts/timer.ps1
+++ b/examples/scripts/timer.ps1
@@ -1,0 +1,3 @@
+{
+    'Hello, there!' | Out-PodeHost
+}

--- a/examples/timers.ps1
+++ b/examples/timers.ps1
@@ -14,6 +14,8 @@ Start-PodeServer {
         'Hello, world' | Out-PodeHost
     } -Limit 5
 
+    Add-PodeTimer -Name 'from-file' -Interval 2 -FilePath './scripts/timer.ps1'
+
     # runs forever, but skips the first 3 "loops" - is paused for 15secs then loops every 5secs
     Add-PodeTimer -Name 'pause-first-3' -Interval 5 -ScriptBlock {
         # logic

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -1933,3 +1933,27 @@ function Get-PodeHandler
 
     return $PodeContext.Server.Handlers[$Type][$Name]
 }
+
+function Convert-PodeFileToScriptBlock
+{
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]
+        $FilePath
+    )
+
+    # resolve for relative path
+    $FilePath = Get-PodeRelativePath -Path $FilePath -JoinRoot
+
+    # if file doesn't exist, error
+    if (!(Test-PodePath -Path $FilePath -NoStatus)) {
+        throw "The FilePath supplied does not exist: $($FilePath)"
+    }
+
+    # if the path is a wildcard or directory, error
+    if (!(Test-PodePathIsFile -Path $FilePath -FailOnWildcard)) {
+        throw "The FilePath supplied cannot be a wildcard or a directory: $($FilePath)"
+    }
+
+    return ([scriptblock](Use-PodeScript -Path $FilePath))
+}

--- a/src/Public/Core.ps1
+++ b/src/Public/Core.ps1
@@ -665,6 +665,9 @@ The number of "invokes" to skip before the Timer actually runs.
 .PARAMETER ArgumentList
 An array of arguments to supply to the Timer's ScriptBlock.
 
+.PARAMETER FilePath
+A literal, or relative, path to a file containing a ScriptBlock for the Timer's logic.
+
 .PARAMETER OnStart
 If supplied, the timer will trigger when the server starts.
 
@@ -682,7 +685,7 @@ Add-PodeTimer -Name 'Args' -Interval 2 -ScriptBlock { /* logic */ } -ArgumentLis
 #>
 function Add-PodeTimer
 {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName='Script')]
     param (
         [Parameter(Mandatory=$true)]
         [string]
@@ -692,7 +695,7 @@ function Add-PodeTimer
         [int]
         $Interval,
 
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory=$true, ParameterSetName='Script')]
         [scriptblock]
         $ScriptBlock,
 
@@ -703,6 +706,10 @@ function Add-PodeTimer
         [Parameter()]
         [int]
         $Skip = 0,
+
+        [Parameter(Mandatory=$true, ParameterSetName='File')]
+        [string]
+        $FilePath,
 
         [Parameter()]
         [object[]]
@@ -733,6 +740,11 @@ function Add-PodeTimer
     # is the skip valid?
     if ($Skip -lt 0) {
         throw "[Timer] $($Name): Cannot have a negative skip value"
+    }
+
+    # if we have a file path supplied, load that path as a scriptblock
+    if ($PSCmdlet.ParameterSetName -ieq 'file') {
+        $ScriptBlock = Convert-PodeFileToScriptBlock -FilePath $FilePath
     }
 
     # calculate the next tick time (based on Skip)
@@ -859,6 +871,9 @@ A DateTime for when the Schedule should stop triggering, and be removed.
 .PARAMETER ArgumentList
 A hashtable of arguments to supply to the Schedule's ScriptBlock.
 
+.PARAMETER FilePath
+A literal, or relative, path to a file containing a ScriptBlock for the Schedule's logic.
+
 .PARAMETER OnStart
 If supplied, the schedule will trigger when the server starts, regardless if the cron-expression matches the current time.
 
@@ -876,7 +891,7 @@ Add-PodeSchedule -Name 'Args' -Cron '@minutely' -ScriptBlock { /* logic */ } -Ar
 #>
 function Add-PodeSchedule
 {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName='Script')]
     param (
         [Parameter(Mandatory=$true)]
         [string]
@@ -886,7 +901,7 @@ function Add-PodeSchedule
         [string[]]
         $Cron,
 
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory=$true, ParameterSetName='Script')]
         [scriptblock]
         $ScriptBlock,
 
@@ -901,6 +916,10 @@ function Add-PodeSchedule
         [Parameter()]
         [DateTime]
         $EndTime,
+
+        [Parameter(Mandatory=$true, ParameterSetName='File')]
+        [string]
+        $FilePath,
 
         [Parameter()]
         [hashtable]
@@ -930,6 +949,11 @@ function Add-PodeSchedule
 
     if (($null -ne $StartTime) -and ($null -ne $EndTime) -and ($EndTime -lt $StartTime)) {
         throw "[Schedule] $($Name): Cannot have a StartTime after the EndTime"
+    }
+
+    # if we have a file path supplied, load that path as a scriptblock
+    if ($PSCmdlet.ParameterSetName -ieq 'file') {
+        $ScriptBlock = Convert-PodeFileToScriptBlock -FilePath $FilePath
     }
 
     # add the schedule

--- a/src/Public/Routes.ps1
+++ b/src/Public/Routes.ps1
@@ -137,20 +137,7 @@ function Add-PodeRoute
 
     # if we have a file path supplied, load that path as a scriptblock
     if ($PSCmdlet.ParameterSetName -ieq 'file') {
-        # resolve for relative path
-        $FilePath = Get-PodeRelativePath -Path $FilePath -JoinRoot
-
-        # if file doesn't exist, error
-        if (!(Test-PodePath -Path $FilePath -NoStatus)) {
-            throw "[$($Method)] $($Path): The FilePath does not exist: $($FilePath)"
-        }
-
-        # if the path is a wildcard or directory, error
-        if (!(Test-PodePathIsFile -Path $FilePath -FailOnWildcard)) {
-            throw "[$($Method)] $($Path): The FilePath cannot be a wildcard or directory: $($FilePath)"
-        }
-
-        $ScriptBlock = [scriptblock](Use-PodeScript -Path $FilePath)
+        $ScriptBlock = Convert-PodeFileToScriptBlock -FilePath $FilePath
     }
 
     # ensure supplied middlewares are either a scriptblock, or a valid hashtable

--- a/tests/unit/Routes.Tests.ps1
+++ b/tests/unit/Routes.Tests.ps1
@@ -294,14 +294,14 @@ Describe 'Add-PodeRoute' {
         Mock Get-PodeRelativePath { return $Path }
         Mock Test-PodePath { return $true }
         $PodeContext.Server = @{ 'Routes' = @{ 'GET' = @{} } }
-        { Add-PodeRoute -Method GET -Path '/' -FilePath './path' } | Should Throw 'cannot be a wildcard or directory'
+        { Add-PodeRoute -Method GET -Path '/' -FilePath './path' } | Should Throw 'cannot be a wildcard or a directory'
     }
 
     It 'Throws error when file path is a wildcard' {
         Mock Get-PodeRelativePath { return $Path }
         Mock Test-PodePath { return $true }
         $PodeContext.Server = @{ 'Routes' = @{ 'GET' = @{} } }
-        { Add-PodeRoute -Method GET -Path '/' -FilePath './path/*' } | Should Throw 'cannot be a wildcard or directory'
+        { Add-PodeRoute -Method GET -Path '/' -FilePath './path/*' } | Should Throw 'cannot be a wildcard or a directory'
     }
 
     It 'Throws error because no scriptblock supplied' {


### PR DESCRIPTION
### Description of the Change
Adds a new `-FilePath` parameter to the `Add-PodeSchedule` and `Add-PodeTimer` functions.

### Related Issue
Resolves #421

### Examples
```powershell
Add-PodeTimer -Name 'timer' -Interval 2 -FilePath './file.ps1'
Add-PodeSchedule -Name 'schedule' -Cron '@minutely' -FilePath './file.ps1'
```
