### PR TITLE
Allows Windows AD authentication to work cross-platform

### DIFF
--- a/docs/Tutorials/Authentication/Inbuilt/WindowsAD.md
+++ b/docs/Tutorials/Authentication/Inbuilt/WindowsAD.md
@@ -1,11 +1,10 @@
 # Windows AD
 
-!!! important
-    The Windows AD authentication method is only supported on Windows (PowerShell, and PS Core v6.1+ only).
+Pode's inbuilt Windows AD authentication works cross-platform, using OpenLDAP to work in *nix environments.
 
 ## Usage
 
-To use Windows AD authentication you use the  [`Add-PodeAuthWindowsAd`](../../../../Functions/Authentication/Add-PodeAuthWindowsAd) function. The following example will validate a user's credentials, supplied via a web-form against the default DNS domain defined in `$env:USERDNSDOMAIN`:
+To enable Windows AD authentication you can use the [`Add-PodeAuthWindowsAd`](../../../../Functions/Authentication/Add-PodeAuthWindowsAd) function. The following example will validate a user's credentials, supplied via a web-form, against the default AD the current server is joined to:
 
 ```powershell
 Start-PodeServer {
@@ -23,6 +22,7 @@ The User object returned, and accessible on Routes, and other functions via `$e.
 | Name | string | The user's fullname in AD |
 | FQDN | string | The DNS domain of the AD |
 | Groups | string[] | The groups that the user is a member of in AD, both directly and recursively |
+| Domain | string | The domain part of the username |
 
 Such as:
 
@@ -33,9 +33,9 @@ Add-PodeRoute -Method Get -Path '/info' -Middleware (Get-PodeAuthMiddleware -Nam
 }
 ```
 
-### Custom Domain
+### Server
 
-If you want to supply a custom DNS domain, then you can supply the `-FQDN` parameter:
+If you want to supply a custom DNS domain, then you can supply the `-Fqdn` parameter:
 
 ```powershell
 Start-PodeServer {
@@ -60,37 +60,5 @@ You can supply a list of authorised usernames to validate a user's access, after
 ```powershell
 Start-PodeServer {
     New-PodeAuthType -Form | Add-PodeAuthWindowsAd -Name 'Login' -Users @('jsnow', 'rsanchez')
-}
-```
-
-## Linux
-
-The inbuilt authentication only supports Windows, but you can use libraries such as [Novell.Directory.Ldap.NETStandard](https://www.nuget.org/packages/Novell.Directory.Ldap.NETStandard/) with dotnet core on *nix environments:
-
-```powershell
-Start-PodeServer {
-    New-PodeAuthType -Form | Add-PodeAuth -Name 'Login' -ScriptBlock {
-        param ($username, $password)
-
-        Add-Type -Path '<path-to-novell-dll>'
-
-        try {
-            $ldap = New-Object Novell.Directory.Ldap.LdapConnection
-            $ldap.Connect('ad-server-name', 389)
-            $ldap.Bind("<domain>\$username", $password)
-        }
-        catch {
-            return $null
-        }
-        finally {
-            $ldap.Dispose()
-        }
-
-        return @{
-            User = @{
-                Username = "<domain>\$username"
-            }
-        }
-    }
 }
 ```

--- a/docs/Tutorials/Authentication/Inbuilt/WindowsAD.md
+++ b/docs/Tutorials/Authentication/Inbuilt/WindowsAD.md
@@ -18,11 +18,14 @@ The User object returned, and accessible on Routes, and other functions via `$e.
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
+| AuthenticationType | string | Value is fixed to LDAP |
+| DistinguishedName | string | The distinguished name of the user |
 | Username | string | The username of the user |
 | Name | string | The user's fullname in AD |
+| Email | string | The user's email address in AD |
 | FQDN | string | The DNS domain of the AD |
-| Groups | string[] | The groups that the user is a member of in AD, both directly and recursively |
 | Domain | string | The domain part of the username |
+| Groups | string[] | The groups that the user is a member of in AD, both directly and recursively |
 
 Such as:
 

--- a/docs/Tutorials/Authentication/Inbuilt/WindowsAD.md
+++ b/docs/Tutorials/Authentication/Inbuilt/WindowsAD.md
@@ -20,12 +20,12 @@ The User object returned, and accessible on Routes, and other functions via `$e.
 | ---- | ---- | ----------- |
 | AuthenticationType | string | Value is fixed to LDAP |
 | DistinguishedName | string | The distinguished name of the user |
-| Username | string | The username of the user |
-| Name | string | The user's fullname in AD |
-| Email | string | The user's email address in AD |
-| FQDN | string | The DNS domain of the AD |
-| Domain | string | The domain part of the username |
-| Groups | string[] | The groups that the user is a member of in AD, both directly and recursively |
+| Username | string | The user's username (without domain) |
+| Name | string | The user's fullname |
+| Email | string | The user's email address |
+| FQDN | string | The FQDN of the AD server |
+| Domain | string | The domain part of the user's username |
+| Groups | string[] | All groups, and nested groups, of which the the user is a member |
 
 Such as:
 

--- a/examples/web-auth-form-ad.ps1
+++ b/examples/web-auth-form-ad.ps1
@@ -19,6 +19,7 @@ Start-PodeServer -Threads 2 {
 
     # listen on localhost:8085
     Add-PodeEndpoint -Address * -Port 8085 -Protocol Http
+	New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
 
     # set the view engine
     Set-PodeViewEngine -Type Pode

--- a/examples/web-auth-form-ad.ps1
+++ b/examples/web-auth-form-ad.ps1
@@ -27,7 +27,7 @@ Start-PodeServer -Threads 2 {
     Enable-PodeSessionMiddleware -Secret 'schwifty' -Duration 120 -Extend
 
     # setup form auth against windows AD (<form> in HTML)
-    New-PodeAuthType -Form | Add-PodeAuthWindowsAd -Name 'Login' -Fqdn $env:USERDNSDOMAIN -Groups @() -Users @()
+    New-PodeAuthType -Form | Add-PodeAuthWindowsAd -Name 'Login' -Groups @() -Users @()
 
 
     # home page:

--- a/src/Private/Authentication.ps1
+++ b/src/Private/Authentication.ps1
@@ -337,7 +337,7 @@ function Get-PodeAuthFormType
     }
 }
 
-function Get-PodeAuthWindowsAdMethod
+function Get-PodeAuthWindowsADMethod
 {
     return {
         param($username, $password, $options)
@@ -646,7 +646,7 @@ function Test-PodeAuthADUser
             User = @{
                 Username = $Username
                 Name = $user.name
-                Server = $Server
+                Fqdn = $Server
                 Domain = $Domain
                 Groups = $groups
             }

--- a/src/Private/Authentication.ps1
+++ b/src/Private/Authentication.ps1
@@ -346,7 +346,7 @@ function Get-PodeAuthWindowsADMethod
         $noGroups = $options.NoGroups
         $openLdap = $options.OpenLDAP
 
-        $result = Test-PodeAuthADUser `
+        $result = Get-PodeAuthADUser `
             -Server $options.Server `
             -Domain $options.Domain `
             -Username $username `
@@ -592,7 +592,7 @@ function Set-PodeAuthStatus
     return $true
 }
 
-function Test-PodeAuthADUser
+function Get-PodeAuthADUser
 {
     param (
         [Parameter()]
@@ -644,8 +644,9 @@ function Test-PodeAuthADUser
         # return the user
         return @{
             User = @{
+                AuthenticationType = 'LDAP'
                 DistinguishedName = $user.DistinguishedName
-                Username = $Username
+                Username = ($Username -split '\\')[-1]
                 Name = $user.Name
                 Email = $user.Email
                 Fqdn = $Server

--- a/src/Private/Authentication.ps1
+++ b/src/Private/Authentication.ps1
@@ -346,7 +346,7 @@ function Get-PodeAuthWindowsADMethod
         $noGroups = $options.NoGroups
         $openLdap = $options.OpenLDAP
 
-        $result = Get-PodeAuthADUser `
+        $result = Get-PodeAuthADResult `
             -Server $options.Server `
             -Domain $options.Domain `
             -Username $username `
@@ -592,7 +592,7 @@ function Set-PodeAuthStatus
     return $true
 }
 
-function Get-PodeAuthADUser
+function Get-PodeAuthADResult
 {
     param (
         [Parameter()]

--- a/src/Public/Authentication.ps1
+++ b/src/Public/Authentication.ps1
@@ -294,7 +294,10 @@ A unique Name for the Authentication method.
 The Type to use for retrieving credentials (From New-PodeAuthType).
 
 .PARAMETER Fqdn
-A custom FQDN for the DNS of the AD you wish to authenticate against.
+A custom FQDN for the DNS of the AD you wish to authenticate against. (Alias: Server)
+
+.PARAMETER Domain
+(Unix Only) A custom domain name that is prepended onto usernames that are missing it (<Domain>\<Username>).
 
 .PARAMETER Groups
 An array of Group names to only allow access.
@@ -305,6 +308,9 @@ An array of Usernames to only allow access.
 .PARAMETER NoGroups
 If supplied, groups will not be retrieved for the user in AD.
 
+.PARAMETER OpenLDAP
+If supplied, and on Windows, OpenLDAP will be used instead.
+
 .EXAMPLE
 New-PodeAuthType -Form | Add-PodeAuthWindowsAd -Name 'WinAuth'
 
@@ -313,6 +319,9 @@ New-PodeAuthType -Basic | Add-PodeAuthWindowsAd -Name 'WinAuth' -Groups @('Devel
 
 .EXAMPLE
 New-PodeAuthType -Form | Add-PodeAuthWindowsAd -Name 'WinAuth' -NoGroups
+
+.EXAMPLE
+New-PodeAuthType -Form | Add-PodeAuthWindowsAd -Name 'UnixAuth' -Server 'testdomain.company.com' -Domain 'testdomain'
 #>
 function Add-PodeAuthWindowsAd
 {
@@ -327,8 +336,13 @@ function Add-PodeAuthWindowsAd
         $Type,
 
         [Parameter()]
+        [Alias('Server')]
         [string]
-        $Fqdn = $env:USERDNSDOMAIN,
+        $Fqdn,
+
+        [Parameter()]
+        [string]
+        $Domain,
 
         [Parameter(ParameterSetName='Groups')]
         [string[]]
@@ -340,14 +354,11 @@ function Add-PodeAuthWindowsAd
 
         [Parameter(ParameterSetName='NoGroups')]
         [switch]
-        $NoGroups
-    )
+        $NoGroups,
 
-    # Check PowerShell/OS version
-    $version = $PSVersionTable.PSVersion
-    if ((Test-IsUnix) -or ($version.Major -eq 6 -and $version.Minor -eq 0)) {
-        throw 'Windows AD authentication is currently only supported on Windows PowerShell, and Windows PowerShell Core v6.1+'
-    }
+        [switch]
+        $OpenLDAP
+    )
 
     # ensure the name doesn't already exist
     if ($PodeContext.Server.Authentications.ContainsKey($Name)) {
@@ -359,15 +370,31 @@ function Add-PodeAuthWindowsAd
         throw "The supplied Type for the '$($Name)' Windows AD authentication method requires a valid ScriptBlock"
     }
 
+    # set server name if not passed
+    if ([string]::IsNullOrWhiteSpace($Fqdn)) {
+        $Fqdn = Get-PodeAuthDomainName
+
+        if ([string]::IsNullOrWhiteSpace($Fqdn)) {
+            throw 'No domain server name has been supplied for Windows AD authentication'
+        }
+    }
+
+    # set the domain if not passed
+    if ([string]::IsNullOrWhiteSpace($Domain)) {
+        $Domain = ($Fqdn -split '\.')[0]
+    }
+
     # add Windows AD auth method to server
     $PodeContext.Server.Authentications[$Name] = @{
         Type = $Type
-        ScriptBlock = (Get-PodeAuthInbuiltMethod -Type WindowsAd)
+        ScriptBlock = (Get-PodeAuthWindowsAdMethod)
         Arguments = @{
-            Fqdn = $Fqdn
+            Server = $Fqdn
+            Domain = $Domain
             Users = $Users
             Groups = $Groups
             NoGroups = $NoGroups
+            OpenLDAP = $OpenLDAP
         }
     }
 }

--- a/src/Public/Authentication.ps1
+++ b/src/Public/Authentication.ps1
@@ -387,7 +387,7 @@ function Add-PodeAuthWindowsAd
     # add Windows AD auth method to server
     $PodeContext.Server.Authentications[$Name] = @{
         Type = $Type
-        ScriptBlock = (Get-PodeAuthWindowsAdMethod)
+        ScriptBlock = (Get-PodeAuthWindowsADMethod)
         Arguments = @{
             Server = $Fqdn
             Domain = $Domain

--- a/tests/unit/Authentication.Tests.ps1
+++ b/tests/unit/Authentication.Tests.ps1
@@ -51,7 +51,7 @@ Describe 'Get-PodeAuthFormType' {
 
 Describe 'Get-PodeAuthInbuiltMethod' {
     It 'Returns Windows AD auth' {
-        $result = Get-PodeAuthInbuiltMethod -Type WindowsAd
+        $result = Get-PodeAuthWindowsADMethod
         $result | Should Not Be $null
         $result.GetType().Name | Should Be 'ScriptBlock'
     }


### PR DESCRIPTION
### Description of the Change
Extends the Windows AD authenticator to work cross-platform, by using OpenLDAP on *nix environments. There's also an `-OpenLDAP` switch on `Add-PodeAuthWindowsAd` to allow the use of OpenLDAP on Windows as well.

### Related Issue
Resolves #474
