### PR TITLE
Bumps the version of mkdocs material theme

### DIFF
--- a/pode.build.ps1
+++ b/pode.build.ps1
@@ -13,7 +13,7 @@ $Versions = @{
     PSCoveralls = '1.0.0'
     SevenZip = '18.5.0.20180730'
     Checksum = '0.2.0'
-    MkDocsTheme = '4.4.0'
+    MkDocsTheme = '4.6.0'
     PlatyPS = '0.14.0'
 }
 


### PR DESCRIPTION
### Description of the Change
Bumps the version of MkDocs Material theme from 4.4.0 to 4.6.0
