### PR TITLE
Fixes payload parsing in AzFunc/Lambdas

### DIFF
--- a/src/Private/Serverless.ps1
+++ b/src/Private/Serverless.ps1
@@ -37,8 +37,8 @@ function Start-PodeAzFuncServer
                 Method = $request.Method.ToLowerInvariant()
                 Query = $request.Query
                 Protocol = ($request.Url -split '://')[0]
-                Endpoint = ((Get-PodeHeader -Name 'host') -split ':')[0]
-                ContentType = (Get-PodeHeader -Name 'content-type')
+                Endpoint = $null
+                ContentType = $null
                 ErrorType = $null
                 Cookies = @{}
                 PendingCookies = @{}
@@ -46,6 +46,9 @@ function Start-PodeAzFuncServer
                 Streamed = $false
                 Timestamp = [datetime]::UtcNow
             }
+
+            $WebEvent.Endpoint = ((Get-PodeHeader -Name 'host') -split ':')[0]
+            $WebEvent.ContentType = (Get-PodeHeader -Name 'content-type')
 
             # set the path, using static content query parameter if passed
             if (![string]::IsNullOrWhiteSpace($request.Query['static-file'])) {
@@ -131,15 +134,19 @@ function Start-PodeAwsLambdaServer
                 Path = $request.path
                 Method = $request.httpMethod.ToLowerInvariant()
                 Query = $request.queryStringParameters
-                Protocol = (Get-PodeHeader -Name 'X-Forwarded-Proto')
-                Endpoint = ((Get-PodeHeader -Name 'Host') -split ':')[0]
-                ContentType = (Get-PodeHeader -Name 'Content-Type')
+                Protocol = $null
+                Endpoint = $null
+                ContentType = $null
                 ErrorType = $null
                 Cookies = @{}
                 PendingCookies = @{}
                 Streamed = $false
                 Timestamp = [datetime]::UtcNow
             }
+
+            $WebEvent.Protocol = (Get-PodeHeader -Name 'X-Forwarded-Proto')
+            $WebEvent.Endpoint = ((Get-PodeHeader -Name 'Host') -split ':')[0]
+            $WebEvent.ContentType = (Get-PodeHeader -Name 'Content-Type')
 
             # set pode in server response header
             Set-PodeServerHeader -Type 'Lambda'


### PR DESCRIPTION
### Description of the Change
Moves the setting of the ContentType, Endpoint and Protocol to just beneath the `$WebEvent` creation for AzFunc/Lambda. This will fixes payload parsing on POST requests, etc.

### Related Issue
Resolves #461
