### PR TITLE
#441: Fix local module path and loading

### DIFF
--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -46,7 +46,7 @@ function New-PodeContext
 
     # basic context object
     $ctx = New-Object -TypeName psobject |
-        Add-Member -MemberType NoteProperty -Name Threads -Value $Threads -PassThru |
+        Add-Member -MemberType NoteProperty -Name Threads -Value @{} -PassThru |
         Add-Member -MemberType NoteProperty -Name Timers -Value @{} -PassThru |
         Add-Member -MemberType NoteProperty -Name Schedules -Value @{} -PassThru |
         Add-Member -MemberType NoteProperty -Name RunspacePools -Value $null -PassThru |
@@ -68,6 +68,12 @@ function New-PodeContext
     $ctx.Server.Logging = @{
         Enabled = $true
         Types = @{}
+    }
+
+    # set thread counts
+    $ctx.Threads = @{
+        Web = $Threads
+        Schedules = 10
     }
 
     # set socket details for pode server
@@ -256,23 +262,32 @@ function New-PodeRunspacePools
         Misc = 1
     }
 
-    $totalThreadCount = ($threadsCounts.Values | Measure-Object -Sum).Sum + $PodeContext.Threads
+    $totalThreadCount = ($threadsCounts.Values | Measure-Object -Sum).Sum + $PodeContext.Threads.Web
     $PodeContext.RunspacePools.Main = [runspacefactory]::CreateRunspacePool(1, $totalThreadCount, $PodeContext.RunspaceState, $Host)
-    $PodeContext.RunspacePools.Main.Open()
 
     # setup signal runspace pool
-    $PodeContext.RunspacePools.Signals = [runspacefactory]::CreateRunspacePool(1, ($PodeContext.Threads + 2), $PodeContext.RunspaceState, $Host)
-    $PodeContext.RunspacePools.Signals.Open()
+    $PodeContext.RunspacePools.Signals = [runspacefactory]::CreateRunspacePool(1, ($PodeContext.Threads.Web + 2), $PodeContext.RunspaceState, $Host)
 
     # setup schedule runspace pool
-    $PodeContext.RunspacePools.Schedules = [runspacefactory]::CreateRunspacePool(1, 10, $PodeContext.RunspaceState, $Host)
-    $PodeContext.RunspacePools.Schedules.Open()
+    $PodeContext.RunspacePools.Schedules = [runspacefactory]::CreateRunspacePool(1, $PodeContext.Threads.Schedules, $PodeContext.RunspaceState, $Host)
 
     # setup gui runspace pool (only for non-ps-core)
     if (!((Test-IsPSCore) -and ($PSVersionTable.PSVersion.Major -eq 6))) {
         $PodeContext.RunspacePools.Gui = [runspacefactory]::CreateRunspacePool(1, 1, $PodeContext.RunspaceState, $Host)
         $PodeContext.RunspacePools.Gui.ApartmentState = 'STA'
-        $PodeContext.RunspacePools.Gui.Open()
+    }
+}
+
+function Open-PodeRunspacePools
+{
+    if ($PodeContext.Server.IsServerless) {
+        return
+    }
+
+    foreach ($key in $PodeContext.RunspacePools.Keys) {
+        if ($null -ne $PodeContext.RunspacePools[$key]) {
+            $PodeContext.RunspacePools[$key].Open()
+        }
     }
 }
 

--- a/src/Private/PodeServer.ps1
+++ b/src/Private/PodeServer.ps1
@@ -93,7 +93,7 @@ function Start-PodeSocketServer
     }
 
     # start the runspace for listening on x-number of threads
-    1..$PodeContext.Threads | ForEach-Object {
+    1..$PodeContext.Threads.Web | ForEach-Object {
         Add-PodeRunspace -Type 'Main' -ScriptBlock $listenScript `
             -Parameters @{ 'ThreadId' = $_ }
     }

--- a/src/Private/Server.ps1
+++ b/src/Private/Server.ps1
@@ -16,9 +16,6 @@ function Start-PodeInternalServer
         # create the shared runspace state
         New-PodeRunspaceState
 
-        # start the runspace pools for web, schedules, etc
-        New-PodeRunspacePools
-
         # get the server's script and invoke it - to set up routes, timers, middleware, etc
         $_script = $PodeContext.Server.Logic
         if (Test-PodePath -Path $PodeContext.Server.LogicPath -NoStatus) {
@@ -26,6 +23,10 @@ function Start-PodeInternalServer
         }
 
         Invoke-PodeScriptBlock -ScriptBlock $_script -NoNewClosure
+
+        # start the runspace pools for web, schedules, etc
+        New-PodeRunspacePools
+        Open-PodeRunspacePools
 
         # create timer/schedules for auto-restarting
         New-PodeAutoRestartServer
@@ -87,7 +88,7 @@ function Start-PodeInternalServer
 
         # state what endpoints are being listened on
         if ($endpoints.Length -gt 0) {
-            Write-Host "Listening on the following $($endpoints.Length) endpoint(s) [$($PodeContext.Threads) thread(s)]:" -ForegroundColor Yellow
+            Write-Host "Listening on the following $($endpoints.Length) endpoint(s) [$($PodeContext.Threads.Web) thread(s)]:" -ForegroundColor Yellow
             $endpoints | ForEach-Object {
                 Write-Host "`t- $($_)" -ForegroundColor Yellow
             }

--- a/src/Private/SignalServer.ps1
+++ b/src/Private/SignalServer.ps1
@@ -76,7 +76,7 @@ function Start-PodeSignalServer
     }
 
     # start the runspace for listening on x-number of threads
-    1..$PodeContext.Threads | ForEach-Object {
+    1..$PodeContext.Threads.Web | ForEach-Object {
         Add-PodeRunspace -Type 'Signals' -ScriptBlock $listenScript `
             -Parameters @{ 'ThreadId' = $_ }
     }

--- a/src/Private/SmtpServer.ps1
+++ b/src/Private/SmtpServer.ps1
@@ -172,7 +172,7 @@ function Start-PodeSmtpServer
     }
 
     # start the runspace for listening on x-number of threads
-    1..$PodeContext.Threads | ForEach-Object {
+    1..$PodeContext.Threads.Web | ForEach-Object {
         Add-PodeRunspace -Type 'Main' -ScriptBlock $listenScript `
             -Parameters @{ 'Listener' = $listener; 'ThreadId' = $_ }
     }

--- a/src/Private/TcpServer.ps1
+++ b/src/Private/TcpServer.ps1
@@ -84,7 +84,7 @@ function Start-PodeTcpServer
     }
 
     # start the runspace for listening on x-number of threads
-    1..$PodeContext.Threads | ForEach-Object {
+    1..$PodeContext.Threads.Web | ForEach-Object {
         Add-PodeRunspace -Type 'Main' -ScriptBlock $listenScript `
             -Parameters @{ 'Listener' = $listener; 'ThreadId' = $_ }
     }

--- a/src/Private/WebServer.ps1
+++ b/src/Private/WebServer.ps1
@@ -160,7 +160,7 @@ function Start-PodeWebServer
     }
 
     # start the runspace for listening on x-number of threads
-    1..$PodeContext.Threads | ForEach-Object {
+    1..$PodeContext.Threads.Web | ForEach-Object {
         Add-PodeRunspace -Type 'Main' -ScriptBlock $listenScript `
             -Parameters @{ 'Listener' = $listener; 'ThreadId' = $_ }
     }

--- a/src/Public/Core.ps1
+++ b/src/Public/Core.ps1
@@ -1096,13 +1096,20 @@ function Set-PodeScheduleConcurrency
     }
 
     # ensure max > min
-    $_min = $PodeContext.RunspacePools.Schedules.GetMinRunspaces()
+    $_min = 1
+    if ($null -ne $PodeContext.RunspacePools.Schedules) {
+        $_min = $PodeContext.RunspacePools.Schedules.GetMinRunspaces()
+    }
+
     if ($_min -gt $Maximum) {
         throw "Maximum concurrent schedules cannot be less than the minimum of $($_min) but got: $($Maximum)"
     }
 
     # set the max schedules
-    $PodeContext.RunspacePools.Schedules.SetMaxRunspaces($Maximum)
+    $PodeContext.Threads.Schedules = $Maximum
+    if ($null -ne $PodeContext.RunspacePools.Schedules) {
+        $PodeContext.RunspacePools.Schedules.SetMaxRunspaces($Maximum)
+    }
 }
 
 <#

--- a/src/Public/Utilities.ps1
+++ b/src/Public/Utilities.ps1
@@ -412,7 +412,7 @@ function Import-PodeModule
     switch ($PSCmdlet.ParameterSetName.ToLowerInvariant()) {
         'name' {
             $modulePath = Join-PodeServerRoot -Folder (Join-PodePaths @('ps_modules', $Name))
-            if ([string]::IsNullOrWhiteSpace($modulePath)) {
+            if (Test-PodePath -Path $modulePath -NoStatus) {
                 $Path = (Get-ChildItem (Join-PodePaths @($modulePath, '*', "$($Name).ps*1")) -Recurse -Force | Select-Object -First 1).FullName
             }
             else {


### PR DESCRIPTION
### Description of the Change
Moves the `New-PodeRunspacePools` back to after the server's scriptblock has been invoked - to allow modules to be imported properly.

Fixes the path check when loading local modules so the path is correct.

Fixes threads for Schedules so we can use the `Set-PodeScheduleConcurrency` before the pools are created by storing initial values in the context.

### Related Issue
Resolves #441
