### PR TITLE
Bump docker image to use PS7.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/powershell:6.2.3-ubuntu-16.04
+FROM mcr.microsoft.com/powershell:7.0.0-ubuntu-16.04
 LABEL maintainer="Matthew Kelly (Badgerati)"
 RUN mkdir -p /usr/local/share/powershell/Modules/Pode
 COPY ./src/ /usr/local/share/powershell/Modules/Pode

--- a/arm32.dockerfile
+++ b/arm32.dockerfile
@@ -1,4 +1,4 @@
-FROM badgerati/ps-core:6.2.3-arm32
+FROM badgerati/ps-core:7.0.0-arm32
 LABEL maintainer="Matthew Kelly (Badgerati)"
 RUN mkdir -p /usr/local/share/powershell/Modules/Pode
 COPY ./src/ /usr/local/share/powershell/Modules/Pode

--- a/packers/docker/arm32/Dockerfile
+++ b/packers/docker/arm32/Dockerfile
@@ -1,6 +1,6 @@
 FROM arm32v7/ubuntu:bionic
 
-ENV PS_VERSION=6.2.3
+ENV PS_VERSION=7.0.0
 ENV PS_PACKAGE=powershell-${PS_VERSION}-linux-arm32.tar.gz
 ENV PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/${PS_PACKAGE}
 


### PR DESCRIPTION
### Description of the Change
Bumps the main docker image for Pode to use PS7.0. Also bumps the version of the ARM32 image to PS7.0 as well.

### Related Issue
Resolves #503
