### PR TITLE
Fix query string parsing, and ensure it's a hashtable

### DIFF
--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -1253,11 +1253,12 @@ function ConvertFrom-PodeNameValueToHashTable
 {
     param (
         [Parameter()]
+        [System.Collections.Specialized.NameValueCollection]
         $Collection
     )
 
-    if ($null -eq $Collection) {
-        return $null
+    if ((Get-PodeCount -Object $Collection) -eq 0) {
+        return @{}
     }
 
     $ht = @{}
@@ -1281,6 +1282,16 @@ function Get-PodeCount
 
     if ($Object -is [string]){
         return $Object.Length
+    }
+
+    if ($Object -is [System.Collections.Specialized.NameValueCollection]) {
+        if ($Object.Count -eq 0) {
+            return 0
+        }
+
+        if (($Object.Count -eq 1) -and ($null -eq $Object.Keys[0])) {
+            return 0
+        }
     }
 
     return $Object.Count

--- a/src/Private/PodeServer.ps1
+++ b/src/Private/PodeServer.ps1
@@ -212,10 +212,9 @@ function Invoke-PodeSocketHandler
         $WebEvent.Endpoint = $req_info.Headers['Host']
         $WebEvent.ContentType = $req_info.Headers['Content-Type']
 
-        $WebEvent.Query = [System.Web.HttpUtility]::ParseQueryString($req_info.Query)
-        if ($null -eq $WebEvent.Query) {
-            $WebEvent.Query = @{}
-        }
+        # parse the query string and convert it to a hashtable
+        $tmpQuery = [System.Web.HttpUtility]::ParseQueryString($req_info.Query.TrimStart('/', '?'))
+        $WebEvent.Query = (ConvertFrom-PodeNameValueToHashTable -Collection $tmpQuery)
 
         # add logging endware for post-request
         Add-PodeRequestLogEndware -WebEvent $WebEvent

--- a/tests/unit/Helpers.Tests.ps1
+++ b/tests/unit/Helpers.Tests.ps1
@@ -866,8 +866,10 @@ Describe 'Invoke-PodeScriptBlock' {
 }
 
 Describe 'ConvertFrom-PodeNameValueToHashTable' {
-    It 'Returns null for no collection' {
-        ConvertFrom-PodeNameValueToHashTable -Collection $null | Should Be $null
+    It 'Returns an empty hashtable for no collection' {
+        $result = ConvertFrom-PodeNameValueToHashTable -Collection $null
+        ($result -is [hashtable]) | Should Be $true
+        $result.Count | Should Be 0
     }
 
     It 'Returns a hashtable from a NameValue collection' {

--- a/tests/unit/Middleware.Tests.ps1
+++ b/tests/unit/Middleware.Tests.ps1
@@ -395,7 +395,7 @@ Describe 'Get-PodeQueryMiddleware' {
 
         Mock ConvertFrom-PodeNameValueToHashTable { return 'string' }
         (. $r.Logic @{
-            'Request' = @{ 'QueryString' = 'name=bob' }
+            'Request' = @{ 'QueryString' = [System.Web.HttpUtility]::ParseQueryString('name=bob') }
         }) | Should Be $true
     }
 


### PR DESCRIPTION
### Description of the Change
When running a server using the `Pode` server type, the QueryString was being incorrectly parsed. This fixes is so that the web event's `.Query` property is a hashtable not a NameValueCollection, and also ensure the first key is parsed correctly.

### Related Issue
Resolves #477
