### PR TITLE
Adds support for response compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Then navigate to `http://127.0.0.1:8000` in your browser.
 * Cross-platform support for server-to-client WebSockets, including secure WebSockets
 * Host REST APIs, Web Pages, and Static Content (with caching)
 * Support for custom error pages
+* Request and Response compression using GZip/Deflate
 * Multi-thread support for incoming requests
 * Inbuilt template engine, with support for third-parties
 * Async timers for short-running repeatable processes

--- a/docs/Tutorials/Compression/Requests.md
+++ b/docs/Tutorials/Compression/Requests.md
@@ -23,6 +23,16 @@ HttpListener is the default web server, unless you specify `-Type Pode` on `Star
 !!! note
     The Pode server does also support `X-Transfer-Encoding`, but it will check `Transfer-Encoding` first.
 
+An example of the header in the request is as follows:
+
+```text
+Transfer-Encoding: gzip
+Transfer-Encoding: deflate
+
+// or:
+Transfer-Encoding: gzip,chunked
+```
+
 ## Route
 
 Like content types, you can force a Route to use a specific transfer encoding by using the `-TransferEncoding` parameter on [`Add-PodeRoute`](../../../Functions/Routes/Add-PodeRoute). If specified, Pode will use this compression type to decompress the payload regardless if the header is present or not.

--- a/docs/Tutorials/Compression/Responses.md
+++ b/docs/Tutorials/Compression/Responses.md
@@ -1,0 +1,53 @@
+# Responses
+
+Pode has support for sending back compressed Responses, if enabled, and if a client sends an appropriate `Accept-Encoding` header.
+
+The followings compression methods are supported:
+
+* gzip
+* deflate
+
+When enabled, Pode will compress the response's bytes prior to sending the response; the `Content-Encoding` header will also be sent appropriately on the response.
+
+## Enable
+
+By default response compression is disabled in Pode. To enable compression you can set the following value in your server's `server.psd1` [configuration](../../Configuration) file:
+
+```powershell
+@{
+    Web = @{
+        Compression = @{
+            Enable = $true
+        }
+    }
+}
+```
+
+Once enabled, compression will be used if a valid `Accept-Encoding` header is sent in the request.
+
+## Headers
+
+For your Pode server to compress the response, the client must send an `Accept-Encoding` header for with `gzip` or `deflate`:
+
+```text
+Accept-Encoding: gzip
+Accept-Encoding: deflate
+Accept-Encoding: identity
+Accept-Encoding: *
+```
+
+Or any valid combination:
+
+```text
+Accept-Encoding: gzip,deflate
+```
+
+If multiple encodings are sent, then Pode will use the first supported value. There is also support for quality values as well, so you can weight encodings or fully disable non-compression (if no q-value is on an encoding it is assumed to be 1)
+
+```text
+Accept-Encoding: gzip,deflate,identity;q=0
+```
+
+In a scenario where no encodings are supported, and identity (no-compression) is disabled, then Pode will respond with a 406.
+
+If an encoding is used to compress the response, then Pode will set the `Content-Encoding` on the response.

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,6 +23,7 @@ Pode is a Cross-Platform framework, *completely written in PowerShell*, to creat
 * Cross-platform support for server-to-client WebSockets, including secure WebSockets
 * Host REST APIs, Web Pages, and Static Content (with caching)
 * Support for custom error pages
+* Request and Response compression using GZip/Deflate
 * Multi-thread support for incoming requests
 * Inbuilt template engine, with support for third-parties
 * Async timers for short-running repeatable processes

--- a/examples/server.psd1
+++ b/examples/server.psd1
@@ -21,6 +21,9 @@
                 '/john' = 'application/json'
             }
         }
+        Compression = @{
+            Enable = $false
+        }
     }
     Server = @{
         FileMonitor = @{

--- a/packers/choco/pode.nuspec
+++ b/packers/choco/pode.nuspec
@@ -22,6 +22,7 @@ Pode is a Cross-Platform framework, completely written in PowerShell, for creati
 * Cross-platform support for server-to-client WebSockets, including secure WebSockets
 * Host REST APIs, Web Pages, and Static Content (with caching)
 * Support for custom error pages
+* Request and Response compression using GZip/Deflate
 * Multi-thread support for incoming requests
 * Inbuilt template engine, with support for third-parties
 * Async timers for short-running repeatable processes

--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -243,8 +243,8 @@ function New-PodeContext
     $ctx.Server.BodyParsers = @{}
 
     # common support values
-    $ctx.Server.Supported = @{
-        TransferEncodings = @('gzip', 'deflate', 'x-gzip')
+    $ctx.Server.Compression = @{
+        Encodings = @('gzip', 'deflate', 'x-gzip')
     }
 
     # endware that needs to run
@@ -461,6 +461,9 @@ function Set-PodeWebConfiguration
         TransferEncoding = @{
             Default = $Configuration.TransferEncoding.Default
             Routes = @{}
+        }
+        Compression = @{
+            Enabled = [bool]$Configuration.Compression.Enable
         }
     }
 

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -955,30 +955,7 @@ function Join-PodePaths
         $Paths
     )
 
-    # remove any empty/null paths
-    $Paths = @(Remove-PodeEmptyItemsFromArray $Paths)
-
-    # if there are no paths, return blank
-    if ($null -eq $Paths -or $Paths.Length -eq 0) {
-        return ([string]::Empty)
-    }
-
-    # return the first path if singular
-    if ($Paths.Length -eq 1) {
-        return $Paths[0]
-    }
-
-    # join the first two paths
-    $_path = Join-Path $Paths[0] $Paths[1]
-
-    # if there are any more, add them on
-    if ($Paths.Length -gt 2) {
-        foreach ($p in $Paths[2..($Paths.Length - 1)]) {
-            $_path = Join-Path $_path $p
-        }
-    }
-
-    return $_path
+    return [System.IO.Path]::Combine($Paths)
 }
 
 function Get-PodeFileExtension

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -1094,7 +1094,7 @@ function Get-PodeAcceptEncoding
 
     # if it's empty, just return empty
     if ($valid.Length -eq 0) {
-        [string]::Empty
+        return [string]::Empty
     }
 
     # find the highest ranked match
@@ -1126,8 +1126,6 @@ function Get-PodeAcceptEncoding
             $err.Data.Add('PodeStatusCode', 406)
             throw $err
         }
-
-        return $found.Name
     }
 
     # else, we're safe

--- a/src/Private/PodeServer.ps1
+++ b/src/Private/PodeServer.ps1
@@ -207,19 +207,19 @@ function Invoke-PodeSocketHandler
             Protocol = $req_info.Protocol
             ProtocolVersion = ($req_info.Protocol -isplit '/')[1]
             ContentEncoding = (Get-PodeEncodingFromContentType -ContentType $req_info.Headers['Content-Type'])
-            TransferEncoding = (Get-PodeTransferEncoding -TransferEncoding $req_info.Headers['Transfer-Encoding'] -ThrowError)
-        }
-
-        # if the transfer encoding is empty, attempt X-Transfer-Encoding for support from HttpListener
-        if ([string]::IsNullOrWhiteSpace($WebEvent.Request.TransferEncoding)) {
-            $WebEvent.Request.TransferEncoding = (Get-PodeTransferEncoding -TransferEncoding $req_info.Headers['X-Transfer-Encoding'] -ThrowError)
         }
 
         $WebEvent.Path = $req_info.Uri.AbsolutePath
         $WebEvent.Method = $req_info.Method.ToLowerInvariant()
         $WebEvent.Endpoint = $req_info.Headers['Host']
         $WebEvent.ContentType = $req_info.Headers['Content-Type']
-        $WebEvent.TransferEncoding = $WebEvent.Request.TransferEncoding
+        $WebEvent.AcceptEncoding = (Get-PodeAcceptEncoding -AcceptEncoding $req_info.Headers['Accept-Encoding'] -ThrowError)
+
+        # transfer encoding
+        $WebEvent.TransferEncoding = (Get-PodeTransferEncoding -TransferEncoding $req_info.Headers['Transfer-Encoding'] -ThrowError)
+        if ([string]::IsNullOrWhiteSpace($WebEvent.TransferEncoding)) {
+            $WebEvent.TransferEncoding = (Get-PodeTransferEncoding -TransferEncoding $req_info.Headers['X-Transfer-Encoding'] -ThrowError)
+        }
 
         # parse the query string and convert it to a hashtable
         $WebEvent.Query = (Convert-PodeQueryStringToHashTable -Uri $req_info.Query)

--- a/src/Private/Streams.ps1
+++ b/src/Private/Streams.ps1
@@ -120,18 +120,14 @@ function ConvertFrom-PodeValueToBytes
 {
     param (
         [Parameter()]
-        [object]
+        [string]
         $Value,
 
         [Parameter()]
         $Encoding = [System.Text.Encoding]::UTF8
     )
 
-    if ($Value.GetType().Name -ieq 'string') {
-        $Value = $Encoding.GetBytes($Value)
-    }
-
-    return $Value
+    return $Encoding.GetBytes($Value)
 }
 
 function ConvertFrom-PodeBytesToString

--- a/src/Private/WebServer.ps1
+++ b/src/Private/WebServer.ps1
@@ -109,9 +109,11 @@ function Start-PodeWebServer
                         Route = $null
                         Timestamp = [datetime]::UtcNow
                         TransferEncoding = $null
+                        AcceptEncoding = $null
                     }
 
-                    $WebEvent.TransferEncoding = (Get-PodeTransferEncoding -TransferEncoding (Get-PodeHeader -Name 'x-transfer-encoding') -ThrowError)
+                    $WebEvent.TransferEncoding = (Get-PodeTransferEncoding -TransferEncoding (Get-PodeHeader -Name 'X-Transfer-Encoding') -ThrowError)
+                    $WebEvent.AcceptEncoding = (Get-PodeAcceptEncoding -AcceptEncoding (Get-PodeHeader -Name 'Accept-Encoding') -ThrowError)
 
                     # set pode in server response header
                     Set-PodeServerHeader -AllowEmptyType


### PR DESCRIPTION
### Description of the Change
This adds support into Pode for response compression - which is disabled by default, and can be enabled via the `server.psd1` file.

Supported are `gzip` and `deflate` compression, with identity (no-compression) being the default.

When compression is used, Pode will also send back an appropriate value for the `Content-Encoding` header.

### Related Issue
Resolves #507 

### Examples
When enabled, the following header is an example of what the client should send:
```plain
Accept-Encoding: gzip
```
