### PR TITLE
Adds functions to get routes from Pode

### DIFF
--- a/src/Pode.psd1
+++ b/src/Pode.psd1
@@ -114,6 +114,8 @@
         'Clear-PodeStaticRoutes',
         'ConvertTo-PodeRoute',
         'Add-PodePage',
+        'Get-PodeRoute',
+        'Get-PodeStaticRoute',
 
         # handlers
         'Add-PodeHandler',

--- a/src/Private/Middleware.ps1
+++ b/src/Private/Middleware.ps1
@@ -120,7 +120,7 @@ function Get-PodePublicMiddleware
 
         # get the static file path
         $info = Get-PodeStaticRoutePath -Route $e.Path -Protocol $e.Protocol -Endpoint $e.Endpoint
-        if ([string]::IsNullOrWhiteSpace($info.Path)) {
+        if ([string]::IsNullOrWhiteSpace($info.Source)) {
             return $true
         }
 
@@ -144,7 +144,7 @@ function Get-PodePublicMiddleware
             Set-PodeResponseAttachment -Path $e.Path
         }
         else {
-            Write-PodeFileResponse -Path $info.Path -MaxAge $PodeContext.Server.Web.Static.Cache.MaxAge -Cache:$caching
+            Write-PodeFileResponse -Path $info.Source -MaxAge $PodeContext.Server.Web.Static.Cache.MaxAge -Cache:$caching
         }
 
         # static content found, stop
@@ -160,14 +160,14 @@ function Get-PodeRouteValidateMiddleware
             param($e)
 
             # ensure the path has a route
-            $route = Get-PodeRoute -Method $e.Method -Route $e.Path -Protocol $e.Protocol -Endpoint $e.Endpoint -CheckWildMethod
+            $route = Find-PodeRoute -Method $e.Method -Route $e.Path -Protocol $e.Protocol -Endpoint $e.Endpoint -CheckWildMethod
 
             # if there's no route defined, it's a 404 - or a 405 if a route exists for any other method
             if ($null -eq $route) {
                 # check if a route exists for another method
                 $methods = @('DELETE', 'GET', 'HEAD', 'MERGE', 'OPTIONS', 'PATCH', 'POST', 'PUT', 'TRACE')
                 $routes = @(foreach ($method in $methods) {
-                    $r = Get-PodeRoute -Method $method -Route $e.Path -Protocol $e.Protocol -Endpoint $e.Endpoint
+                    $r = Find-PodeRoute -Method $method -Route $e.Path -Protocol $e.Protocol -Endpoint $e.Endpoint
                     if ($null -ne $r) {
                         $r
                     }

--- a/src/Private/PodeServer.ps1
+++ b/src/Private/PodeServer.ps1
@@ -222,7 +222,7 @@ function Invoke-PodeSocketHandler
         # invoke middleware
         if ((Invoke-PodeMiddleware -WebEvent $WebEvent -Middleware $PodeContext.Server.Middleware -Route $WebEvent.Path)) {
             # get the route logic
-            $route = Get-PodeRoute -Method $WebEvent.Method -Route $WebEvent.Path -Protocol $WebEvent.Protocol `
+            $route = Find-PodeRoute -Method $WebEvent.Method -Route $WebEvent.Path -Protocol $WebEvent.Protocol `
                 -Endpoint $WebEvent.Endpoint -CheckWildMethod
 
             # invoke route and custom middleware

--- a/src/Private/Routes.ps1
+++ b/src/Private/Routes.ps1
@@ -1,4 +1,4 @@
-function Get-PodeRoute
+function Find-PodeRoute
 {
     param (
         [Parameter(Mandatory=$true)]
@@ -25,7 +25,7 @@ function Get-PodeRoute
 
     # first, if supplied, check the wildcard method
     if ($CheckWildMethod -and $PodeContext.Server.Routes['*'].Count -ne 0) {
-        $found = Get-PodeRoute -Method '*' -Route $Route -Protocol $Protocol -Endpoint $Endpoint
+        $found = Find-PodeRoute -Method '*' -Route $Route -Protocol $Protocol -Endpoint $Endpoint
         if ($null -ne $found) {
             return $found
         }
@@ -76,7 +76,7 @@ function Get-PodeRoute
 
         if ($isStatic) {
             return @{
-                Path = $found.Path
+                Source = $found.Source
                 Defaults = $found.Defaults
                 Protocol = $found.Protocol
                 Endpoint = $found.Endpoint
@@ -117,7 +117,7 @@ function Get-PodeStaticRoutePath
     )
 
     # attempt to get a static route for the path
-    $found = Get-PodeRoute -Method 'static' -Route $Route -Protocol $Protocol -Endpoint $Endpoint
+    $found = Find-PodeRoute -Method 'static' -Route $Route -Protocol $Protocol -Endpoint $Endpoint
     $havePublicDir = (![string]::IsNullOrWhiteSpace($PodeContext.Server.InbuiltDrives['public']))
     $path = $null
     $download = $false
@@ -140,7 +140,7 @@ function Get-PodeStaticRoutePath
             }
             else {
                 foreach ($def in $found.Defaults) {
-                    if (Test-PodePath (Join-Path $found.Path $def) -NoStatus) {
+                    if (Test-PodePath (Join-Path $found.Source $def) -NoStatus) {
                         $found.File = Join-PodePaths @($found.File, $def)
                         break
                     }
@@ -148,7 +148,7 @@ function Get-PodeStaticRoutePath
             }
         }
 
-        $path = (Join-Path $found.Path $found.File)
+        $path = (Join-Path $found.Source $found.File)
     }
 
     # use the public static directory (but only if path is a file, and a public dir is present)
@@ -158,7 +158,7 @@ function Get-PodeStaticRoutePath
 
     # return the route details
     return @{
-        Path = $path
+        Source = $path
         Download = $download
     }
 }

--- a/src/Private/Serverless.ps1
+++ b/src/Private/Serverless.ps1
@@ -64,7 +64,7 @@ function Start-PodeAzFuncServer
             # invoke middleware
             if ((Invoke-PodeMiddleware -WebEvent $WebEvent -Middleware $PodeContext.Server.Middleware -Route $WebEvent.Path)) {
                 # get the route logic
-                $route = Get-PodeRoute -Method $WebEvent.Method -Route $WebEvent.Path -Protocol $WebEvent.Protocol `
+                $route = Find-PodeRoute -Method $WebEvent.Method -Route $WebEvent.Path -Protocol $WebEvent.Protocol `
                     -Endpoint $WebEvent.Endpoint -CheckWildMethod
 
                 # invoke route and custom middleware
@@ -154,7 +154,7 @@ function Start-PodeAwsLambdaServer
             # invoke middleware
             if ((Invoke-PodeMiddleware -WebEvent $WebEvent -Middleware $PodeContext.Server.Middleware -Route $WebEvent.Path)) {
                 # get the route logic
-                $route = Get-PodeRoute -Method $WebEvent.Method -Route $WebEvent.Path -Protocol $WebEvent.Protocol `
+                $route = Find-PodeRoute -Method $WebEvent.Method -Route $WebEvent.Path -Protocol $WebEvent.Protocol `
                     -Endpoint $WebEvent.Endpoint -CheckWildMethod
 
                 # invoke route and custom middleware

--- a/src/Private/WebServer.ps1
+++ b/src/Private/WebServer.ps1
@@ -118,7 +118,7 @@ function Start-PodeWebServer
                     # invoke middleware
                     if ((Invoke-PodeMiddleware -WebEvent $WebEvent -Middleware $PodeContext.Server.Middleware -Route $WebEvent.Path)) {
                         # get the route logic
-                        $route = Get-PodeRoute -Method $WebEvent.Method -Route $WebEvent.Path -Protocol $WebEvent.Protocol `
+                        $route = Find-PodeRoute -Method $WebEvent.Method -Route $WebEvent.Path -Protocol $WebEvent.Protocol `
                             -Endpoint $WebEvent.Endpoint -CheckWildMethod
 
                         # invoke route and custom middleware

--- a/src/Public/Responses.ps1
+++ b/src/Public/Responses.ps1
@@ -41,7 +41,7 @@ function Set-PodeResponseAttachment
     )
 
     # only attach files from public/static-route directories when path is relative
-    $_path = (Get-PodeStaticRoutePath -Route $Path).Path
+    $_path = (Get-PodeStaticRoutePath -Route $Path).Source
 
     # if there's no path, check the original path (in case it's literal/relative)
     if (!(Test-PodePath $_path -NoStatus)) {

--- a/src/Public/Routes.ps1
+++ b/src/Public/Routes.ps1
@@ -436,7 +436,7 @@ The endpoint of the static Route to remove.
 Remove-PodeStaticRoute -Path '/assets'
 
 .EXAMPLE
-Remove-PodeStaticRoute -Path '/assets' -Protocol
+Remove-PodeStaticRoute -Path '/assets' -Protocol 127.0.0.1
 #>
 function Remove-PodeStaticRoute
 {
@@ -853,18 +853,6 @@ function Add-PodePage
     Add-PodeRoute -Method Get -Path $_path -Middleware $Middleware -ArgumentList $arg -ScriptBlock $logic
 }
 
-
-
-
-
-
-
-
-
-
-
-
-
 <#
 .SYNOPSIS
 Get a Route(s).
@@ -970,7 +958,7 @@ An Endpoint to filter the static routes.
 Get-PodeStaticRoute -Path '/assets'
 
 .EXAMPLE
-Get-PodeStaticRoute -Path '/assets' -Protocol
+Get-PodeStaticRoute -Path '/assets' -Protocol 127.0.0.1
 #>
 function Get-PodeStaticRoute
 {

--- a/src/Public/Routes.ps1
+++ b/src/Public/Routes.ps1
@@ -917,7 +917,13 @@ function Get-PodeRoute
 
     # if we have a method, filter
     if (![string]::IsNullOrWhiteSpace($Method)) {
-        $routes = ($routes | Where-Object { $_.Method -ieq $Method })
+        $routes = @(foreach ($route in $routes) {
+            if ($route.Method -ine $Method) {
+                continue
+            }
+
+            $route
+        })
     }
 
     # if we have a path, filter
@@ -925,7 +931,14 @@ function Get-PodeRoute
         $Path = Split-PodeRouteQuery -Path $Path
         $Path = Update-PodeRouteSlashes -Path $Path
         $Path = Update-PodeRoutePlaceholders -Path $Path
-        $routes = ($routes | Where-Object { $_.Path -ieq $Path })
+
+        $routes = @(foreach ($route in $routes) {
+            if ($route.Path -ine $Path) {
+                continue
+            }
+
+            $route
+        })
     }
 
     # attempt to filter by protocol/endpoint
@@ -982,7 +995,13 @@ function Get-PodeStaticRoute
     # if we have a path, filter
     if (![string]::IsNullOrWhiteSpace($Path)) {
         $Path = Update-PodeRouteSlashes -Path $Path -Static
-        $routes = ($routes | Where-Object { $_.Path -ieq $Path })
+        $routes = @(foreach ($route in $routes) {
+            if ($route.Path -ine $Path) {
+                continue
+            }
+
+            $route
+        })
     }
 
     # attempt to filter by protocol/endpoint

--- a/tests/unit/Middleware.Tests.ps1
+++ b/tests/unit/Middleware.Tests.ps1
@@ -309,7 +309,7 @@ Describe 'Get-PodeRouteValidateMiddleware' {
         $r.Name | Should Be '__pode_mw_route_validation__'
         $r.Logic | Should Not Be $null
 
-        Mock Get-PodeRoute { return @{ 'Parameters' = @{}; 'Logic' = { Write-Host 'hello' }; } }
+        Mock Find-PodeRoute { return @{ 'Parameters' = @{}; 'Logic' = { Write-Host 'hello' }; } }
         (. $r.Logic @{
             'Method' = 'GET';
             'Path' = '/';
@@ -328,7 +328,7 @@ Describe 'Get-PodeRouteValidateMiddleware' {
         $r.Name | Should Be '__pode_mw_route_validation__'
         $r.Logic | Should Not Be $null
 
-        Mock Get-PodeRoute { return @{
+        Mock Find-PodeRoute { return @{
             'Parameters' = @{};
             'Logic' = { Write-Host 'hello' };
             'ContentType' = 'application/json';
@@ -343,7 +343,7 @@ Describe 'Get-PodeRouteValidateMiddleware' {
         $r.Name | Should Be '__pode_mw_route_validation__'
         $r.Logic | Should Not Be $null
 
-        Mock Get-PodeRoute { return $null }
+        Mock Find-PodeRoute { return $null }
         Mock Set-PodeResponseStatus { }
         (. $r.Logic @{
             'Method' = 'GET';
@@ -423,7 +423,7 @@ Describe 'Get-PodePublicMiddleware' {
         $r.Name | Should Be '__pode_mw_static_content__'
         $r.Logic | Should Not Be $null
 
-        Mock Get-PodeStaticRoutePath { return @{ 'Path' = $null } }
+        Mock Get-PodeStaticRoutePath { return @{ 'Source' = $null } }
         (. $r.Logic @{
             'Path' = '/'; 'Protocol' = 'http'; 'Endpoint' = '';
         }) | Should Be $true
@@ -438,7 +438,7 @@ Describe 'Get-PodePublicMiddleware' {
             'Web' = @{ 'Static' = @{ } }
         }}
 
-        Mock Get-PodeStaticRoutePath { return @{ 'Path' = '/'; 'Download' = $true } }
+        Mock Get-PodeStaticRoutePath { return @{ 'Source' = '/'; 'Download' = $true } }
         Mock Set-PodeResponseAttachment { }
         (. $r.Logic @{
             'Path' = '/'; 'Protocol' = 'http'; 'Endpoint' = '';
@@ -460,7 +460,7 @@ Describe 'Get-PodePublicMiddleware' {
             }}
         }}
 
-        Mock Get-PodeStaticRoutePath { return @{ 'Path' = '/' } }
+        Mock Get-PodeStaticRoutePath { return @{ 'Source' = '/' } }
         Mock Write-PodeFileResponse { }
         (. $r.Logic @{
             'Path' = '/'; 'Protocol' = 'http'; 'Endpoint' = '';
@@ -483,7 +483,7 @@ Describe 'Get-PodePublicMiddleware' {
             }}
         }}
 
-        Mock Get-PodeStaticRoutePath { return @{ 'Path' = '/' } }
+        Mock Get-PodeStaticRoutePath { return @{ 'Source' = '/' } }
         Mock Write-PodeFileResponse { }
         (. $r.Logic @{
             'Path' = '/'; 'Protocol' = 'http'; 'Endpoint' = '';
@@ -506,7 +506,7 @@ Describe 'Get-PodePublicMiddleware' {
             }}
         }}
 
-        Mock Get-PodeStaticRoutePath { return @{ 'Path' = '/' } }
+        Mock Get-PodeStaticRoutePath { return @{ 'Source' = '/' } }
         Mock Write-PodeFileResponse { }
         (. $r.Logic @{
             'Path' = '/'; 'Protocol' = 'http'; 'Endpoint' = '';
@@ -528,7 +528,7 @@ Describe 'Get-PodePublicMiddleware' {
             }}
         }}
 
-        Mock Get-PodeStaticRoutePath { return @{ 'Path' = '/' } }
+        Mock Get-PodeStaticRoutePath { return @{ 'Source' = '/' } }
         Mock Write-PodeFileResponse { }
         (. $r.Logic @{
             'Path' = '/'; 'Protocol' = 'http'; 'Endpoint' = '';

--- a/tests/unit/Routes.Tests.ps1
+++ b/tests/unit/Routes.Tests.ps1
@@ -4,35 +4,35 @@ Get-ChildItem "$($src)/*.ps1" -Recurse | Resolve-Path | ForEach-Object { . $_ }
 
 $PodeContext = @{ 'Server' = $null; }
 
-Describe 'Get-PodeRoute' {
+Describe 'Find-PodeRoute' {
     Context 'Invalid parameters supplied' {
         It 'Throw invalid method error for no method' {
-            { Get-PodeRoute -Method 'MOO' -Route '/' } | Should Throw "Cannot validate argument on parameter 'Method'"
+            { Find-PodeRoute -Method 'MOO' -Route '/' } | Should Throw "Cannot validate argument on parameter 'Method'"
         }
 
         It 'Throw null route parameter error' {
-            { Get-PodeRoute -Method GET -Route $null } | Should Throw 'The argument is null or empty'
+            { Find-PodeRoute -Method GET -Route $null } | Should Throw 'The argument is null or empty'
         }
 
         It 'Throw empty route parameter error' {
-            { Get-PodeRoute -Method GET -Route ([string]::Empty) } | Should Throw 'The argument is null or empty'
+            { Find-PodeRoute -Method GET -Route ([string]::Empty) } | Should Throw 'The argument is null or empty'
         }
     }
 
     Context 'Valid method and route' {
         It 'Return null as method does not exist' {
             $PodeContext.Server = @{ 'Routes' = @{}; }
-            Get-PodeRoute -Method GET -Route '/' | Should Be $null
+            Find-PodeRoute -Method GET -Route '/' | Should Be $null
         }
 
         It 'Returns no logic for method/route that do not exist' {
             $PodeContext.Server = @{ 'Routes' = @{ 'GET' = @{}; }; }
-            Get-PodeRoute -Method GET -Route '/' | Should Be $null
+            Find-PodeRoute -Method GET -Route '/' | Should Be $null
         }
 
         It 'Returns logic for method and exact route' {
             $PodeContext.Server = @{ 'Routes' = @{ 'GET' = @{ '/' = @(@{ 'Logic'= { Write-Host 'Test' }; }); }; }; }
-            $result = (Get-PodeRoute -Method GET -Route '/')
+            $result = (Find-PodeRoute -Method GET -Route '/')
 
             $result | Should BeOfType System.Collections.Hashtable
             $result.Logic.ToString() | Should Be ({ Write-Host 'Test' }).ToString()
@@ -45,7 +45,7 @@ Describe 'Get-PodeRoute' {
                 @{ 'Logic'= { Write-Host 'Test' }; 'Protocol' = 'http' };
             ); }; }; }
 
-            $result = (Get-PodeRoute -Method GET -Route '/' -Protocol 'http')
+            $result = (Find-PodeRoute -Method GET -Route '/' -Protocol 'http')
 
             $result | Should BeOfType System.Collections.Hashtable
             $result.Protocol | Should Be 'http'
@@ -59,7 +59,7 @@ Describe 'Get-PodeRoute' {
                 @{ 'Logic'= { Write-Host 'Test' }; 'Endpoint' = 'pode.foo.com' };
             ); }; }; }
 
-            $result = (Get-PodeRoute -Method GET -Route '/' -Endpoint 'pode.foo.com')
+            $result = (Find-PodeRoute -Method GET -Route '/' -Endpoint 'pode.foo.com')
 
             $result | Should BeOfType System.Collections.Hashtable
             $result.Endpoint | Should Be 'pode.foo.com'
@@ -74,7 +74,7 @@ Describe 'Get-PodeRoute' {
                 @{ 'Logic'= { Write-Host 'Test' }; 'Endpoint' = 'pode.foo.com'; 'Protocol' = 'https' };
             ); }; }; }
 
-            $result = (Get-PodeRoute -Method GET -Route '/' -Endpoint 'pode.foo.com' -Protocol 'https')
+            $result = (Find-PodeRoute -Method GET -Route '/' -Endpoint 'pode.foo.com' -Protocol 'https')
 
             $result | Should BeOfType System.Collections.Hashtable
             $result.Protocol | Should Be 'https'
@@ -89,7 +89,7 @@ Describe 'Get-PodeRoute' {
                 @{ 'Logic'= { Write-Host 'Test' }; 'Endpoint' = '*:8080' };
             ); }; }; }
 
-            $result = (Get-PodeRoute -Method GET -Route '/' -Endpoint 'localhost:8080')
+            $result = (Find-PodeRoute -Method GET -Route '/' -Endpoint 'localhost:8080')
 
             $result | Should BeOfType System.Collections.Hashtable
             $result.Endpoint | Should Be '*:8080'
@@ -99,7 +99,7 @@ Describe 'Get-PodeRoute' {
 
         It 'Returns logic and middleware for method and exact route' {
             $PodeContext.Server = @{ 'Routes' = @{ 'GET' = @{ '/' = @(@{ 'Logic'= { Write-Host 'Test' }; 'Middleware' = { Write-Host 'Middle' }; }); }; }; }
-            $result = (Get-PodeRoute -Method GET -Route '/')
+            $result = (Find-PodeRoute -Method GET -Route '/')
 
             $result | Should BeOfType System.Collections.Hashtable
             $result.Logic.ToString() | Should Be ({ Write-Host 'Test' }).ToString()
@@ -109,7 +109,7 @@ Describe 'Get-PodeRoute' {
 
         It 'Returns logic for method and exact route under star' {
             $PodeContext.Server = @{ 'Routes' = @{ '*' = @{ '/' = @(@{ 'Logic'= { Write-Host 'Test' }; }); }; }; }
-            $result = (Get-PodeRoute -Method * -Route '/')
+            $result = (Find-PodeRoute -Method * -Route '/')
 
             $result | Should BeOfType System.Collections.Hashtable
             $result.Logic.ToString() | Should Be ({ Write-Host 'Test' }).ToString()
@@ -118,7 +118,7 @@ Describe 'Get-PodeRoute' {
 
         It 'Returns logic and parameters for parameterised route' {
             $PodeContext.Server = @{ 'Routes' = @{ 'GET' = @{ '/(?<userId>[^\/]+?)' = @(@{ 'Logic'= { Write-Host 'Test' }; }); }; }; }
-            $result = (Get-PodeRoute -Method GET -Route '/123')
+            $result = (Find-PodeRoute -Method GET -Route '/123')
 
             $result | Should BeOfType System.Collections.Hashtable
             $result.Logic.ToString() | Should Be ({ Write-Host 'Test' }).ToString()
@@ -140,7 +140,7 @@ Describe 'Add-PodeStaticRoute' {
         $route = $PodeContext.Server.Routes['static']
         $route | Should Not Be $null
         $route.ContainsKey('/assets[/]{0,1}(?<file>.*)') | Should Be $true
-        $route['/assets[/]{0,1}(?<file>.*)'].Path | Should Be './assets'
+        $route['/assets[/]{0,1}(?<file>.*)'].Source | Should Be './assets'
     }
 
     It 'Throws error when adding static route for non-existing folder' {
@@ -199,7 +199,7 @@ Describe 'Remove-PodeStaticRoute' {
         $routes = $PodeContext.Server.Routes['static']
         $routes | Should Not be $null
         $routes.ContainsKey('/assets[/]{0,1}(?<file>.*)') | Should Be $true
-        $routes['/assets[/]{0,1}(?<file>.*)'].Path | Should Be './assets'
+        $routes['/assets[/]{0,1}(?<file>.*)'].Source | Should Be './assets'
 
         Remove-PodeStaticRoute -Path '/assets'
 

--- a/tests/unit/Routes.Tests.ps1
+++ b/tests/unit/Routes.Tests.ps1
@@ -1164,3 +1164,78 @@ Describe 'Get-PodeRouteByUrl' {
         $Result | Should Be $routeNeitherSet
     }
 }
+
+Describe 'Get-PodeRoute' {
+    It 'Returns both routes whe nothing supplied' {
+        $PodeContext.Server = @{ Routes = @{ GET = @{}; POST = @{}; }; }
+        Add-PodeRoute -Method Get -Path '/users' -ScriptBlock { Write-Host 'hello' }
+        Add-PodeRoute -Method Get -Path '/about' -ScriptBlock { Write-Host 'hello' }
+        Add-PodeRoute -Method Post -Path '/users' -ScriptBlock { Write-Host 'hello' }
+
+        $routes = Get-PodeRoute
+        $routes.Length | Should Be 3
+    }
+
+    It 'Returns both routes for GET method' {
+        $PodeContext.Server = @{ Routes = @{ GET = @{}; POST = @{}; }; }
+        Add-PodeRoute -Method Get -Path '/users' -ScriptBlock { Write-Host 'hello' }
+        Add-PodeRoute -Method Get -Path '/about' -ScriptBlock { Write-Host 'hello' }
+        Add-PodeRoute -Method Post -Path '/users' -ScriptBlock { Write-Host 'hello' }
+
+        $routes = Get-PodeRoute -Method Get
+        $routes.Length | Should Be 2
+    }
+
+    It 'Returns one route for POST method' {
+        $PodeContext.Server = @{ Routes = @{ GET = @{}; POST = @{}; }; }
+        Add-PodeRoute -Method Get -Path '/users' -ScriptBlock { Write-Host 'hello' }
+        Add-PodeRoute -Method Get -Path '/about' -ScriptBlock { Write-Host 'hello' }
+        Add-PodeRoute -Method Post -Path '/users' -ScriptBlock { Write-Host 'hello' }
+
+        $routes = Get-PodeRoute -Method Post
+        $routes.Length | Should Be 1
+    }
+
+    It 'Returns both routes for users path' {
+        $PodeContext.Server = @{ Routes = @{ GET = @{}; POST = @{}; }; }
+        Add-PodeRoute -Method Get -Path '/users' -ScriptBlock { Write-Host 'hello' }
+        Add-PodeRoute -Method Get -Path '/about' -ScriptBlock { Write-Host 'hello' }
+        Add-PodeRoute -Method Post -Path '/users' -ScriptBlock { Write-Host 'hello' }
+
+        $routes = Get-PodeRoute -Path '/users'
+        $routes.Length | Should Be 2
+    }
+
+    It 'Returns one route for users path and GET metho' {
+        $PodeContext.Server = @{ Routes = @{ GET = @{}; POST = @{}; }; }
+        Add-PodeRoute -Method Get -Path '/users' -ScriptBlock { Write-Host 'hello' }
+        Add-PodeRoute -Method Get -Path '/about' -ScriptBlock { Write-Host 'hello' }
+        Add-PodeRoute -Method Post -Path '/users' -ScriptBlock { Write-Host 'hello' }
+
+        $routes = Get-PodeRoute -Method Get -Path '/users'
+        $routes.Length | Should Be 1
+    }
+}
+
+Describe 'Get-PodeStaticRoute' {
+    Mock Test-PodePath { return $true }
+    Mock New-PodePSDrive { return './assets' }
+
+    It 'Returns all static routes' {
+        $PodeContext.Server = @{ Routes = @{ STATIC = @{}; }; Root = $pwd }
+        Add-PodeStaticRoute -Path '/assets' -Source './assets'
+        Add-PodeStaticRoute -Path '/images' -Source './images'
+
+        $routes = Get-PodeStaticRoute
+        $routes.Length | Should Be 2
+    }
+
+    It 'Returns one static route' {
+        $PodeContext.Server = @{ Routes = @{ STATIC = @{}; }; Root = $pwd }
+        Add-PodeStaticRoute -Path '/assets' -Source './assets'
+        Add-PodeStaticRoute -Path '/images' -Source './images'
+
+        $routes = Get-PodeStaticRoute -Path '/images'
+        $routes.Length | Should Be 1
+    }
+}

--- a/tests/unit/Serverless.Tests.ps1
+++ b/tests/unit/Serverless.Tests.ps1
@@ -13,7 +13,7 @@ Describe 'Start-PodeAzFuncServer' {
     Mock Get-PodeCookieMiddleware { }
     Mock New-Object { return @{} }
     Mock Get-PodeHeader { return 'some-value' }
-    Mock Get-PodeRoute { return @{ Logic = { Write-Host 'Helo' } } }
+    Mock Find-PodeRoute { return @{ Logic = { Write-Host 'Helo' } } }
     Mock Invoke-PodeScriptBlock { }
     Mock Write-Host { }
     Mock Invoke-PodeEndware { }
@@ -44,7 +44,7 @@ Describe 'Start-PodeAzFuncServer' {
 
         Assert-MockCalled Set-PodeResponseStatus -Times 0 -Scope It
         Assert-MockCalled Invoke-PodeMiddleware -Times 1 -Scope It
-        Assert-MockCalled Get-PodeRoute -Times 0 -Scope It
+        Assert-MockCalled Find-PodeRoute -Times 0 -Scope It
     }
 
     It 'Runs the server, using static content path from query' {
@@ -67,7 +67,7 @@ Describe 'Start-PodeAzFuncServer' {
 
         Assert-MockCalled Set-PodeResponseStatus -Times 0 -Scope It
         Assert-MockCalled Invoke-PodeMiddleware -Times 1 -Scope It
-        Assert-MockCalled Get-PodeRoute -Times 0 -Scope It
+        Assert-MockCalled Find-PodeRoute -Times 0 -Scope It
     }
 
     It 'Runs the server, succeeds middleware with route' {
@@ -90,7 +90,7 @@ Describe 'Start-PodeAzFuncServer' {
 
         Assert-MockCalled Set-PodeResponseStatus -Times 0 -Scope It
         Assert-MockCalled Invoke-PodeMiddleware -Times 2 -Scope It
-        Assert-MockCalled Get-PodeRoute -Times 1 -Scope It
+        Assert-MockCalled Find-PodeRoute -Times 1 -Scope It
         Assert-MockCalled Invoke-PodeScriptBlock -Times 1 -Scope It
     }
 
@@ -114,7 +114,7 @@ Describe 'Start-PodeAzFuncServer' {
 
         Assert-MockCalled Set-PodeResponseStatus -Times 1 -Scope It
         Assert-MockCalled Invoke-PodeMiddleware -Times 1 -Scope It
-        Assert-MockCalled Get-PodeRoute -Times 0 -Scope It
+        Assert-MockCalled Find-PodeRoute -Times 0 -Scope It
     }
 
     It 'Runs the server, errors in endware' {
@@ -137,7 +137,7 @@ Describe 'Start-PodeAzFuncServer' {
 
         Assert-MockCalled Set-PodeResponseStatus -Times 0 -Scope It
         Assert-MockCalled Invoke-PodeMiddleware -Times 1 -Scope It
-        Assert-MockCalled Get-PodeRoute -Times 0 -Scope It
+        Assert-MockCalled Find-PodeRoute -Times 0 -Scope It
     }
 }
 
@@ -148,7 +148,7 @@ Describe 'Start-PodeAwsLambdaServer' {
     Mock Get-PodeCookieMiddleware { }
     Mock Get-PodeHeader { return 'some-value' }
     Mock Set-PodeHeader { }
-    Mock Get-PodeRoute { return @{ Logic = { Write-Host 'Helo' } } }
+    Mock Find-PodeRoute { return @{ Logic = { Write-Host 'Helo' } } }
     Mock Invoke-PodeScriptBlock { }
     Mock Write-Host { }
     Mock Invoke-PodeEndware { }
@@ -173,7 +173,7 @@ Describe 'Start-PodeAwsLambdaServer' {
 
         Assert-MockCalled Set-PodeResponseStatus -Times 0 -Scope It
         Assert-MockCalled Invoke-PodeMiddleware -Times 1 -Scope It
-        Assert-MockCalled Get-PodeRoute -Times 0 -Scope It
+        Assert-MockCalled Find-PodeRoute -Times 0 -Scope It
     }
 
     It 'Runs the server, succeeds middleware with route' {
@@ -190,7 +190,7 @@ Describe 'Start-PodeAwsLambdaServer' {
 
         Assert-MockCalled Set-PodeResponseStatus -Times 0 -Scope It
         Assert-MockCalled Invoke-PodeMiddleware -Times 2 -Scope It
-        Assert-MockCalled Get-PodeRoute -Times 1 -Scope It
+        Assert-MockCalled Find-PodeRoute -Times 1 -Scope It
         Assert-MockCalled Invoke-PodeScriptBlock -Times 1 -Scope It
     }
 
@@ -208,7 +208,7 @@ Describe 'Start-PodeAwsLambdaServer' {
 
         Assert-MockCalled Set-PodeResponseStatus -Times 1 -Scope It
         Assert-MockCalled Invoke-PodeMiddleware -Times 1 -Scope It
-        Assert-MockCalled Get-PodeRoute -Times 0 -Scope It
+        Assert-MockCalled Find-PodeRoute -Times 0 -Scope It
     }
 
     It 'Runs the server, errors in endware' {
@@ -226,6 +226,6 @@ Describe 'Start-PodeAwsLambdaServer' {
 
         Assert-MockCalled Set-PodeResponseStatus -Times 0 -Scope It
         Assert-MockCalled Invoke-PodeMiddleware -Times 1 -Scope It
-        Assert-MockCalled Get-PodeRoute -Times 0 -Scope It
+        Assert-MockCalled Find-PodeRoute -Times 0 -Scope It
     }
 }


### PR DESCRIPTION
### Description of the Change
Adds two new functions: `Get-PodeRoute` and `Get-PodeStaticRoute`. These will return routes from within Pode, and allow you to filter the routes returned.

### Related Issue
Resolves #425

### Examples
```powershell
# all routes
Get-PodeRoute
Get-PodeStaticRoute

# filter by path
Get-PodeRoute -Path '/users'
```
