### PR TITLE
#431: enable pode to response with a www-auth header

### DIFF
--- a/docs/Tutorials/Authentication/Overview.md
+++ b/docs/Tutorials/Authentication/Overview.md
@@ -3,15 +3,15 @@
 Authentication can either be sessionless (requiring validation on every request), or session-persistent (only requiring validation once, and then checks against a session signed-cookie).
 
 !!! info
-    To use session-persistent authentication you will also need to use Session Middleware.
+    To use session-persistent authentication you will also need to use [Session Middleware](../../Middleware/Types/Sessions).
 
-To setup and use authentication in Pode you need to use the  [`New-PodeAuthType`](../../../Functions/Authentication/New-PodeAuthType) and  [`New-PodeAuthType`](../../../Functions/Authentication/New-PodeAuthType) functions, as well as the  [`New-PodeAuthType`](../../../Functions/Authentication/New-PodeAuthType) function for defining authentication Middleware.
+To setup and use authentication in Pode you need to use the [`New-PodeAuthType`](../../../Functions/Authentication/New-PodeAuthType) and [`Add-PodeAuth`](../../../Functions/Authentication/Add-PodeAuth) functions, as well as the [`Get-PodeAuthMiddleware`](../../../Functions/Authentication/Get-PodeAuthMiddleware) function for defining authentication Middleware.
 
 ## Functions
 
 ### New-PodeAuthType
 
-The  [`New-PodeAuthType`](../../../Functions/Authentication/New-PodeAuthType) function allows you to create and configure Basic/Form authentication types, or you can create your own Custom authentication types. These types can then be used on the  [`New-PodeAuthType`](../../../Functions/Authentication/New-PodeAuthType) function.
+The [`New-PodeAuthType`](../../../Functions/Authentication/New-PodeAuthType) function allows you to create and configure Basic/Form authentication types, or you can create your own Custom authentication types. These types can then be used on the [`Add-PodeAuth`](../../../Functions/Authentication/Add-PodeAuth) function.
 
 An example of creating Basic/Form authentication is as follows:
 
@@ -22,7 +22,7 @@ Start-PodeServer {
 }
 ```
 
-Where as the following example defines a Custom type that retrieves the user credentials from Headers:
+Where as the following example defines a Custom type that retrieves the user's credentials from the Request's Payload:
 
 ```powershell
 Start-PodeServer {
@@ -47,9 +47,9 @@ Start-PodeServer {
 
 ### Add-PodeAuth
 
-The  [`Add-PodeAuth`](../../../Functions/Authentication/Add-PodeAuth) function allows you to add authentication methods to your server. You can have many methods configured, defining which one to validate against using the  [`Add-PodeAuth`](../../../Functions/Authentication/Add-PodeAuth) function.
+The [`Add-PodeAuth`](../../../Functions/Authentication/Add-PodeAuth) function allows you to add authentication methods to your server. You can have many methods configured, defining which one to validate against using the [`Get-PodeAuthMiddleware`](../../../Functions/Authentication/Get-PodeAuthMiddleware) function.
 
-An example of using  [`Add-PodeAuth`](../../../Functions/Authentication/Add-PodeAuth) for Basic authentication is as follows:
+An example of using [`Add-PodeAuth`](../../../Functions/Authentication/Add-PodeAuth) for Basic authentication is as follows:
 
 ```powershell
 Start-PodeServer {
@@ -61,13 +61,13 @@ Start-PodeServer {
 }
 ```
 
-The `-Name` of the authentication method must be unique. The `-Type` comes from  [`New-PodeAuthType`](../../../Functions/Authentication/New-PodeAuthType), and can also be piped in.
+The `-Name` of the authentication method must be unique. The `-Type` comes from the object returned via the [`New-PodeAuthType`](../../../Functions/Authentication/New-PodeAuthType) function, and can also be piped in.
 
-The `-ScriptBlock` is used to validate a user, checking if they exist and the password is correct (or checking if they exist in some data store). If the ScriptBlock succeeds, then a `User` needs to be returned from the script as `@{ User = $user }`. If `$null`, or a null user, is returned then the script is assumed to have failed - meaning the user will have failed authentication, and a 401 response is returned.
+The `-ScriptBlock` is used to validate a user, checking if they exist and the password is correct (or checking if they exist in some data store). If the ScriptBlock succeeds, then a `User` object needs to be returned from the script as `@{ User = $user }`. If `$null`, or a null user, is returned then the script is assumed to have failed - meaning the user will have failed authentication, and a 401 response is returned.
 
 #### Custom Message and Status
 
-When authenticating a user in Pode, any failures will return a 401 response with a generic message. You can inform Pode to return a custom message/status from [`Add-PodeAuth`](../../../Functions/Authentication/Add-PodeAuth) by returning a relevant hashtable.
+When authenticating a user in Pode, any failures will return a 401 response with a generic message. You can inform Pode to return a custom message/status from [`Add-PodeAuth`](../../../Functions/Authentication/Add-PodeAuth) by returning the relevant hashtable values.
 
 You can return a custom status code as follows:
 
@@ -85,11 +85,32 @@ New-PodeAuthType -Basic | Add-PodeAuth -Name 'Login' -ScriptBlock {
 }
 ```
 
+#### Authenticate Type/Realm
+
+When authentication fails, and a 401 response is returned, then Pode will also attempt to Response back to the client with a `WWW-Authenticate` header. For the inbuilt types, such as Basic, this Header will always be returned on a 401 response.
+
+You can set the `-Name` and `-Realm` of the header using the [`New-PodeAuthType`](../../../Functions/Authentication/New-PodeAuthType) function. If no Name is supplied, then the header will not be returned - also if there is no Realm, then this will not be added onto the header.
+
+For example, if you setup Basic authenticate with a custom Realm as follows:
+
+```powershell
+New-PodeAuthType -Basic -Realm 'Enter creds to access site'
+```
+
+Then on a 401 response the `WWW-Authenticate` header will look as follows:
+
+```plain
+WWW-Authenticate: Basic realm="Enter creds to access site"
+```
+
+!!! note
+    If no Realm was set then it would just look as follows: `WWW-Authenticate: Basic`
+
 ### Get-PodeAuthMiddleware
 
-The  [`Get-PodeAuthMiddleware`](../../../Functions/Authentication/Get-PodeAuthMiddleware) function allows you to define which authentication method to validate a Request against. It returns valid Middleware, meaning you can either use it on specific Routes, or globally for all routes as Middleware. If this action fails, then a 401 response is returned.
+The [`Get-PodeAuthMiddleware`](../../../Functions/Authentication/Get-PodeAuthMiddleware) function allows you to define which authentication method to validate a Request against. It returns valid Middleware, meaning you can either use it on specific Routes, or globally for all routes as global Middleware. If this action fails, then a 401 response is returned.
 
-An example of using  [`Get-PodeAuthMiddleware`](../../../Functions/Authentication/Get-PodeAuthMiddleware) against Basic authentication is as follows. The first example sets up global middleware, whereas the second example sets up custom Route Middleware:
+An example of using [`Get-PodeAuthMiddleware`](../../../Functions/Authentication/Get-PodeAuthMiddleware) against Basic authentication is as follows. The first example sets up global middleware, whereas the second example sets up custom Route Middleware:
 
 ```powershell
 Start-PodeServer {
@@ -105,11 +126,11 @@ Start-PodeServer {
 
 On success, it will allow the Route logic to be invoked. If Session Middleware has been configured then an authenticated session is also created for future requests, using a signed session-cookie.
 
-When the user makes another call using the same authenticated session and that cookie is present, then  [`Get-PodeAuthMiddleware`](../../../Functions/Authentication/Get-PodeAuthMiddleware) will detect the already authenticated session and skip validation. If you're using sessions and you don't want to check the session, or store the user against a session, then use the `-Sessionless` switch.
+When the user makes another call using the same authenticated session and that cookie is present, then [`Get-PodeAuthMiddleware`](../../../Functions/Authentication/Get-PodeAuthMiddleware) will detect the already authenticated session and skip validation. If you're using sessions and you don't want to check the session, or store the user against a session, then use the `-Sessionless` switch.
 
 ## Users
 
-After successful validation, an `Auth` object will be created for use against the current web event. This `Auth` object will be accessible via the argument supplied to Routes and Middleware (though it will only be available in Middleware created after the Middleware from  [`Get-PodeAuthMiddleware`](../../../Functions/Authentication/Get-PodeAuthMiddleware) is invoked).
+After successful validation, an `Auth` object will be created for use against the current web event. This `Auth` object will be accessible via the argument supplied to Routes and Middleware (though it will only be available in Middleware created after the Middleware from [`Get-PodeAuthMiddleware`](../../../Functions/Authentication/Get-PodeAuthMiddleware) is invoked).
 
 The `Auth` object will also contain:
 
@@ -126,7 +147,7 @@ Add-PodeRoute -Method Get -Path '/' -Middleware (Get-PodeAuthMiddleware -Name 'L
     param($e)
 
     Write-PodeViewResponse -Path 'index' -Data @{
-        'Username' = $e.Auth.User.Name;
+        'Username' = $e.Auth.User.Name
     }
 }
 ```

--- a/examples/web-auth-basic.ps1
+++ b/examples/web-auth-basic.ps1
@@ -12,7 +12,11 @@ Calling the '[POST] http://localhost:8085/users' endpoint, with an Authorization
 header of 'Basic bW9ydHk6cGlja2xl' will display the uesrs. Anything else and
 you'll get a 401 status code back.
 
+Success:
 Invoke-RestMethod -Uri http://localhost:8085/users -Method Post -Headers @{ Authorization = 'Basic bW9ydHk6cGlja2xl' }
+
+Failure:
+Invoke-RestMethod -Uri http://localhost:8085/users -Method Post -Headers @{ Authorization = 'Basic bW9ydHk6cmljaw==' }
 #>
 
 # create a server, and start listening on port 8085
@@ -22,7 +26,7 @@ Start-PodeServer -Threads 2 {
     Add-PodeEndpoint -Address * -Port 8085 -Protocol Http
 
     # setup basic auth (base64> username:password in header)
-    New-PodeAuthType -Basic | Add-PodeAuth -Name 'Validate' -ScriptBlock {
+    New-PodeAuthType -Basic -Realm 'WOOP' | Add-PodeAuth -Name 'Validate' -ScriptBlock {
         param($username, $password)
 
         # here you'd check a real user storage, this is just for example
@@ -41,6 +45,22 @@ Start-PodeServer -Threads 2 {
 
     # POST request to get list of users (since there's no session, authentication will always happen)
     Add-PodeRoute -Method Post -Path '/users' -Middleware (Get-PodeAuthMiddleware -Name 'Validate' -Sessionless) -ScriptBlock {
+        Write-PodeJsonResponse -Value @{
+            Users = @(
+                @{
+                    Name = 'Deep Thought'
+                    Age = 42
+                },
+                @{
+                    Name = 'Leeroy Jenkins'
+                    Age = 1337
+                }
+            )
+        }
+    }
+
+    # GET request to get list of users (since there's no session, authentication will always happen)
+    Add-PodeRoute -Method Get -Path '/users' -Middleware (Get-PodeAuthMiddleware -Name 'Validate' -Sessionless) -ScriptBlock {
         Write-PodeJsonResponse -Value @{
             Users = @(
                 @{

--- a/examples/web-auth-basic.ps1
+++ b/examples/web-auth-basic.ps1
@@ -26,7 +26,7 @@ Start-PodeServer -Threads 2 {
     Add-PodeEndpoint -Address * -Port 8085 -Protocol Http
 
     # setup basic auth (base64> username:password in header)
-    New-PodeAuthType -Basic -Realm 'WOOP' | Add-PodeAuth -Name 'Validate' -ScriptBlock {
+    New-PodeAuthType -Basic -Realm 'Pode Example Page' | Add-PodeAuth -Name 'Validate' -ScriptBlock {
         param($username, $password)
 
         # here you'd check a real user storage, this is just for example

--- a/src/Private/Authentication.ps1
+++ b/src/Private/Authentication.ps1
@@ -185,8 +185,19 @@ function Get-PodeAuthMiddlewareScript
 
         # if there is no result, return false (failed auth)
         if ((Test-IsEmpty $result) -or (Test-IsEmpty $result.User)) {
+            $_code = (Protect-PodeValue -Value $result.Code -Default 401)
+
+            if (![string]::IsNullOrWhiteSpace($auth.Type.Name) -and ($_code -eq 401)) {
+                $_wwwAuth = $auth.Type.Name
+                if (![string]::IsNullOrWhiteSpace($auth.Type.Realm)) {
+                    $_wwwAuth += " realm=`"$($auth.Type.Realm)`""
+                }
+
+                Set-PodeHeader -Name 'WWW-Authenticate' -Value $_wwwAuth
+            }
+
             return (Set-PodeAuthStatus `
-                -StatusCode (Protect-PodeValue -Value $result.Code -Default 401) `
+                -StatusCode $_code `
                 -Description $result.Message `
                 -Options $opts)
         }

--- a/src/Public/Authentication.ps1
+++ b/src/Public/Authentication.ps1
@@ -32,6 +32,12 @@ The ScriptBlock to retrieve user credentials.
 .PARAMETER ArgumentList
 An array of arguments to supply to the Custom Authentication type's ScriptBlock.
 
+.PARAMETER Name
+The Name of an Authentication type - such as Basic or NTLM.
+
+.PARAMETER Realm
+The name of scope of the protected area.
+
 .EXAMPLE
 $basic_auth = New-PodeAuthType -Basic
 
@@ -87,13 +93,23 @@ function New-PodeAuthType
 
         [Parameter(ParameterSetName='Custom')]
         [hashtable]
-        $ArgumentList
+        $ArgumentList,
+
+        [Parameter()]
+        [string]
+        $Name,
+
+        [Parameter()]
+        [string]
+        $Realm
     )
 
     # configure the auth type
     switch ($PSCmdlet.ParameterSetName.ToLowerInvariant()) {
         'basic' {
             return @{
+                Name = (Protect-PodeValue -Value $Name -Default 'Basic')
+                Realm = $Realm
                 ScriptBlock = (Get-PodeAuthBasicType)
                 Arguments = @{
                     HeaderTag = (Protect-PodeValue -Value $HeaderTag -Default 'Basic')
@@ -104,6 +120,8 @@ function New-PodeAuthType
 
         'form' {
             return @{
+                Name = (Protect-PodeValue -Value $Name -Default 'Form')
+                Realm = $Realm
                 ScriptBlock = (Get-PodeAuthFormType)
                 Arguments = @{
                     Fields = @{
@@ -116,6 +134,8 @@ function New-PodeAuthType
 
         'custom' {
             return @{
+                Name = $Name
+                Realm = $Realm
                 ScriptBlock = $ScriptBlock
                 Arguments = $ArgumentList
             }


### PR DESCRIPTION
### Description of the Change
Enables support for the `WWW-Authenticate` header on 401 responses from failed authentication. This adds two new parameters onto `New-PodeAuthType` of `-Name` and `-Realm`.

### Related Issue
Resolves #431
