### PR TITLE
#440: Adds support for custom repos in package.json

### DIFF
--- a/docs/Getting-Started/LocalModules.md
+++ b/docs/Getting-Started/LocalModules.md
@@ -1,9 +1,9 @@
 # Local Modules
 
-To save installing PowerShell modules globally, Pode allows you to specify modules in the `package.json` file; these modules will be downloaded into a `ps_modules` folder at the root of your server.
+To save installing PowerShell modules globally, Pode allows you to specify modules in the `package.json` file. These modules will be downloaded into a `ps_modules` folder at the root of your server.
 
 !!! Important
-    Pode will only download modules from the PowerShell Gallery. This is only a basic implementation, if you wish to download from other locations, we'd recommend looking at other tools such as [`PSDepend`](https://github.com/RamblingCookieMonster/PSDepend/) or [`PSPM`](https://github.com/mkht/pspm)
+    Pode will only download modules from registered PowerShell Repositories - such as the PowerShell Gallery. This is only a basic implementation, if you wish to download from other locations, such as GitHub, we'd recommend looking at other tools such as [`Parcel`](https://github.com/Badgerati/Parcel), [`PSDepend`](https://github.com/RamblingCookieMonster/PSDepend/) or [`PSPM`](https://github.com/mkht/pspm)
 
 ## Package.json
 
@@ -20,7 +20,26 @@ Within your server's `package.json` file, you can specify a `modules` and `devMo
 }
 ```
 
-The `"latest"` version will always install the latest version of the module. When installing, if Pode detects a different version already downloaded then it will be removed.
+You can also use an expanded format where you can specify custom repositories as well. If you use this format, or the above, and don't specify a repository then the PSGallery is used by default:
+
+```json
+{
+    "modules": {
+        "eps": {
+            "version": "0.5.0",
+            "repository": "CustomGallery"
+        }
+    },
+    "devModules": {
+        "pester": {
+            "version": "latest",
+            "repository": "PSGallery"
+        }
+    }
+}
+```
+
+The `"latest"` version will always install the latest version of the module. When installing the modules, if Pode detects a different version is already downloaded then it will be removed.
 
 ## Pode Install
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -10,9 +10,11 @@
 * #431: Support for the `WWW-Authenticate` header on failed Authentication (401) responses
 * #433: Support in custom Authentication types to allow returning extra Headers on the response
 * #435: New `Set-PodeScheduleConcurrency` function to set the max number of concurrent schedules
+* #440: Adds support in the `package.json` for custom PowerShell Repositories
 
 ### Bugs
 * #429: Running `pode start` failed to invoke server script on some platforms
+* #441: Fixes an issue where local modules failed to resolve correct path
 ```
 
 ## v1.2.1

--- a/src/Private/Setup.ps1
+++ b/src/Private/Setup.ps1
@@ -29,15 +29,23 @@ function Install-PodeLocalModules
     # download modules to ps_modules
     $Modules.psobject.properties.name | ForEach-Object {
         $_name = $_
-        $_version = $Modules.$_name
+
+        # get the module version
+        $_version = $Modules.$_name.version
+        if ([string]::IsNullOrWhiteSpace($_version)) {
+            $_version = $Modules.$_name
+        }
+
+        # get the module repository
+        $_repository = Protect-PodeValue -Value $Modules.$_name.repository -Default 'PSGallery'
 
         try {
             # if version is latest, retrieve current
             if ($_version -ieq 'latest') {
-                $_version = [string]((Find-Module $_name -ErrorAction Ignore).Version)
+                $_version = [string]((Find-Module $_name -Repository $_repository -ErrorAction Ignore).Version)
             }
 
-            Write-Host "=> Downloading $($_name)@$($_version)... " -NoNewline -ForegroundColor Cyan
+            Write-Host "=> Downloading $($_name)@$($_version) from $($_repository)... " -NoNewline -ForegroundColor Cyan
 
             # if the current version exists, do nothing
             if (!(Test-Path (Join-Path $psModules "$($_name)/$($_version)"))) {
@@ -47,14 +55,14 @@ function Install-PodeLocalModules
                 }
 
                 # download the module
-                Save-Module -Name $_name -RequiredVersion $_version -Path $psModules -Force -ErrorAction Stop | Out-Null
+                Save-Module -Name $_name -RequiredVersion $_version -Repository $_repository -Path $psModules -Force -ErrorAction Stop | Out-Null
             }
 
             Write-Host 'Success' -ForegroundColor Green
         }
         catch {
             Write-Host 'Failed' -ForegroundColor Red
-            throw "Module or version not found: $($_name)@$($_version)"
+            throw "Module or version not found on $($_repository): $($_name)@$($_version)"
         }
     }
 }


### PR DESCRIPTION
### Description of the Change
Updates the `Install-PodeLocalModules` function to allow support for custom repositories registered via `Register-PSRepository`.

### Related Issue
Resolves #440

### Examples
From the `modules` section in the `package.json` file:
```json
"modules": {
    "eps": {
        "version": "0.5.0",
        "repository": "CustomRepo"
    }
}
```
