### PR TITLE
Adds support for generating OpenAPI definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Then navigate to `http://127.0.0.1:8000` in your browser.
 * Cross-platform using PowerShell Core (with support for PS5)
 * Docker support, including images for ARM/Raspberry Pi
 * Azure Functions and AWS Lambda support
-* OpenAPI and Swagger support
+* OpenAPI, Swagger, and ReDoc support
 * Listen on a single or multiple IP address/hostnames
 * Cross-platform support for HTTP, HTTPS, TCP and SMTP
 * Cross-platform support for server-to-client WebSockets, including secure WebSockets

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Then navigate to `http://127.0.0.1:8000` in your browser.
 * Cross-platform using PowerShell Core (with support for PS5)
 * Docker support, including images for ARM/Raspberry Pi
 * Azure Functions and AWS Lambda support
+* OpenAPI and Swagger support
 * Listen on a single or multiple IP address/hostnames
 * Cross-platform support for HTTP, HTTPS, TCP and SMTP
 * Cross-platform support for server-to-client WebSockets, including secure WebSockets

--- a/docs/Tutorials/OpenAPI.md
+++ b/docs/Tutorials/OpenAPI.md
@@ -104,11 +104,71 @@ the JSON response payload defined is as follows:
 
 #### Parameters
 
-You can add route parameter definitions, such as parameters used in the path/querystring, by using the [`Set-PodeOARequest`] function.
+You can set route parameter definitions, such as parameters passed in the path/query, by using the [`Set-PodeOARequest`] function with the `-Parameters` parameter. The parameter takes an array of properties converted into parameters, using the [`New-PodeOARequestParameter`] function.
+
+For example, to create some integer `userId` parameter that is supplied in the path of the request, the following will work:
+
+```powershell
+Add-PodeRoute -Method Get -Path '/api/users/:userId' -ScriptBlock {
+    param($e)
+    Write-PodeJsonResponse -Value @{
+        Name = 'Rick'
+        UserId = $e.Parameters['userId']
+    }
+} -PassThru |
+    Set-PodeOARequest -Parameters @(
+        (New-PodeOAIntProperty -Name 'userId' -Required | New-PodeOARequestParameter -In Path)
+    )
+```
+
+Whereas you could use the next example to define 2 query parameters, both strings:
+
+```powershell
+Add-PodeRoute -Method Get -Path '/api/users' -ScriptBlock {
+    param($e)
+    Write-PodeJsonResponse -Value @{
+        Name = 'Rick'
+        UserId = $e.Query['name']
+    }
+} -PassThru |
+    Set-PodeOARequest -Parameters @(
+        (New-PodeOAStringProperty -Name 'name' -Required | New-PodeOARequestParameter -In Query),
+        (New-PodeOAStringProperty -Name 'city' -Required | New-PodeOARequestParameter -In Query)
+    )
+```
 
 #### Payload
 
-TODO: lorem
+You can set request payload schemas by using the [`Set-PodeOARequest`] function, with the `-RequestBody` parameter. The request body can be defined using the [`New-PodeOARequestBody`] function, and supplying schema definitions for content types - this works in very much a similar way to defining responses above.
+
+For example, to define a request JSON payload of some `userId` and `name` you could use the following:
+
+```powershell
+Add-PodeRoute -Method Patch -Path '/api/users' -ScriptBlock {
+    param($e)
+    Write-PodeJsonResponse -Value @{
+        Name = $e.Data.name
+        UserId = $e.Data.userId
+    }
+} -PassThru |
+    Set-PodeOARequest -RequestBody (
+        New-PodeOARequestBody -Required -ContentSchemas @{
+            'application/json' = (New-PodeOAObjectProperty -Properties @(
+                (New-PodeOAStringProperty -Name 'name'),
+                (New-PodeOAIntProperty -Name 'userId')
+            ))
+        }
+    )
+```
+
+The expected payload would look as follows:
+
+```json
+{
+    "name": [string],
+    "userId": [integer]
+}
+```
 
 ### Authentication
 

--- a/docs/Tutorials/OpenAPI.md
+++ b/docs/Tutorials/OpenAPI.md
@@ -523,14 +523,12 @@ If you're not using a custom OpenAPI viewer, then you can use one of the inbuilt
 
 For both you can customise the path to access the page on, but by default Swagger is at `/swagger` and ReDoc is at `/redoc`. If you've written your own custom OpenAPI definition then you can also set a custom path to fetch the definition.
 
-To enable Swagger you can use the [`Enable-PodeSwagger`](../../Functions/OpenApi/Enable-PodeSwagger) function:
+To enable either you can use the [`Enable-PodeOpenApiViewer`](../../Functions/OpenApi/Enable-PodeOpenApiViewer) function:
 
 ```powershell
-Enable-PodeSwagger -Path '/docs/swagger' -DarkMode
-```
+# for swagger at "/docs/swagger"
+Enable-PodeOpenApiViewer -Type Swagger -Path '/docs/swagger' -DarkMode
 
-And to enable ReDoc you can use the [`Enable-PodeReDoc`](../../Functions/OpenApi/Enable-PodeReDoc) function:
-
-```powershell
-Enable-PodeReDoc -Path '/docs/redoc' -OpenApi '/custom_openapi.yml'
+# or ReDoc at the default "/redoc"
+Enable-PodeOpenApiViewer -Type ReDoc
 ```

--- a/docs/Tutorials/OpenAPI.md
+++ b/docs/Tutorials/OpenAPI.md
@@ -1,0 +1,1 @@
+# OpenAPI and Swagger

--- a/docs/Tutorials/OpenAPI.md
+++ b/docs/Tutorials/OpenAPI.md
@@ -6,14 +6,20 @@ You can simply enable OpenAPI in Pode, and a very simple definition will be gene
 
 ## Enabling OpenAPI
 
-To enable support for generating OpenAPI definitions you'll need to use the [`Enable-PodeOpenApi`](../../Functions/OpenApi/Enable-PodeOpenApi) function. This will allow you to set a title and version for your API, as well as a custom path to fetch the definition - the default is at `/openapi`.
+To enable support for generating OpenAPI definitions you'll need to use the [`Enable-PodeOpenApi`](../../Functions/OpenApi/Enable-PodeOpenApi) function. This will allow you to set a title and version for your API. You can also set a default route to retrieve the OpenAPI definition for tools like Swagger or ReDoc, the default is at `/openapi`.
 
 You can also set a route filter (such as `/api/*`, the default is `/*` for everything), so only those routes are included in the definition.
 
 An example of enabling OpenAPI is a follows:
 
 ```powershell
-Enable-PodeOpenApi -Title 'My Awesome API' -Version 9.0.0.1 -Route '/api/*'
+Enable-PodeOpenApi -Title 'My Awesome API' -Version 9.0.0.1
+```
+
+An example of setting the OpenAPI route is a follows. This will create a route accessible at `/docs/openapi`:
+
+```powershell
+Enable-PodeOpenApi -Path '/docs/openapi' -Title 'My Awesome API' -Version 9.0.0.1
 ```
 
 ### Default Setup
@@ -26,6 +32,21 @@ When you enable OpenAPI, and don't set any other OpenAPI data, the following is 
 * Although routes will be included, no request bodies, parameters or response payloads will be defined
 * If you have multiple endpoints, then the servers section will be included
 * Any authentication will be included, but won't be bound to any routes
+
+### Get Definition
+
+Instead of defining a route to return the definition, you can write the definition to the response whenever you want, and in any route, using the [`Get-PodeOpenApiDefinition`] function. This could be useful in certain scenarios like in Azure Functions, where you can enable OpenAPI, and then write the definition to the response of a GET request if some query parameter is set; eg: `?openapi=1`.
+
+For example:
+
+```powershell
+Add-PodeRoute -Method Get -Path '/' -ScriptBlock {
+    param($e)
+    if ($e.Query.openapi -eq 1) {
+        Get-PodeOpenApiDefinition | Write-PodeJsonResponse
+    }
+}
+```
 
 ## Authentication
 

--- a/docs/Tutorials/OpenAPI.md
+++ b/docs/Tutorials/OpenAPI.md
@@ -2,18 +2,18 @@
 
 Pode has inbuilt support for converting your routes into OpenAPI 3.0 definitions. There is also support for a enabling simple Swagger and/or ReDoc viewers.
 
-You can simply enable OpenAPI in Pode, and a very simple definition will be generated. However, you get a more complex definition with request bodies, parameters and response payloads, you'll need to use the relevant OpenAPI functions detailed below.
+You can simply enable OpenAPI in Pode, and a very simple definition will be generated. However, to get a more complex definition with request bodies, parameters and response payloads, you'll need to use the relevant OpenAPI functions detailed below.
 
 ## Enabling OpenAPI
 
-To enable support for generating OpenAPI definitions you use the [`Enable-PodeOpenApi`] function. This will allow you to set a title and version for your API, as well as a custom path to fetch the definition - the default is at `/openapi`.
+To enable support for generating OpenAPI definitions you'll need to use the [`Enable-PodeOpenApi`](../../Functions/OpenApi/Enable-PodeOpenApi) function. This will allow you to set a title and version for your API, as well as a custom path to fetch the definition - the default is at `/openapi`.
 
-You can also set a route filter (such as `/api/`, the default is `/` for everything), so only though routes are included in the definition.
+You can also set a route filter (such as `/api/*`, the default is `/*` for everything), so only those routes are included in the definition.
 
 An example of enabling OpenAPI is a follows:
 
 ```powershell
-Enable-PodeOpenApi -Title 'My Awesome API' -Version 9.0.0.1 -Route '/api/'
+Enable-PodeOpenApi -Title 'My Awesome API' -Version 9.0.0.1 -Route '/api/*'
 ```
 
 ### Default Setup
@@ -29,7 +29,7 @@ When you enable OpenAPI, and don't set any other OpenAPI data, the following is 
 
 ## Authentication
 
-If your API requires the same authentication on every route, then the quickest way to define global authentication is to use the [`Set-PodeOAGlobalAuth`] function. This takes an array of authentication names:
+If your API requires the same authentication on every route, then the quickest way to define global authentication is to use the [`Set-PodeOAGlobalAuth`](../../Functions/OpenApi/Set-PodeOAGlobalAuth) function. This takes an array of authentication names:
 
 ```powershell
 # define the authentication
@@ -44,11 +44,13 @@ Get-PodeAuthMiddleware -Name 'Validate' -Sessionless | Add-PodeMiddleware -Name 
 Set-PodeOAGlobalAuth -Name 'Validate'
 ```
 
+This will set the `security` section of the OpenAPI definition.
+
 ## Routes
 
-To extend the definition of a route, you can use the `-PassThru` switch on the [`Add-PodeRoute`] function. This will cause the route that was created to be returned, so you can pass it down the pipe into more OpenAPI functions.
+To extend the definition of a route, you can use the `-PassThru` switch on the [`Add-PodeRoute`](../../Functions/Routes/Add-PodeRoute) function. This will cause the route that was created to be returned, so you can pass it down the pipe into more OpenAPI functions.
 
-To add metadata to a route's definition you can use the [`Set-PodeOARouteInfo`] function. This will allow you to define a summary/description for the route, as well as tags for grouping:
+To add metadata to a route's definition you can use the [`Set-PodeOARouteInfo`](../../Functions/OpenApi/Set-PodeOARouteInfo) function. This will allow you to define a summary/description for the route, as well as tags for grouping:
 
 ```powershell
 Add-PodeRoute -Method Get -Path "/api/resources" -ScriptBlock {
@@ -61,9 +63,9 @@ Each of the following OpenAPI functions have a `-PassThru` switch, allowing you 
 
 ### Responses
 
-You can define multiple responses for a route, but only one of each status code, using the [`Add-PodeOAResponse`] function. You can either just define the response and status code; with a custom description; or with a schema defining the payload of the response.
+You can define multiple responses for a route, but only one of each status code, using the [`Add-PodeOAResponse`](../../Functions/OpenApi/Add-PodeOAResponse) function. You can either just define the response and status code; with a custom description; or with a schema defining the payload of the response.
 
-The following is an example of defining a simple 200 and 404 responses on a route:
+The following is an example of defining simple 200 and 404 responses on a route:
 
 ```powershell
 Add-PodeRoute -Method Get -Path "/api/user/:userId" -ScriptBlock {
@@ -104,7 +106,7 @@ the JSON response payload defined is as follows:
 
 #### Parameters
 
-You can set route parameter definitions, such as parameters passed in the path/query, by using the [`Set-PodeOARequest`] function with the `-Parameters` parameter. The parameter takes an array of properties converted into parameters, using the [`New-PodeOARequestParameter`] function.
+You can set route parameter definitions, such as parameters passed in the path/query, by using the [`Set-PodeOARequest`](../../Functions/OpenApi/Set-PodeOARequest) function with the `-Parameters` parameter. The parameter takes an array of properties converted into parameters, using the [`ConvertTo-PodeOAParameter`](../../Functions/OpenApi/ConvertTo-PodeOAParameter) function.
 
 For example, to create some integer `userId` parameter that is supplied in the path of the request, the following will work:
 
@@ -117,7 +119,7 @@ Add-PodeRoute -Method Get -Path '/api/users/:userId' -ScriptBlock {
     }
 } -PassThru |
     Set-PodeOARequest -Parameters @(
-        (New-PodeOAIntProperty -Name 'userId' -Required | New-PodeOARequestParameter -In Path)
+        (New-PodeOAIntProperty -Name 'userId' -Required | ConvertTo-PodeOAParameter -In Path)
     )
 ```
 
@@ -132,14 +134,14 @@ Add-PodeRoute -Method Get -Path '/api/users' -ScriptBlock {
     }
 } -PassThru |
     Set-PodeOARequest -Parameters @(
-        (New-PodeOAStringProperty -Name 'name' -Required | New-PodeOARequestParameter -In Query),
-        (New-PodeOAStringProperty -Name 'city' -Required | New-PodeOARequestParameter -In Query)
+        (New-PodeOAStringProperty -Name 'name' -Required | ConvertTo-PodeOAParameter -In Query),
+        (New-PodeOAStringProperty -Name 'city' -Required | ConvertTo-PodeOAParameter -In Query)
     )
 ```
 
 #### Payload
 
-You can set request payload schemas by using the [`Set-PodeOARequest`] function, with the `-RequestBody` parameter. The request body can be defined using the [`New-PodeOARequestBody`] function, and supplying schema definitions for content types - this works in very much a similar way to defining responses above.
+You can set request payload schemas by using the [`Set-PodeOARequest`](../../Functions/OpenApi/Set-PodeOARequest) function, with the `-RequestBody` parameter. The request body can be defined using the [`New-PodeOARequestBody`](../../Functions/OpenApi/New-PodeOARequestBody) function, and supplying schema definitions for content types - this works in very much a similar way to defining responses above.
 
 For example, to define a request JSON payload of some `userId` and `name` you could use the following:
 
@@ -172,7 +174,7 @@ The expected payload would look as follows:
 
 ### Authentication
 
-To add the authentication used on a route's definition you can pipe the route into the [`Set-PodeOAAuth`] function. This function takes the name of an authentication type being used on the route.
+To add the authentication used on a route's definition you can pipe the route into the [`Set-PodeOAAuth`](../../Functions/OpenApi/Set-PodeOAAuth) function. This function takes the name of an authentication type being used on the route.
 
 ```powershell
 # add the auth type
@@ -195,7 +197,7 @@ You can define reusable OpenAPI components in Pode. Currently supported are Sche
 
 ### Schemas
 
-To define a reusable schema that can be used in request bodies, and responses, you can use the [`Add-PodeOAComponentSchema`] function. You'll need to supply a Name, and a Schema that can be reused.
+To define a reusable schema that can be used in request bodies, and responses, you can use the [`Add-PodeOAComponentSchema`](../../Functions/OpenApi/Add-PodeOAComponentSchema) function. You'll need to supply a Name, and a Schema that can be reused.
 
 The following is an example of defining a schema which is a object of Name, UserId, and Age:
 
@@ -225,7 +227,7 @@ Add-PodeRoute -Method Get -Path '/api/users/:userId' -ScriptBlock {
 
 ### Request Bodies
 
-To define a reusable request bodies you can use the [`Add-PodeOAComponentRequestBody`] function. You'll need to supply a Name, as well as the needed schemas for each content type.
+To define a reusable request bodies you can use the [`Add-PodeOAComponentRequestBody`](../../Functions/OpenApi/Add-PodeOAComponentRequestBody) function. You'll need to supply a Name, as well as the needed schemas for each content type.
 
 The following is an example of defining a JSON object that a Name, UserId, and an Enable flag:
 
@@ -259,13 +261,13 @@ The JSON payload expected is of the format:
 
 ### Parameters
 
-To define reusable parameters that are used on requests, you can use the [`Add-PodeOAComponentParameter`] function. You'll need to supply a Name and the Parameter definition.
+To define reusable parameters that are used on requests, you can use the [`Add-PodeOAComponentParameter`](../../Functions/OpenApi/Add-PodeOAComponentParameter) function. You'll need to supply a Name and the Parameter definition.
 
 The following is an example of defining an integer path parameter for a `userId`, and then using that parameter on a route.
 
 ```powershell
 # define a reusable {userid} path parameter
-New-PodeOAIntProperty -Name 'userId' -Required | New-PodeOARequestParameter -In Path |Add-PodeOAComponentParameter -Name 'UserId'
+New-PodeOAIntProperty -Name 'userId' -Required | ConvertTo-PodeOAParameter -In Path |Add-PodeOAComponentParameter -Name 'UserId'
 
 # use this parameter in a route
 Add-PodeRoute -Method Get -Path '/api/users/:userId' -ScriptBlock {
@@ -275,12 +277,12 @@ Add-PodeRoute -Method Get -Path '/api/users/:userId' -ScriptBlock {
         UserId = $e.Parameters['userId']
     }
 } -PassThru |
-    Set-PodeOARequest -Parameters @(New-PodeOARequestParameter -Reference 'UserId')
+    Set-PodeOARequest -Parameters @(ConvertTo-PodeOAParameter -Reference 'UserId')
 ```
 
 ### Responses
 
-To define a reusable response definition you can use the [`Add-PodeOAComponentResponse`] function. You'll need to supply a Name, and optionally any Content/Header schemas that define the responses payload.
+To define a reusable response definition you can use the [`Add-PodeOAComponentResponse`](../../Functions/OpenApi/Add-PodeOAComponentResponse) function. You'll need to supply a Name, and optionally any Content/Header schemas that define the responses payload.
 
 The following is an example of defining a 200 response, that has a JSON payload of an array of objects for Name/UserId. This can then be used by name on a route:
 
@@ -320,13 +322,13 @@ If you're not using a custom OpenAPI viewer, then you can use one of the inbuilt
 
 For both you can customise the path to access the page on, but by default Swagger is at `/swagger` and ReDoc is at `/redoc`. If you've written your own custom OpenAPI definition then you can also set a custom path to fetch the definition.
 
-To enable Swagger you can use the [`Enable-PodeSwagger`] function:
+To enable Swagger you can use the [`Enable-PodeSwagger`](../../Functions/OpenApi/Enable-PodeSwagger) function:
 
 ```powershell
 Enable-PodeSwagger -Path '/docs/swagger' -DarkMode
 ```
 
-And to enable ReDoc you can use the [`Enable-PodeReDoc`] function:
+And to enable ReDoc you can use the [`Enable-PodeReDoc`](../../Functions/OpenApi/Enable-PodeReDoc) function:
 
 ```powershell
 Enable-PodeReDoc -Path '/docs/redoc' -OpenApi '/custom_openapi.yml'

--- a/docs/Tutorials/OpenAPI.md
+++ b/docs/Tutorials/OpenAPI.md
@@ -1,1 +1,196 @@
-# OpenAPI and Swagger
+# OpenAPI
+
+Pode has inbuilt support for converting your routes into OpenAPI 3.0 definitions. There is also support for a enabling simple Swagger and/or ReDoc viewers.
+
+You can simply enable OpenAPI in Pode, and a very simple definition will be generated. However, you get a more complex definition with request bodies, parameters and response payloads, you'll need to use the relevant OpenAPI functions detailed below.
+
+## Enabling OpenAPI
+
+To enable support for generating OpenAPI definitions you use the [`Enable-PodeOpenApi`] function. This will allow you to set a title and version for your API, as well as a custom path to fetch the definition - the default is at `/openapi`.
+
+You can also set a route filter (such as `/api/`, the default is `/` for everything), so only though routes are included in the definition.
+
+An example of enabling OpenAPI is a follows:
+
+```powershell
+Enable-PodeOpenApi -Title 'My Awesome API' -Version 9.0.0.1 -Route '/api/'
+```
+
+### Default Setup
+
+In the very simplest of scenarios, just enabling OpenAPI will generate a minimal definition. It can be viewed in Swagger/ReDoc etc, but won't be usable for trying calls.
+
+When you enable OpenAPI, and don't set any other OpenAPI data, the following is the minimal data that is included:
+
+* Every route will have a 200 and Default response
+* Although routes will be included, no request bodies, parameters or response payloads will be defined
+* If you have multiple endpoints, then the servers section will be included
+* Any authentication will be included, but won't be bound to any routes
+
+
+
+## Authentication
+
+If your API requires the same authentication on every route, then the quickest way to define global authentication is to use the [`Set-PodeOAGlobalAuth`] function. This takes an array of authentication names:
+
+```powershell
+# define the authentication
+New-PodeAuthType -Basic | Add-PodeAuth -Name 'Validate' -ScriptBlock {
+    return @{ User = @{} }
+}
+
+# set the auth as global middleware for all /api routes
+Get-PodeAuthMiddleware -Name 'Validate' -Sessionless | Add-PodeMiddleware -Name 'AuthMiddleware' -Route '/api/*'
+
+# set the OpenAPI global auth
+Set-PodeOAGlobalAuth -Name 'Validate'
+```
+
+
+
+
+
+
+
+## Routes
+
+lorem
+
+### Responses
+
+lorem
+
+### Requests
+
+lorem
+
+### Authentication
+
+lorem
+
+
+
+
+
+## Components
+
+You can define reusable OpenAPI components in Pode. Currently supported are Schemas, Parameters, Request Bodies, and Responses.
+
+### Schemas
+
+lorem
+
+### Request Bodies
+
+To define a reusable request bodies you can use the [`Add-PodeOAComponentRequestBody`] function. You'll need to supply a Name, as well as the needed schemas for each content type.
+
+The following is an example of defining a JSON object that a Name, UserId, and an Enable flag:
+
+```powershell
+# define a reusable request body
+Add-PodeOAComponentRequestBody -Name 'UserBody' -Required -Schemas @{
+    'application/json' = (New-PodeOAObjectProperty -Properties @(
+        (New-PodeOAStringProperty -Name 'Name'),
+        (New-PodeOAIntProperty -Name 'UserId'),
+        (New-PodeOABoolProperty -Name 'Enabled')
+    ))
+}
+
+# use the request body in a route
+Add-PodeRoute -Method Patch -Path '/api/users' -ScriptBlock {
+    param($e)
+    Set-PodeResponseStatus -StatusCode 200
+} -PassThru |
+    Set-PodeOARequest -RequestBody (New-PodeOARequestBody -Reference 'UserBody')
+```
+
+The JSON payload expected is of the format:
+
+```json
+{
+    "Name": [string],
+    "UserId": [integer],
+    "Enabled": [boolean]
+}
+```
+
+### Parameters
+
+To define reusable parameters that are used on requests, you can use the [`Add-PodeOAComponentParameter`] function. You'll need to supply a Name and the Parameter definition.
+
+The following is an example of defining an integer path parameter for a `userId`, and then using that parameter on a route.
+
+```powershell
+# define a reusable {userid} path parameter
+New-PodeOAIntProperty -Name 'userId' -Required | New-PodeOARequestParameter -In Path |Add-PodeOAComponentParameter -Name 'UserId'
+
+# use this parameter in a route
+Add-PodeRoute -Method Get -Path '/api/users/:userId' -ScriptBlock {
+    param($e)
+    Write-PodeJsonResponse -Value @{
+        Name = 'Rick'
+        UserId = $e.Parameters['userId']
+    }
+} -PassThru |
+    Set-PodeOARequest -Parameters @(New-PodeOARequestParameter -Reference 'UserId')
+```
+
+### Responses
+
+To define a reusable response definition you can use the [`Add-PodeOAComponentResponse`] function. You'll need to supply a Name, and optionally any Content/Header schemas that define the responses payload.
+
+The following is an example of defining a 200 response, that has a JSON payload of an array of objects for Name/UserId. This can then be used by name on a route:
+
+```powershell
+# defines a response with a json payload
+Add-PodeOAComponentResponse -Name 'OK' -Description 'A user object' -ContentSchemas @{
+    'application/json' = (New-PodeOAObjectProperty -Array -Properties @(
+        (New-PodeOAStringProperty -Name 'Name'),
+        (New-PodeOAIntProperty -Name 'UserId')
+    ))
+}
+
+# reuses the above response on a route using its "OK" name
+Add-PodeRoute -Method Get -Path "/api/users" -ScriptBlock {
+    Write-PodeJsonResponse -Value @(
+        @{ Name = 'Rick'; UserId = 123 },
+        @{ Name = 'Geralt'; UserId = 124 }
+    )
+} -PassThru |
+    Add-PodeOAResponse -StatusCode 200 -Reference 'OK'
+```
+
+the JSON response payload defined is as follows:
+
+```json
+[
+    {
+        "Name": [string],
+        "UserId": [integer]
+    }
+]
+```
+
+
+
+
+
+
+
+## Swagger and ReDoc
+
+If you're not using a custom OpenAPI viewer, then you can use one of the inbuilt ones with Pode - either Swagger and ReDoc, or both!
+
+For both you can customise the path to access the page on, but by default Swagger is at `/swagger` and ReDoc is at `/redoc`. If you've written your own custom OpenAPI definition then you can also set a custom path to fetch the definition.
+
+To enable Swagger you can use the [`Enable-PodeSwagger`] function:
+
+```powershell
+Enable-PodeSwagger -Path '/docs/swagger' -DarkMode
+```
+
+And to enable ReDoc you can use the [`Enable-PodeReDoc`] function:
+
+```powershell
+Enable-PodeReDoc -Path '/docs/redoc' -OpenApi '/custom_openapi.yml'
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ Pode is a Cross-Platform framework, *completely written in PowerShell*, to creat
 * Cross-platform using PowerShell Core (with support for PS5)
 * Docker support, including images for ARM/Raspberry Pi
 * Azure Functions and AWS Lambda support
-* OpenAPI and Swagger support
+* OpenAPI, Swagger, and ReDoc support
 * Listen on a single or multiple IP address/hostnames
 * Cross-platform support for HTTP, HTTPS, TCP and SMTP
 * Cross-platform support for server-to-client WebSockets, including secure WebSockets

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,6 +17,7 @@ Pode is a Cross-Platform framework, *completely written in PowerShell*, to creat
 * Cross-platform using PowerShell Core (with support for PS5)
 * Docker support, including images for ARM/Raspberry Pi
 * Azure Functions and AWS Lambda support
+* OpenAPI and Swagger support
 * Listen on a single or multiple IP address/hostnames
 * Cross-platform support for HTTP, HTTPS, TCP and SMTP
 * Cross-platform support for server-to-client WebSockets, including secure WebSockets

--- a/examples/web-rest-openapi-funcs.ps1
+++ b/examples/web-rest-openapi-funcs.ps1
@@ -5,7 +5,8 @@ Start-PodeServer {
     Add-PodeEndpoint -Address localhost -Port 8080 -Protocol Http
 
     Enable-PodeOpenApi -Title 'OpenAPI Example' -RouteFilter '/api/*' -RestrictRoutes
-    Enable-PodeSwagger -DarkMode
+    Enable-PodeOpenApiViewer -Type Swagger -DarkMode
+    Enable-PodeOpenApiViewer -Type ReDoc
 
     #ConvertTo-PodeRoute -Path '/api' -Commands @('Get-ChildItem', 'New-Item')
     ConvertTo-PodeRoute -Path '/api' -Module Pester

--- a/examples/web-rest-openapi-funcs.ps1
+++ b/examples/web-rest-openapi-funcs.ps1
@@ -1,0 +1,12 @@
+$path = Split-Path -Parent -Path (Split-Path -Parent -Path $MyInvocation.MyCommand.Path)
+Import-Module "$($path)/src/Pode.psm1" -Force -ErrorAction Stop
+
+Start-PodeServer {
+    Add-PodeEndpoint -Address localhost -Port 8080 -Protocol Http
+
+    Enable-PodeOpenApi -Title 'OpenAPI Function Example' -Route '/api/*' -RestrictRoutes
+    Enable-PodeSwagger -DarkMode
+
+    #ConvertTo-PodeRoute -Path '/api' -Commands @('Get-ChildItem', 'New-Item')
+    ConvertTo-PodeRoute -Path '/api' -Module Pester
+}

--- a/examples/web-rest-openapi-funcs.ps1
+++ b/examples/web-rest-openapi-funcs.ps1
@@ -4,7 +4,7 @@ Import-Module "$($path)/src/Pode.psm1" -Force -ErrorAction Stop
 Start-PodeServer {
     Add-PodeEndpoint -Address localhost -Port 8080 -Protocol Http
 
-    Enable-PodeOpenApi -Title 'OpenAPI Function Example' -Route '/api/*' -RestrictRoutes
+    Enable-PodeOpenApi -Title 'OpenAPI Example' -RouteFilter '/api/*' -RestrictRoutes
     Enable-PodeSwagger -DarkMode
 
     #ConvertTo-PodeRoute -Path '/api' -Commands @('Get-ChildItem', 'New-Item')

--- a/examples/web-rest-openapi-shared.ps1
+++ b/examples/web-rest-openapi-shared.ps1
@@ -7,7 +7,7 @@ Start-PodeServer {
 
     New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
 
-    Enable-PodeOpenApi -Title 'OpenAPI Example' -Route '/api/' -RestrictRoutes
+    Enable-PodeOpenApi -Title 'OpenAPI Example' -Route '/api/*' -RestrictRoutes
     Enable-PodeSwagger -DarkMode
 
 
@@ -54,7 +54,7 @@ Start-PodeServer {
     } -PassThru |
         Set-PodeOARouteInfo -Summary 'A cool summary' -Tags 'Users' -PassThru |
         Set-PodeOARequest -Parameters @(
-            (New-PodeOAIntProperty -Name 'userId' -Required | New-PodeOARequestParameter -In Path)
+            (New-PodeOAIntProperty -Name 'userId' -Required | ConvertTo-PodeOAParameter -In Path)
         ) -PassThru |
         Add-PodeOAResponse -StatusCode 200 -Reference 'OK'
 
@@ -65,7 +65,7 @@ Start-PodeServer {
     } -PassThru |
         Set-PodeOARouteInfo -Summary 'A cool summary' -Tags 'Users' -PassThru |
         Set-PodeOARequest -Parameters @(
-            (New-PodeOAIntProperty -Name 'userId' -Required | New-PodeOARequestParameter -In Query)
+            (New-PodeOAIntProperty -Name 'userId' -Required | ConvertTo-PodeOAParameter -In Query)
         ) -PassThru |
         Add-PodeOAResponse -StatusCode 200 -Reference 'OK'
 

--- a/examples/web-rest-openapi-shared.ps1
+++ b/examples/web-rest-openapi-shared.ps1
@@ -76,7 +76,7 @@ Start-PodeServer {
     } -PassThru |
         Set-PodeOARouteInfo -Summary 'A cool summary' -Tags 'Users' -PassThru |
         Set-PodeOARequest -RequestBody (
-            New-PodeOARequestBody -Required -Schemas @{
+            New-PodeOARequestBody -Required -ContentSchemas @{
                 'application/json' = (New-PodeOAIntProperty -Name 'userId' -Object)
             }
         ) -PassThru |

--- a/examples/web-rest-openapi-shared.ps1
+++ b/examples/web-rest-openapi-shared.ps1
@@ -7,7 +7,7 @@ Start-PodeServer {
 
     New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
 
-    Enable-PodeOpenApi -Title 'OpenAPI Example' -Filter '/api/' -RestrictRoutes
+    Enable-PodeOpenApi -Title 'OpenAPI Example' -Route '/api/' -RestrictRoutes
     Enable-PodeSwagger -DarkMode
 
 

--- a/examples/web-rest-openapi-shared.ps1
+++ b/examples/web-rest-openapi-shared.ps1
@@ -7,7 +7,7 @@ Start-PodeServer {
 
     New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
 
-    Enable-PodeOpenApi -Title 'OpenAPI Example' -Route '/api/*' -RestrictRoutes
+    Enable-PodeOpenApi -Title 'OpenAPI Example' -RouteFilter '/api/*' -RestrictRoutes
     Enable-PodeSwagger -DarkMode
 
 

--- a/examples/web-rest-openapi-shared.ps1
+++ b/examples/web-rest-openapi-shared.ps1
@@ -8,7 +8,8 @@ Start-PodeServer {
     New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
 
     Enable-PodeOpenApi -Title 'OpenAPI Example' -RouteFilter '/api/*' -RestrictRoutes
-    Enable-PodeSwagger -DarkMode
+    Enable-PodeOpenApiViewer -Type Swagger -DarkMode
+    Enable-PodeOpenApiViewer -Type ReDoc
 
 
     New-PodeAuthType -Basic | Add-PodeAuth -Name 'Validate' -ScriptBlock {

--- a/examples/web-rest-openapi-simple.ps1
+++ b/examples/web-rest-openapi-simple.ps1
@@ -1,0 +1,52 @@
+$path = Split-Path -Parent -Path (Split-Path -Parent -Path $MyInvocation.MyCommand.Path)
+Import-Module "$($path)/src/Pode.psm1" -Force -ErrorAction Stop
+
+Start-PodeServer {
+    Add-PodeEndpoint -Address localhost -Port 8080 -Protocol Http -Name 'user'
+    Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http -Name 'admin'
+
+    Enable-PodeOpenApi -Title 'OpenAPI Example' -Filter '/api/' -RestrictRoutes
+    Enable-PodeSwagger -DarkMode
+
+
+    Add-PodeRoute -Method Get -Path "/api/resources" -EndpointName 'user' -ScriptBlock {
+        Set-PodeResponseStatus -Code 200
+    }
+
+
+    Add-PodeRoute -Method Post -Path "/api/resources" -ScriptBlock {
+        Set-PodeResponseStatus -Code 200
+    }
+
+
+    Add-PodeRoute -Method Get -Path '/api/users/:userId' -ScriptBlock {
+        param($e)
+        Write-PodeJsonResponse -Value @{ Name = 'Rick'; UserId = $e.Parameters['userId'] }
+    } -PassThru |
+        Set-PodeOARequest -Parameters @(
+            (New-PodeOAIntProperty -Name 'userId' -Required | New-PodeOARequestParameter -In Path)
+        )
+
+
+    Add-PodeRoute -Method Get -Path '/api/users' -ScriptBlock {
+        param($e)
+        Write-PodeJsonResponse -Value @{ Name = 'Rick'; UserId = $e.Query['userId'] }
+    } -PassThru |
+        Set-PodeOARequest -Parameters @(
+            (New-PodeOAIntProperty -Name 'userId' -Required | New-PodeOARequestParameter -In Query)
+        )
+
+
+    Add-PodeRoute -Method Post -Path '/api/users' -ScriptBlock {
+        param($e)
+        Write-PodeJsonResponse -Value @{ Name = 'Rick'; UserId = $e.Data.userId }
+    } -PassThru |
+        Set-PodeOARequest -RequestBody (
+            New-PodeOARequestBody -Required -Schemas @{
+                'application/json' = (New-PodeOAObjectProperty -Properties @(
+                    (New-PodeOAStringProperty -Name 'Name'),
+                    (New-PodeOAIntProperty -Name 'UserId')
+                ))
+            }
+        )
+}

--- a/examples/web-rest-openapi-simple.ps1
+++ b/examples/web-rest-openapi-simple.ps1
@@ -42,7 +42,7 @@ Start-PodeServer {
         Write-PodeJsonResponse -Value @{ Name = 'Rick'; UserId = $e.Data.userId }
     } -PassThru |
         Set-PodeOARequest -RequestBody (
-            New-PodeOARequestBody -Required -Schemas @{
+            New-PodeOARequestBody -Required -ContentSchemas @{
                 'application/json' = (New-PodeOAObjectProperty -Properties @(
                     (New-PodeOAStringProperty -Name 'Name'),
                     (New-PodeOAIntProperty -Name 'UserId')

--- a/examples/web-rest-openapi-simple.ps1
+++ b/examples/web-rest-openapi-simple.ps1
@@ -5,7 +5,7 @@ Start-PodeServer {
     Add-PodeEndpoint -Address localhost -Port 8080 -Protocol Http -Name 'user'
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http -Name 'admin'
 
-    Enable-PodeOpenApi -Title 'OpenAPI Example' -Route '/api/' -RestrictRoutes
+    Enable-PodeOpenApi -Title 'OpenAPI Example' -Route '/api/*' -RestrictRoutes
     Enable-PodeSwagger -DarkMode
 
 
@@ -24,7 +24,7 @@ Start-PodeServer {
         Write-PodeJsonResponse -Value @{ Name = 'Rick'; UserId = $e.Parameters['userId'] }
     } -PassThru |
         Set-PodeOARequest -Parameters @(
-            (New-PodeOAIntProperty -Name 'userId' -Required | New-PodeOARequestParameter -In Path)
+            (New-PodeOAIntProperty -Name 'userId' -Required | ConvertTo-PodeOAParameter -In Path)
         )
 
 
@@ -33,7 +33,7 @@ Start-PodeServer {
         Write-PodeJsonResponse -Value @{ Name = 'Rick'; UserId = $e.Query['userId'] }
     } -PassThru |
         Set-PodeOARequest -Parameters @(
-            (New-PodeOAIntProperty -Name 'userId' -Required | New-PodeOARequestParameter -In Query)
+            (New-PodeOAIntProperty -Name 'userId' -Required | ConvertTo-PodeOAParameter -In Query)
         )
 
 

--- a/examples/web-rest-openapi-simple.ps1
+++ b/examples/web-rest-openapi-simple.ps1
@@ -5,7 +5,7 @@ Start-PodeServer {
     Add-PodeEndpoint -Address localhost -Port 8080 -Protocol Http -Name 'user'
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http -Name 'admin'
 
-    Enable-PodeOpenApi -Title 'OpenAPI Example' -Route '/api/*' -RestrictRoutes
+    Enable-PodeOpenApi -Title 'OpenAPI Example' -RouteFilter '/api/*' -RestrictRoutes
     Enable-PodeSwagger -DarkMode
 
 

--- a/examples/web-rest-openapi-simple.ps1
+++ b/examples/web-rest-openapi-simple.ps1
@@ -6,7 +6,8 @@ Start-PodeServer {
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http -Name 'admin'
 
     Enable-PodeOpenApi -Title 'OpenAPI Example' -RouteFilter '/api/*' -RestrictRoutes
-    Enable-PodeSwagger -DarkMode
+    Enable-PodeOpenApiViewer -Type Swagger -DarkMode
+    Enable-PodeOpenApiViewer -Type ReDoc
 
 
     Add-PodeRoute -Method Get -Path "/api/resources" -EndpointName 'user' -ScriptBlock {

--- a/examples/web-rest-openapi-simple.ps1
+++ b/examples/web-rest-openapi-simple.ps1
@@ -5,7 +5,7 @@ Start-PodeServer {
     Add-PodeEndpoint -Address localhost -Port 8080 -Protocol Http -Name 'user'
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http -Name 'admin'
 
-    Enable-PodeOpenApi -Title 'OpenAPI Example' -Filter '/api/' -RestrictRoutes
+    Enable-PodeOpenApi -Title 'OpenAPI Example' -Route '/api/' -RestrictRoutes
     Enable-PodeSwagger -DarkMode
 
 

--- a/examples/web-rest-openapi.ps1
+++ b/examples/web-rest-openapi.ps1
@@ -9,6 +9,7 @@ Start-PodeServer {
 
     Enable-PodeOpenApi -Title 'OpenAPI Example' -Route '/api/' -RestrictRoutes
     Enable-PodeSwagger -DarkMode
+    Enable-PodeReDoc -DarkMode
 
 
     New-PodeAuthType -Basic | Add-PodeAuth -Name 'Validate' -ScriptBlock {

--- a/examples/web-rest-openapi.ps1
+++ b/examples/web-rest-openapi.ps1
@@ -7,7 +7,7 @@ Start-PodeServer {
 
     New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
 
-    Enable-PodeOpenApi -Title 'OpenAPI Example' -Route '/api/' -RestrictRoutes
+    Enable-PodeOpenApi -Title 'OpenAPI Example' -Route '/api/*' -RestrictRoutes
     Enable-PodeSwagger -DarkMode
     Enable-PodeReDoc
 
@@ -48,7 +48,7 @@ Start-PodeServer {
     } -PassThru |
         Set-PodeOARouteInfo -Summary 'A cool summary' -Tags 'Users' -PassThru |
         Set-PodeOARequest -Parameters @(
-            (New-PodeOAIntProperty -Name 'userId' -Required | New-PodeOARequestParameter -In Path)
+            (New-PodeOAIntProperty -Name 'userId' -Required | ConvertTo-PodeOAParameter -In Path)
         ) -PassThru |
         Add-PodeOAResponse -StatusCode 200 -Description 'A user object' -ContentSchemas @{
             'application/json' = (New-PodeOAObjectProperty -Properties @(
@@ -64,7 +64,7 @@ Start-PodeServer {
     } -PassThru |
         Set-PodeOARouteInfo -Summary 'A cool summary' -Tags 'Users' -PassThru |
         Set-PodeOARequest -Parameters @(
-            (New-PodeOAIntProperty -Name 'userId' -Required | New-PodeOARequestParameter -In Query)
+            (New-PodeOAIntProperty -Name 'userId' -Required | ConvertTo-PodeOAParameter -In Query)
         ) -PassThru |
         Add-PodeOAResponse -StatusCode 200 -Description 'A user object'
 

--- a/examples/web-rest-openapi.ps1
+++ b/examples/web-rest-openapi.ps1
@@ -7,10 +7,29 @@ Start-PodeServer {
     Enable-PodeOpenApiRoute -Title 'OpenAPI Example' -Filter '/api/'
     Enable-PodeSwaggerRoute
 
-    foreach ($i in 1..100)
-    {
-        Add-PodeRoute -Method Get -Path "/api/resources_$($i)" -ScriptBlock {
-            Set-PodeResponseStatus -Code 200
-        }
-    }
+
+    Add-PodeRoute -Method Get -Path "/api/resources" -ScriptBlock {
+        Set-PodeResponseStatus -Code 200
+    } -PassThru |
+        Set-PodeOpenApiRouteMetaData -Summary 'A cool summary' -Tags 'Resources' -PassThru |
+        Add-PodeOpenApiRouteResponse -StatusCode 200 -PassThru |
+        Add-PodeOpenApiRouteResponse -StatusCode 404
+
+
+    Add-PodeRoute -Method Post -Path "/api/resources" -ScriptBlock {
+        Set-PodeResponseStatus -Code 200
+    } -PassThru |
+        Set-PodeOpenApiRouteMetaData -Summary 'A cool summary' -Tags 'Resources' -PassThru |
+        Add-PodeOpenApiRouteResponse -StatusCode 200 -PassThru |
+        Add-PodeOpenApiRouteResponse -StatusCode 404
+
+
+    Add-PodeRoute -Method Get -Path '/api/users/:userId' -ScriptBlock {
+        Write-PodeJsonResponse -Value @{ Name = 'Rick' }
+    } -PassThru |
+        Set-PodeOpenApiRouteMetaData -Summary 'A cool summary' -Tags 'Users' -PassThru |
+        Set-PodeOpenApiRouteRequest -Parameters @(
+            New-PodeOpenApiRouteRequestParameter -Integer -Name 'userId' -In Path -Required
+        ) -PassThru |
+        Add-PodeOpenApiRouteResponse -Status 200
 }

--- a/examples/web-rest-openapi.ps1
+++ b/examples/web-rest-openapi.ps1
@@ -7,7 +7,7 @@ Start-PodeServer {
 
     New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
 
-    Enable-PodeOpenApi -Title 'OpenAPI Example' -Route '/api/*' -RestrictRoutes
+    Enable-PodeOpenApi -Title 'OpenAPI Example' -RouteFilter '/api/*' -RestrictRoutes
     Enable-PodeSwagger -DarkMode
     Enable-PodeReDoc
 

--- a/examples/web-rest-openapi.ps1
+++ b/examples/web-rest-openapi.ps1
@@ -7,8 +7,8 @@ Start-PodeServer {
 
     New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
 
-    Enable-PodeOpenApiRoute -Title 'OpenAPI Example' -Filter '/api/' -RestrictRoutes
-    Enable-PodeSwaggerRoute -DarkMode
+    Enable-PodeOpenApi -Title 'OpenAPI Example' -Filter '/api/' -RestrictRoutes
+    Enable-PodeSwagger -DarkMode
 
 
     New-PodeAuthType -Basic | Add-PodeAuth -Name 'Validate' -ScriptBlock {
@@ -27,59 +27,57 @@ Start-PodeServer {
     Add-PodeRoute -Method Get -Path "/api/resources" -Middleware $auth -EndpointName 'user' -ScriptBlock {
         Set-PodeResponseStatus -Code 200
     } -PassThru |
-        Set-PodeOpenApiRouteMetaData -Summary 'A cool summary' -Tags 'Resources' -PassThru |
-        Set-PodeOpenApiRouteAuth -Name 'Validate' -PassThru |
-        Add-PodeOpenApiRouteResponse -StatusCode 200 -PassThru |
-        Add-PodeOpenApiRouteResponse -StatusCode 404
+        Set-PodeOARouteInfo -Summary 'A cool summary' -Tags 'Resources' -PassThru |
+        Set-PodeOAAuth -Name 'Validate' -PassThru |
+        Add-PodeOAResponse -StatusCode 200 -PassThru |
+        Add-PodeOAResponse -StatusCode 404
 
 
     Add-PodeRoute -Method Post -Path "/api/resources" -ScriptBlock {
         Set-PodeResponseStatus -Code 200
     } -PassThru |
-        Set-PodeOpenApiRouteMetaData -Summary 'A cool summary' -Tags 'Resources' -PassThru |
-        Add-PodeOpenApiRouteResponse -StatusCode 200 -PassThru |
-        Add-PodeOpenApiRouteResponse -StatusCode 404
+        Set-PodeOARouteInfo -Summary 'A cool summary' -Tags 'Resources' -PassThru |
+        Add-PodeOAResponse -StatusCode 200 -PassThru |
+        Add-PodeOAResponse -StatusCode 404
 
 
     Add-PodeRoute -Method Get -Path '/api/users/:userId' -ScriptBlock {
         param($e)
         Write-PodeJsonResponse -Value @{ Name = 'Rick'; UserId = $e.Parameters['userId'] }
     } -PassThru |
-        Set-PodeOpenApiRouteMetaData -Summary 'A cool summary' -Tags 'Users' -PassThru |
-        Set-PodeOpenApiRouteRequest -Parameters @(
-            New-PodeOpenApiRouteRequestParameter -Integer -Name 'userId' -In Path -Required
+        Set-PodeOARouteInfo -Summary 'A cool summary' -Tags 'Users' -PassThru |
+        Set-PodeOARequest -Parameters @(
+            (New-PodeOAIntProperty -Name 'userId' -Required | New-PodeOARequestParameter -In Path)
         ) -PassThru |
-        Add-PodeOpenApiRouteResponse -StatusCode 200 -Description 'A list of users' -Schemas @(
-            New-PodeOpenApiSchema -Object -ContentType 'application/json' -Properties @(
-                New-PodeOpenApiSchemaProperty -Name 'Name' -String
-                New-PodeOpenApiSchemaProperty -Name 'UserId' -Integer
-            )
-        )
+        Add-PodeOAResponse -StatusCode 200 -Description 'A user object' -Schemas @{
+            'application/json' = (New-PodeOAObjectProperty -Properties @(
+                (New-PodeOAStringProperty -Name 'Name'),
+                (New-PodeOAIntProperty -Name 'UserId')
+            ))
+        }
 
 
     Add-PodeRoute -Method Get -Path '/api/users' -ScriptBlock {
         param($e)
         Write-PodeJsonResponse -Value @{ Name = 'Rick'; UserId = $e.Query['userId'] }
     } -PassThru |
-        Set-PodeOpenApiRouteMetaData -Summary 'A cool summary' -Tags 'Users' -PassThru |
-        Set-PodeOpenApiRouteRequest -Parameters @(
-            New-PodeOpenApiRouteRequestParameter -Integer -Name 'userId' -In Query -Required
+        Set-PodeOARouteInfo -Summary 'A cool summary' -Tags 'Users' -PassThru |
+        Set-PodeOARequest -Parameters @(
+            (New-PodeOAIntProperty -Name 'userId' -Required | New-PodeOARequestParameter -In Query)
         ) -PassThru |
-        Add-PodeOpenApiRouteResponse -StatusCode 200 -Description 'A list of users'
+        Add-PodeOAResponse -StatusCode 200 -Description 'A user object'
 
 
     Add-PodeRoute -Method Post -Path '/api/users' -Middleware $auth -ScriptBlock {
         param($e)
         Write-PodeJsonResponse -Value @{ Name = 'Rick'; UserId = $e.Data.userId }
     } -PassThru |
-        Set-PodeOpenApiRouteMetaData -Summary 'A cool summary' -Tags 'Users' -PassThru |
-        Set-PodeOpenApiRouteAuth -Name 'Validate' -PassThru |
-        Set-PodeOpenApiRouteRequest -RequestBody (
-            New-PodeOpenApiRouteRequestBody -Required -Schemas @(
-                New-PodeOpenApiSchema -Object -ContentType 'application/json' -Properties @(
-                    New-PodeOpenApiSchemaProperty -Name 'userId' -Integer -Required
-                )
-            )
+        Set-PodeOARouteInfo -Summary 'A cool summary' -Tags 'Users' -PassThru |
+        Set-PodeOAAuth -Name 'Validate' -PassThru |
+        Set-PodeOARequest -RequestBody (
+            New-PodeOARequestBody -Required -Schemas @{
+                'application/json' = (New-PodeOAIntProperty -Name 'userId' -Object)
+            }
         ) -PassThru |
-        Add-PodeOpenApiRouteResponse -StatusCode 200 -Description 'A list of users'
+        Add-PodeOAResponse -StatusCode 200 -Description 'A user object'
 }

--- a/examples/web-rest-openapi.ps1
+++ b/examples/web-rest-openapi.ps1
@@ -7,7 +7,7 @@ Start-PodeServer {
 
     New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
 
-    Enable-PodeOpenApiRoute -Title 'OpenAPI Example' -Filter '/api/'
+    Enable-PodeOpenApiRoute -Title 'OpenAPI Example' -Filter '/api/' -RestrictRoutes
     Enable-PodeSwaggerRoute -DarkMode
 
 

--- a/examples/web-rest-openapi.ps1
+++ b/examples/web-rest-openapi.ps1
@@ -8,8 +8,8 @@ Start-PodeServer {
     New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
 
     Enable-PodeOpenApi -Title 'OpenAPI Example' -RouteFilter '/api/*' -RestrictRoutes
-    Enable-PodeSwagger -DarkMode
-    Enable-PodeReDoc
+    Enable-PodeOpenApiViewer -Type Swagger -DarkMode
+    Enable-PodeOpenApiViewer -Type ReDoc
 
 
     New-PodeAuthType -Basic | Add-PodeAuth -Name 'Validate' -ScriptBlock {

--- a/examples/web-rest-openapi.ps1
+++ b/examples/web-rest-openapi.ps1
@@ -9,7 +9,7 @@ Start-PodeServer {
 
     Enable-PodeOpenApi -Title 'OpenAPI Example' -Route '/api/' -RestrictRoutes
     Enable-PodeSwagger -DarkMode
-    Enable-PodeReDoc -DarkMode
+    Enable-PodeReDoc
 
 
     New-PodeAuthType -Basic | Add-PodeAuth -Name 'Validate' -ScriptBlock {

--- a/examples/web-rest-openapi.ps1
+++ b/examples/web-rest-openapi.ps1
@@ -25,11 +25,43 @@ Start-PodeServer {
 
 
     Add-PodeRoute -Method Get -Path '/api/users/:userId' -ScriptBlock {
-        Write-PodeJsonResponse -Value @{ Name = 'Rick' }
+        param($e)
+        Write-PodeJsonResponse -Value @{ Name = 'Rick'; UserId = $e.Parameters['userId'] }
     } -PassThru |
         Set-PodeOpenApiRouteMetaData -Summary 'A cool summary' -Tags 'Users' -PassThru |
         Set-PodeOpenApiRouteRequest -Parameters @(
             New-PodeOpenApiRouteRequestParameter -Integer -Name 'userId' -In Path -Required
         ) -PassThru |
-        Add-PodeOpenApiRouteResponse -Status 200
+        Add-PodeOpenApiRouteResponse -StatusCode 200 -Description 'A list of users' -Schemas @(
+            New-PodeOpenApiSchema -Object -ContentType 'application/json' -Properties @(
+                New-PodeOpenApiSchemaProperty -Name 'Name' -String
+                New-PodeOpenApiSchemaProperty -Name 'UserId' -Integer
+            )
+        )
+
+
+    Add-PodeRoute -Method Get -Path '/api/users' -ScriptBlock {
+        param($e)
+        Write-PodeJsonResponse -Value @{ Name = 'Rick'; UserId = $e.Query['userId'] }
+    } -PassThru |
+        Set-PodeOpenApiRouteMetaData -Summary 'A cool summary' -Tags 'Users' -PassThru |
+        Set-PodeOpenApiRouteRequest -Parameters @(
+            New-PodeOpenApiRouteRequestParameter -Integer -Name 'userId' -In Query -Required
+        ) -PassThru |
+        Add-PodeOpenApiRouteResponse -StatusCode 200 -Description 'A list of users'
+
+
+    Add-PodeRoute -Method Post -Path '/api/users' -ScriptBlock {
+        param($e)
+        Write-PodeJsonResponse -Value @{ Name = 'Rick'; UserId = $e.Data.userId }
+    } -PassThru |
+        Set-PodeOpenApiRouteMetaData -Summary 'A cool summary' -Tags 'Users' -PassThru |
+        Set-PodeOpenApiRouteRequest -RequestBody (
+            New-PodeOpenApiRouteRequestBody -Required -Schemas @(
+                New-PodeOpenApiSchema -Object -ContentType 'application/json' -Properties @(
+                    New-PodeOpenApiSchemaProperty -Name 'userId' -Integer -Required
+                )
+            )
+        ) -PassThru |
+        Add-PodeOpenApiRouteResponse -StatusCode 200 -Description 'A list of users'
 }

--- a/examples/web-rest-openapi.ps1
+++ b/examples/web-rest-openapi.ps1
@@ -2,13 +2,16 @@ $path = Split-Path -Parent -Path (Split-Path -Parent -Path $MyInvocation.MyComma
 Import-Module "$($path)/src/Pode.psm1" -Force -ErrorAction Stop
 
 Start-PodeServer {
-    Add-PodeEndpoint -Address localhost -Port 8080 -Protocol Http
+    Add-PodeEndpoint -Address localhost -Port 8080 -Protocol Http -Name 'user'
+    Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http -Name 'admin'
+
+    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
 
     Enable-PodeOpenApiRoute -Title 'OpenAPI Example' -Filter '/api/'
     Enable-PodeSwaggerRoute
 
 
-    Add-PodeRoute -Method Get -Path "/api/resources" -ScriptBlock {
+    Add-PodeRoute -Method Get -Path "/api/resources" -EndpointName 'user' -ScriptBlock {
         Set-PodeResponseStatus -Code 200
     } -PassThru |
         Set-PodeOpenApiRouteMetaData -Summary 'A cool summary' -Tags 'Resources' -PassThru |

--- a/examples/web-rest-openapi.ps1
+++ b/examples/web-rest-openapi.ps1
@@ -76,7 +76,7 @@ Start-PodeServer {
         Set-PodeOARouteInfo -Summary 'A cool summary' -Tags 'Users' -PassThru |
         Set-PodeOAAuth -Name 'Validate' -PassThru |
         Set-PodeOARequest -RequestBody (
-            New-PodeOARequestBody -Required -Schemas @{
+            New-PodeOARequestBody -Required -ContentSchemas @{
                 'application/json' = (New-PodeOAIntProperty -Name 'userId' -Object)
             }
         ) -PassThru |
@@ -98,7 +98,7 @@ Start-PodeServer {
     } -PassThru |
         Set-PodeOARouteInfo -Tags 'Users' -PassThru |
         Set-PodeOARequest -RequestBody (
-            New-PodeOARequestBody -Required -Schemas @{
+            New-PodeOARequestBody -Required -ContentSchemas @{
                 'application/json' = (New-PodeOAIntProperty -Name 'userId' -Array)
             }
         ) -PassThru |

--- a/examples/web-rest-openapi.ps1
+++ b/examples/web-rest-openapi.ps1
@@ -1,0 +1,16 @@
+$path = Split-Path -Parent -Path (Split-Path -Parent -Path $MyInvocation.MyCommand.Path)
+Import-Module "$($path)/src/Pode.psm1" -Force -ErrorAction Stop
+
+Start-PodeServer {
+    Add-PodeEndpoint -Address localhost -Port 8080 -Protocol Http
+
+    Enable-PodeOpenApiRoute -Title 'OpenAPI Example' -Filter '/api/'
+    Enable-PodeSwaggerRoute
+
+    foreach ($i in 1..100)
+    {
+        Add-PodeRoute -Method Get -Path "/api/resources_$($i)" -ScriptBlock {
+            Set-PodeResponseStatus -Code 200
+        }
+    }
+}

--- a/examples/web-rest-openapi.ps1
+++ b/examples/web-rest-openapi.ps1
@@ -7,7 +7,7 @@ Start-PodeServer {
 
     New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
 
-    Enable-PodeOpenApi -Title 'OpenAPI Example' -Filter '/api/' -RestrictRoutes
+    Enable-PodeOpenApi -Title 'OpenAPI Example' -Route '/api/' -RestrictRoutes
     Enable-PodeSwagger -DarkMode
 
 
@@ -80,4 +80,31 @@ Start-PodeServer {
             }
         ) -PassThru |
         Add-PodeOAResponse -StatusCode 200 -Description 'A user object'
+
+
+    Add-PodeRoute -Method Put -Path '/api/users' -ScriptBlock {
+        param($e)
+
+        $users = @()
+        foreach ($id in $e.Data) {
+            $users += @{
+                Name = (New-Guid).Guid
+                UserIdd = $id
+            }
+        }
+
+        Write-PodeJsonResponse -Value $users
+    } -PassThru |
+        Set-PodeOARouteInfo -Tags 'Users' -PassThru |
+        Set-PodeOARequest -RequestBody (
+            New-PodeOARequestBody -Required -Schemas @{
+                'application/json' = (New-PodeOAIntProperty -Name 'userId' -Array)
+            }
+        ) -PassThru |
+        Add-PodeOAResponse -StatusCode 200 -Description 'A list of users' -ContentSchemas @{
+            'application/json' = (New-PodeOAObjectProperty -Array -Properties @(
+                (New-PodeOAStringProperty -Name 'Name'),
+                (New-PodeOAIntProperty -Name 'UserId')
+            ))
+        }
 }

--- a/examples/web-rest-openapi.ps1
+++ b/examples/web-rest-openapi.ps1
@@ -8,7 +8,7 @@ Start-PodeServer {
     New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
 
     Enable-PodeOpenApiRoute -Title 'OpenAPI Example' -Filter '/api/'
-    Enable-PodeSwaggerRoute
+    Enable-PodeSwaggerRoute -DarkMode
 
 
     Add-PodeRoute -Method Get -Path "/api/resources" -EndpointName 'user' -ScriptBlock {

--- a/packers/choco/pode.nuspec
+++ b/packers/choco/pode.nuspec
@@ -16,7 +16,7 @@ Pode is a Cross-Platform framework, completely written in PowerShell, for creati
 * Cross-platform using PowerShell Core (with support for PS5)
 * Docker support, including images for ARM/Raspberry Pi
 * Azure Functions and AWS Lambda support
-* OpenAPI and Swagger support
+* OpenAPI, Swagger, and ReDoc support
 * Listen on a single or multiple IP address/hostnames
 * Cross-platform support for HTTP, HTTPS, TCP and SMTP
 * Cross-platform support for server-to-client WebSockets, including secure WebSockets
@@ -42,7 +42,7 @@ Pode is a Cross-Platform framework, completely written in PowerShell, for creati
     <packageSourceUrl>https://github.com/Badgerati/Pode/tree/master/packers</packageSourceUrl>
     <docsUrl>https://badgerati.github.io/Pode</docsUrl>
     <bugTrackerUrl>https://github.com/Badgerati/Pode/issues</bugTrackerUrl>
-    <tags>powershell web server rest api http tcp smtp listener unix cross-platform file-monitoring multithreaded schedule middleware session authentication active-directory csrf lambda aws azure functions websockets openapi swagger</tags>
+    <tags>powershell web server rest api http tcp smtp listener unix cross-platform file-monitoring multithreaded schedule middleware session authentication active-directory csrf lambda aws azure functions websockets openapi swagger redoc</tags>
     <copyright>Copyright 2017-2020</copyright>
     <licenseUrl>https://github.com/Badgerati/Pode/blob/master/LICENSE.txt</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/packers/choco/pode.nuspec
+++ b/packers/choco/pode.nuspec
@@ -16,6 +16,7 @@ Pode is a Cross-Platform framework, completely written in PowerShell, for creati
 * Cross-platform using PowerShell Core (with support for PS5)
 * Docker support, including images for ARM/Raspberry Pi
 * Azure Functions and AWS Lambda support
+* OpenAPI and Swagger support
 * Listen on a single or multiple IP address/hostnames
 * Cross-platform support for HTTP, HTTPS, TCP and SMTP
 * Cross-platform support for server-to-client WebSockets, including secure WebSockets
@@ -41,7 +42,7 @@ Pode is a Cross-Platform framework, completely written in PowerShell, for creati
     <packageSourceUrl>https://github.com/Badgerati/Pode/tree/master/packers</packageSourceUrl>
     <docsUrl>https://badgerati.github.io/Pode</docsUrl>
     <bugTrackerUrl>https://github.com/Badgerati/Pode/issues</bugTrackerUrl>
-    <tags>powershell web server rest api http tcp smtp listener webpages json html unix cross-platform file-monitoring multithreaded cron schedule middleware session authentication active-directory csrf lambda aws azure functions websockets</tags>
+    <tags>powershell web server rest api http tcp smtp listener unix cross-platform file-monitoring multithreaded schedule middleware session authentication active-directory csrf lambda aws azure functions websockets openapi swagger</tags>
     <copyright>Copyright 2017-2020</copyright>
     <licenseUrl>https://github.com/Badgerati/Pode/blob/master/LICENSE.txt</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/src/Misc/default-redoc.html.pode
+++ b/src/Misc/default-redoc.html.pode
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>$($data.Title)</title>
+        <meta charset="utf-8"/>
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">
+
+        <style>
+            body {
+                margin: 0;
+                padding: 0;
+            }
+        </style>
+    </head>
+    <body>
+        <redoc spec-url='$($data.OpenApiPath)'></redoc>
+        <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js" theme="dark"></script>
+    </body>
+</html>

--- a/src/Misc/default-redoc.html.pode
+++ b/src/Misc/default-redoc.html.pode
@@ -14,7 +14,7 @@
         </style>
     </head>
     <body>
-        <redoc spec-url='$($data.OpenApiPath)'></redoc>
+        <redoc spec-url='$($data.OpenApi)'></redoc>
         <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js" theme="dark"></script>
     </body>
 </html>

--- a/src/Misc/default-swagger.html.pode
+++ b/src/Misc/default-swagger.html.pode
@@ -1,0 +1,21 @@
+<html>
+    <head>
+        <title>$($data.Title)</title>
+        <link rel="stylesheet" type="text/css" href="https://unpkg.com/swagger-ui-dist@3/swagger-ui.css">
+        <script src="https://unpkg.com/swagger-ui-dist@3/swagger-ui-bundle.js"></script>
+        <script type="text/javascript">
+            window.onload = function() {
+                SwaggerUIBundle({
+                    deepLinking: true,
+                    dom_id: '#swagger-ui',
+                    showExtensions: true,
+                    showCommonExtensions: true,
+                    url: '$($data.OpenApiPath)'
+                });
+            };
+        </script>
+    </head>
+    <body>
+        <div id="swagger-ui"></div>
+    </body>
+</html>

--- a/src/Misc/default-swagger.html.pode
+++ b/src/Misc/default-swagger.html.pode
@@ -2,6 +2,8 @@
 <html>
     <head>
         <title>$($data.Title)</title>
+        <meta charset="utf-8"/>
+        <meta name="viewport" content="width=device-width, initial-scale=1">
         <link rel="stylesheet" type="text/css" href="https://unpkg.com/swagger-ui-dist@3/swagger-ui.css">
         <script src="https://unpkg.com/swagger-ui-dist@3/swagger-ui-bundle.js"></script>
         <script type="text/javascript">
@@ -11,7 +13,7 @@
                     dom_id: '#swagger-ui',
                     showExtensions: true,
                     showCommonExtensions: true,
-                    url: '$($data.OpenApiPath)'
+                    url: '$($data.OpenApi)'
                 });
             };
         </script>

--- a/src/Misc/default-swagger.html.pode
+++ b/src/Misc/default-swagger.html.pode
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
     <head>
         <title>$($data.Title)</title>

--- a/src/Misc/default-swagger.html.pode
+++ b/src/Misc/default-swagger.html.pode
@@ -14,6 +14,77 @@
                 });
             };
         </script>
+
+        $(if ($data.DarkMode) {
+            "<style>
+                .swagger-ui .info .title,
+                .swagger-ui a.nostyle,
+                .swagger-ui .parameter__name,
+                .swagger-ui .parameter__type,
+                .swagger-ui .parameter__deprecated,
+                .swagger-ui .parameter__in,
+                .swagger-ui table thead tr th,
+                .swagger-ui .response-col_status,
+                .swagger-ui table thead tr td,
+                .swagger-ui .opblock .opblock-section-header h4,
+                .swagger-ui label,
+                .swagger-ui .tab li,
+                .swagger-ui .opblock .opblock-section-header label,
+                .swagger-ui .opblock .opblock-summary-path span,
+                .swagger-ui .opblock-tag span,
+                .swagger-ui .response-col_links,
+                .swagger-ui .response-col_links i,
+                .swagger-ui .btn
+                {
+                    color: #CCCCCC !important;
+                }
+
+                .swagger-ui svg.arrow
+                {
+                    fill: #CCCCCC;
+                }
+
+                .swagger-ui .scheme-container
+                {
+                    box-shadow: none;
+                    border-bottom: 1px solid #CCCCCC;
+                }
+
+                .swagger-ui .opblock .opblock-summary-description,
+                .swagger-ui .opblock-description-wrapper p,
+                .swagger-ui h4,
+                .swagger-ui h5
+                {
+                    color: #BBBBBB !important;
+                }
+
+                body,
+                .swagger-ui .info .title,
+                .swagger-ui .scheme-container,
+                .swagger-ui select
+                {
+                    background-color: #222;
+                    color: #CCC;
+                }
+
+                .swagger-ui .opblock .opblock-section-header
+                {
+                    background-color: transparent;
+                }
+
+                .swagger-ui textarea,
+                .swagger-ui input[type=text]
+                {
+                    background-color: #41444e;
+                    color: #CCC;
+                }
+
+                .swagger-ui .topbar
+                {
+                    background-color: #000;
+                }
+            </style>"
+        })
     </head>
     <body>
         <div id="swagger-ui"></div>

--- a/src/Misc/default-swagger.html.pode
+++ b/src/Misc/default-swagger.html.pode
@@ -39,9 +39,11 @@
                     color: #CCCCCC !important;
                 }
 
-                .swagger-ui svg.arrow
+                .swagger-ui svg.arrow,
+                .swagger-ui button.unlocked
                 {
                     fill: #CCCCCC;
+                    opacity: 1 !important;
                 }
 
                 .swagger-ui .scheme-container

--- a/src/Pode.psd1
+++ b/src/Pode.psd1
@@ -178,16 +178,24 @@
         'Pode',
 
         # openapi
-        'Enable-PodeOpenApiRoute',
-        'Enable-PodeSwaggerRoute',
-        'Add-PodeOpenApiRouteResponse',
-        'Set-PodeOpenApiRouteRequest',
-        'New-PodeOpenApiRouteRequestBody',
-        'Add-PodeOpenApiComponentSchema',
-        'New-PodeOpenApiSchema',
-        'New-PodeOpenApiSchemaProperty',
-        'New-PodeOpenApiRouteRequestParameter',
-        'Set-PodeOpenApiRouteMetaData'
+        'Enable-PodeOpenApi',
+        'Add-PodeOAResponse',
+        'Add-PodeOAComponentResponse',
+        'Set-PodeOAAuth',
+        'Set-PodeOAGlobalAuth',
+        'Set-PodeOARequest',
+        'New-PodeOARequestBody',
+        'Add-PodeOAComponentSchema',
+        'Add-PodeOAComponentRequestBody',
+        'Add-PodeOAComponentParameter',
+        'New-PodeOAIntProperty',
+        'New-PodeOANumberProperty',
+        'New-PodeOAStringProperty',
+        'New-PodeOABoolProperty',
+        'New-PodeOAObjectProperty',
+        'New-PodeOARequestParameter',
+        'Set-PodeOARouteInfo',
+        'Enable-PodeSwagger'
     )
 
     # Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.

--- a/src/Pode.psd1
+++ b/src/Pode.psd1
@@ -179,7 +179,7 @@
 
         # openapi
         'Enable-PodeOpenApi',
-        'Get-PodeOpenApiDefintion',
+        'Get-PodeOpenApiDefinition',
         'Add-PodeOAResponse',
         'Add-PodeOAComponentResponse',
         'Set-PodeOAAuth',

--- a/src/Pode.psd1
+++ b/src/Pode.psd1
@@ -196,8 +196,7 @@
         'New-PodeOAObjectProperty',
         'ConvertTo-PodeOAParameter',
         'Set-PodeOARouteInfo',
-        'Enable-PodeSwagger',
-        'Enable-PodeReDoc'
+        'Enable-PodeOpenApiViewer'
     )
 
     # Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.

--- a/src/Pode.psd1
+++ b/src/Pode.psd1
@@ -179,7 +179,9 @@
 
         # openapi
         'Enable-PodeOpenApiRoute',
-        'Enable-PodeSwaggerRoute'
+        'Enable-PodeSwaggerRoute',
+        'Add-PodeOpenApiRouteResponse',
+        'Set-PodeOpenApiRouteMetaData'
     )
 
     # Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.

--- a/src/Pode.psd1
+++ b/src/Pode.psd1
@@ -193,7 +193,7 @@
         'New-PodeOAStringProperty',
         'New-PodeOABoolProperty',
         'New-PodeOAObjectProperty',
-        'New-PodeOARequestParameter',
+        'ConvertTo-PodeOAParameter',
         'Set-PodeOARouteInfo',
         'Enable-PodeSwagger',
         'Enable-PodeReDoc'

--- a/src/Pode.psd1
+++ b/src/Pode.psd1
@@ -175,7 +175,11 @@
         'Start-PodeStaticServer',
         'Show-PodeGui',
         'Add-PodeEndpoint',
-        'Pode'
+        'Pode',
+
+        # openapi
+        'Enable-PodeOpenApiRoute',
+        'Enable-PodeSwaggerRoute'
     )
 
     # Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.

--- a/src/Pode.psd1
+++ b/src/Pode.psd1
@@ -179,6 +179,7 @@
 
         # openapi
         'Enable-PodeOpenApi',
+        'Get-PodeOpenApiDefintion',
         'Add-PodeOAResponse',
         'Add-PodeOAComponentResponse',
         'Set-PodeOAAuth',

--- a/src/Pode.psd1
+++ b/src/Pode.psd1
@@ -181,6 +181,12 @@
         'Enable-PodeOpenApiRoute',
         'Enable-PodeSwaggerRoute',
         'Add-PodeOpenApiRouteResponse',
+        'Set-PodeOpenApiRouteRequest',
+        'New-PodeOpenApiRouteRequestBody',
+        'Add-PodeOpenApiComponentSchema',
+        'New-PodeOpenApiSchema',
+        'New-PodeOpenApiSchemaProperty',
+        'New-PodeOpenApiRouteRequestParameter',
         'Set-PodeOpenApiRouteMetaData'
     )
 
@@ -193,7 +199,7 @@
                 'powershell-core', 'windows', 'unix', 'linux', 'pode', 'PSEdition_Core', 'cross-platform', 'access-control',
                 'file-monitoring', 'multithreaded', 'rate-limiting', 'cron', 'schedule', 'middleware', 'session',
                 'authentication', 'active-directory', 'caching', 'csrf', 'arm', 'raspberry-pi', 'aws-lambda',
-                'azure-functions', 'websockets')
+                'azure-functions', 'websockets', 'swagger', 'openapi')
 
             # A URL to the license for this module.
             LicenseUri = 'https://raw.githubusercontent.com/Badgerati/Pode/master/LICENSE.txt'

--- a/src/Pode.psd1
+++ b/src/Pode.psd1
@@ -195,7 +195,8 @@
         'New-PodeOAObjectProperty',
         'New-PodeOARequestParameter',
         'Set-PodeOARouteInfo',
-        'Enable-PodeSwagger'
+        'Enable-PodeSwagger',
+        'Enable-PodeReDoc'
     )
 
     # Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.
@@ -207,7 +208,7 @@
                 'powershell-core', 'windows', 'unix', 'linux', 'pode', 'PSEdition_Core', 'cross-platform', 'access-control',
                 'file-monitoring', 'multithreaded', 'rate-limiting', 'cron', 'schedule', 'middleware', 'session',
                 'authentication', 'active-directory', 'caching', 'csrf', 'arm', 'raspberry-pi', 'aws-lambda',
-                'azure-functions', 'websockets', 'swagger', 'openapi')
+                'azure-functions', 'websockets', 'swagger', 'openapi', 'redoc')
 
             # A URL to the license for this module.
             LicenseUri = 'https://raw.githubusercontent.com/Badgerati/Pode/master/LICENSE.txt'

--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -194,7 +194,6 @@ function New-PodeContext
 
     # swagger and openapi
     $ctx.Server.OpenAPI = @{
-        Enabled = $false
         Path = $null
         Title = $null
         components = @{

--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -194,6 +194,7 @@ function New-PodeContext
 
     # swagger and openapi
     $ctx.Server.OpenAPI = @{
+        Enabled = $false
         Path = $null
         Title = $null
         components = @{

--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -196,6 +196,9 @@ function New-PodeContext
     $ctx.Server.OpenAPI = @{
         Path = $null
         Title = $null
+        components = @{
+            schemas = @{}
+        }
     }
 
     # authnetication methods

--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -192,6 +192,12 @@ function New-PodeContext
     # sessions
     $ctx.Server.Sessions = @{}
 
+    # swagger and openapi
+    $ctx.Server.OpenAPI = @{
+        Path = $null
+        Title = $null
+    }
+
     # authnetication methods
     $ctx.Server.Authentications = @{}
 

--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -198,7 +198,12 @@ function New-PodeContext
         Title = $null
         components = @{
             schemas = @{}
+            responses = @{}
+            securitySchemas = @{}
+            requestBodies = @{}
+            parameters = @{}
         }
+        security = @()
     }
 
     # authnetication methods

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -355,8 +355,8 @@ function Get-PodeEndpointInfo
 
     # return the info
     return @{
-        'Host' = $_host;
-        'Port' = (Resolve-PodeValue -Check ($AnyPortOnZero -and $_port -eq 0) -TrueValue '*' -FalseValue $_port);
+        Host = $_host
+        Port = (Resolve-PodeValue -Check ($AnyPortOnZero -and ($_port -eq 0)) -TrueValue '*' -FalseValue $_port)
     }
 }
 
@@ -1907,16 +1907,31 @@ function Get-PodeEndpointUrl
         $Endpoint = $PodeContext.Server.Endpoints[0]
     }
 
-    # work out the protocol
-    $protocol = (Resolve-PodeValue -Check $Endpoint.Ssl -TrueValue 'https' -FalseValue 'http')
-
-    # grab the port number
-    $port = $Endpoint.Port
-    if ($port -eq 0) {
-        $port = (Resolve-PodeValue -Check $Endpoint.Ssl -TrueValue 8443 -FalseValue 8080)
+    $url = $Endpoint.Url
+    if ([string]::IsNullOrWhiteSpace($url)) {
+        $url = "$($Endpoint.Protocol)://$($Endpoint.HostName):$($Endpoint.Port)"
     }
 
-    return "$($protocol)://$($Endpoint.HostName):$($port)"
+    return $url
+}
+
+function Get-PodeDefaultPort
+{
+    param(
+        [Parameter()]
+        [ValidateSet('Http', 'Https', 'Smtp', 'Tcp', 'Ws', 'Wss')]
+        [string]
+        $Protocol
+    )
+
+    return (@{
+        Http    = 8080
+        Https   = 8443
+        Smtp    = 25
+        Tcp     = 9001
+        Ws      = 9080
+        Wss     = 9443
+    })[$Protocol.ToLowerInvariant()]
 }
 
 function Set-PodeServerHeader

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -932,13 +932,13 @@ function Remove-PodeNullKeysFromHashtable
         $Hashtable
     )
 
-    ($Hashtable.Clone()).Keys | ForEach-Object {
-        if ($null -eq $Hashtable[$_]) {
-            $Hashtable.Remove($_) | Out-Null
+    foreach ($key in ($Hashtable.Clone()).Keys) {
+        if ($null -eq $Hashtable[$key]) {
+            $Hashtable.Remove($key) | Out-Null
         }
 
-        if ($Hashtable[$_] -is [hashtable]) {
-            $Hashtable[$_] | Remove-PodeNullKeysFromHashtable
+        if ($Hashtable[$key] -is [hashtable]) {
+            $Hashtable[$key] | Remove-PodeNullKeysFromHashtable
         }
     }
 }

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -924,6 +924,25 @@ function Remove-PodeEmptyItemsFromArray
     return @(@($Array -ne ([string]::Empty)) -ne $null)
 }
 
+function Remove-PodeNullKeysFromHashtable
+{
+    param(
+        [Parameter(ValueFromPipeline=$true)]
+        [hashtable]
+        $Hashtable
+    )
+
+    ($Hashtable.Clone()).Keys | ForEach-Object {
+        if ($null -eq $Hashtable[$_]) {
+            $Hashtable.Remove($_) | Out-Null
+        }
+
+        if ($Hashtable[$_] -is [hashtable]) {
+            $Hashtable[$_] | Remove-PodeNullKeysFromHashtable
+        }
+    }
+}
+
 function Join-PodePaths
 {
     param (

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -937,6 +937,10 @@ function Remove-PodeNullKeysFromHashtable
             $Hashtable.Remove($key) | Out-Null
         }
 
+        if (($Hashtable[$key] -is [array]) -and ($Hashtable[$key].Length -eq 1) -and ($null -eq $Hashtable[$key][0])) {
+            $Hashtable.Remove($key) | Out-Null
+        }
+
         if ($Hashtable[$key] -is [hashtable]) {
             $Hashtable[$key] | Remove-PodeNullKeysFromHashtable
         }

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -913,7 +913,7 @@ function Join-PodeServerRoot
 function Remove-PodeEmptyItemsFromArray
 {
     param (
-        [Parameter()]
+        [Parameter(ValueFromPipeline=$true)]
         $Array
     )
 

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -1517,6 +1517,11 @@ function Get-PodeModuleRootPath
     return (Split-Path -Parent -Path $PodeContext.Server.PodeModulePath)
 }
 
+function Get-PodeModuleMiscPath
+{
+    return (Join-Path (Get-PodeModuleRootPath) 'Misc')
+}
+
 function Get-PodeUrl
 {
     return "$($WebEvent.Protocol)://$($WebEvent.Endpoint)$($WebEvent.Path)"
@@ -1619,7 +1624,7 @@ function Get-PodeErrorPage
 
     # if there's no custom page found, attempt to find an inbuilt page
     if ([string]::IsNullOrWhiteSpace($path)) {
-        $podeRoot = Join-Path (Get-PodeModuleRootPath) 'Misc'
+        $podeRoot = Get-PodeModuleMiscPath
         $path = Find-PodeFileForContentType -Path $podeRoot -Name 'default-error-page' -ContentType $ContentType -Engine 'pode'
     }
 

--- a/src/Private/OpenApi.ps1
+++ b/src/Private/OpenApi.ps1
@@ -1,0 +1,15 @@
+function ConvertFrom-PodeOpenApiComponentSchemaProperties
+{
+    param(
+        [Parameter(Mandatory=$true)]
+        [hashtable[]]
+        $Properties
+    )
+
+    $props = @{}
+    foreach ($prop in $Properties) {
+        $props[$prop.name] = $prop
+    }
+
+    return $props
+}

--- a/src/Private/OpenApi.ps1
+++ b/src/Private/OpenApi.ps1
@@ -1,7 +1,7 @@
 function ConvertFrom-PodeOpenApiComponentSchemaProperties
 {
     param(
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
         [hashtable[]]
         $Properties
     )
@@ -12,4 +12,26 @@ function ConvertFrom-PodeOpenApiComponentSchemaProperties
     }
 
     return $props
+}
+
+function ConvertFrom-PodeOpenApiContentTypeSchema
+{
+    param(
+        [Parameter(ValueFromPipeline=$true)]
+        [hashtable[]]
+        $Schemas
+    )
+
+    if (Test-IsEmpty $Schemas) {
+        return $null
+    }
+
+    $contents = @{}
+    foreach ($schema in $Schemas) {
+        $contents["$($schema.Keys | Select-Object -First 1)"] = @{
+            schema = ($schema.Values | Select-Object -First 1)
+        }
+    }
+
+    return $contents
 }

--- a/src/Private/OpenApi.ps1
+++ b/src/Private/OpenApi.ps1
@@ -1,24 +1,24 @@
-function ConvertFrom-PodeOpenApiComponentSchemaProperties
-{
-    param(
-        [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
-        [hashtable[]]
-        $Properties
-    )
+# function ConvertFrom-PodeOAComponentSchemaProperties
+# {
+#     param(
+#         [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
+#         [hashtable[]]
+#         $Properties
+#     )
 
-    $props = @{}
-    foreach ($prop in $Properties) {
-        $props[$prop.name] = $prop
-    }
+#     $props = @{}
+#     foreach ($prop in $Properties) {
+#         $props[$prop.name] = $prop
+#     }
 
-    return $props
-}
+#     return $props
+# }
 
-function ConvertFrom-PodeOpenApiContentTypeSchema
+function ConvertTo-PodeOAContentTypeSchema
 {
     param(
         [Parameter(ValueFromPipeline=$true)]
-        [hashtable[]]
+        [hashtable]
         $Schemas
     )
 
@@ -26,12 +26,83 @@ function ConvertFrom-PodeOpenApiContentTypeSchema
         return $null
     }
 
+    # ensure all content types are valid
+    foreach ($type in $Schemas.Keys) {
+        if ($type -inotmatch '^\w+\/[\w\.\+-]+$') {
+            throw "Invalid content-type found for schema: $($type)"
+        }
+    }
+
+    # convert each content schema to openapi format
     $contents = @{}
-    foreach ($schema in $Schemas) {
-        $contents["$($schema.Keys | Select-Object -First 1)"] = @{
-            schema = ($schema.Values | Select-Object -First 1)
+    foreach ($type in $Schemas.Keys) {
+        $contents[$type] = @{
+            schema = ($Schemas[$type] | ConvertTo-PodeOASchemaProperty)
         }
     }
 
     return $contents
+}
+
+function ConvertTo-PodeOASchemaProperty
+{
+    param(
+        [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
+        [hashtable]
+        $Property
+    )
+
+    # base schema type
+    $schema = @{
+        type = $Property.type
+        format = $Property.format
+    }
+
+    # are we using an array?
+    if ($Property.array) {
+        $Property.array = $false
+
+        $schema = @{
+            type = 'array'
+            items = ($Property | ConvertTo-PodeOASchemaProperty)
+        }
+    }
+
+    # are we using an object?
+    if ($Property.object) {
+        $Property.object = $false
+
+        $schema = @{
+            type = 'object'
+            properties = (ConvertTo-PodeOASchemaObjectProperty -Properties $Property)
+        }
+
+        if ($Property.required) {
+            $schema['required'] = @($Property.name)
+        }
+    }
+
+    if ($Property.type -ieq 'object') {
+        $schema['properties'] = (ConvertTo-PodeOASchemaObjectProperty -Properties $Property.properties)
+        $schema['required'] = @(($Property.properties | Where-Object { $_.required }).name)
+    }
+
+    return $schema
+}
+
+function ConvertTo-PodeOASchemaObjectProperty
+{
+    param(
+        [Parameter(Mandatory=$true)]
+        [hashtable[]]
+        $Properties
+    )
+
+    $schema = @{}
+
+    foreach ($prop in $Properties) {
+        $schema[$prop.name] = ($prop | ConvertTo-PodeOASchemaProperty)
+    }
+
+    return $schema
 }

--- a/src/Private/OpenApi.ps1
+++ b/src/Private/OpenApi.ps1
@@ -179,16 +179,12 @@ function ConvertTo-PodeOASchemaObjectProperty
     return $schema
 }
 
-function Get-PodeOpenApiDefinition
+function Get-PodeOpenApiDefinitionInternal
 {
     param(
-        [Parameter()]
+        [Parameter(Mandatory=$true)]
         [string]
         $Title,
-
-        [Parameter()]
-        [string]
-        $Description,
 
         [Parameter()]
         [string]
@@ -196,7 +192,11 @@ function Get-PodeOpenApiDefinition
 
         [Parameter()]
         [string]
-        $Route,
+        $Description,
+
+        [Parameter()]
+        [string]
+        $RouteFilter,
 
         [Parameter()]
         $Protocol,
@@ -250,7 +250,7 @@ function Get-PodeOpenApiDefinition
 
     # paths
     $def['paths'] = @{}
-    $filter = "^$($Route)"
+    $filter = "^$($RouteFilter)"
 
     foreach ($method in $PodeContext.Server.Routes.Keys) {
         foreach ($path in $PodeContext.Server.Routes[$method].Keys) {

--- a/src/Private/OpenApi.ps1
+++ b/src/Private/OpenApi.ps1
@@ -317,3 +317,29 @@ function Get-PodeOpenApiDefinition
     $def | Remove-PodeNullKeysFromHashtable
     return $def
 }
+
+function ConvertTo-PodeOAPropertyFromCmdletParameter
+{
+    param(
+        [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
+        [System.Management.Automation.ParameterMetadata]
+        $Parameter
+    )
+
+    if ($Parameter.SwitchParameter -or ($Parameter.ParameterType.Name -ieq 'boolean')) {
+        New-PodeOABoolProperty -Name $Parameter.Name
+    }
+    else {
+        switch ($Parameter.ParameterType.Name) {
+            { @('int32', 'int64') -icontains $_ } {
+                New-PodeOAIntProperty -Name $Parameter.Name -Format $_
+            }
+
+            { @('double', 'float') -icontains $_ } {
+                New-PodeOANumberProperty -Name $Parameter.Name -Format $_
+            }
+        }
+    }
+
+    New-PodeOAStringProperty -Name $Parameter.Name
+}

--- a/src/Private/PodeServer.ps1
+++ b/src/Private/PodeServer.ps1
@@ -23,26 +23,17 @@ function Start-PodeSocketServer
     # work out which endpoints to listen on
     $endpoints = @()
     @(Get-PodeEndpoints -Type Http) | ForEach-Object {
-        # get the protocol
-        $_protocol = (Resolve-PodeValue -Check $_.Ssl -TrueValue 'https' -FalseValue 'http')
-
         # get the ip address
         $_ip = [string]($_.Address)
         $_ip = (Get-PodeIPAddressesForHostname -Hostname $_ip -Type All | Select-Object -First 1)
         $_ip = (Get-PodeIPAddress $_ip)
 
-        # get the port
-        $_port = [int]($_.Port)
-        if ($_port -eq 0) {
-            $_port = (Resolve-PodeValue $_.Ssl -TrueValue 8443 -FalseValue 8080)
-        }
-
         # add endpoint to list
         $endpoints += @{
             Address = $_ip
-            Port = $_port
+            Port = $_.Port
             Certificate = $_.Certificate.Raw
-            HostName = "$($_protocol)://$($_.HostName):$($_port)/"
+            HostName = $_.Url
         }
     }
 

--- a/src/Private/Routes.ps1
+++ b/src/Private/Routes.ps1
@@ -167,7 +167,7 @@ function Get-PodeRouteByUrl
 {
     param (
         [Parameter()]
-        [object[]]
+        [hashtable[]]
         $Routes,
 
         [Parameter()]
@@ -179,8 +179,35 @@ function Get-PodeRouteByUrl
         $Endpoint
     )
 
-    # get the value routes
-    $rs = @(foreach ($route in $Routes) {
+    # get the routes
+    $rs = @(Get-PodeRoutesByUrl -Routes $Routes -Protocol $Protocol -Endpoint $Endpoint)
+
+    # return null if empty
+    if (($rs.Length -eq 0) -or ($null -eq $rs[0])) {
+        return $null
+    }
+
+    return @($rs | Sort-Object -Property { $_.Protocol }, { $_.Endpoint } -Descending)[0]
+}
+
+function Get-PodeRoutesByUrl
+{
+    param (
+        [Parameter()]
+        [hashtable[]]
+        $Routes,
+
+        [Parameter()]
+        [string]
+        $Protocol,
+
+        [Parameter()]
+        [string]
+        $Endpoint
+    )
+
+    # get the routes for the protocol/endpoint
+    return @(foreach ($route in $Routes) {
         if (
             (($route.Protocol -ieq $Protocol) -or [string]::IsNullOrWhiteSpace($route.Protocol)) -and
             ([string]::IsNullOrWhiteSpace($route.Endpoint) -or ($Endpoint -ilike $route.Endpoint))
@@ -188,12 +215,6 @@ function Get-PodeRouteByUrl
             $route
         }
     })
-
-    if ($null -eq $rs[0]) {
-        return $null
-    }
-
-    return @($rs | Sort-Object -Property { $_.Protocol }, { $_.Endpoint } -Descending)[0]
 }
 
 function Update-PodeRoutePlaceholders

--- a/src/Private/Routes.ps1
+++ b/src/Private/Routes.ps1
@@ -217,6 +217,27 @@ function Update-PodeRoutePlaceholders
     return $Path
 }
 
+function ConvertTo-PodeOpenApiRoutePath
+{
+    param (
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Path
+    )
+
+    # replace placeholder parameters with regex
+    $placeholder = '\:(?<tag>[\w]+)'
+    if ($Path -imatch $placeholder) {
+        $Path = [regex]::Escape($Path)
+    }
+
+    while ($Path -imatch $placeholder) {
+        $Path = ($Path -ireplace $Matches[0], "{$($Matches['tag'])}")
+    }
+
+    return $Path
+}
+
 function Update-PodeRouteSlashes
 {
     param (

--- a/src/Private/Server.ps1
+++ b/src/Private/Server.ps1
@@ -138,6 +138,9 @@ function Restart-PodeInternalServer
         # clear endpoints
         $PodeContext.Server.Endpoints = @()
 
+        # clear openapi
+        $PodeContext.Server.OpenAPI.Clear()
+
         # clear the sockets
         $PodeContext.Server.Sockets.Listeners = @()
         $PodeContext.Server.Sockets.Queues.Connections = [System.Collections.Concurrent.ConcurrentQueue[System.Net.Sockets.SocketAsyncEventArgs]]::new()

--- a/src/Private/SignalServer.ps1
+++ b/src/Private/SignalServer.ps1
@@ -6,26 +6,17 @@ function Start-PodeSignalServer
     # work out which endpoints to listen on
     $endpoints = @()
     @(Get-PodeEndpoints -Type Ws) | ForEach-Object {
-        # get the protocol
-        $_protocol = (Resolve-PodeValue -Check $_.Ssl -TrueValue 'wss' -FalseValue 'ws')
-
         # get the ip address
         $_ip = [string]($_.Address)
         $_ip = (Get-PodeIPAddressesForHostname -Hostname $_ip -Type All | Select-Object -First 1)
         $_ip = (Get-PodeIPAddress $_ip)
 
-        # get the port
-        $_port = [int]($_.Port)
-        if ($_port -eq 0) {
-            $_port = (Resolve-PodeValue $_.Ssl -TrueValue 9443 -FalseValue 9080)
-        }
-
         # add endpoint to list
         $endpoints += @{
             Address = $_ip
-            Port = $_port
+            Port = $_.Port
             Certificate = $_.Certificate.Raw
-            HostName = "$($_protocol)://$($_.HostName):$($_port)/"
+            HostName = $_.Url
         }
     }
 

--- a/src/Private/SmtpServer.ps1
+++ b/src/Private/SmtpServer.ps1
@@ -7,9 +7,6 @@ function Start-PodeSmtpServer
 
     # grab the relavant port
     $port = $PodeContext.Server.Endpoints[0].Port
-    if ($port -eq 0) {
-        $port = 25
-    }
 
     # get the IP address for the server
     $ipAddress = $PodeContext.Server.Endpoints[0].Address

--- a/src/Private/TcpServer.ps1
+++ b/src/Private/TcpServer.ps1
@@ -7,9 +7,6 @@ function Start-PodeTcpServer
 
     # grab the relavant port
     $port = $PodeContext.Server.Endpoints[0].Port
-    if ($port -eq 0) {
-        $port = 9001
-    }
 
     # get the IP address for the server
     $ipAddress = $PodeContext.Server.Endpoints[0].Address

--- a/src/Private/WebServer.ps1
+++ b/src/Private/WebServer.ps1
@@ -20,32 +20,23 @@ function Start-PodeWebServer
     # work out which endpoints to listen on
     $endpoints = @()
     @(Get-PodeEndpoints -Type Http) | ForEach-Object {
-        # get the protocol
-        $_protocol = (Resolve-PodeValue -Check $_.Ssl -TrueValue 'https' -FalseValue 'http')
-
         # get the ip address
         $_ip = "$($_.Address)"
         if ($_ip -ieq '0.0.0.0') {
             $_ip = '*'
         }
 
-        # get the port
-        $_port = [int]($_.Port)
-        if ($_port -eq 0) {
-            $_port = (Resolve-PodeValue $_.Ssl -TrueValue 8443 -FalseValue 8080)
-        }
-
         # if this endpoint is https, generate a self-signed cert or bind an existing one
         if ($_.Ssl) {
             $addr = (Resolve-PodeValue -Check $_.IsIPAddress -TrueValue $_.Address -FalseValue $_.HostName)
             $selfSigned = $_.Certificate.SelfSigned
-            Set-PodeCertificate -Address $addr -Port $_port -Certificate $_.Certificate.Name -Thumbprint $_.Certificate.Thumbprint -SelfSigned:$selfSigned
+            Set-PodeCertificate -Address $addr -Port $_.Port -Certificate $_.Certificate.Name -Thumbprint $_.Certificate.Thumbprint -SelfSigned:$selfSigned
         }
 
         # add endpoint to list
         $endpoints += @{
-            Prefix = "$($_protocol)://$($_ip):$($_port)/"
-            HostName = "$($_protocol)://$($_.HostName):$($_port)/"
+            Prefix = "$($_.Protocol)://$($_ip):$($_.Port)/"
+            HostName = $_.Url
         }
     }
 

--- a/src/Public/Authentication.ps1
+++ b/src/Public/Authentication.ps1
@@ -38,6 +38,9 @@ The Name of an Authentication type - such as Basic or NTLM.
 .PARAMETER Realm
 The name of scope of the protected area.
 
+.PARAMETER Scheme
+The scheme type for custom Authentication types. Default is HTTP.
+
 .EXAMPLE
 $basic_auth = New-PodeAuthType -Basic
 
@@ -101,7 +104,12 @@ function New-PodeAuthType
 
         [Parameter()]
         [string]
-        $Realm
+        $Realm,
+
+        [Parameter(ParameterSetName='Custom')]
+        [ValidateSet('ApiKey', 'Http', 'OAuth2', 'OpenIdConnect')]
+        [string]
+        $Scheme = 'Http'
     )
 
     # configure the auth type
@@ -111,6 +119,7 @@ function New-PodeAuthType
                 Name = (Protect-PodeValue -Value $Name -Default 'Basic')
                 Realm = $Realm
                 ScriptBlock = (Get-PodeAuthBasicType)
+                Scheme = 'http'
                 Arguments = @{
                     HeaderTag = (Protect-PodeValue -Value $HeaderTag -Default 'Basic')
                     Encoding = (Protect-PodeValue -Value $Encoding -Default 'ISO-8859-1')
@@ -123,6 +132,7 @@ function New-PodeAuthType
                 Name = (Protect-PodeValue -Value $Name -Default 'Form')
                 Realm = $Realm
                 ScriptBlock = (Get-PodeAuthFormType)
+                Scheme = 'http'
                 Arguments = @{
                     Fields = @{
                         Username = (Protect-PodeValue -Value $UsernameField -Default 'username')
@@ -136,6 +146,7 @@ function New-PodeAuthType
             return @{
                 Name = $Name
                 Realm = $Realm
+                Scheme = $Scheme.ToLowerInvariant()
                 ScriptBlock = $ScriptBlock
                 Arguments = $ArgumentList
             }

--- a/src/Public/Core.ps1
+++ b/src/Public/Core.ps1
@@ -601,6 +601,9 @@ An optional name for the endpoint, that can be used with other functions.
 .PARAMETER RedirectTo
 The Name of another Endpoint to automatically generate a redirect route for all traffic.
 
+.PARAMETER Description
+A quick description of the Endpoint - normally used in OpenAPI.
+
 .PARAMETER Force
 Ignore Adminstrator checks for non-localhost endpoints.
 

--- a/src/Public/OpenApi.ps1
+++ b/src/Public/OpenApi.ps1
@@ -9,7 +9,7 @@ function Enable-PodeOpenApi
 
         [Parameter()]
         [string]
-        $Route = '/',
+        $Route = '/*',
 
         [Parameter()]
         [object[]]
@@ -689,7 +689,7 @@ function New-PodeOAObjectProperty
     return $param
 }
 
-function New-PodeOARequestParameter
+function ConvertTo-PodeOAParameter
 {
     [CmdletBinding(DefaultParameterSetName='Reference')]
     param(

--- a/src/Public/OpenApi.ps1
+++ b/src/Public/OpenApi.ps1
@@ -838,3 +838,48 @@ function Enable-PodeSwagger
         }
     }
 }
+
+function Enable-PodeReDoc
+{
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $Path = '/redoc',
+
+        [Parameter()]
+        [string]
+        $OpenApiPath,
+
+        [Parameter()]
+        [object[]]
+        $Middleware,
+
+        [Parameter()]
+        [string]
+        $Title
+    )
+
+    # error if there's no OpenAPI path
+    $OpenApiPath = Protect-PodeValue -Value $OpenApiPath -Default $PodeContext.Server.OpenAPI.Path
+    if ([string]::IsNullOrWhiteSpace($OpenApiPath)) {
+        throw "No OpenAPI path supplied for ReDoc to use"
+    }
+
+    # fail if no title
+    $Title = Protect-PodeValue -Value $Title -Default $PodeContext.Server.OpenAPI.Title
+    if ([string]::IsNullOrWhiteSpace($Title)) {
+        throw "No title supplied for ReDoc page"
+    }
+
+    # add the redoc route
+    Add-PodeRoute -Method Get -Path $Path -Middleware $Middleware -ScriptBlock {
+        param($e)
+        $podeRoot = Get-PodeModuleMiscPath
+        Write-PodeFileResponse -Path (Join-Path $podeRoot 'default-redoc.html.pode') -Data @{
+            Title = $PodeContext.Server.OpenAPI.Title
+            OpenApiPath = $PodeContext.Server.OpenAPI.Path
+        }
+    }
+}

--- a/src/Public/OpenApi.ps1
+++ b/src/Public/OpenApi.ps1
@@ -1,0 +1,135 @@
+function Enable-PodeOpenApiRoute
+{
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $Path = '/openapi',
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $SwaggerPath = '/swagger',
+
+        [Parameter()]
+        [string]
+        $Filter = '/',
+
+        [Parameter()]
+        [object[]]
+        $Middleware,
+
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Title,
+
+        [Parameter()]
+        [string]
+        $Version = '0.0.1',
+
+        [Parameter()]
+        [string]
+        $Description
+    )
+
+    # initialise openapi info
+    $PodeContext.Server.OpenAPI.Title = $Title
+    $PodeContext.Server.OpenAPI.Path = $Path
+
+    $meta = @{
+        Title = $Title
+        Version = $Version
+        Description = $Description
+        Filter = $Filter
+    }
+
+    # add the OpenAPI route
+    Add-PodeRoute -Method Get -Path $Path -ArgumentList $meta -Middleware $Middleware -ScriptBlock {
+        param($e, $meta)
+        $def = @{
+            'openapi' = '3.0.2'
+        }
+
+        # metadata
+        $def['info'] = @{
+            'title' = $meta.Title
+            'version' = $meta.Version
+            'description' = $meta.Description
+        }
+
+        # paths
+        $def['paths'] = @{}
+        foreach ($method in $PodeContext.Server.Routes.Keys) {
+            foreach ($path in $PodeContext.Server.Routes[$method].Keys) {
+                # does it match the filter?
+                if ($path -inotmatch "^$($meta.Filter)") {
+                    continue
+                }
+
+                # do nothing if it has no response set
+
+                # add path to defintion
+                $def['paths'][$path] = @{
+                    "$($method)" = @{
+                        'responses' = @{
+                            '200' = @{
+                                'description' = 'OK'
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        # write
+        Write-PodeJsonResponse -Value $def
+    }
+}
+
+function Enable-PodeSwaggerRoute
+{
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $Path = '/swagger',
+
+        [Parameter()]
+        [string]
+        $OpenApiPath,
+
+        [Parameter()]
+        [object[]]
+        $Middleware,
+
+        [Parameter()]
+        [string]
+        $Title
+    )
+
+    # error if there's no OpenAPI path
+    $OpenApiPath = Protect-PodeValue -Value $OpenApiPath -Default $PodeContext.Server.OpenAPI.Path
+    if ([string]::IsNullOrWhiteSpace($OpenApiPath)) {
+        throw "No OpenAPI path supplied for Swagger to use"
+    }
+
+    # fail if no title
+    $Title = Protect-PodeValue -Value $Title -Default $PodeContext.Server.OpenAPI.Title
+    if ([string]::IsNullOrWhiteSpace($Title)) {
+        throw "No title supplied for Swagger page"
+    }
+
+    # add the swagger route
+    Add-PodeRoute -Method Get -Path $Path -Middleware $Middleware -ScriptBlock {
+        param($e)
+        $podeRoot = Get-PodeModuleMiscPath
+        Write-PodeFileResponse -Path (Join-Path $podeRoot 'default-swagger.html.pode') -Data @{
+            Title = $PodeContext.Server.OpenAPI.Title
+            OpenApiPath = $PodeContext.Server.OpenAPI.Path
+        }
+    }
+}
+
+

--- a/src/Public/OpenApi.ps1
+++ b/src/Public/OpenApi.ps1
@@ -568,7 +568,10 @@ function Enable-PodeSwaggerRoute
 
         [Parameter()]
         [string]
-        $Title
+        $Title,
+
+        [switch]
+        $DarkMode
     )
 
     # error if there's no OpenAPI path
@@ -584,12 +587,13 @@ function Enable-PodeSwaggerRoute
     }
 
     # add the swagger route
-    Add-PodeRoute -Method Get -Path $Path -Middleware $Middleware -ScriptBlock {
-        param($e)
+    Add-PodeRoute -Method Get -Path $Path -Middleware $Middleware -ArgumentList @{ DarkMode = $DarkMode } -ScriptBlock {
+        param($e, $meta)
         $podeRoot = Get-PodeModuleMiscPath
         Write-PodeFileResponse -Path (Join-Path $podeRoot 'default-swagger.html.pode') -Data @{
             Title = $PodeContext.Server.OpenAPI.Title
             OpenApiPath = $PodeContext.Server.OpenAPI.Path
+            DarkMode = $meta.DarkMode
         }
     }
 }

--- a/src/Public/OpenApi.ps1
+++ b/src/Public/OpenApi.ps1
@@ -294,7 +294,7 @@ function New-PodeOARequestBody
 
         [Parameter(Mandatory=$true, ParameterSetName='Schema')]
         [hashtable]
-        $Schemas,
+        $ContentSchemas,
 
         [Parameter(ParameterSetName='Schema')]
         [string]
@@ -310,7 +310,7 @@ function New-PodeOARequestBody
             return @{
                 required = $Required.IsPresent
                 description = $Description
-                content = ($Schemas | ConvertTo-PodeOAContentTypeSchema)
+                content = ($ContentSchemas | ConvertTo-PodeOAContentTypeSchema)
             }
         }
 
@@ -352,7 +352,7 @@ function Add-PodeOAComponentRequestBody
 
         [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
         [hashtable]
-        $Schemas,
+        $ContentSchemas,
 
         [Parameter()]
         [string]
@@ -366,7 +366,7 @@ function Add-PodeOAComponentRequestBody
     $PodeContext.Server.OpenAPI.components.requestBodies[$Name] = @{
         required = $Required.IsPresent
         description = $Description
-        content = ($Schemas | ConvertTo-PodeOAContentTypeSchema)
+        content = ($ContentSchemas | ConvertTo-PodeOAContentTypeSchema)
     }
 }
 

--- a/src/Public/OpenApi.ps1
+++ b/src/Public/OpenApi.ps1
@@ -1,3 +1,40 @@
+<#
+.SYNOPSIS
+Enables the OpenAPI default route in Pode.
+
+.DESCRIPTION
+Enables the OpenAPI default route in Pode, as well as setting up details like Title and API Version.
+
+.PARAMETER Path
+An optional custom route path to access the OpenAPI definition. (Default: /openapi)
+
+.PARAMETER Title
+The Title of the API.
+
+.PARAMETER Version
+The Version of the API. (Default: 0.0.0)
+
+.PARAMETER Description
+A Description of the API.
+
+.PARAMETER RouteFilter
+An optional route filter for routes that should be included in the definition. (Default: /*)
+
+.PARAMETER Middleware
+Like normal Routes, an array of Middleware that will be applied to the route.
+
+.PARAMETER RestrictRoutes
+If supplied, only routes that are available on the Requests URI will be used to generate the OpenAPI definition.
+
+.EXAMPLE
+Enable-PodeOpenApi -Title 'My API' -Version '1.0.0' -RouteFilter '/api/*'
+
+.EXAMPLE
+Enable-PodeOpenApi -Title 'My API' -Version '1.0.0' -RouteFilter '/api/*' -RestrictRoutes
+
+.EXAMPLE
+Enable-PodeOpenApi -Path '/docs/openapi' -Title 'My API' -Version '1.0.0'
+#>
 function Enable-PodeOpenApi
 {
     [CmdletBinding()]
@@ -64,6 +101,31 @@ function Enable-PodeOpenApi
     }
 }
 
+<#
+.SYNOPSIS
+Gets the OpenAPI definition.
+
+.DESCRIPTION
+Gets the OpenAPI definition for custom use in routes, or other functions.
+
+.PARAMETER Title
+The Title of the API. (Default: the title supplied in Enable-PodeOpenApi)
+
+.PARAMETER Version
+The Version of the API. (Default: the version supplied in Enable-PodeOpenApi)
+
+.PARAMETER Description
+A Description of the API. (Default: the description supplied into Enable-PodeOpenApi)
+
+.PARAMETER RouteFilter
+An optional route filter for routes that should be included in the definition. (Default: /*)
+
+.PARAMETER RestrictRoutes
+If supplied, only routes that are available on the Requests URI will be used to generate the OpenAPI definition.
+
+.EXAMPLE
+$def = Get-PodeOpenApiDefinition -RouteFilter '/api/*'
+#>
 function Get-PodeOpenApiDefinition
 {
     [CmdletBinding()]
@@ -105,6 +167,46 @@ function Get-PodeOpenApiDefinition
         -RestrictRoutes:$RestrictRoutes)
 }
 
+<#
+.SYNOPSIS
+Adds a response definition to the supplied route.
+
+.DESCRIPTION
+Adds a response definition to the supplied route.
+
+.PARAMETER Route
+The route to add the response definition, usually from -PassThru on Add-PodeRoute.
+
+.PARAMETER StatusCode
+The HTTP StatusCode for the response.
+
+.PARAMETER ContentSchemas
+The content-types and schema the response returns (the schema is created using the Property functions).
+
+.PARAMETER HeaderSchemas
+The header name and schema the response returns (the schema is created using the Property functions).
+
+.PARAMETER Description
+A Description of the response. (Default: the HTTP StatusCode description)
+
+.PARAMETER Reference
+A Reference Name of an existing component response to use.
+
+.PARAMETER Default
+If supplied, the response will be used as a default response - this overrides the StatusCode supplied.
+
+.PARAMETER PassThru
+If supplied, the route passed in will be returned for further chaining.
+
+.EXAMPLE
+Add-PodeRoute -PassThru | Add-PodeOAResponse -StatusCode 200 -ContentSchemas @{ 'application/json' = (New-PodeOAIntProperty -Name 'userId' -Object) }
+
+.EXAMPLE
+Add-PodeRoute -PassThru | Add-PodeOAResponse -StatusCode 200 -ContentSchemas @{ 'application/json' = 'UserIdSchema' }
+
+.EXAMPLE
+Add-PodeRoute -PassThru | Add-PodeOAResponse -StatusCode 200 -Reference 'OKResponse'
+#>
 function Add-PodeOAResponse
 {
     [CmdletBinding(DefaultParameterSetName='Schema')]
@@ -199,6 +301,31 @@ function Add-PodeOAResponse
     }
 }
 
+<#
+.SYNOPSIS
+Adds a reusable component for responses.
+
+.DESCRIPTION
+Adds a reusable component for responses.
+
+.PARAMETER Name
+The reference Name of the response.
+
+.PARAMETER ContentSchemas
+The content-types and schema the response returns (the schema is created using the Property functions).
+
+.PARAMETER HeaderSchemas
+The header name and schema the response returns (the schema is created using the Property functions).
+
+.PARAMETER Description
+The Description of the response.
+
+.EXAMPLE
+Add-PodeOAComponentResponse -Name 'OKResponse' -ContentSchemas @{ 'application/json' = (New-PodeOAIntProperty -Name 'userId' -Object) }
+
+.EXAMPLE
+Add-PodeOAComponentResponse -Name 'ErrorResponse' -ContentSchemas @{ 'application/json' = 'ErrorSchema' }
+#>
 function Add-PodeOAComponentResponse
 {
     [CmdletBinding()]
@@ -237,6 +364,25 @@ function Add-PodeOAComponentResponse
     }
 }
 
+<#
+.SYNOPSIS
+Sets the names of defined Authentication types as the security the supplied route uses.
+
+.DESCRIPTION
+Sets the names of defined Authentication types as the security the supplied route uses.
+
+.PARAMETER Route
+The route to set a security definition, usually from -PassThru on Add-PodeRoute.
+
+.PARAMETER Name
+The Name(s) of any defined Authentication types (from Add-PodeAuth).
+
+.PARAMETER PassThru
+If supplied, the route passed in will be returned for further chaining.
+
+.EXAMPLE
+Add-PodeRoute -PassThru | Set-PodeOAAuth -Name 'Validate'
+#>
 function Set-PodeOAAuth
 {
     [CmdletBinding()]
@@ -273,6 +419,19 @@ function Set-PodeOAAuth
     }
 }
 
+<#
+.SYNOPSIS
+Sets the names of defined Authentication types as global OpenAPI Security.
+
+.DESCRIPTION
+Sets the names of defined Authentication types as global OpenAPI Security.
+
+.PARAMETER Name
+The Name(s) of any defined Authentication types (from Add-PodeAuth).
+
+.EXAMPLE
+Set-PodeOAGlobalAuth -Name 'Validate'
+#>
 function Set-PodeOAGlobalAuth
 {
     [CmdletBinding()]
@@ -295,6 +454,28 @@ function Set-PodeOAGlobalAuth
     })
 }
 
+<#
+.SYNOPSIS
+Sets the definition of a request for a route.
+
+.DESCRIPTION
+Sets the definition of a request for a route.
+
+.PARAMETER Route
+The route to set a request definition, usually from -PassThru on Add-PodeRoute.
+
+.PARAMETER Parameters
+The Parameter definitions the request uses (from ConvertTo-PodeOAParameter).
+
+.PARAMETER RequestBody
+The Request Body definition the request uses (from New-PodeOARequestBody).
+
+.PARAMETER PassThru
+If supplied, the route passed in will be returned for further chaining.
+
+.EXAMPLE
+Add-PodeRoute -PassThru | Set-PodeOARequest -RequestBody (New-PodeOARequestBody -Reference 'UserIdBody')
+#>
 function Set-PodeOARequest
 {
     [CmdletBinding()]
@@ -326,6 +507,34 @@ function Set-PodeOARequest
     }
 }
 
+<#
+.SYNOPSIS
+Creates a Request Body definition for routes.
+
+.DESCRIPTION
+Creates a Request Body definition for routes from the supplied content-types and schemas.
+
+.PARAMETER Reference
+A reference name from an existing component request body.
+
+.PARAMETER ContentSchemas
+The content-types and schema the request body accepts (the schema is created using the Property functions).
+
+.PARAMETER Description
+A Description of the request body.
+
+.PARAMETER Required
+If supplied, the request body will be flagged as required.
+
+.EXAMPLE
+New-PodeOARequestBody -ContentSchemas @{ 'application/json' = (New-PodeOAIntProperty -Name 'userId' -Object) }
+
+.EXAMPLE
+New-PodeOARequestBody -ContentSchemas @{ 'application/json' = 'UserIdSchema' }
+
+.EXAMPLE
+New-PodeOARequestBody -Reference 'UserIdBody'
+#>
 function New-PodeOARequestBody
 {
     [CmdletBinding(DefaultParameterSetName='Schema')]
@@ -368,6 +577,22 @@ function New-PodeOARequestBody
     }
 }
 
+<#
+.SYNOPSIS
+Adds a reusable component for a request body.
+
+.DESCRIPTION
+Adds a reusable component for a request body.
+
+.PARAMETER Name
+The reference Name of the schema.
+
+.PARAMETER Schema
+The Schema definition (the schema is created using the Property functions).
+
+.EXAMPLE
+Add-PodeOAComponentSchema -Name 'UserIdSchema' -Schema (New-PodeOAIntProperty -Name 'userId' -Object)
+#>
 function Add-PodeOAComponentSchema
 {
     [CmdletBinding()]
@@ -384,6 +609,31 @@ function Add-PodeOAComponentSchema
     $PodeContext.Server.OpenAPI.components.schemas[$Name] = ($Schema | ConvertTo-PodeOASchemaProperty)
 }
 
+<#
+.SYNOPSIS
+Adds a reusable component for a request body.
+
+.DESCRIPTION
+Adds a reusable component for a request body.
+
+.PARAMETER Name
+The reference Name of the request body.
+
+.PARAMETER ContentSchemas
+The content-types and schema the request body accepts (the schema is created using the Property functions).
+
+.PARAMETER Description
+A Description of the request body.
+
+.PARAMETER Required
+If supplied, the request body will be flagged as required.
+
+.EXAMPLE
+Add-PodeOAComponentRequestBody -Name 'UserIdBody' -ContentSchemas @{ 'application/json' = (New-PodeOAIntProperty -Name 'userId' -Object) }
+
+.EXAMPLE
+Add-PodeOAComponentRequestBody -Name 'UserIdBody' -ContentSchemas @{ 'application/json' = 'UserIdSchema' }
+#>
 function Add-PodeOAComponentRequestBody
 {
     [CmdletBinding()]
@@ -412,6 +662,22 @@ function Add-PodeOAComponentRequestBody
     }
 }
 
+<#
+.SYNOPSIS
+Adds a reusable component for a request parameter.
+
+.DESCRIPTION
+Adds a reusable component for a request parameter.
+
+.PARAMETER Name
+The reference Name of the parameter.
+
+.PARAMETER Parameter
+The Parameter to use for the component (from ConvertTo-PodeOAParameter)
+
+.EXAMPLE
+New-PodeOAIntProperty -Name 'userId' | ConvertTo-PodeOAParameter -In Query | Add-PodeOAComponentParameter -Name 'UserIdParam'
+#>
 function Add-PodeOAComponentParameter
 {
     [CmdletBinding()]
@@ -432,6 +698,49 @@ function Add-PodeOAComponentParameter
     $PodeContext.Server.OpenAPI.components.responses[$Name] = $Parameter
 }
 
+<#
+.SYNOPSIS
+Creates a new OpenAPI integer property.
+
+.DESCRIPTION
+Creates a new OpenAPI integer property, for Schemas or Parameters.
+
+.PARAMETER Name
+The Name of the property.
+
+.PARAMETER Format
+The inbuilt OpenAPI Format of the integer. (Default: Any)
+
+.PARAMETER Default
+The default value of the property. (Default: 0)
+
+.PARAMETER Minimum
+The minimum value of the integer. (Default: Int.Min)
+
+.PARAMETER Maximum
+The maximum value of the integer. (Default: Int.Max)
+
+.PARAMETER MultiplesOf
+The integer must be in multiples of the supplied value.
+
+.PARAMETER Description
+A Description of the property.
+
+.PARAMETER Required
+If supplied, the object will be treated as Required where supported.
+
+.PARAMETER Deprecated
+If supplied, the object will be treated as Deprecated where supported.
+
+.PARAMETER Array
+If supplied, the integer will be treated as an array of integers.
+
+.PARAMETER Object
+If supplied, the integer will be automatically wrapped in an object.
+
+.EXAMPLE
+New-PodeOANumberProperty -Name 'age' -Required
+#>
 function New-PodeOAIntProperty
 {
     [CmdletBinding()]
@@ -505,6 +814,49 @@ function New-PodeOAIntProperty
     return $param
 }
 
+<#
+.SYNOPSIS
+Creates a new OpenAPI number property.
+
+.DESCRIPTION
+Creates a new OpenAPI number property, for Schemas or Parameters.
+
+.PARAMETER Name
+The Name of the property.
+
+.PARAMETER Format
+The inbuilt OpenAPI Format of the number. (Default: Any)
+
+.PARAMETER Default
+The default value of the property. (Default: 0)
+
+.PARAMETER Minimum
+The minimum value of the number. (Default: Double.Min)
+
+.PARAMETER Maximum
+The maximum value of the number. (Default: Double.Max)
+
+.PARAMETER MultiplesOf
+The number must be in multiples of the supplied value.
+
+.PARAMETER Description
+A Description of the property.
+
+.PARAMETER Required
+If supplied, the object will be treated as Required where supported.
+
+.PARAMETER Deprecated
+If supplied, the object will be treated as Deprecated where supported.
+
+.PARAMETER Array
+If supplied, the number will be treated as an array of numbers.
+
+.PARAMETER Object
+If supplied, the number will be automatically wrapped in an object.
+
+.EXAMPLE
+New-PodeOANumberProperty -Name 'gravity' -Default 9.8
+#>
 function New-PodeOANumberProperty
 {
     [CmdletBinding()]
@@ -545,7 +897,10 @@ function New-PodeOANumberProperty
         $Deprecated,
 
         [switch]
-        $Array
+        $Array,
+
+        [switch]
+        $Object
     )
 
     $param = @{
@@ -575,6 +930,55 @@ function New-PodeOANumberProperty
     return $param
 }
 
+<#
+.SYNOPSIS
+Creates a new OpenAPI string property.
+
+.DESCRIPTION
+Creates a new OpenAPI string property, for Schemas or Parameters.
+
+.PARAMETER Name
+The Name of the property.
+
+.PARAMETER Format
+The inbuilt OpenAPI Format of the string. (Default: Any)
+
+.PARAMETER CustomFormat
+The name of a custom OpenAPI Format of the string. (Default: None)
+
+.PARAMETER Default
+The default value of the property. (Default: $null)
+
+.PARAMETER MinLength
+The minimum length of the string. (Default: Int.Min)
+
+.PARAMETER MaxLength
+The maximum length of the string. (Default: Int.Max)
+
+.PARAMETER Pattern
+A Regex pattern that the string must match.
+
+.PARAMETER Description
+A Description of the property.
+
+.PARAMETER Required
+If supplied, the object will be treated as Required where supported.
+
+.PARAMETER Deprecated
+If supplied, the object will be treated as Deprecated where supported.
+
+.PARAMETER Array
+If supplied, the string will be treated as an array of strings.
+
+.PARAMETER Object
+If supplied, the string will be automatically wrapped in an object.
+
+.EXAMPLE
+New-PodeOAStringProperty -Name 'userType' -Default 'admin'
+
+.EXAMPLE
+New-PodeOAStringProperty -Name 'password' -Format Password
+#>
 function New-PodeOAStringProperty
 {
     [CmdletBinding(DefaultParameterSetName='Inbuilt')]
@@ -619,7 +1023,10 @@ function New-PodeOAStringProperty
         $Deprecated,
 
         [switch]
-        $Array
+        $Array,
+
+        [switch]
+        $Object
     )
 
     $_format = $Format
@@ -651,6 +1058,37 @@ function New-PodeOAStringProperty
     return $param
 }
 
+<#
+.SYNOPSIS
+Creates a new OpenAPI boolean property.
+
+.DESCRIPTION
+Creates a new OpenAPI boolean property, for Schemas or Parameters.
+
+.PARAMETER Name
+The Name of the property.
+
+.PARAMETER Default
+The default value of the property. (Default: $false)
+
+.PARAMETER Description
+A Description of the property.
+
+.PARAMETER Required
+If supplied, the object will be treated as Required where supported.
+
+.PARAMETER Deprecated
+If supplied, the object will be treated as Deprecated where supported.
+
+.PARAMETER Array
+If supplied, the boolean will be treated as an array of booleans.
+
+.PARAMETER Object
+If supplied, the boolean will be automatically wrapped in an object.
+
+.EXAMPLE
+New-PodeOABoolProperty -Name 'enabled' -Required
+#>
 function New-PodeOABoolProperty
 {
     [CmdletBinding()]
@@ -674,7 +1112,10 @@ function New-PodeOABoolProperty
         $Deprecated,
 
         [switch]
-        $Array
+        $Array,
+
+        [switch]
+        $Object
     )
 
     $param = @{
@@ -691,6 +1132,34 @@ function New-PodeOABoolProperty
     return $param
 }
 
+<#
+.SYNOPSIS
+Creates a new OpenAPI object property from other properties.
+
+.DESCRIPTION
+Creates a new OpenAPI object property from other properties, for Schemas or Parameters.
+
+.PARAMETER Name
+The Name of the property.
+
+.PARAMETER Properties
+An array of other int/string/etc properties wrap up as an object.
+
+.PARAMETER Description
+A Description of the property.
+
+.PARAMETER Required
+If supplied, the object will be treated as Required where supported.
+
+.PARAMETER Deprecated
+If supplied, the object will be treated as Deprecated where supported.
+
+.PARAMETER Array
+If supplied, the object will be treated as an array of objects.
+
+.EXAMPLE
+New-PodeOAObjectProperty -Name 'user' -Properties @('<ARRAY_OF_PROPERTIES>')
+#>
 function New-PodeOAObjectProperty
 {
     [CmdletBinding()]
@@ -731,6 +1200,28 @@ function New-PodeOAObjectProperty
     return $param
 }
 
+<#
+.SYNOPSIS
+Converts an OpenAPI property into a Request Parameter.
+
+.DESCRIPTION
+Converts an OpenAPI property (such as from New-PodeOAIntProperty) into a Request Parameter.
+
+.PARAMETER In
+Where in the Request can the parameter be found?
+
+.PARAMETER Property
+The Property that need converting (such as from New-PodeOAIntProperty).
+
+.PARAMETER Reference
+The name of an existing component parameter to be reused.
+
+.EXAMPLE
+New-PodeOAIntProperty -Name 'userId' | ConvertTo-PodeOAParameter -In Query
+
+.EXAMPLE
+ConvertTo-PodeOAParameter -Reference 'UserIdParam'
+#>
 function ConvertTo-PodeOAParameter
 {
     [CmdletBinding(DefaultParameterSetName='Reference')]
@@ -787,6 +1278,34 @@ function ConvertTo-PodeOAParameter
     return $prop
 }
 
+<#
+.SYNOPSIS
+Sets metadate for the supplied route.
+
+.DESCRIPTION
+Sets metadate for the supplied route, such as Summary and Tags.
+
+.PARAMETER Route
+The route to update info, usually from -PassThru on Add-PodeRoute.
+
+.PARAMETER Summary
+A quick Summary of the route.
+
+.PARAMETER Description
+A longer Description of the route.
+
+.PARAMETER Tags
+An array of Tags for the route, mostly for grouping.
+
+.PARAMETER Deprecated
+If supplied, the route will be flagged as deprecated.
+
+.PARAMETER PassThru
+If supplied, the route passed in will be returned for further chaining.
+
+.EXAMPLE
+Add-PodeRoute -PassThru | Set-PodeOARouteInfo -Summary 'A quick summary' -Tags 'Admin'
+#>
 function Set-PodeOARouteInfo
 {
     [CmdletBinding()]
@@ -827,6 +1346,34 @@ function Set-PodeOARouteInfo
     }
 }
 
+<#
+.SYNOPSIS
+Adds a route that enables Swagger to be used.
+
+.DESCRIPTION
+Adds a route that enables Swagger to be used to view some OpenAPI definition.
+
+.PARAMETER Path
+The route Path where Swagger can be accessed. (Default: /swagger)
+
+.PARAMETER OpenApi
+The URL where the OpenAPI definition can be retrieved. (Default is the OpenAPI path from Enable-PodeOpenApi)
+
+.PARAMETER Middleware
+Like normal Routes, an array of Middleware that will be applied.
+
+.PARAMETER Title
+The title of the Swagger web page.
+
+.PARAMETER DarkMode
+If supplied, Swagger be be rendered using a dark theme.
+
+.EXAMPLE
+Enable-PodeSwagger
+
+.EXAMPLE
+Enable-PodeSwagger -Title 'Some Title' -OpenApi 'http://some-url/openapi'
+#>
 function Enable-PodeSwagger
 {
     [CmdletBinding()]
@@ -884,6 +1431,31 @@ function Enable-PodeSwagger
     }
 }
 
+<#
+.SYNOPSIS
+Adds a route that enables ReDoc to be used.
+
+.DESCRIPTION
+Adds a route that enables ReDoc to be used to view some OpenAPI definition.
+
+.PARAMETER Path
+The route Path where ReDoc can be accessed. (Default: /redoc)
+
+.PARAMETER OpenApi
+The URL where the OpenAPI definition can be retrieved. (Default is the OpenAPI path from Enable-PodeOpenApi)
+
+.PARAMETER Middleware
+Like normal Routes, an array of Middleware that will be applied.
+
+.PARAMETER Title
+The title of the ReDoc web page.
+
+.EXAMPLE
+Enable-PodeReDoc
+
+.EXAMPLE
+Enable-PodeReDoc -Title 'Some Title' -OpenApi 'http://some-url/openapi'
+#>
 function Enable-PodeReDoc
 {
     [CmdletBinding()]

--- a/src/Public/OpenApi.ps1
+++ b/src/Public/OpenApi.ps1
@@ -8,11 +8,6 @@ function Enable-PodeOpenApi
         $Path = '/openapi',
 
         [Parameter()]
-        [ValidateNotNullOrEmpty()]
-        [string]
-        $SwaggerPath = '/swagger',
-
-        [Parameter()]
         [string]
         $Route = '/',
 
@@ -379,13 +374,13 @@ function Add-PodeOAComponentParameter
 {
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
-        [hashtable]
-        $Parameter,
-
         [Parameter()]
         [string]
-        $Name
+        $Name,
+
+        [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
+        [hashtable]
+        $Parameter
     )
 
     if ([string]::IsNullOrWhiteSpace($Name)) {
@@ -801,7 +796,7 @@ function Enable-PodeSwagger
 
         [Parameter()]
         [string]
-        $OpenApiPath,
+        $OpenApi,
 
         [Parameter()]
         [object[]]
@@ -816,8 +811,8 @@ function Enable-PodeSwagger
     )
 
     # error if there's no OpenAPI path
-    $OpenApiPath = Protect-PodeValue -Value $OpenApiPath -Default $PodeContext.Server.OpenAPI.Path
-    if ([string]::IsNullOrWhiteSpace($OpenApiPath)) {
+    $OpenApi = Protect-PodeValue -Value $OpenApi -Default $PodeContext.Server.OpenAPI.Path
+    if ([string]::IsNullOrWhiteSpace($OpenApi)) {
         throw "No OpenAPI path supplied for Swagger to use"
     }
 
@@ -833,7 +828,7 @@ function Enable-PodeSwagger
         $podeRoot = Get-PodeModuleMiscPath
         Write-PodeFileResponse -Path (Join-Path $podeRoot 'default-swagger.html.pode') -Data @{
             Title = $PodeContext.Server.OpenAPI.Title
-            OpenApiPath = $PodeContext.Server.OpenAPI.Path
+            OpenApi = $PodeContext.Server.OpenAPI.Path
             DarkMode = $meta.DarkMode
         }
     }
@@ -850,7 +845,7 @@ function Enable-PodeReDoc
 
         [Parameter()]
         [string]
-        $OpenApiPath,
+        $OpenApi,
 
         [Parameter()]
         [object[]]
@@ -862,8 +857,8 @@ function Enable-PodeReDoc
     )
 
     # error if there's no OpenAPI path
-    $OpenApiPath = Protect-PodeValue -Value $OpenApiPath -Default $PodeContext.Server.OpenAPI.Path
-    if ([string]::IsNullOrWhiteSpace($OpenApiPath)) {
+    $OpenApi = Protect-PodeValue -Value $OpenApi -Default $PodeContext.Server.OpenAPI.Path
+    if ([string]::IsNullOrWhiteSpace($OpenApi)) {
         throw "No OpenAPI path supplied for ReDoc to use"
     }
 
@@ -879,7 +874,7 @@ function Enable-PodeReDoc
         $podeRoot = Get-PodeModuleMiscPath
         Write-PodeFileResponse -Path (Join-Path $podeRoot 'default-redoc.html.pode') -Data @{
             Title = $PodeContext.Server.OpenAPI.Title
-            OpenApiPath = $PodeContext.Server.OpenAPI.Path
+            OpenApi = $PodeContext.Server.OpenAPI.Path
         }
     }
 }

--- a/src/Public/OpenApi.ps1
+++ b/src/Public/OpenApi.ps1
@@ -60,30 +60,320 @@ function Enable-PodeOpenApiRoute
 
         # paths
         $def['paths'] = @{}
+        $filter = "^$($meta.Filter)"
+
         foreach ($method in $PodeContext.Server.Routes.Keys) {
             foreach ($path in $PodeContext.Server.Routes[$method].Keys) {
                 # does it match the filter?
-                if ($path -inotmatch "^$($meta.Filter)") {
+                if ($path -inotmatch $filter) {
                     continue
                 }
 
-                # do nothing if it has no response set
+                # the current route
+                $route = $PodeContext.Server.Routes[$method][$path]
+
+                # do nothing if it has no responses set
+                if ($route.OpenApi.Responses.Count -eq 0) {
+                    continue
+                }
 
                 # add path to defintion
-                $def['paths'][$path] = @{
-                    "$($method)" = @{
-                        'responses' = @{
-                            '200' = @{
-                                'description' = 'OK'
-                            }
-                        }
-                    }
+                if ($null -eq $def['paths'][$route.OpenApi.Path]) {
+                    $def['paths'][$route.OpenApi.Path] = @{}
+                }
+
+                # add path's http method to defintition
+                $def['paths'][$route.OpenApi.Path][$method] = @{
+                    summary = $route.OpenApi.Summary
+                    description = $route.OpenApi.Description
+                    tags = @($route.OpenApi.Tags)
+                    deprecated = $route.OpenApi.Deprecated
+                    responses = $route.OpenApi.Responses
+                    parameters = $route.OpenApi.Parameters
                 }
             }
         }
 
         # write
         Write-PodeJsonResponse -Value $def
+    }
+}
+
+function Add-PodeOpenApiRouteResponse
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [hashtable[]]
+        $Route,
+
+        [Parameter(Mandatory=$true)]
+        [int]
+        $StatusCode,
+
+        [Parameter()]
+        [string]
+        $Description,
+
+        [switch]
+        $PassThru
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Description)) {
+        $Description = Get-PodeStatusDescription -StatusCode $StatusCode
+    }
+
+    foreach ($r in @($Route)) {
+        $r.OpenApi.Responses["$($StatusCode)"] = @{
+            description = $Description
+        }
+    }
+
+    if ($PassThru) {
+        return $Route
+    }
+}
+
+function Set-PodeOpenApiRouteRequest
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [hashtable[]]
+        $Route,
+
+        [Parameter()]
+        [hashtable[]]
+        $Parameters,
+
+        [switch]
+        $PassThru
+    )
+
+    foreach ($r in @($Route)) {
+        $r.OpenApi.Parameters = @($Parameters)
+    }
+
+    if ($PassThru) {
+        return $Route
+    }
+}
+
+function Add-PodeOpenApiComponentSchema
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Name,
+
+        [Parameter(Mandatory=$true)]
+        [hashtable[]]
+        $Properties
+    )
+
+    $PodeContext.Server.OpenAPI.components.schemas[$Name] = @{
+        type = 'object'
+        properties = (ConvertFrom-PodeOpenApiComponentSchemaProperties -Properties $Properties)
+    }
+}
+
+function New-PodeOpenApiSchemaProperty
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Name,
+
+        [Parameter(ParameterSetName='String')]
+        [switch]
+        $String,
+
+        [Parameter(ParameterSetName='Integer')]
+        [switch]
+        $Integer,
+
+        [Parameter(ParameterSetName='Boolean')]
+        [switch]
+        $Boolean,
+
+        [Parameter(ParameterSetName='String')]
+        [Parameter(ParameterSetName='Integer')]
+        [ValidateSet('', 'Binary', 'Byte', 'Date', 'DateTime', 'Int32', 'Int64', 'Time', 'Uuid')]
+        $Format,
+
+        [Parameter()]
+        [object]
+        $Example,
+
+        [Parameter()]
+        [string]
+        $Description,
+
+        [switch]
+        $Required
+    )
+
+    # base property object
+    $prop = @{
+        name = $Name
+        required = $Required.IsPresent
+        description = $Description
+        type = $PSCmdlet.ParameterSetName.ToLowerInvariant()
+    }
+
+    # add enums if supplied
+    if ($null -ne $Example) {
+        $prop['example'] = $Example
+    }
+
+    # add format if supplied
+    if (!$Boolean -and !(Test-IsEmpty $Format)) {
+        $prop['format'] = $Format
+    }
+
+    return $prop
+}
+
+function New-PodeOpenApiRouteRequestParameter
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Name,
+
+        [Parameter(Mandatory=$true)]
+        [ValidateSet('Cookie', 'Header', 'Path', 'Query')]
+        [string]
+        $In,
+
+        [Parameter(ParameterSetName='String')]
+        [switch]
+        $String,
+
+        [Parameter(ParameterSetName='Integer')]
+        [switch]
+        $Integer,
+
+        [Parameter(ParameterSetName='Boolean')]
+        [switch]
+        $Boolean,
+
+        [Parameter(ParameterSetName='String')]
+        [Parameter(ParameterSetName='Integer')]
+        [ValidateSet('', 'Binary', 'Byte', 'Date', 'DateTime', 'Int32', 'Int64', 'Time', 'Uuid')]
+        $Format,
+
+        [Parameter(ParameterSetName='String')]
+        [Parameter(ParameterSetName='Integer')]
+        [object[]]
+        $Enum,
+
+        [Parameter()]
+        [object]
+        $Default,
+
+        [Parameter(ParameterSetName='Integer')]
+        [int]
+        $Minimum = [int]::MinValue,
+
+        [Parameter(ParameterSetName='Integer')]
+        [int]
+        $Maximum = [int]::MaxValue,
+
+        [Parameter()]
+        [string]
+        $Description,
+
+        [switch]
+        $Required,
+
+        [switch]
+        $Deprecated
+    )
+
+    # base parameter object
+    $param = @{
+        name = $Name
+        in = $In
+        required = $Required.IsPresent
+        deprecated = $Deprecated.IsPresent
+        description = $Description
+        schema = @{
+            type = $PSCmdlet.ParameterSetName.ToLowerInvariant()
+        }
+    }
+
+    # add enums if supplied
+    if (!$Boolean -and !(Test-IsEmpty $Enum)) {
+        $param.schema['enum'] = @($Enum)
+    }
+
+    # add format if supplied
+    if (!$Boolean -and !(Test-IsEmpty $Format)) {
+        $param.schema['format'] = $Format
+    }
+
+    # add default if supplied
+    if ($null -ne $Default) {
+        $param.schema['default'] = $Default
+    }
+
+    # add int minimum/maximum
+    if ($Integer) {
+        if ($Minimum -ne [int]::MinValue) {
+            $param.schema['minimum'] = $Minimum
+        }
+
+        if ($Maximum -ne [int]::MaxValue) {
+            $param.schema['maximum'] = $Maximum
+        }
+    }
+
+    return $param
+}
+
+function Set-PodeOpenApiRouteMetaData
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [hashtable[]]
+        $Route,
+
+        [Parameter()]
+        [string]
+        $Summary,
+
+        [Parameter()]
+        [string]
+        $Description,
+
+        [Parameter()]
+        [string[]]
+        $Tags,
+
+        [switch]
+        $Deprecated,
+
+        [switch]
+        $PassThru
+    )
+
+    foreach ($r in @($Route)) {
+        $r.OpenApi.Summary = $Summary
+        $r.OpenApi.Description = $Description
+        $r.OpenApi.Tags = $Tags
+        $r.OpenApi.Deprecated = $Deprecated.IsPresent
+    }
+
+    if ($PassThru) {
+        return $Route
     }
 }
 

--- a/src/Public/OpenApi.ps1
+++ b/src/Public/OpenApi.ps1
@@ -32,6 +32,7 @@ function Enable-PodeOpenApi
     )
 
     # initialise openapi info
+    $PodeContext.Server.OpenAPI.Enabled = $true
     $PodeContext.Server.OpenAPI.Title = $Title
     $PodeContext.Server.OpenAPI.Path = $Path
 

--- a/src/Public/OpenApi.ps1
+++ b/src/Public/OpenApi.ps1
@@ -413,6 +413,18 @@ function New-PodeOAIntProperty
         $Default = 0,
 
         [Parameter()]
+        [int]
+        $Minimum = [int]::MinValue,
+
+        [Parameter()]
+        [int]
+        $Maximum = [int]::MaxValue,
+
+        [Parameter()]
+        [int]
+        $MultiplesOf = 0,
+
+        [Parameter()]
         [string]
         $Description,
 
@@ -441,6 +453,18 @@ function New-PodeOAIntProperty
         default = $Default
     }
 
+    if ($Minimum -ne [int]::MinValue) {
+        $param['minimum'] = $Minimum
+    }
+
+    if ($Maximum -ne [int]::MaxValue) {
+        $param['maximum'] = $Maximum
+    }
+
+    if ($MultiplesOf -ne 0) {
+        $param['multipleOf'] = $MultiplesOf
+    }
+
     return $param
 }
 
@@ -460,6 +484,18 @@ function New-PodeOANumberProperty
         [Parameter()]
         [double]
         $Default = 0,
+
+        [Parameter()]
+        [double]
+        $Minimum = [double]::MinValue,
+
+        [Parameter()]
+        [double]
+        $Maximum = [double]::MaxValue,
+
+        [Parameter()]
+        [double]
+        $MultiplesOf = 0,
 
         [Parameter()]
         [string]
@@ -487,25 +523,53 @@ function New-PodeOANumberProperty
         default = $Default
     }
 
+    if ($Minimum -ne [double]::MinValue) {
+        $param['minimum'] = $Minimum
+    }
+
+    if ($Maximum -ne [double]::MaxValue) {
+        $param['maximum'] = $Maximum
+    }
+
+    if ($MultiplesOf -ne 0) {
+        $param['multipleOf'] = $MultiplesOf
+    }
+
     return $param
 }
 
 function New-PodeOAStringProperty
 {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName='Inbuilt')]
     param(
         [Parameter()]
         [string]
         $Name,
 
-        [Parameter()]
-        [ValidateSet('', 'Base64', 'Binary', 'Byte', 'Date', 'Date-Time', 'Email', 'Password', 'Time', 'Uuid', 'Zip-Code')]
+        [Parameter(ParameterSetName='Inbuilt')]
+        [ValidateSet('', 'Binary', 'Byte', 'Date', 'Date-Time', 'Password')]
         [string]
         $Format,
+
+        [Parameter(ParameterSetName='Custom')]
+        [string]
+        $CustomFormat,
 
         [Parameter()]
         [string]
         $Default = $null,
+
+        [Parameter()]
+        [int]
+        $MinLength = [int]::MinValue,
+
+        [Parameter()]
+        [int]
+        $MaxLength = [int]::MaxValue,
+
+        [Parameter()]
+        [string]
+        $Pattern = $null,
 
         [Parameter()]
         [string]
@@ -521,6 +585,11 @@ function New-PodeOAStringProperty
         $Array
     )
 
+    $_format = $Format
+    if (![string]::IsNullOrWhiteSpace($CustomFormat)) {
+        $_format = $CustomFormat
+    }
+
     $param = @{
         name = $Name
         type = 'string'
@@ -529,8 +598,17 @@ function New-PodeOAStringProperty
         required = $Required.IsPresent
         deprecated = $Deprecated.IsPresent
         description = $Description
-        format = $Format.ToLowerInvariant()
+        format = $_format.ToLowerInvariant()
+        pattern = $Pattern
         default = $Default
+    }
+
+    if ($MinLength -ne [int]::MinValue) {
+        $param['minLength'] = $MinLength
+    }
+
+    if ($MaxLength -ne [int]::MaxValue) {
+        $param['maxLength'] = $MaxLength
     }
 
     return $param

--- a/src/Public/Responses.ps1
+++ b/src/Public/Responses.ps1
@@ -31,7 +31,7 @@ function Set-PodeResponseAttachment
 {
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
         [string]
         $Path,
 
@@ -146,7 +146,7 @@ function Write-PodeTextResponse
 {
     [CmdletBinding(DefaultParameterSetName='String')]
     param (
-        [Parameter(ParameterSetName='String')]
+        [Parameter(ParameterSetName='String', ValueFromPipeline=$true)]
         [string]
         $Value,
 
@@ -294,7 +294,7 @@ function Write-PodeFileResponse
 {
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
         [ValidateNotNull()]
         [string]
         $Path,
@@ -384,7 +384,7 @@ function Write-PodeCsvResponse
 {
     [CmdletBinding(DefaultParameterSetName='Value')]
     param (
-        [Parameter(Mandatory=$true, ParameterSetName='Value')]
+        [Parameter(Mandatory=$true, ParameterSetName='Value', ValueFromPipeline=$true)]
         $Value,
 
         [Parameter(Mandatory=$true, ParameterSetName='File')]
@@ -457,7 +457,7 @@ function Write-PodeHtmlResponse
 {
     [CmdletBinding(DefaultParameterSetName='Value')]
     param (
-        [Parameter(Mandatory=$true, ParameterSetName='Value')]
+        [Parameter(Mandatory=$true, ParameterSetName='Value', ValueFromPipeline=$true)]
         $Value,
 
         [Parameter(Mandatory=$true, ParameterSetName='File')]
@@ -520,7 +520,7 @@ function Write-PodeMarkdownResponse
 {
     [CmdletBinding(DefaultParameterSetName='Value')]
     param (
-        [Parameter(Mandatory=$true, ParameterSetName='Value')]
+        [Parameter(Mandatory=$true, ParameterSetName='Value', ValueFromPipeline=$true)]
         $Value,
 
         [Parameter(Mandatory=$true, ParameterSetName='File')]
@@ -591,7 +591,7 @@ function Write-PodeJsonResponse
 {
     [CmdletBinding(DefaultParameterSetName='Value')]
     param (
-        [Parameter(Mandatory=$true, ParameterSetName='Value')]
+        [Parameter(Mandatory=$true, ParameterSetName='Value', ValueFromPipeline=$true)]
         $Value,
 
         [Parameter(Mandatory=$true, ParameterSetName='File')]
@@ -662,7 +662,7 @@ function Write-PodeXmlResponse
 {
     [CmdletBinding(DefaultParameterSetName='Value')]
     param (
-        [Parameter(Mandatory=$true, ParameterSetName='Value')]
+        [Parameter(Mandatory=$true, ParameterSetName='Value', ValueFromPipeline=$true)]
         $Value,
 
         [Parameter(Mandatory=$true, ParameterSetName='File')]
@@ -731,7 +731,7 @@ function Write-PodeViewResponse
 {
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
         [string]
         $Path,
 
@@ -987,7 +987,7 @@ function Write-PodeTcpClient
 {
     [CmdletBinding()]
     param (
-        [Parameter()]
+        [Parameter(ValueFromPipeline=$true)]
         [string]
         $Message,
 
@@ -1182,7 +1182,7 @@ function Use-PodePartialView
     [CmdletBinding()]
     [OutputType([string])]
     param (
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
         [string]
         $Path,
 

--- a/src/Public/Routes.ps1
+++ b/src/Public/Routes.ps1
@@ -101,7 +101,10 @@ function Add-PodeRoute
 
         [Parameter()]
         [object[]]
-        $ArgumentList
+        $ArgumentList,
+
+        [switch]
+        $PassThru
     )
 
     # split route on '?' for query
@@ -182,10 +185,10 @@ function Add-PodeRoute
         }
     }
 
-    # add the route
+    # add the route(s)
     Write-Verbose "Adding Route: [$($Method)] $($Path)"
-    foreach ($_endpoint in $endpoints) {
-        $PodeContext.Server.Routes[$Method][$Path] += @(@{
+    $newRoutes = @(foreach ($_endpoint in $endpoints) {
+        @{
             Logic = $ScriptBlock
             Middleware = $Middleware
             Protocol = $_endpoint.Protocol
@@ -193,7 +196,14 @@ function Add-PodeRoute
             ContentType = $ContentType
             ErrorType = $ErrorContentType
             Arguments = $ArgumentList
-        })
+        }
+    })
+
+    $PodeContext.Server.Routes[$Method][$Path] += @($newRoutes)
+
+    # return the routes?
+    if ($PassThru) {
+        return $newRoutes
     }
 }
 

--- a/src/Public/Routes.ps1
+++ b/src/Public/Routes.ps1
@@ -203,6 +203,7 @@ function Add-PodeRoute
                 Responses = @{}
                 Parameters = @()
                 RequestBody = @{}
+                Authentication = @()
             }
         }
     })

--- a/src/Public/Routes.ps1
+++ b/src/Public/Routes.ps1
@@ -194,6 +194,7 @@ function Add-PodeRoute
             Middleware = $Middleware
             Protocol = $_endpoint.Protocol
             Endpoint = $_endpoint.Address.Trim()
+            EndpointName = @($EndpointName)
             ContentType = $ContentType
             ErrorType = $ErrorContentType
             Arguments = $ArgumentList

--- a/src/Public/Routes.ps1
+++ b/src/Public/Routes.ps1
@@ -115,6 +115,7 @@ function Add-PodeRoute
 
     # ensure the route has appropriate slashes
     $Path = Update-PodeRouteSlashes -Path $Path
+    $OpenApiPath = ConvertTo-PodeOpenApiRoutePath -Path $Path
     $Path = Update-PodeRoutePlaceholders -Path $Path
 
     # get endpoints from name, or use single passed endpoint/protocol
@@ -196,6 +197,12 @@ function Add-PodeRoute
             ContentType = $ContentType
             ErrorType = $ErrorContentType
             Arguments = $ArgumentList
+            OpenApi = @{
+                Path = $OpenApiPath
+                Responses = @{}
+                Parameters = @()
+                RequestBody = @{}
+            }
         }
     })
 

--- a/src/Public/Routes.ps1
+++ b/src/Public/Routes.ps1
@@ -200,7 +200,10 @@ function Add-PodeRoute
             Arguments = $ArgumentList
             OpenApi = @{
                 Path = $OpenApiPath
-                Responses = @{}
+                Responses = @{
+                    '200' = @{ description = 'OK' }
+                    'default' = @{ description = 'Internal server error' }
+                }
                 Parameters = @()
                 RequestBody = @{}
                 Authentication = @()

--- a/tests/unit/Context.Tests.ps1
+++ b/tests/unit/Context.Tests.ps1
@@ -32,7 +32,7 @@ Describe 'Add-PodeEndpoint' {
             $PodeContext.Server.Type | Should Be 'HTTP'
             $PodeContext.Server.Endpoints | Should Not Be $null
             $PodeContext.Server.Endpoints.Length | Should Be 1
-            $PodeContext.Server.Endpoints[0].Port | Should Be 0
+            $PodeContext.Server.Endpoints[0].Port | Should Be 8080
             $PodeContext.Server.Endpoints[0].Name | Should Be ([string]::Empty)
             $PodeContext.Server.Endpoints[0].HostName | Should Be 'foo.com'
             $PodeContext.Server.Endpoints[0].Address.ToString() | Should Be 'foo.com'
@@ -46,7 +46,7 @@ Describe 'Add-PodeEndpoint' {
             $PodeContext.Server.Type | Should Be 'HTTP'
             $PodeContext.Server.Endpoints | Should Not Be $null
             $PodeContext.Server.Endpoints.Length | Should Be 1
-            $PodeContext.Server.Endpoints[0].Port | Should Be 0
+            $PodeContext.Server.Endpoints[0].Port | Should Be 8080
             $PodeContext.Server.Endpoints[0].Name | Should Be 'Example'
             $PodeContext.Server.Endpoints[0].HostName | Should Be 'foo.com'
             $PodeContext.Server.Endpoints[0].Address.ToString() | Should Be 'foo.com'
@@ -59,7 +59,7 @@ Describe 'Add-PodeEndpoint' {
             $PodeContext.Server.Type | Should Be 'HTTP'
             $PodeContext.Server.Endpoints | Should Not Be $null
             $PodeContext.Server.Endpoints.Length | Should Be 1
-            $PodeContext.Server.Endpoints[0].Port | Should Be 0
+            $PodeContext.Server.Endpoints[0].Port | Should Be 8080
             $PodeContext.Server.Endpoints[0].HostName | Should Be 'foo.com'
             $PodeContext.Server.Endpoints[0].Address.ToString() | Should Be 'foo.com'
             $PodeContext.Server.Endpoints[0].RawAddress | Should Be 'foo.com:0'
@@ -84,7 +84,7 @@ Describe 'Add-PodeEndpoint' {
             $PodeContext.Server.Type | Should Be 'HTTP'
             $PodeContext.Server.Endpoints | Should Not Be $null
             $PodeContext.Server.Endpoints.Length | Should Be 1
-            $PodeContext.Server.Endpoints[0].Port | Should Be 0
+            $PodeContext.Server.Endpoints[0].Port | Should Be 8080
             $PodeContext.Server.Endpoints[0].HostName | Should Be 'localhost'
             $PodeContext.Server.Endpoints[0].Address.ToString() | Should Be '127.0.0.1'
         }
@@ -96,7 +96,7 @@ Describe 'Add-PodeEndpoint' {
             $PodeContext.Server.Type | Should Be 'HTTP'
             $PodeContext.Server.Endpoints | Should Not Be $null
             $PodeContext.Server.Endpoints.Length | Should Be 1
-            $PodeContext.Server.Endpoints[0].Port | Should Be 0
+            $PodeContext.Server.Endpoints[0].Port | Should Be 8080
             $PodeContext.Server.Endpoints[0].HostName | Should Be 'localhost'
             $PodeContext.Server.Endpoints[0].Address.ToString() | Should Be '0.0.0.0'
             $PodeContext.Server.Endpoints[0].RawAddress | Should Be 'all:0'
@@ -109,7 +109,7 @@ Describe 'Add-PodeEndpoint' {
             $PodeContext.Server.Type | Should Be 'HTTP'
             $PodeContext.Server.Endpoints | Should Not Be $null
             $PodeContext.Server.Endpoints.Length | Should Be 1
-            $PodeContext.Server.Endpoints[0].Port | Should Be 0
+            $PodeContext.Server.Endpoints[0].Port | Should Be 8080
             $PodeContext.Server.Endpoints[0].HostName | Should Be 'localhost'
             $PodeContext.Server.Endpoints[0].Address.ToString() | Should Be '127.0.0.1'
         }

--- a/tests/unit/Helpers.Tests.ps1
+++ b/tests/unit/Helpers.Tests.ps1
@@ -1407,3 +1407,48 @@ Describe 'Out-PodeHost' {
         Assert-MockCalled Out-Default -Scope It -Times 1
     }
 }
+
+Describe 'Remove-PodeNullKeysFromHashtable' {
+    It 'Removes all null values keys' {
+        $ht = @{
+            Value1 = $null
+            Value2 = @{
+                Value3 = @()
+                Value4 = $null
+            }
+        }
+
+        $ht | Remove-PodeNullKeysFromHashtable
+
+        $ht.ContainsKey('Value1') | Should Be $false
+        $ht.ContainsKey('Value2') | Should Be $true
+        $ht.Value2.ContainsKey('Value3') | Should Be $true
+        $ht.Value2.ContainsKey('Value4') | Should Be $false
+    }
+}
+
+Describe 'Get-PodeDefaultPort' {
+    It 'Returns default port for http' {
+        Get-PodeDefaultPort -Protocol Http | Should Be 8080
+    }
+
+    It 'Returns default port for https' {
+        Get-PodeDefaultPort -Protocol Https | Should Be 8443
+    }
+
+    It 'Returns default port for smtp' {
+        Get-PodeDefaultPort -Protocol Smtp | Should Be 25
+    }
+
+    It 'Returns default port for tcp' {
+        Get-PodeDefaultPort -Protocol Tcp | Should Be 9001
+    }
+
+    It 'Returns default port for ws' {
+        Get-PodeDefaultPort -Protocol Ws | Should Be 9080
+    }
+
+    It 'Returns default port for wss' {
+        Get-PodeDefaultPort -Protocol Wss | Should Be 9443
+    }
+}

--- a/tests/unit/Helpers.Tests.ps1
+++ b/tests/unit/Helpers.Tests.ps1
@@ -1223,9 +1223,9 @@ Describe 'Get-PodeEndpointUrl' {
     It 'Returns default endpoint url' {
         $PodeContext = @{ Server = @{
             Endpoints = @(@{
-                Ssl = $true
                 Port = 6000
                 Hostname = 'thing.com'
+                Protocol = 'https'
             })
         } }
 
@@ -1234,9 +1234,9 @@ Describe 'Get-PodeEndpointUrl' {
 
     It 'Returns a passed endpoint url' {
         $endpoint = @{
-            Ssl = $false
             Port = 7000
             Hostname = 'stuff.com'
+            Protocol = 'http'
         }
 
         Get-PodeEndpointUrl -Endpoint $endpoint | Should Be 'http://stuff.com:7000'
@@ -1244,9 +1244,9 @@ Describe 'Get-PodeEndpointUrl' {
 
     It 'Returns a passed endpoint url, with default port for http' {
         $endpoint = @{
-            Ssl = $false
-            Port = 0
+            Port = 8080
             Hostname = 'stuff.com'
+            Protocol = 'http'
         }
 
         Get-PodeEndpointUrl -Endpoint $endpoint | Should Be 'http://stuff.com:8080'
@@ -1254,9 +1254,17 @@ Describe 'Get-PodeEndpointUrl' {
 
     It 'Returns a passed endpoint url, with default port for https' {
         $endpoint = @{
-            Ssl = $true
-            Port = 0
+            Port = 8443
             Hostname = 'stuff.com'
+            Protocol = 'https'
+        }
+
+        Get-PodeEndpointUrl -Endpoint $endpoint | Should Be 'https://stuff.com:8443'
+    }
+
+    It 'Returns a passed endpoint url, using raw url' {
+        $endpoint = @{
+            Url = 'https://stuff.com:8443'
         }
 
         Get-PodeEndpointUrl -Endpoint $endpoint | Should Be 'https://stuff.com:8443'

--- a/tests/unit/Routes.Tests.ps1
+++ b/tests/unit/Routes.Tests.ps1
@@ -707,17 +707,17 @@ Describe 'ConvertTo-PodeRoute' {
     }
 
     It 'Calls Add-PodeRoute twice for commands' {
-        ConvertTo-PodeRoute -Commands @('Get-ChildItem', 'Invoke-Expression')
+        ConvertTo-PodeRoute -Commands @('Get-ChildItem', 'Invoke-Expression') -NoOpenApi
         Assert-MockCalled Add-PodeRoute -Times 2 -Scope It
     }
 
     It 'Calls Add-PodeRoute twice for module commands' {
-        ConvertTo-PodeRoute -Module Example
+        ConvertTo-PodeRoute -Module Example -NoOpenApi
         Assert-MockCalled Add-PodeRoute -Times 2 -Scope It
     }
 
     It 'Calls Add-PodeRoute once for module filtered commands' {
-        ConvertTo-PodeRoute -Module Example -Commands 'Some-ModuleCommand1'
+        ConvertTo-PodeRoute -Module Example -Commands 'Some-ModuleCommand1' -NoOpenApi
         Assert-MockCalled Add-PodeRoute -Times 1 -Scope It
     }
 }

--- a/tests/unit/Server.Tests.ps1
+++ b/tests/unit/Server.Tests.ps1
@@ -143,6 +143,7 @@ Describe 'Restart-PodeInternalServer' {
                         Connections = [System.Collections.Concurrent.ConcurrentQueue[System.Net.Sockets.SocketAsyncEventArgs]]::new()
                     }
                 }
+                OpenAPI = @{}
                 BodyParsers = @{}
             };
             Timers = @{ 'key' = 'value' }


### PR DESCRIPTION
### Description of the Change
Adds support for generating OpenAPI definitions for Swagger/ReDoc. This is done through a combination of turning internal objects into an OpenAPI definition, and by using new OpenAPI functions.

The new functions can be used to create new objects (properties, responses, etc). To set these against routes there is a new `-PassThru` switch on `Add-PodeRoute` so the multiple functions can be chained together via pipes.

There is also support for reusable components, that can be referenced.

### Related Issue
Issue #218

### Examples
The following is a simple example of adding a 404 response, and some metadata to a route.
The response includes and object with an error message and code:
```powershell
Add-PodeRoute -Method Get -Path "/api/resources" -ScriptBlock {
    # logic
} -PassThru |
    Set-PodeOARouteInfo -Summary 'A cool summary' -Tags 'Resources' -PassThru |
    Add-PodeOAResponse -StatusCode 404 -ContentSchemas @{
        'application/json' = (New-PodeOAObjectProperty -Properties @(
            (New-PodeOAIntProperty -Name 'ErrorCode'),
            (New-PodeOAStringProperty -Name 'ErrorMessage')
    ))
}
```

On the 404, the JSON response defined will be:

```json
{
    "ErrorCode": "001",
    "ErrorMessage": "This is a serious error"
}
```