### PR TITLE
#423: adds new Edit-PodeSchedule/Timer functions

### DIFF
--- a/src/Pode.psd1
+++ b/src/Pode.psd1
@@ -124,12 +124,14 @@
         'Remove-PodeSchedule',
         'Clear-PodeSchedule',
         'Invoke-PodeSchedule',
+        'Edit-PodeSchedule',
 
         # timers
         'Add-PodeTimer',
         'Remove-PodeTimer',
         'Clear-PodeTimers',
         'Invoke-PodeTimer',
+        'Edit-PodeTimer',
 
         # middleware
         'Add-PodeMiddleware',

--- a/src/Public/Core.ps1
+++ b/src/Public/Core.ps1
@@ -877,6 +877,70 @@ function Clear-PodeTimers
 
 <#
 .SYNOPSIS
+Edits an existing Timer.
+
+.DESCRIPTION
+Edits an existing Timer's properties, such as interval or scriptblock.
+
+.PARAMETER Name
+The Name of the Timer.
+
+.PARAMETER Interval
+The new Interval for the Timer in seconds.
+
+.PARAMETER ScriptBlock
+The new ScriptBlock for the Timer.
+
+.PARAMETER ArgumentList
+Any new Arguments for the Timer.
+
+.EXAMPLE
+Edit-PodeTimer -Name 'Hello' -Interval 10
+#>
+function Edit-PodeTimer
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
+        [string]
+        $Name,
+
+        [Parameter()]
+        [int]
+        $Interval = 0,
+
+        [Parameter()]
+        [scriptblock]
+        $ScriptBlock,
+
+        [Parameter()]
+        [object[]]
+        $ArgumentList
+    )
+
+    # ensure the timer exists
+    if (!$PodeContext.Timers.ContainsKey($Name)) {
+        throw "Timer '$($Name)' does not exist"
+    }
+
+    # edit interval if supplied
+    if ($Interval -gt 0) {
+        $PodeContext.Timers[$Name].Interval = $Interval
+    }
+
+    # edit scriptblock if supplied
+    if (!(Test-IsEmpty $ScriptBlock)) {
+        $PodeContext.Timers[$Name].Script = $ScriptBlock
+    }
+
+    # edit arguments if supplied
+    if (!(Test-IsEmpty $ArgumentList)) {
+        $PodeContext.Timers[$Name].Arguments = $ArgumentList
+    }
+}
+
+<#
+.SYNOPSIS
 Adds a new Schedule with logic to periodically invoke, defined using Cron Expressions.
 
 .DESCRIPTION
@@ -1076,6 +1140,73 @@ function Clear-PodeSchedules
     param()
 
     $PodeContext.Schedules.Clear()
+}
+
+<#
+.SYNOPSIS
+Edits an existing Schedule.
+
+.DESCRIPTION
+Edits an existing Schedule's properties, such an cron expressions or scriptblock.
+
+.PARAMETER Name
+The Name of the Schedule.
+
+.PARAMETER Cron
+Any new Cron Expressions for the Schedule.
+
+.PARAMETER ScriptBlock
+The new ScriptBlock for the Schedule.
+
+.PARAMETER ArgumentList
+Any new Arguments for the Schedule.
+
+.EXAMPLE
+Edit-PodeSchedule -Name 'Hello' -Cron '@minutely'
+
+.EXAMPLE
+Edit-PodeSchedule -Name 'Hello' -Cron @('@hourly', '0 0 * * TUE')
+#>
+function Edit-PodeSchedule
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
+        [string]
+        $Name,
+
+        [Parameter()]
+        [string[]]
+        $Cron,
+
+        [Parameter()]
+        [scriptblock]
+        $ScriptBlock,
+
+        [Parameter()]
+        [hashtable]
+        $ArgumentList
+    )
+
+    # ensure the schedule exists
+    if (!$PodeContext.Schedules.ContainsKey($Name)) {
+        throw "Schedule '$($Name)' does not exist"
+    }
+
+    # edit cron if supplied
+    if (!(Test-IsEmpty $Cron)) {
+        $PodeContext.Schedules[$Name].Crons = (ConvertFrom-PodeCronExpressions -Expressions @($Cron))
+    }
+
+    # edit scriptblock if supplied
+    if (!(Test-IsEmpty $ScriptBlock)) {
+        $PodeContext.Schedules[$Name].Script = $ScriptBlock
+    }
+
+    # edit arguments if supplied
+    if (!(Test-IsEmpty $ArgumentList)) {
+        $PodeContext.Schedules[$Name].Arguments = $ArgumentList
+    }
 }
 
 <#

--- a/tests/unit/Schedules.Tests.ps1
+++ b/tests/unit/Schedules.Tests.ps1
@@ -162,3 +162,27 @@ Describe 'Clear-PodeSchedules' {
         $PodeContext.Schedules.Count | Should Be 0
     }
 }
+
+Describe 'Edit-PodeSchedule' {
+    It 'Adds a new schedule, then edits the cron' {
+        $PodeContext = @{ 'Schedules' = @{}; }
+        Add-PodeSchedule -Name 'test1' -Cron '@hourly' -ScriptBlock { Write-Host 'hello1' }
+        $PodeContext.Schedules['test1'].Crons.Length | Should Be 1
+        $PodeContext.Schedules['test1'].Script.ToString() | Should Be ({ Write-Host 'hello1' }).ToString()
+
+        Edit-PodeSchedule -Name 'test1' -Cron @('@minutely', '@hourly')
+        $PodeContext.Schedules['test1'].Crons.Length | Should Be 2
+        $PodeContext.Schedules['test1'].Script.ToString() | Should Be ({ Write-Host 'hello1' }).ToString()
+    }
+
+    It 'Adds a new schedule, then edits the script' {
+        $PodeContext = @{ 'Schedules' = @{}; }
+        Add-PodeSchedule -Name 'test1' -Cron '@hourly' -ScriptBlock { Write-Host 'hello1' }
+        $PodeContext.Schedules['test1'].Crons.Length | Should Be 1
+        $PodeContext.Schedules['test1'].Script.ToString() | Should Be ({ Write-Host 'hello1' }).ToString()
+
+        Edit-PodeSchedule -Name 'test1' -ScriptBlock { Write-Host 'hello2' }
+        $PodeContext.Schedules['test1'].Crons.Length | Should Be 1
+        $PodeContext.Schedules['test1'].Script.ToString() | Should Be ({ Write-Host 'hello2' }).ToString()
+    }
+}

--- a/tests/unit/Timers.Tests.ps1
+++ b/tests/unit/Timers.Tests.ps1
@@ -119,3 +119,27 @@ Describe 'Clear-PodeTimers' {
         $PodeContext.Timers.Count | Should Be 0
     }
 }
+
+Describe 'Edit-PodeTimer' {
+    It 'Adds a new timer, then edits the interval' {
+        $PodeContext = @{ 'Timers' = @{}; }
+        Add-PodeTimer -Name 'test1' -Interval 1 -ScriptBlock { Write-Host 'hello1' }
+        $PodeContext.Timers['test1'].Interval | Should Be 1
+        $PodeContext.Timers['test1'].Script.ToString() | Should Be ({ Write-Host 'hello1' }).ToString()
+
+        Edit-PodeTimer -Name 'test1' -Interval 3
+        $PodeContext.Timers['test1'].Interval | Should Be 3
+        $PodeContext.Timers['test1'].Script.ToString() | Should Be ({ Write-Host 'hello1' }).ToString()
+    }
+
+    It 'Adds a new timer, then edits the script' {
+        $PodeContext = @{ 'Timers' = @{}; }
+        Add-PodeTimer -Name 'test1' -Interval 1 -ScriptBlock { Write-Host 'hello1' }
+        $PodeContext.Timers['test1'].Interval | Should Be 1
+        $PodeContext.Timers['test1'].Script.ToString() | Should Be ({ Write-Host 'hello1' }).ToString()
+
+        Edit-PodeTimer -Name 'test1' -ScriptBlock { Write-Host 'hello2' }
+        $PodeContext.Timers['test1'].Interval | Should Be 1
+        $PodeContext.Timers['test1'].Script.ToString() | Should Be ({ Write-Host 'hello2' }).ToString()
+    }
+}


### PR DESCRIPTION
### Description of the Change
Adds two new functions of `Edit-PodeSchedule` and `Edit-PodeTimer`. Each will allow the user to edit an existing schedule/timer's interval/script.

### Related Issue
Resolves #423

### Examples
Update a Timer to be every 3secs:
```powershell
Edit-PodeTimer -Name '<name>' -Interval 3
```

Update a Schedule to be every hour:
```powershell
Edit-PodeSchedule -Name '<name>' -Cron '@hourly'
```
