### PR TITLE
Add a new Get-PodeEndpoint function

### DIFF
--- a/docs/Tutorials/Endpoints/Basics.md
+++ b/docs/Tutorials/Endpoints/Basics.md
@@ -1,0 +1,116 @@
+# Basics
+
+Endpoints in Pode are used to bind your server to specific IPs and ports, over specific protocols (such as HTTP or HTTPS). Endpoints can have unique names, so you can bind Routes to certain endpoints only.
+
+## Usage
+
+To add new endpoints to your server, you can use the [`Add-PodeEndpoint`](../../../Functions/Core/Add-PodeEndpoint) function. A quick and simple example is the following, which will bind your server to `http://localhost:8080`:
+
+```powershell
+Start-PodeServer {
+    Add-PodeEndpoint -Address * -Port 8080 -Protocol Http
+}
+```
+
+The `-Address` can be local or private IP address, or a hostname that is bound to an IP address (either in the hosts file, or in DNS). The `-Port` is any valid port number, and the `-Protocol` defines which protocol the endpoint will use: HTTP, HTTPS, SMTP, TCP, WS and WSS.
+
+You can also supply an optional unique `-Name` to your endpoint. This name will allow you to bind routes to certain endpoints; so if you have endpoint A and B, and you bind some route to endpoint A, then it won't be accessible over endpoint B.
+
+## Certificates
+
+If you add an HTTPS or WSS endpoint, then you'll be required to also supply certificate details. Depending on which web server type you're using depends on how you supply a certificate.
+
+### HttpListener
+
+This is the default web server type, if you don't supply a `-Type` on the [`Start-PodeServer`](../../../Functions/Core/Start-PodeServer) function then you'll be using HttpListener.
+
+The HttpListener web server only supports HTTPS on Windows, and does not support Web Sockets.
+
+To configure a certificate you can use one of the following parameters:
+
+| Name | Description |
+| ---- | ----------- |
+| Certificate | The name of a certificate to use, this certificate should be installed in the `MY` certifcate store |
+| CertificateThumbprint | The thumbprint of a certificate to use, this certificate should be installed in the `MY` certifcate store |
+| SelfSigned | If supplied, Pode will automatically generate a self-signed local certificate |
+
+The below example will create a local self-signed HTTPS endpoint:
+
+```powershell
+Add-PodeEndpoint -Address * -Port 8443 -Protocol Https -SelfSigned
+```
+
+Whereas the following will create the same endpoint, but will instead bind an installed certificate:
+
+```powershell
+# by name:
+Add-PodeEndpoint -Address * -Port 8443 -Protocol Https -Certificate '*.example.com'
+
+# by thumbprint
+Add-PodeEndpoint -Address * -Port 8443 -Protocol Https -CertificateThumbprint '2A9467F7D3940243D6C07DE61E7FCCE292'
+```
+
+### Pode
+
+If you have specified `-Type Pode` on your [`Start-PodeServer`](../../../Functions/Core/Start-PodeServer) function, or you're hosting via IIS, then you'll be using the Pode type web server.
+
+The Pode web server supports HTTPS cross-platform, and supports Web Sockets.
+
+To configure a certificate you can use one of the following parameters:
+
+| Name | Description |
+| ---- | ----------- |
+| CertificateFile | The path to a `.pfx` or `.cer` certificate |
+| CertificatePassword | The password for the above `.pfx` certificate |
+| RawCertificate | A raw X509Certificate object |
+
+The below example will create an endpoint using a `.pfx` certificate:
+
+```powershell
+Add-PodeEndpoint -Address * -Port 8443 -Protocol Https -CertificateFile './certs/example.pfx' -CertificatePassword 'hunter2'
+```
+
+Whereas the following will instead create an X509Certificate, and pass that to the endpoint instead:
+
+```powershell
+$cert = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new('./certs/example.cer')
+Add-PodeEndpoint -Address * -Port 8443 -Protocol Https -RawCertificate $cert
+```
+
+## Getting Endpoints
+
+The [`Get-PodeEndpoint`](../../../Functions/Core/Get-PodeEndpoint) helper function will allow you to retrieve a list of endpoints configured within Pode. You can use it to retrieve all of the endpoints, or supply filters to retrieve specific endpoints.
+
+To retrieve all of the endpoints, you can call the function will no parameters. To filter, here are some examples:
+
+```powershell
+# all endpoints using port 80
+Get-PodeEndpoint -Port 80
+
+# all endpoints using HTTP
+Get-PodeEndpoint -Protocol Http
+
+# retrieve specific named endpoints
+Get-PodeEndpoint -Name Admin, User
+```
+
+## Endpoint Object
+
+!!! warning
+    Be careful if you choose to edit these objects, as they will affect the server.
+
+The following is the structure of the Endpoint object internally, as well as the object that is returned from [`Get-PodeEndpoint`](../../../Functions/Core/Get-PodeEndpoint):
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| Name | string | The name of the Endpoint, if a name was supplied |
+| Description | string | A description of the Endpoint, usually used for OpenAPI |
+| Address | IPAddress | The IP address that will be used for the Endpoint |
+| RawAddress | string | The address/host and port of the Endpoint |
+| Port | int | The port the Endpoint will use |
+| IsIPAddress | bool | Whether or not the listener will bind using Hostname or IP address |
+| Hostname | string | The hostname of the Endpoint |
+| Url | string | The full base URL of the Endpoint |
+| Ssl | bool | Whether or not this Endpoint support support SSL |
+| Protocol | string | The protocol of the Endpoint |
+| Certificate | hashtable | Details about the certificate that will be used for SSL Endpoints |

--- a/docs/Tutorials/Endpoints/External.md
+++ b/docs/Tutorials/Endpoints/External.md
@@ -1,4 +1,4 @@
-# External Endpoints
+# External
 
 At most times you'll possibly be accessing your Pode server locally. However, you can access your server externally if you setup the endpoints appropriately using the [`Add-PodeEndpoint`](../../Functions/Core/Add-PodeEndpoint) function. These will work on a your VMs, or in a Container.
 

--- a/docs/Tutorials/Routes/Overview.md
+++ b/docs/Tutorials/Routes/Overview.md
@@ -174,7 +174,7 @@ The [`Get-PodeStaticRoute`](../../../Functions/Routes/Get-PodeStaticRoute) funct
 !!! warning
     Be careful if you choose to edit these objects, as they will affect the server.
 
-The following is the structure of the Route object internally, as well as the object that is returned from `Add-PodeRoute -PassThru` or `Get-PodeRoute`:
+The following is the structure of the Route object internally, as well as the object that is returned from `Add-PodeRoute -PassThru` or [`Get-PodeRoute`](../../../Functions/Routes/Get-PodeRoute):
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |

--- a/examples/web-pages-https.ps1
+++ b/examples/web-pages-https.ps1
@@ -19,7 +19,6 @@ Start-PodeServer {
 
     # bind to ip/port and set as https with self-signed cert
     Add-PodeEndpoint -Address * -Port 8443 -Protocol HTTPS -SelfSigned
-    #listen "pode.foo.com:8443" https -cert self
 
     # set view engine for web pages
     Set-PodeViewEngine -Type Pode

--- a/src/Pode.psd1
+++ b/src/Pode.psd1
@@ -180,6 +180,7 @@
         'Start-PodeStaticServer',
         'Show-PodeGui',
         'Add-PodeEndpoint',
+        'Get-PodeEndpoint',
         'Pode',
 
         # openapi

--- a/src/Public/Core.ps1
+++ b/src/Public/Core.ps1
@@ -820,6 +820,124 @@ function Add-PodeEndpoint
 
 <#
 .SYNOPSIS
+Get an Endpoint(s).
+
+.DESCRIPTION
+Get an Endpoint(s).
+
+.PARAMETER Address
+An Address to filter the endpoints.
+
+.PARAMETER Port
+A Port to filter the endpoints.
+
+.PARAMETER Protocol
+A Protocol to filter the endpoints.
+
+.PARAMETER Name
+Any endpoints Names to filter endpoints.
+
+.EXAMPLE
+Get-PodeEndpoint -Address 127.0.0.1
+
+.EXAMPLE
+Get-PodeEndpoint -Protocol Http
+
+.EXAMPLE
+Get-PodeEndpoint -Name Admin, User
+#>
+function Get-PodeEndpoint
+{
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [string]
+        $Address,
+
+        [Parameter()]
+        [int]
+        $Port = 0,
+
+        [Parameter()]
+        [ValidateSet('', 'Http', 'Https', 'Smtp', 'Tcp', 'Ws', 'Wss')]
+        [string]
+        $Protocol,
+
+        [Parameter()]
+        [string[]]
+        $Name
+    )
+
+    $endpoints = $PodeContext.Server.Endpoints
+
+    # if we have an address, filter
+    if (![string]::IsNullOrWhiteSpace($Address)) {
+        if ($Address -eq '*') {
+            $Address = '0.0.0.0'
+        }
+
+        if ($PodeContext.Server.IsIIS) {
+            $Address = '127.0.0.1'
+        }
+
+        $endpoints = @(foreach ($endpoint in $endpoints) {
+            if ($endpoint.Address -ine $Address) {
+                continue
+            }
+
+            $endpoint
+        })
+    }
+
+    # if we have a port, filter
+    if ($Port -gt 0) {
+        if ($PodeContext.Server.IsIIS) {
+            $Port = [int]$env:ASPNETCORE_PORT
+        }
+
+        $endpoints = @(foreach ($endpoint in $endpoints) {
+            if ($endpoint.Port -ne $Port) {
+                continue
+            }
+
+            $endpoint
+        })
+    }
+
+    # if we have a protocol, filter
+    if (![string]::IsNullOrWhiteSpace($Protocol)) {
+        if ($PodeContext.Server.IsIIS) {
+            $Protocol = 'Http'
+        }
+
+        $endpoints = @(foreach ($endpoint in $endpoints) {
+            if ($endpoint.Protocol -ine $Protocol) {
+                continue
+            }
+
+            $endpoint
+        })
+    }
+
+    # further filter by endpoint names
+    if (($null -ne $Name) -and ($Name.Length -gt 0)) {
+        $endpoints = @(foreach ($_name in $Name) {
+            foreach ($endpoint in $endpoints) {
+                if ($endpoint.Name -ine $_name) {
+                    continue
+                }
+
+                $endpoint
+            }
+        })
+    }
+
+    # return
+    return $endpoints
+}
+
+<#
+.SYNOPSIS
 Adds a new Timer with logic to periodically invoke.
 
 .DESCRIPTION

--- a/src/Public/Core.ps1
+++ b/src/Public/Core.ps1
@@ -881,7 +881,7 @@ function Get-PodeEndpoint
         }
 
         $endpoints = @(foreach ($endpoint in $endpoints) {
-            if ($endpoint.Address -ine $Address) {
+            if ($endpoint.Address.ToString() -ine $Address) {
                 continue
             }
 

--- a/tests/unit/Context.Tests.ps1
+++ b/tests/unit/Context.Tests.ps1
@@ -281,6 +281,112 @@ Describe 'Add-PodeEndpoint' {
     }
 }
 
+Describe 'Get-PodeEndpoint' {
+    Mock Test-PodeIPAddress { return $true }
+    Mock Test-IsAdminUser { return $true }
+
+    It 'Returns no Endpoints' {
+        $PodeContext.Server = @{ Endpoints = @(); Type = $null }
+        $endpoints = Get-PodeEndpoint
+        $endpoints.Length | Should Be 0
+    }
+
+    It 'Returns all Endpoints' {
+        $PodeContext.Server = @{ Endpoints = @(); Type = $null }
+
+        Add-PodeEndpoint -Address '127.0.0.1' -Port 80 -Protocol 'HTTP'
+        Add-PodeEndpoint -Address 'pode.foo.com' -Port 80 -Protocol 'HTTP'
+        Add-PodeEndpoint -Address 'pode.foo.com' -Port 8080 -Protocol 'HTTP'
+
+        $endpoints = Get-PodeEndpoint
+        $endpoints.Length | Should Be 3
+    }
+
+    It 'Returns 1 endpoint by address' {
+        $PodeContext.Server = @{ Endpoints = @(); Type = $null }
+
+        Add-PodeEndpoint -Address '127.0.0.1' -Port 80 -Protocol 'HTTP'
+        Add-PodeEndpoint -Address 'pode.foo.com' -Port 80 -Protocol 'HTTP'
+        Add-PodeEndpoint -Address 'pode.foo.com' -Port 8080 -Protocol 'HTTP'
+
+        $endpoints = Get-PodeEndpoint -Address '127.0.0.1'
+        $endpoints.Length | Should Be 1
+    }
+
+    It 'Returns 2 endpoints by address' {
+        $PodeContext.Server = @{ Endpoints = @(); Type = $null }
+
+        Add-PodeEndpoint -Address '127.0.0.1' -Port 80 -Protocol 'HTTP'
+        Add-PodeEndpoint -Address 'pode.foo.com' -Port 80 -Protocol 'HTTP'
+        Add-PodeEndpoint -Address 'pode.foo.com' -Port 8080 -Protocol 'HTTP'
+
+        $endpoints = Get-PodeEndpoint -Address 'pode.foo.com'
+        $endpoints.Length | Should Be 2
+    }
+
+    It 'Returns 2 endpoints by port' {
+        $PodeContext.Server = @{ Endpoints = @(); Type = $null }
+
+        Add-PodeEndpoint -Address '127.0.0.1' -Port 80 -Protocol 'HTTP'
+        Add-PodeEndpoint -Address 'pode.foo.com' -Port 80 -Protocol 'HTTP'
+        Add-PodeEndpoint -Address 'pode.foo.com' -Port 8080 -Protocol 'HTTP'
+
+        $endpoints = Get-PodeEndpoint -Port 80
+        $endpoints.Length | Should Be 2
+    }
+
+    It 'Returns all endpoints by protocol' {
+        $PodeContext.Server = @{ Endpoints = @(); Type = $null }
+
+        Add-PodeEndpoint -Address '127.0.0.1' -Port 80 -Protocol 'HTTP'
+        Add-PodeEndpoint -Address 'pode.foo.com' -Port 80 -Protocol 'HTTP'
+        Add-PodeEndpoint -Address 'pode.foo.com' -Port 8080 -Protocol 'HTTP'
+
+        $endpoints = Get-PodeEndpoint -Protocol Http
+        $endpoints.Length | Should Be 3
+    }
+
+    It 'Returns 2 endpoints by name' {
+        $PodeContext.Server = @{ Endpoints = @(); Type = $null }
+
+        Add-PodeEndpoint -Address '127.0.0.1' -Port 80 -Protocol 'HTTP' -Name 'Admin'
+        Add-PodeEndpoint -Address 'pode.foo.com' -Port 80 -Protocol 'HTTP' -Name 'User'
+        Add-PodeEndpoint -Address 'pode.foo.com' -Port 8080 -Protocol 'HTTP' -Name 'Dev'
+
+        $endpoints = Get-PodeEndpoint -Name Admin, User
+        $endpoints.Length | Should Be 2
+    }
+
+    It 'Returns 1 endpoint using everything' {
+        $PodeContext.Server = @{ Endpoints = @(); Type = $null }
+
+        Add-PodeEndpoint -Address '127.0.0.1' -Port 80 -Protocol 'HTTP' -Name 'Admin'
+        Add-PodeEndpoint -Address 'pode.foo.com' -Port 80 -Protocol 'HTTP' -Name 'User'
+        Add-PodeEndpoint -Address 'pode.foo.com' -Port 8080 -Protocol 'HTTP' -Name 'Dev'
+
+        $endpoints = Get-PodeEndpoint -Address 'pode.foo.com' -Port 80 -Protocol Http -Name User
+        $endpoints.Length | Should Be 1
+    }
+
+    It 'Returns endpoint set using wildcard' {
+        $PodeContext.Server = @{ Endpoints = @(); Type = $null }
+
+        Add-PodeEndpoint -Address '*' -Port 80 -Protocol 'HTTP'
+
+        $endpoints = Get-PodeEndpoint -Address '*'
+        $endpoints.Length | Should Be 1
+    }
+
+    It 'Returns endpoint set using localhost' {
+        $PodeContext.Server = @{ Endpoints = @(); Type = $null }
+
+        Add-PodeEndpoint -Address 'localhost' -Port 80 -Protocol 'HTTP'
+
+        $endpoints = Get-PodeEndpoint -Address 'localhost'
+        $endpoints.Length | Should Be 1
+    }
+}
+
 Describe 'Import-PodeModule' {
     Context 'Invalid parameters supplied' {
         It 'Throw null path parameter error' {

--- a/tests/unit/Routes.Tests.ps1
+++ b/tests/unit/Routes.Tests.ps1
@@ -1274,11 +1274,6 @@ Describe 'Get-PodeStaticRoute' {
         $routes.Length | Should Be 1
     }
 
-
-
-
-    
-
     It 'Returns one static route for endpoint' {
         $PodeContext.Server = @{ Routes = @{ STATIC = @{}; }; Root = $pwd; Endpoints = @(); Type = $null }
 


### PR DESCRIPTION
### Description of the Change
Adds a new Get-PodeEndpoint function to get and filter endpoints in Pode.

```powershell
Get-PodeEndpoint [-Address] [-Port] [-Protocol] [-Name]
```

### Related Issue
Resolves #518 

### Examples
```powershell
$all = Get-PodeEndpoint

$proto = Get-PodeEndpoint -Protocol Http
```