### PR TITLE
Adds Bearer Authentication Support

### DIFF
--- a/docs/Tutorials/Authentication/Methods/Bearer.md
+++ b/docs/Tutorials/Authentication/Methods/Bearer.md
@@ -1,0 +1,97 @@
+# Bearer
+
+Bearer Authentication lets you authenticate a user based on a token, with optional support for scopes.
+
+## Setup
+
+To setup and start using Bearer Authentication in Pode you use the `New-PodeAuthType -Bearer` function, and then pipe this into the [`Add-PodeAuth`](../../../../Functions/Authentication/Add-PodeAuth) function. The parameter supplied to the [`Add-PodeAuth`](../../../../Functions/Authentication/Add-PodeAuth) function's ScriptBlock is the `$token`:
+
+```powershell
+Start-PodeServer {
+    New-PodeAuthType -Bearer | Add-PodeAuth -Name 'Authenticate' -ScriptBlock {
+        param($token)
+
+        # check if the token is valid, and get user
+
+        return @{ User = $user }
+    }
+}
+```
+
+By default, Pode will check if the Request's header contains an `Authorization` key, and whether the value of that key starts with `Bearer`.
+
+You can also optionally return a `Scope` property alongside the `User`. If you specify any scopes with [`New-PodeAuthType`](../../../../Functions/Authentication/New-PodeAuthType) then it will be validated in the Bearer's post validator - a 403 will be returned if the scope is invalid.
+
+```powershell
+Start-PodeServer {
+    New-PodeAuthType -Bearer -Scope 'write' | Add-PodeAuth -Name 'Authenticate' -ScriptBlock {
+        param($token)
+
+        # check if the token is valid, and get user
+
+        return @{ User = $user; Scope = 'read' }
+    }
+}
+```
+
+## Middleware
+
+Once configured you can start using Bearer Authentication to validate incoming Requests. You can either configure the validation to happen on every Route as global Middleware, or as custom Route Middleware.
+
+The following will use Bearer Authentication to validate every request on every Route:
+
+```powershell
+Start-PodeServer {
+    Get-PodeAuthMiddleware -Name 'Authenticate' | Add-PodeMiddleware -Name 'GlobalAuthValidation'
+}
+```
+
+Whereas the following example will use Bearer authentication to only validate requests on specific a Route:
+
+```powershell
+Start-PodeServer {
+    Add-PodeRoute -Method Get -Path '/info' -Middleware (Get-PodeAuthMiddleware -Name 'Authenticate') -ScriptBlock {
+        # logic
+    }
+}
+```
+
+## Full Example
+
+The following full example of Bearer authentication will setup and configure authentication, validate the token, and then validate on a specific Route:
+
+```powershell
+Start-PodeServer {
+    Add-PodeEndpoint -Address * -Port 8080 -Protocol Http
+
+    # setup bearer authentication to validate a user
+    New-PodeAuthType -Bearer | Add-PodeAuth -Name 'Authenticate' -ScriptBlock {
+        param($token)
+
+        # here you'd check a real storage, this is just for example
+        if ($token -eq 'test-token') {
+            return @{
+                User = @{
+                    'ID' ='M0R7Y302'
+                    'Name' = 'Morty'
+                    'Type' = 'Human'
+                }
+                # Scope = 'read'
+            }
+        }
+
+        # authentication failed
+        return $null
+    }
+
+    # check the request on this route against the authentication
+    Add-PodeRoute -Method Get -Path '/cpu' -Middleware (Get-PodeAuthMiddleware -Name 'Authenticate') -ScriptBlock {
+        Write-PodeJsonResponse -Value @{ 'cpu' = 82 }
+    }
+
+    # this route will not be validated against the authentication
+    Add-PodeRoute -Method Get -Path '/memory' -ScriptBlock {
+        Write-PodeJsonResponse -Value @{ 'memory' = 14 }
+    }
+}
+```

--- a/docs/Tutorials/Authentication/Methods/Custom.md
+++ b/docs/Tutorials/Authentication/Methods/Custom.md
@@ -49,7 +49,7 @@ Start-PodeServer {
 
 The typical setup of authentication is that you create some type to parse the request ([`New-PodeAuthType`](../../../../Functions/Authentication/New-PodeAuthType)), and then you pipe this into a validator/method to validate the parsed user's credentials ([`Add-PodeAuth`](../../../../Functions/Authentication/Add-PodeAuth)).
 
-There is however also an optional `-PostValidator` ScriptBlock that can be passed to your Custom Authentication type on the [`New-PodeAuthType`](../../../../Functions/Authentication/New-PodeAuthType) function. This `-PostValidator` script runs after normal user validation, as is supplied the current web event, the original splatted array returned from the [`New-PodeAuthType`](../../../../Functions/Authentication/New-PodeAuthType) ScriptBlock, and also the result HashTable from the validator. You can use this script to re-generate any hashes for further validation, but if successful you *must* return the User object again (ie: re-return the last parameter which is the original validation result).
+There is however also an optional `-PostValidator` ScriptBlock that can be passed to your Custom Authentication type on the [`New-PodeAuthType`](../../../../Functions/Authentication/New-PodeAuthType) function. This `-PostValidator` script runs after normal user validation, and is supplied the current web event, the original splatted array returned from the [`New-PodeAuthType`](../../../../Functions/Authentication/New-PodeAuthType) ScriptBlock, the result HashTable from the user validator from `Add-PodeAuth`, and the `-ArgumentList` HashTable from `New-PodeAuthType`. You can use this script to re-generate any hashes for further validation, but if successful you *must* return the User object again (ie: re-return the last parameter which is the original validation result).
 
 For example, if you have a post validator script for the above Client Custom Authentication, then it would be supplied the following parameters:
 
@@ -59,6 +59,7 @@ For example, if you have a post validator script for the above Client Custom Aut
 * Password
 * ClientName
 * Validation Result
+* Type ArgumentsList
 
 For example:
 
@@ -82,7 +83,7 @@ Start-PodeServer {
         return @($client, $username, $password)
     } `
     -PostValidator {
-        param($e, $client, $username, $password, $result)
+        param($e, $client, $username, $password, $result, $opts)
 
         # run any extra post-validation logic
 

--- a/docs/Tutorials/Authentication/Overview.md
+++ b/docs/Tutorials/Authentication/Overview.md
@@ -11,14 +11,15 @@ To setup and use authentication in Pode you need to use the [`New-PodeAuthType`]
 
 ### Types/Parsers
 
-The [`New-PodeAuthType`](../../../Functions/Authentication/New-PodeAuthType) function allows you to create and configure Basic/Digest/Form authentication types/parsers, or you can create your own Custom authentication types. These types can then be used on the [`Add-PodeAuth`](../../../Functions/Authentication/Add-PodeAuth) function. There job is to parse the request for any user credentials, or other information, that is required for a user to be authenticated.
+The [`New-PodeAuthType`](../../../Functions/Authentication/New-PodeAuthType) function allows you to create and configure authentication types/parsers, or you can create your own Custom authentication types. These types can then be used on the [`Add-PodeAuth`](../../../Functions/Authentication/Add-PodeAuth) function. There job is to parse the request for any user credentials, or other information, that is required for a user to be authenticated.
 
-An example of creating Basic/Digest/Form authentication is as follows:
+An example of creating some authentication types is as follows:
 
 ```powershell
 Start-PodeServer {
     $basic_auth = New-PodeAuthType -Basic
     $digest_auth = New-PodeAuthType -Digest
+    $bearer_auth = New-PodeAuthType -Bearer
     $form_auth = New-PodeAuthType -Form
 }
 ```
@@ -98,7 +99,7 @@ New-PodeAuthType -Basic | Add-PodeAuth -Name 'Login' -ScriptBlock {
 }
 ```
 
-If you're defining an authenticator that need to send back a Challenge, then you can also do this by setting the response Code property to 401, and also supplying a Challenge property.
+If you're defining an authenticator that need to send back a Challenge, then you can also do this by setting the response Code property to 401, and/or by also supplying a Challenge property.
 This Challenge property is a string, and will be automatically appended onto the `WWW-Authenticate` Header. It *does not* need to include the Authentication Type or Realm (these will be added for you).
 
 For example, in Digest you could return:

--- a/examples/web-auth-bearer.ps1
+++ b/examples/web-auth-bearer.ps1
@@ -11,7 +11,7 @@ Start-PodeServer -Threads 2 {
     Add-PodeEndpoint -Address * -Port 8085 -Protocol Http
 
     # setup bearer auth
-    New-PodeAuthType -Bearer | Add-PodeAuth -Name 'Validate' -ScriptBlock {
+    New-PodeAuthType -Bearer -Scope write | Add-PodeAuth -Name 'Validate' -ScriptBlock {
         param($token)
 
         # here you'd check a real user storage, this is just for example
@@ -22,6 +22,7 @@ Start-PodeServer -Threads 2 {
                     Name = 'Morty'
                     Type = 'Human'
                 }
+                Scope = 'read'
             }
         }
 

--- a/examples/web-auth-bearer.ps1
+++ b/examples/web-auth-bearer.ps1
@@ -10,19 +10,18 @@ Start-PodeServer -Threads 2 {
     # listen on localhost:8085
     Add-PodeEndpoint -Address * -Port 8085 -Protocol Http
 
-    # setup digest auth
-    New-PodeAuthType -Digest | Add-PodeAuth -Name 'Validate' -ScriptBlock {
-        param($username, $params)
+    # setup bearer auth
+    New-PodeAuthType -Bearer | Add-PodeAuth -Name 'Validate' -ScriptBlock {
+        param($token)
 
         # here you'd check a real user storage, this is just for example
-        if ($username -ieq 'morty') {
+        if ($token -ieq 'test-token') {
             return @{
                 User = @{
                     ID ='M0R7Y302'
                     Name = 'Morty'
                     Type = 'Human'
                 }
-                Password = 'pickle'
             }
         }
 

--- a/src/Private/Authentication.ps1
+++ b/src/Private/Authentication.ps1
@@ -24,7 +24,7 @@ function Get-PodeAuthBasicType
         if ($atoms[0] -ine $options.HeaderTag) {
             return @{
                 Message = "Header is not for $($options.HeaderTag) Authorization"
-                Code = 401
+                Code = 400
             }
         }
 

--- a/src/Private/Authentication.ps1
+++ b/src/Private/Authentication.ps1
@@ -14,10 +14,17 @@ function Get-PodeAuthBasicType
 
         # ensure the first atom is basic (or opt override)
         $atoms = $header -isplit '\s+'
+        if ($atoms.Length -lt 2) {
+            return @{
+                Message = 'Invalid Authorization header'
+                Code = 400
+            }
+        }
+
         if ($atoms[0] -ine $options.HeaderTag) {
             return @{
                 Message = "Header is not for $($options.HeaderTag) Authorization"
-                Code = 400
+                Code = 401
             }
         }
 
@@ -50,6 +57,127 @@ function Get-PodeAuthBasicType
         # return data for calling validator
         return @($username, $password)
     }
+}
+
+function Get-PodeAuthBearerType
+{
+    return {
+        param($e, $options)
+
+        # get the auth header
+        $header = (Get-PodeHeader -Name 'Authorization')
+        if ($null -eq $header) {
+            return @{
+                Message = 'No Authorization header found'
+                Challenge = (New-PodeAuthBearerChallenge -Scopes $options.Scopes -ErrorType invalid_request)
+                Code = 400
+            }
+        }
+
+        # ensure the first atom is bearer
+        $atoms = $header -isplit '\s+'
+        if ($atoms.Length -lt 2) {
+            return @{
+                Message = 'Invalid Authorization header'
+                Challenge = (New-PodeAuthBearerChallenge -Scopes $options.Scopes -ErrorType invalid_request)
+                Code = 400
+            }
+        }
+
+        if ($atoms[0] -ine 'Bearer') {
+            return @{
+                Message = 'Authorization header is not Bearer'
+                Challenge = (New-PodeAuthBearerChallenge -Scopes $options.Scopes -ErrorType invalid_request)
+                Code = 400
+            }
+        }
+
+        # return token for calling validator
+        return @($atoms[1].Trim())
+    }
+}
+
+function Get-PodeAuthBearerPostValidator
+{
+    return {
+        param($e, $token, $result, $options)
+
+        # if there's no user, fail with challenge
+        if (($null -eq $result) -or ($null -eq $result.User)) {
+            return @{
+                Message = 'User not found'
+                Challenge = (New-PodeAuthBearerChallenge -Scopes $options.Scopes -ErrorType invalid_token)
+                Code = 401
+            }
+        }
+
+        # check for an error and description
+        if (![string]::IsNullOrWhiteSpace($result.Error)) {
+            return @{
+                Message = 'Authorization failed'
+                Challenge = (New-PodeAuthBearerChallenge -Scopes $options.Scopes -ErrorType $result.Error -ErrorDescription $result.ErrorDescription)
+                Code = 401
+            }
+        }
+
+        # check the scopes
+        $hasAuthScopes = (($null -ne $options.Scopes) -and ($options.Scopes.Length -gt 0))
+        $hasTokenScope = ![string]::IsNullOrWhiteSpace($result.Scope)
+
+        # 403 if we have auth scopes but no token scope
+        if ($hasAuthScopes -and !$hasTokenScope) {
+            return @{
+                Message = 'Invalid Scope'
+                Challenge = (New-PodeAuthBearerChallenge -Scopes $options.Scopes -ErrorType insufficient_scope)
+                Code = 403
+            }
+        }
+
+        # 403 if we have both, but token not in auth scope
+        if ($hasAuthScopes -and $hasTokenScope -and ($options.Scopes -notcontains $result.Scope)) {
+            return @{
+                Message = 'Invalid Scope'
+                Challenge = (New-PodeAuthBearerChallenge -Scopes $options.Scopes -ErrorType insufficient_scope)
+                Code = 403
+            }
+        }
+
+        # return result
+        return $result
+    }
+}
+
+function New-PodeAuthBearerChallenge
+{
+    param(
+        [Parameter()]
+        [string[]]
+        $Scopes,
+
+        [Parameter()]
+        [ValidateSet('', 'invalid_request', 'invalid_token', 'insufficient_scope')]
+        [string]
+        $ErrorType,
+
+        [Parameter()]
+        [string]
+        $ErrorDescription
+    )
+
+    $items = @()
+    if (($null -ne $Scopes) -and ($Scopes.Length -gt 0)) {
+        $items += "scope=`"$($Scopes -join ' ')`""
+    }
+
+    if (![string]::IsNullOrWhiteSpace($ErrorType)) {
+        $items += "error=`"$($ErrorType)`""
+    }
+
+    if (![string]::IsNullOrWhiteSpace($ErrorDescription)) {
+        $items += "error_description=`"$($ErrorDescription)`""
+    }
+
+    return ($items -join ', ')
 }
 
 function Get-PodeAuthDigestType
@@ -118,7 +246,7 @@ function Get-PodeAuthDigestType
 function Get-PodeAuthDigestPostValidator
 {
     return {
-        param($e, $username, $params, $result)
+        param($e, $username, $params, $result, $options)
 
         # if there's no user or password, fail with challenge
         if (($null -eq $result) -or ($null -eq $result.User) -or [string]::IsNullOrWhiteSpace($result.Password)) {
@@ -317,8 +445,8 @@ function Get-PodeAuthMiddlewareScript
                 $result = (Invoke-PodeScriptBlock -ScriptBlock $auth.ScriptBlock -Arguments (@($result) + @($auth.Arguments)) -Return -Splat)
 
                 # if we have user, then run post validator if present
-                if (!(Test-IsEmpty $auth.Type.PostValidator)) {
-                    $result = (Invoke-PodeScriptBlock -ScriptBlock $auth.Type.PostValidator -Arguments (@($e) + @($original) + @($result)) -Return -Splat)
+                if ([string]::IsNullOrWhiteSpace($result.Code) -and !(Test-IsEmpty $auth.Type.PostValidator)) {
+                    $result = (Invoke-PodeScriptBlock -ScriptBlock $auth.Type.PostValidator -Arguments (@($e) + @($original) + @($result) + @($auth.Type.Arguments)) -Return -Splat)
                 }
             }
         }
@@ -332,7 +460,10 @@ function Get-PodeAuthMiddlewareScript
             $_code = (Protect-PodeValue -Value $result.Code -Default 401)
 
             # set the www-auth header
-            if (($_code -eq 401) -and (($null -eq $result.Headers) -or !$result.Headers.ContainsKey('WWW-Authenticate'))) {
+            $validCode = (($_code -eq 401) -or ![string]::IsNullOrWhiteSpace($result.Challenge))
+            $validHeaders = (($null -eq $result.Headers) -or !$result.Headers.ContainsKey('WWW-Authenticate'))
+
+            if ($validCode -and $validHeaders) {
                 $_wwwHeader = Get-PodeAuthWwwHeaderValue -Name $auth.Type.Name -Realm $auth.Type.Realm -Challenge $result.Challenge
                 if (![string]::IsNullOrWhiteSpace($_wwwHeader)) {
                     Set-PodeHeader -Name 'WWW-Authenticate' -Value $_wwwHeader


### PR DESCRIPTION
### Description of the Change
Adds in Bearer Authentication support to validate tokens, with support for checking a token/user's scope against a list of valid scopes.

### Related Issue
Resolves #478.

### Examples
Simple example with no scope checking
```powershell
New-PodeAuthType -Bearer | Add-PodeAuth -Name 'Validate' -ScriptBlock {
    param($token)

    # validate the token, and get a user

    return @{ User = $user }
}
```

Example using scopes (this example would fail with a 403):
```powershell
New-PodeAuthType -Bearer -Scope write, admin | Add-PodeAuth -Name 'Validate' -ScriptBlock {
    param($token)

    # validate the token, and get a user

    return @{ User = $user; Scope = 'read' }
}
```