### PR TITLE
Support on Routes for supplying multiple EndpointNames

### DIFF
--- a/examples/web-route-listen-names.ps1
+++ b/examples/web-route-listen-names.ps1
@@ -10,18 +10,25 @@ Start-PodeServer {
     # listen on localhost:8080/8443
     Add-PodeEndpoint -Address 127.0.0.1 -Port 8080 -Protocol Http -Name 'local1'
     Add-PodeEndpoint -Address 127.0.0.2 -Port 8080 -Protocol Http -Name 'local2'
+    Add-PodeEndpoint -Address 127.0.0.3 -Port 8080 -Protocol Http -Name 'local3'
+    Add-PodeEndpoint -Address 127.0.0.4 -Port 8080 -Protocol Http -Name 'local4'
 
     # set view engine to pode
     Set-PodeViewEngine -Type Pode
 
-    # GET request for web page
+    # GET request for web page - all endpoints
     Add-PodeRoute -Method Get -Path '/' -ScriptBlock {
         Write-PodeViewResponse -Path 'simple' -Data @{ 'numbers' = @(1, 2, 3); }
     }
 
-    # GET request for web page, but only for the local2 endpoint
+    # GET request for web page -  local2 endpoint
     Add-PodeRoute -Method Get -Path '/' -EndpointName 'local2' -ScriptBlock {
         Write-PodeViewResponse -Path 'simple' -Data @{ 'numbers' = @(1, 2, 3, 4, 5, 6, 7, 8); }
+    }
+
+    # GET request for web page -  local3 and local4 endpoints
+    Add-PodeRoute -Method Get -Path '/' -EndpointName 'local3', 'local4' -ScriptBlock {
+        Write-PodeViewResponse -Path 'simple' -Data @{ 'numbers' = @(2, 4, 6, 8, 10, 12, 14, 16); }
     }
 
     # GET request to download a file

--- a/src/Private/Routes.ps1
+++ b/src/Private/Routes.ps1
@@ -307,7 +307,7 @@ function Test-PodeRouteAndError
 
     $found = @($PodeContext.Server.Routes[$Method][$Path])
 
-    if (($found | Where-Object { $_.Protocol -ieq $Protocol -and $_.Endpoint -ieq $Endpoint } | Measure-Object).Count -eq 0) {
+    if (($found | Where-Object { ($_.Protocol -ieq $Protocol) -and ($_.Endpoint -ieq $Endpoint) } | Measure-Object).Count -eq 0) {
         return
     }
 
@@ -357,6 +357,57 @@ function Get-PodeEndpointByName
     }
 
     return $found
+}
+
+function Find-PodeEndpoints
+{
+    param(
+        [Parameter()]
+        [ValidateSet('', 'Http', 'Https')]
+        [string]
+        $Protocol,
+
+        [Parameter()]
+        [string]
+        $Endpoint,
+
+        [Parameter()]
+        [string[]]
+        $EndpointName
+    )
+
+    $endpoints = @()
+
+    # just use a single endpoint/protocol
+    if ([string]::IsNullOrWhiteSpace($EndpointName)) {
+        $endpoints += @{
+            Protocol = $Protocol
+            Address = $Endpoint
+        }
+    }
+
+    # get all defined endpoints by name
+    else {
+        foreach ($name in @($EndpointName)) {
+            $_endpoint = Get-PodeEndpointByName -EndpointName $name -ThrowError
+            if ($null -ne $_endpoint) {
+                $endpoints += @{
+                    Protocol = $_endpoint.Protocol
+                    Address = $_endpoint.RawAddress
+                }
+            }
+        }
+    }
+
+    # convert the endpoint's address into host:port format
+    foreach ($_endpoint in $endpoints) {
+        if (![string]::IsNullOrWhiteSpace($_endpoint.Address)) {
+            $_addr = Get-PodeEndpointInfo -Endpoint $_endpoint.Address -AnyPortOnZero
+            $_endpoint.Address = "$($_addr.Host):$($_addr.Port)"
+        }
+    }
+
+    return $endpoints
 }
 
 function Convert-PodeFunctionVerbToHttpMethod


### PR DESCRIPTION
### Description of the Change
The `-EndpointName` parameter on `Add-PodeRoute` and `Add-PodeStaticRoute` has been changed to a `string[]`. This will allow multiple endpoint names to be supplied for a single route.

### Related Issue
Resolves #448

### Examples
```powershell
Add-PodeEndpoint -Address 127.0.0.1 -Port 8080 -Name 'User'
Add-PodeEndpoint -Address 127.0.0.1 -Port 8090 -Name 'Admin'

Add-PodeRoute -Method Get -Path '/' -EndpointName 'User', 'Admin' -ScriptBlock { }
```
