### PR TITLE
Added support for Middleware on Static Routes

### DIFF
--- a/docs/Tutorials/Middleware/Overview.md
+++ b/docs/Tutorials/Middleware/Overview.md
@@ -93,7 +93,7 @@ Although you can define your own custom middleware, Pode does have some inbuilt 
 | ----- | ---------- | ----------- |
 | 1 | **Access Rules** | Allowing/Denying IP addresses (if access rules have been defined) |
 | 2 | **Rate Limiting** | Limiting access to IP addresses (if rate limiting rules have been defined) |
-| 3 | **Static Content** | Static Content such as images/css/js/html in the `/public` directory (or other defined static routes) |
+| 3 | **Static Content** | Static Content, such as images/css/js/html, in the `/public` directory |
 | 4 | **Body Parsing** | Parsing request payload as JSON, XML, or other types |
 | 5 | **Query String** | Getting any query string parameters currently on the request URL |
 | 6 | **Cookie Parsing** | Parse the cookies from the request's header (this only applies to serverless) |

--- a/docs/Tutorials/Routes/Overview.md
+++ b/docs/Tutorials/Routes/Overview.md
@@ -140,7 +140,7 @@ For example, to create a route from a file that will write a simple JSON respons
 }
 ```
 
-* Timer
+* Route
 ```powershell
 Add-PodeRoute -Method Get -Path '/ping' -FilePath './Routes/File.ps1'
 ```
@@ -179,10 +179,11 @@ The following is the structure of the Route object internally, as well as the ob
 | Name | Type | Description |
 | ---- | ---- | ----------- |
 | Arguments | object[] | Array of arguments that are splatted onto the route's scriptblock (after the web event) |
-| ContentType | string | Content type to use when parsing the payload a request to the route |
+| ContentType | string | The content type to use when parsing the payload in the request |
 | Endpoint | string | Endpoint the route is bound to as `<address>:<port>` |
 | EndpointName | string | Name of the endpoint the route is bound to |
 | ErrorType | string | Content type of the error page to use for the route |
+| IsStatic | bool | Fixed to false for normal routes |
 | Logic | scriptblock | The main scriptblock logic of the route |
 | Method | string | HTTP method of the route |
 | Metrics | hashtable | Metrics for the route, such as Request counts |
@@ -190,17 +191,24 @@ The following is the structure of the Route object internally, as well as the ob
 | OpenApi | hashtable[] | The OpenAPI definition/settings for the route |
 | Path | string | The path of the route - this path will have regex in place of route parameters |
 | Protocol | string | Protocol the route is bound to |
+| TransferEncoding | string | The transfer encoding to use when parsing the payload in the request |
 
 Static routes have a slightly different format:
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
+| ContentType | string | Content type to use when parsing the payload a request to the route |
 | Defaults | string[] | Array of default file names to render if path in request is a folder |
 | Download | bool | Specifies whether files are rendered in the response, or downloaded |
 | Endpoint | string | Endpoint the route is bound to as `<address>:<port>` |
 | EndpointName | string | Name of the endpoint the route is bound to |
+| ErrorType | string | Content type of the error page to use for the route |
+| IsStatic | bool | Fixed to true for static routes |
 | Method | string | HTTP method of the route |
 | Metrics | hashtable | Metrics for the route, such as Request counts |
+| Middleware | hashtable[] | Array of middleware that runs prior to the route's scriptblock |
+| OpenApi | hashtable[] | The OpenAPI definition/settings for the route |
 | Path | string | The path of the route - this path will have regex in place of dynamic file names |
 | Protocol | string | Protocol the route is bound to |
 | Source | string | The source path within the server that is used for the route |
+| TransferEncoding | string | The transfer encoding to use when parsing the payload in the request |

--- a/docs/Tutorials/Routes/Utilities/StaticContent.md
+++ b/docs/Tutorials/Routes/Utilities/StaticContent.md
@@ -1,12 +1,12 @@
 # Static Content
 
-Static content in Pode can be used by either placing your static files with the `/public` directory, or by defining static routes. You can also specify default pages, such as `index.html`, for when users navigate to root folders.
+Static content in Pode can be used by either placing your static files within the `/public` directory, or by defining custom static routes. You can also specify default pages, such as `index.html`, for when users navigate to root folders.
 
-Caching is also supported on static content.
+Caching is supported on static content.
 
 ## Static Routes
 
-The following is an example of using the  [`Add-PodeStaticRoute`](../../../../Functions/Routes/Add-PodeStaticRoute) function to define a route to some static content directory; this tells Pode where to get static files from for certain routes. This example will define a static route for `/assets`, and will point the route at the internal directory path of `./content/assets`:
+The following is an example of using the [`Add-PodeStaticRoute`](../../../../Functions/Routes/Add-PodeStaticRoute) function to define a route to some static content directory; this tells Pode where to get static files from for certain routes. This example will define a static route for `/assets`, and will point the route at the internal directory path of `./content/assets`:
 
 ```powershell
 Start-PodeServer {
@@ -20,6 +20,14 @@ The following request will retrieve an image from the `./content/assets/images` 
 ```powershell
 Invoke-WebRequest -Uri 'http://localhost:8080/assets/images/icon.png' -Method Get
 ```
+
+## Middleware
+
+Anything placed within your server's `/public` directory will always be public static content. However, if you define custom static routes via [`Add-PodeStaticRoute`](../../../../Functions/Routes/Add-PodeStaticRoute), then you can also supply middleware - including authentication.
+
+Custom static routes follow a similar flow to normal routes, and any query string; payloads; cookies; etc, will all be parsed - allowing you to run any route specific middleware before the static content is actually returned.
+
+Middleware works the same as on normal Routes, so there's nothing extra you need to do. Any global middleware that you've defined will also work on static routes as well.
 
 ## Default Pages
 
@@ -38,7 +46,7 @@ These pages are checked in order, and if one is found then its content is return
 Invoke-WebRequest -Uri 'http://localhost:8080/assets/images/home' -Method Get
 ```
 
-The default pages can be configured in two ways; either by using the `-Defaults` parameter on the  [`Add-PodeStaticRoute`](../../../../Functions/Routes/Add-PodeStaticRoute) function, or by setting them in the `server.psd1` [configuration file](../../../Configuration). To set the defaults to be only a `home.html` page, both ways would work as follows:
+The default pages can be configured in two ways; either by using the `-Defaults` parameter on the [`Add-PodeStaticRoute`](../../../../Functions/Routes/Add-PodeStaticRoute) function, or by setting them in the `server.psd1` [configuration file](../../../Configuration). To set the defaults to be only a `home.html` page, both ways would work as follows:
 
 *Defaults Parameter*
 ```powershell
@@ -55,6 +63,8 @@ Add-PodeStaticRoute -Path '/assets' -Source './content/assets' -Defaults @('inde
     }
 }
 ```
+
+The only difference being, if you have multiple static routes, setting any default pages in the `server.psd1` file will apply to *all* static routes. Any default pages set using the `-Default` parameter will have a higher precedence than the `server.psd1` file.
 
 ## Caching
 
@@ -90,19 +100,6 @@ If you wish to set a max cache time of 30mins, then you would use the `MaxAge` p
     }
 }
 ```
-
-## Downloadable
-
-Normally content accessed on a static route is rendered on the browser, but you can set the route to flag the files for downloading instead. If you set the `-DownloadOnly` switch on the  [`Add-PodeStaticRoute`](../../../../Functions/Routes/Add-PodeStaticRoute) function, then accessing files on this route in a browser will cause them to be downloaded instead of rendered:
-
-```powershell
-Start-PodeServer {
-    Add-PodeEndpoint -Address * -Port 8080 -Protocol Http
-    Add-PodeStaticRoute -Path '/assets' -Source './content/assets' -DownloadOnly
-}
-```
-
-When a static route is set as downloadable, then `-Defaults` and caching are not used.
 
 ### Include/Exclude
 
@@ -142,3 +139,16 @@ Or, you could setup some static routes called `/assets` and `/images`, and you w
     }
 }
 ```
+
+## Downloadable
+
+Normally content accessed on a static route is rendered on the browser, but you can set the route to flag the files for downloading instead. If you set the `-DownloadOnly` switch on the  [Add-PodeStaticRoute`](../../../../Functions/Routes/Add-PodeStaticRoute) function, then accessing files on this route in a browser will cause them to be downloaded instead of rendered:
+
+```powershell
+Start-PodeServer {
+    Add-PodeEndpoint -Address * -Port 8080 -Protocol Http
+    Add-PodeStaticRoute -Path '/assets' -Source './content/assets' -DownloadOnly
+}
+```
+
+When a static route is set as downloadable, then `-Defaults` and caching are not used.

--- a/docs/Tutorials/WebEvent.md
+++ b/docs/Tutorials/WebEvent.md
@@ -37,6 +37,7 @@ Add-PodeRoute -Method Get -Path '/' -ScriptBlock {
 | Response | object | The raw Response object |
 | Route | hashtable | The current Route that is being invoked |
 | Session | hashtable | Contains details about, and any data stored in the current session - this data can be accessed in the sub `.Data` property |
+| StaticContent | hashtable | Contains details about the source path, if the route is a custom Static Route |
 | Streamed | bool | Specifies whether the current server type uses streams for the Request/Response, or raw strings |
 | Timestamp | datetime | The current date and time of the Request |
 

--- a/examples/web-static-auth.ps1
+++ b/examples/web-static-auth.ps1
@@ -1,0 +1,51 @@
+$path = Split-Path -Parent -Path (Split-Path -Parent -Path $MyInvocation.MyCommand.Path)
+Import-Module "$($path)/src/Pode.psm1" -Force -ErrorAction Stop
+
+# or just:
+# Import-Module Pode
+
+# create a server, and start listening on port 8085
+Start-PodeServer -Threads 2 {
+
+    # listen on localhost:8085
+    Add-PodeEndpoint -Address * -Port 8085 -Protocol Http
+
+    New-PodeLoggingMethod -Terminal | Enable-PodeRequestLogging
+    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+
+    # setup basic auth (base64> username:password in header)
+    New-PodeAuthType -Basic -Realm 'Pode Static Page' | Add-PodeAuth -Name 'Validate' -ScriptBlock {
+        param($username, $password)
+
+        # here you'd check a real user storage, this is just for example
+        if ($username -eq 'morty' -and $password -eq 'pickle') {
+            return @{
+                User = @{
+                    ID ='M0R7Y302'
+                    Name = 'Morty'
+                    Type = 'Human'
+                }
+            }
+        }
+
+        return @{ Message = 'Invalid details supplied' }
+    }
+
+    # set view engine to pode renderer
+    Set-PodeViewEngine -Type Pode
+
+    # STATIC asset folder route
+    Add-PodeStaticRoute -Path '/assets' -Source './assets' -Defaults @('index.html') -Middleware (Get-PodeAuthMiddleware -Name 'Validate' -Sessionless)
+    Add-PodeStaticRoute -Path '/assets/download' -Source './assets' -DownloadOnly
+
+    # GET request for web page on "localhost:8085/"
+    Add-PodeRoute -Method Get -Path '/' -ScriptBlock {
+        Write-PodeViewResponse -Path 'web-static' -Data @{ 'numbers' = @(1, 2, 3); }
+    }
+
+    # GET request to download a file from static route
+    Add-PodeRoute -Method Get -Path '/download' -ScriptBlock {
+        Set-PodeResponseAttachment -Path '/assets/images/Fry.png'
+    }
+
+}

--- a/examples/web-static.ps1
+++ b/examples/web-static.ps1
@@ -15,6 +15,7 @@ Start-PodeServer -Threads 2 {
     # listen on localhost:8085
     Add-PodeEndpoint -Address * -Port $port -Protocol Http
     New-PodeLoggingMethod -Terminal | Enable-PodeRequestLogging
+    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
 
     # set view engine to pode renderer
     Set-PodeViewEngine -Type Pode

--- a/src/Private/Endware.ps1
+++ b/src/Private/Endware.ps1
@@ -17,6 +17,10 @@ function Invoke-PodeEndware
     # loop through each of the endware, invoking the next if it returns true
     foreach ($eware in @($Endware))
     {
+        if (($null -eq $eware) -or ($null -eq $eware.Logic)) {
+            continue
+        }
+
         try {
             Invoke-PodeScriptBlock -ScriptBlock $eware.Logic -Arguments (@($WebEvent) + @($eware.Arguments)) -Scoped -Splat | Out-Null
         }

--- a/src/Private/Middleware.ps1
+++ b/src/Private/Middleware.ps1
@@ -118,36 +118,19 @@ function Get-PodePublicMiddleware
     return (Get-PodeInbuiltMiddleware -Name '__pode_mw_static_content__' -ScriptBlock {
         param($e)
 
-        # get the static file path
-        $info = Find-PodeStaticRoutePath -Path $e.Path -Protocol $e.Protocol -Endpoint $e.Endpoint
-        if ([string]::IsNullOrWhiteSpace($info.Source)) {
+        # only find public static content here
+        $path = Find-PodePublicRoute -Path $e.Path
+        if ([string]::IsNullOrWhiteSpace($path)) {
             return $true
         }
 
         # check current state of caching
-        $config = $PodeContext.Server.Web.Static.Cache
-        $caching = $config.Enabled
+        $cachable = Test-PodeRouteValidForCaching -Path $e.Path
 
-        # if caching, check include/exclude
-        if ($caching) {
-            if (($null -ne $config.Exclude) -and ($e.Path -imatch $config.Exclude)) {
-                $caching = $false
-            }
+        # write the file to the response
+        Write-PodeFileResponse -Path $path -MaxAge $PodeContext.Server.Web.Static.Cache.MaxAge -Cache:$cachable
 
-            if (($null -ne $config.Include) -and ($e.Path -inotmatch $config.Include)) {
-                $caching = $false
-            }
-        }
-
-        # write, or attach, the file to the response
-        if ($info.Download) {
-            Set-PodeResponseAttachment -Path $e.Path
-        }
-        else {
-            Write-PodeFileResponse -Path $info.Source -MaxAge $PodeContext.Server.Web.Static.Cache.MaxAge -Cache:$caching
-        }
-
-        # static content found, stop
+        # public static content found, stop
         return $false
     })
 }
@@ -159,8 +142,11 @@ function Get-PodeRouteValidateMiddleware
         Logic = {
             param($e)
 
-            # ensure the path has a route
-            $route = Find-PodeRoute -Method $e.Method -Path $e.Path -Protocol $e.Protocol -Endpoint $e.Endpoint -CheckWildMethod
+            # check if the path is static route first, then check the main routes
+            $route = Find-PodeStaticRoute -Path $e.Path -Protocol $e.Protocol -Endpoint $e.Endpoint
+            if ($null -eq $route) {
+                $route = Find-PodeRoute -Method $e.Method -Path $e.Path -Protocol $e.Protocol -Endpoint $e.Endpoint -CheckWildMethod
+            }
 
             # if there's no route defined, it's a 404 - or a 405 if a route exists for any other method
             if ($null -eq $route) {
@@ -182,6 +168,12 @@ function Get-PodeRouteValidateMiddleware
                 # otheriwse, it's a 404
                 Set-PodeResponseStatus -Code 404
                 return $false
+            }
+
+            # check if static and split
+            if ($null -ne $route.StaticRoute) {
+                $e.StaticRoute = $route.StaticRoute
+                $route = $route.Route
             }
 
             # set the route parameters

--- a/src/Private/Middleware.ps1
+++ b/src/Private/Middleware.ps1
@@ -14,7 +14,7 @@ function Invoke-PodeMiddleware
     )
 
     # if there's no middleware, do nothing
-    if ($null -eq $Middleware -or $Middleware.Length -eq 0) {
+    if (($null -eq $Middleware) -or ($Middleware.Length -eq 0)) {
         return $true
     }
 
@@ -22,6 +22,10 @@ function Invoke-PodeMiddleware
     if (![string]::IsNullOrWhiteSpace($Route))
     {
         $Middleware = @(foreach ($mware in $Middleware) {
+            if ($null -eq $mware) {
+                continue
+            }
+
             if ([string]::IsNullOrWhiteSpace($mware.Route) -or ($mware.Route -ieq '/') -or ($mware.Route -ieq $Route) -or ($Route -imatch "^$($mware.Route)$")) {
                 $mware
             }
@@ -34,6 +38,10 @@ function Invoke-PodeMiddleware
     # loop through each of the middleware, invoking the next if it returns true
     foreach ($midware in @($Middleware))
     {
+        if (($null -eq $midware) -or ($null -eq $midware.Logic)) {
+            continue
+        }
+
         try {
             $continue = Invoke-PodeScriptBlock -ScriptBlock $midware.Logic -Arguments (@($WebEvent) + @($midware.Arguments)) -Return -Scoped -Splat
         }

--- a/src/Private/Middleware.ps1
+++ b/src/Private/Middleware.ps1
@@ -171,8 +171,8 @@ function Get-PodeRouteValidateMiddleware
             }
 
             # check if static and split
-            if ($null -ne $route.StaticRoute) {
-                $e.StaticRoute = $route.StaticRoute
+            if ($null -ne $route.Content) {
+                $e.StaticContent = $route.Content
                 $route = $route.Route
             }
 

--- a/src/Private/PodeServer.ps1
+++ b/src/Private/PodeServer.ps1
@@ -155,6 +155,7 @@ function Invoke-PodeSocketHandler
             Files = $null
             Streamed = $true
             Route = $null
+            StaticRoute = $null
             Timestamp = [datetime]::UtcNow
             TransferEncoding = $null
         }
@@ -227,11 +228,21 @@ function Invoke-PodeSocketHandler
         # add logging endware for post-request
         Add-PodeRequestLogEndware -WebEvent $WebEvent
 
-        # invoke middleware
+        # invoke global and route middleware
         if ((Invoke-PodeMiddleware -WebEvent $WebEvent -Middleware $PodeContext.Server.Middleware -Route $WebEvent.Path)) {
-            # invoke route and custom middleware
-            if ((Invoke-PodeMiddleware -WebEvent $WebEvent -Middleware $WebEvent.Route.Middleware)) {
-                if ($null -ne $WebEvent.Route.Logic) {
+            if ((Invoke-PodeMiddleware -WebEvent $WebEvent -Middleware $WebEvent.Route.Middleware))
+            {
+                # invoke the route
+                if ($null -ne $WebEvent.StaticRoute) {
+                    if ($WebEvent.StaticRoute.IsDownload) {
+                        Set-PodeResponseAttachment -Path $e.Path
+                    }
+                    else {
+                        $cachable = $WebEvent.StaticRoute.IsCachable
+                        Write-PodeFileResponse -Path $WebEvent.StaticRoute.Source -MaxAge $PodeContext.Server.Web.Static.Cache.MaxAge -Cache:$cachable
+                    }
+                }
+                else {
                     Invoke-PodeScriptBlock -ScriptBlock $WebEvent.Route.Logic -Arguments (@($WebEvent) + @($WebEvent.Route.Arguments)) -Scoped -Splat
                 }
             }

--- a/src/Private/PodeServer.ps1
+++ b/src/Private/PodeServer.ps1
@@ -155,7 +155,7 @@ function Invoke-PodeSocketHandler
             Files = $null
             Streamed = $true
             Route = $null
-            StaticRoute = $null
+            StaticContent = $null
             Timestamp = [datetime]::UtcNow
             TransferEncoding = $null
         }
@@ -233,13 +233,13 @@ function Invoke-PodeSocketHandler
             if ((Invoke-PodeMiddleware -WebEvent $WebEvent -Middleware $WebEvent.Route.Middleware))
             {
                 # invoke the route
-                if ($null -ne $WebEvent.StaticRoute) {
-                    if ($WebEvent.StaticRoute.IsDownload) {
+                if ($null -ne $WebEvent.StaticContent) {
+                    if ($WebEvent.StaticContent.IsDownload) {
                         Set-PodeResponseAttachment -Path $e.Path
                     }
                     else {
-                        $cachable = $WebEvent.StaticRoute.IsCachable
-                        Write-PodeFileResponse -Path $WebEvent.StaticRoute.Source -MaxAge $PodeContext.Server.Web.Static.Cache.MaxAge -Cache:$cachable
+                        $cachable = $WebEvent.StaticContent.IsCachable
+                        Write-PodeFileResponse -Path $WebEvent.StaticContent.Source -MaxAge $PodeContext.Server.Web.Static.Cache.MaxAge -Cache:$cachable
                     }
                 }
                 else {

--- a/src/Private/Routes.ps1
+++ b/src/Private/Routes.ps1
@@ -192,7 +192,7 @@ function Find-PodeStaticRoute
 
     # return the route details
     return @{
-        StaticRoute = @{
+        Content = @{
             Source = $source
             IsDownload = $download
             IsCachable = (Test-PodeRouteValidForCaching -Path $Path)

--- a/src/Private/Serverless.ps1
+++ b/src/Private/Serverless.ps1
@@ -45,7 +45,7 @@ function Start-PodeAzFuncServer
                 Path = [string]::Empty
                 Streamed = $false
                 Route = $null
-                StaticRoute = $null
+                StaticContent = $null
                 Timestamp = [datetime]::UtcNow
             }
 
@@ -68,13 +68,13 @@ function Start-PodeAzFuncServer
                 if ((Invoke-PodeMiddleware -WebEvent $WebEvent -Middleware $WebEvent.Route.Middleware))
                 {
                     # invoke the route
-                    if ($null -ne $WebEvent.StaticRoute) {
-                        if ($WebEvent.StaticRoute.IsDownload) {
+                    if ($null -ne $WebEvent.StaticContent) {
+                        if ($WebEvent.StaticContent.IsDownload) {
                             Set-PodeResponseAttachment -Path $e.Path
                         }
                         else {
-                            $cachable = $WebEvent.StaticRoute.IsCachable
-                            Write-PodeFileResponse -Path $WebEvent.StaticRoute.Source -MaxAge $PodeContext.Server.Web.Static.Cache.MaxAge -Cache:$cachable
+                            $cachable = $WebEvent.StaticContent.IsCachable
+                            Write-PodeFileResponse -Path $WebEvent.StaticContent.Source -MaxAge $PodeContext.Server.Web.Static.Cache.MaxAge -Cache:$cachable
                         }
                     }
                     else {
@@ -153,7 +153,7 @@ function Start-PodeAwsLambdaServer
                 PendingCookies = @{}
                 Streamed = $false
                 Route = $null
-                StaticRoute = $null
+                StaticContent = $null
                 Timestamp = [datetime]::UtcNow
             }
 
@@ -169,13 +169,13 @@ function Start-PodeAwsLambdaServer
                 if ((Invoke-PodeMiddleware -WebEvent $WebEvent -Middleware $WebEvent.Route.Middleware))
                 {
                     # invoke the route
-                    if ($null -ne $WebEvent.StaticRoute) {
-                        if ($WebEvent.StaticRoute.IsDownload) {
+                    if ($null -ne $WebEvent.StaticContent) {
+                        if ($WebEvent.StaticContent.IsDownload) {
                             Set-PodeResponseAttachment -Path $e.Path
                         }
                         else {
-                            $cachable = $WebEvent.StaticRoute.IsCachable
-                            Write-PodeFileResponse -Path $WebEvent.StaticRoute.Source -MaxAge $PodeContext.Server.Web.Static.Cache.MaxAge -Cache:$cachable
+                            $cachable = $WebEvent.StaticContent.IsCachable
+                            Write-PodeFileResponse -Path $WebEvent.StaticContent.Source -MaxAge $PodeContext.Server.Web.Static.Cache.MaxAge -Cache:$cachable
                         }
                     }
                     else {

--- a/src/Private/WebServer.ps1
+++ b/src/Private/WebServer.ps1
@@ -107,6 +107,7 @@ function Start-PodeWebServer
                         PendingCookies = @{}
                         Streamed = $true
                         Route = $null
+                        StaticRoute = $null
                         Timestamp = [datetime]::UtcNow
                         TransferEncoding = $null
                         AcceptEncoding = $null
@@ -121,11 +122,21 @@ function Start-PodeWebServer
                     # add logging endware for post-request
                     Add-PodeRequestLogEndware -WebEvent $WebEvent
 
-                    # invoke middleware
+                    # invoke global and route middleware
                     if ((Invoke-PodeMiddleware -WebEvent $WebEvent -Middleware $PodeContext.Server.Middleware -Route $WebEvent.Path)) {
-                        # invoke route and custom middleware
-                        if ((Invoke-PodeMiddleware -WebEvent $WebEvent -Middleware $WebEvent.Route.Middleware)) {
-                            if ($null -ne $WebEvent.Route.Logic) {
+                        if ((Invoke-PodeMiddleware -WebEvent $WebEvent -Middleware $WebEvent.Route.Middleware))
+                        {
+                            # invoke the route
+                            if ($null -ne $WebEvent.StaticRoute) {
+                                if ($WebEvent.StaticRoute.IsDownload) {
+                                    Set-PodeResponseAttachment -Path $e.Path
+                                }
+                                else {
+                                    $cachable = $WebEvent.StaticRoute.IsCachable
+                                    Write-PodeFileResponse -Path $WebEvent.StaticRoute.Source -MaxAge $PodeContext.Server.Web.Static.Cache.MaxAge -Cache:$cachable
+                                }
+                            }
+                            else {
                                 Invoke-PodeScriptBlock -ScriptBlock $WebEvent.Route.Logic -Arguments (@($WebEvent) + @($WebEvent.Route.Arguments)) -Scoped -Splat
                             }
                         }

--- a/src/Private/WebServer.ps1
+++ b/src/Private/WebServer.ps1
@@ -107,7 +107,7 @@ function Start-PodeWebServer
                         PendingCookies = @{}
                         Streamed = $true
                         Route = $null
-                        StaticRoute = $null
+                        StaticContent = $null
                         Timestamp = [datetime]::UtcNow
                         TransferEncoding = $null
                         AcceptEncoding = $null
@@ -127,13 +127,13 @@ function Start-PodeWebServer
                         if ((Invoke-PodeMiddleware -WebEvent $WebEvent -Middleware $WebEvent.Route.Middleware))
                         {
                             # invoke the route
-                            if ($null -ne $WebEvent.StaticRoute) {
-                                if ($WebEvent.StaticRoute.IsDownload) {
+                            if ($null -ne $WebEvent.StaticContent) {
+                                if ($WebEvent.StaticContent.IsDownload) {
                                     Set-PodeResponseAttachment -Path $e.Path
                                 }
                                 else {
-                                    $cachable = $WebEvent.StaticRoute.IsCachable
-                                    Write-PodeFileResponse -Path $WebEvent.StaticRoute.Source -MaxAge $PodeContext.Server.Web.Static.Cache.MaxAge -Cache:$cachable
+                                    $cachable = $WebEvent.StaticContent.IsCachable
+                                    Write-PodeFileResponse -Path $WebEvent.StaticContent.Source -MaxAge $PodeContext.Server.Web.Static.Cache.MaxAge -Cache:$cachable
                                 }
                             }
                             else {

--- a/src/Public/Responses.ps1
+++ b/src/Public/Responses.ps1
@@ -41,7 +41,7 @@ function Set-PodeResponseAttachment
     )
 
     # only attach files from public/static-route directories when path is relative
-    $_path = (Find-PodeStaticRoutePath -Path $Path).Source
+    $_path = (Find-PodeStaticRoute -Path $Path).StaticRoute.Source
 
     # if there's no path, check the original path (in case it's literal/relative)
     if (!(Test-PodePath $_path -NoStatus)) {

--- a/src/Public/Responses.ps1
+++ b/src/Public/Responses.ps1
@@ -41,7 +41,7 @@ function Set-PodeResponseAttachment
     )
 
     # only attach files from public/static-route directories when path is relative
-    $_path = (Find-PodeStaticRoute -Path $Path).Content.Source
+    $_path = (Find-PodeStaticRoute -Path $Path -CheckPublic).Content.Source
 
     # if there's no path, check the original path (in case it's literal/relative)
     if (!(Test-PodePath $_path -NoStatus)) {

--- a/src/Public/Responses.ps1
+++ b/src/Public/Responses.ps1
@@ -41,7 +41,7 @@ function Set-PodeResponseAttachment
     )
 
     # only attach files from public/static-route directories when path is relative
-    $_path = (Find-PodeStaticRoute -Path $Path).StaticRoute.Source
+    $_path = (Find-PodeStaticRoute -Path $Path).Content.Source
 
     # if there's no path, check the original path (in case it's literal/relative)
     if (!(Test-PodePath $_path -NoStatus)) {

--- a/src/Public/Routes.ps1
+++ b/src/Public/Routes.ps1
@@ -271,6 +271,9 @@ The URI path for the static Route.
 .PARAMETER Source
 The literal, or relative, path to the directory that contains the static content.
 
+.PARAMETER Middleware
+An array of ScriptBlocks for optional Middleware.
+
 .PARAMETER Protocol
 The protocol this static Route should be bound against.
 
@@ -280,11 +283,23 @@ The endpoint this static Route should be bound against.
 .PARAMETER EndpointName
 The EndpointName of an Endpoint(s) to bind the static Route against.
 
+.PARAMETER ContentType
+The content type the static Route should use when parsing any payloads.
+
+.PARAMETER TransferEncoding
+The transfer encoding the static Route should use when parsing any payloads.
+
 .PARAMETER Defaults
 An array of default pages to display, such as 'index.html'.
 
+.PARAMETER ErrorContentType
+The content type of any error pages that may get returned.
+
 .PARAMETER DownloadOnly
 When supplied, all static content on this Route will be attached as downloads - rather than rendered.
+
+.PARAMETER PassThru
+If supplied, the static route created will be returned so it can be passed through a pipe.
 
 .EXAMPLE
 Add-PodeStaticRoute -Path '/assets' -Source './assets'
@@ -308,6 +323,10 @@ function Add-PodeStaticRoute
         $Source,
 
         [Parameter()]
+        [object[]]
+        $Middleware,
+
+        [Parameter()]
         [ValidateSet('', 'Http', 'Https')]
         [string]
         $Protocol,
@@ -321,11 +340,27 @@ function Add-PodeStaticRoute
         $EndpointName,
 
         [Parameter()]
+        [string]
+        $ContentType,
+
+        [Parameter()]
+        [ValidateSet('', 'gzip', 'deflate')]
+        [string]
+        $TransferEncoding,
+
+        [Parameter()]
         [string[]]
         $Defaults,
 
+        [Parameter()]
+        [string]
+        $ErrorContentType,
+
         [switch]
-        $DownloadOnly
+        $DownloadOnly,
+
+        [switch]
+        $PassThru
     )
 
     # store the route method
@@ -339,6 +374,8 @@ function Add-PodeStaticRoute
 
     # ensure the route has appropriate slashes
     $Path = Update-PodeRouteSlashes -Path $Path -Static
+    $OpenApiPath = ConvertTo-PodeOpenApiRoutePath -Path $Path
+    $Path = Update-PodeRoutePlaceholders -Path $Path
 
     # get endpoints from name, or use single passed endpoint/protocol
     $endpoints = Find-PodeEndpoints -Endpoint $Endpoint -Protocol $Protocol -EndpointName $EndpointName
@@ -362,17 +399,98 @@ function Add-PodeStaticRoute
         $Defaults = Get-PodeStaticRouteDefaults
     }
 
-    # add the static route for each endpoint
-    foreach ($_endpoint in $endpoints) {
-        $PodeContext.Server.Routes[$Method][$Path] += @(@{
+    # ensure supplied middlewares are either a scriptblock, or a valid hashtable
+    #TODO: generalise?
+    if (!(Test-IsEmpty $Middleware)) {
+        @($Middleware) | ForEach-Object {
+            # check middleware is a type valid
+            if (($_ -isnot [scriptblock]) -and ($_ -isnot [hashtable])) {
+                throw "One of the Route Middlewares supplied for the '[$($Method)] $($Path)' Route is an invalid type. Expected either ScriptBlock or Hashtable, but got: $($_.GetType().Name)"
+            }
+
+            # if middleware is hashtable, ensure the keys are valid (logic is a scriptblock)
+            if ($_ -is [hashtable]) {
+                if ($null -eq $_.Logic) {
+                    throw "A Hashtable Middleware supplied for the '[$($Method)] $($Path)' Route has no Logic defined"
+                }
+
+                if ($_.Logic -isnot [scriptblock]) {
+                    throw "A Hashtable Middleware supplied for the '[$($Method)] $($Path)' Route has has an invalid Logic type. Expected ScriptBlock, but got: $($_.Logic.GetType().Name)"
+                }
+            }
+        }
+    }
+
+    # if we have middleware, convert scriptblocks to hashtables
+    if (!(Test-IsEmpty $Middleware))
+    {
+        $Middleware = @($Middleware)
+
+        for ($i = 0; $i -lt $Middleware.Length; $i++) {
+            if ($Middleware[$i] -is [scriptblock]) {
+                $Middleware[$i] = @{
+                    'Logic' = $Middleware[$i]
+                }
+            }
+        }
+    }
+
+    # workout a default content type for the route
+    if ([string]::IsNullOrWhiteSpace($ContentType)) {
+        $ContentType = $PodeContext.Server.Web.ContentType.Default
+
+        # find type by pattern from settings
+        $matched = ($PodeContext.Server.Web.ContentType.Routes.Keys | Where-Object {
+            $Path -imatch $_
+        } | Select-Object -First 1)
+
+        # if we get a match, set it
+        if (!(Test-IsEmpty $matched)) {
+            $ContentType = $PodeContext.Server.Web.ContentType.Routes[$matched]
+        }
+    }
+
+    # workout a default transfer encoding for the route
+    if ([string]::IsNullOrWhiteSpace($TransferEncoding)) {
+        $TransferEncoding = $PodeContext.Server.Web.TransferEncoding.Default
+
+        # find type by pattern from settings
+        $matched = ($PodeContext.Server.Web.TransferEncoding.Routes.Keys | Where-Object {
+            $Path -imatch $_
+        } | Select-Object -First 1)
+
+        # if we get a match, set it
+        if (!(Test-IsEmpty $matched)) {
+            $TransferEncoding = $PodeContext.Server.Web.TransferEncoding.Routes[$matched]
+        }
+    }
+
+    # add the route(s)
+    Write-Verbose "Adding Route: [$($Method)] $($Path)"
+    $newRoutes = @(foreach ($_endpoint in $endpoints) {
+        @{
             Source = $Source
             Path = $Path
             Method = $Method
             Defaults = $Defaults
+            Middleware = $Middleware
             Protocol = $_endpoint.Protocol
             Endpoint = $_endpoint.Address.Trim()
             EndpointName = $_endpoint.Name
+            ContentType = $ContentType
+            TransferEncoding = $TransferEncoding
+            ErrorType = $ErrorContentType
             Download = $DownloadOnly
+            OpenApi = @{
+                Path = $OpenApiPath
+                Responses = @{
+                    '200' = @{ description = 'OK' }
+                    'default' = @{ description = 'Internal server error' }
+                }
+                Parameters = @()
+                RequestBody = @{}
+                Authentication = @()
+            }
             IsStatic = $true
             Metrics = @{
                 Requests = @{
@@ -380,7 +498,14 @@ function Add-PodeStaticRoute
                     StatusCodes = @{}
                 }
             }
-        })
+        }
+    })
+
+    $PodeContext.Server.Routes[$Method][$Path] += @($newRoutes)
+
+    # return the routes?
+    if ($PassThru) {
+        return $newRoutes
     }
 }
 

--- a/tests/unit/Middleware.Tests.ps1
+++ b/tests/unit/Middleware.Tests.ps1
@@ -384,13 +384,13 @@ Describe 'Get-PodeRouteValidateMiddleware' {
         $r.Name | Should Be '__pode_mw_route_validation__'
         $r.Logic | Should Not Be $null
 
-        Mock Find-PodeStaticRoute { return @{ StaticRoute = @{ Source = '/'; Download = $true }; Route = @{} } }
+        Mock Find-PodeStaticRoute { return @{ Content = @{ Source = '/'; Download = $true }; Route = @{} } }
         Mock Find-PodeRoute { return $null }
 
         (. $r.Logic $WebEvent) | Should Be $true
         $WebEvent.Route | Should Not Be $null
-        $WebEvent.StaticRoute | Should Not Be $null
-        $WebEvent.StaticRoute.Download | Should Be $true
+        $WebEvent.StaticContent | Should Not Be $null
+        $WebEvent.StaticContent.Download | Should Be $true
     }
 
     It 'Returns a ScriptBlock, invokes false for static path, with no caching' {
@@ -413,12 +413,12 @@ Describe 'Get-PodeRouteValidateMiddleware' {
             }}
         }}
 
-        Mock Find-PodeStaticRoute { return @{ StaticRoute = @{ Source = '/' }; Route = @{} } }
+        Mock Find-PodeStaticRoute { return @{ Content = @{ Source = '/' }; Route = @{} } }
         Mock Find-PodeRoute { return $null }
 
         (. $r.Logic $WebEvent) | Should Be $true
         $WebEvent.Route | Should Not Be $null
-        $WebEvent.StaticRoute | Should Not Be $null
+        $WebEvent.StaticContent | Should Not Be $null
     }
 
     It 'Returns a ScriptBlock, invokes false for static path, with no caching from exclude' {
@@ -442,12 +442,12 @@ Describe 'Get-PodeRouteValidateMiddleware' {
             }}
         }}
 
-        Mock Find-PodeStaticRoute { return @{ StaticRoute = @{ Source = '/' }; Route = @{} } }
+        Mock Find-PodeStaticRoute { return @{ Content = @{ Source = '/' }; Route = @{} } }
         Mock Find-PodeRoute { return $null }
 
         (. $r.Logic $WebEvent) | Should Be $true
         $WebEvent.Route | Should Not Be $null
-        $WebEvent.StaticRoute | Should Not Be $null
+        $WebEvent.StaticContent | Should Not Be $null
     }
 
     It 'Returns a ScriptBlock, invokes false for static path, with no caching from include' {
@@ -471,12 +471,12 @@ Describe 'Get-PodeRouteValidateMiddleware' {
             }}
         }}
 
-        Mock Find-PodeStaticRoute { return @{ StaticRoute = @{ Source = '/' }; Route = @{} } }
+        Mock Find-PodeStaticRoute { return @{ Content = @{ Source = '/' }; Route = @{} } }
         Mock Find-PodeRoute { return $null }
 
         (. $r.Logic $WebEvent) | Should Be $true
         $WebEvent.Route | Should Not Be $null
-        $WebEvent.StaticRoute | Should Not Be $null
+        $WebEvent.StaticContent | Should Not Be $null
     }
 
     It 'Returns a ScriptBlock, invokes false for static path, with caching' {
@@ -499,12 +499,12 @@ Describe 'Get-PodeRouteValidateMiddleware' {
             }}
         }}
 
-        Mock Find-PodeStaticRoute { return @{ StaticRoute = @{ Source = '/' }; Route = @{} } }
+        Mock Find-PodeStaticRoute { return @{ Content = @{ Source = '/' }; Route = @{} } }
         Mock Find-PodeRoute { return $null }
 
         (. $r.Logic $WebEvent) | Should Be $true
         $WebEvent.Route | Should Not Be $null
-        $WebEvent.StaticRoute | Should Not Be $null
+        $WebEvent.StaticContent | Should Not Be $null
     }
 }
 

--- a/tests/unit/Routes.Tests.ps1
+++ b/tests/unit/Routes.Tests.ps1
@@ -1316,3 +1316,114 @@ Describe 'Get-PodeStaticRoute' {
         $routes.Length | Should Be 2
     }
 }
+
+Describe 'Find-PodeRouteTransferEncoding' {
+    It 'Returns nothing' {
+        Find-PodeRouteTransferEncoding -Path '/users' | Should Be ([string]::Empty)
+    }
+
+    It 'Returns the passed encoding' {
+        Find-PodeRouteTransferEncoding -Path '/users' -TransferEncoding 'text/xml' | Should Be 'text/xml'
+    }
+
+    It 'Returns a default encoding' {
+        $PodeContext.Server = @{ Web = @{ TransferEncoding = @{ Default = 'text/yml' } } }
+        Find-PodeRouteTransferEncoding -Path '/users' | Should Be 'text/yml'
+    }
+
+    It 'Returns a path match' {
+        $PodeContext.Server = @{ Web = @{ TransferEncoding = @{ Routes = @{
+            '/users' = 'text/json' 
+        } } } }
+
+        Find-PodeRouteTransferEncoding -Path '/users' | Should Be 'text/json'
+    }
+}
+
+Describe 'Find-PodeRouteContentType' {
+    It 'Returns nothing' {
+        Find-PodeRouteContentType -Path '/users' | Should Be ([string]::Empty)
+    }
+
+    It 'Returns the passed type' {
+        Find-PodeRouteContentType -Path '/users' -ContentType 'text/xml' | Should Be 'text/xml'
+    }
+
+    It 'Returns a default type' {
+        $PodeContext.Server = @{ Web = @{ ContentType = @{ Default = 'text/yml' } } }
+        Find-PodeRouteContentType -Path '/users' | Should Be 'text/yml'
+    }
+
+    It 'Returns a path match' {
+        $PodeContext.Server = @{ Web = @{ ContentType = @{ Routes = @{
+            '/users' = 'text/json' 
+        } } } }
+
+        Find-PodeRouteContentType -Path '/users' | Should Be 'text/json'
+    }
+}
+
+Describe 'ConvertTo-PodeRouteMiddleware' {
+    It 'Returns no middleware' {
+        @(ConvertTo-PodeRouteMiddleware -Method Get -Path '/users') | Should Be $null
+    }
+
+    It 'Errors for invalid middleware type' {
+        { ConvertTo-PodeRouteMiddleware -Method Get -Path '/users' -Middleware 'string' } | Should Throw 'invalid type'
+    }
+
+    It 'Errors for invalid middleware hashtable - no logic' {
+        { ConvertTo-PodeRouteMiddleware -Method Get -Path '/users' -Middleware @{} } | Should Throw 'no logic defined'
+    }
+
+    It 'Errors for invalid middleware hashtable - logic not scriptblock' {
+        { ConvertTo-PodeRouteMiddleware -Method Get -Path '/users' -Middleware @{ Logic = 'string' } } | Should Throw 'invalid logic type'
+    }
+
+    It 'Returns hashtable for single hashtable middleware' {
+        $middleware = @{ Logic = { Write-Host 'Hello' } }
+        $converted = @(ConvertTo-PodeRouteMiddleware -Method Get -Path '/users' -Middleware $middleware)
+        $converted.Length | Should Be 1
+        $converted[0].Logic.ToString() | Should Be ($middleware.Logic.ToString())
+    }
+
+    It 'Returns hashtable for multiple hashtable middleware' {
+        $middleware1 = @{ Logic = { Write-Host 'Hello1' } }
+        $middleware2 = @{ Logic = { Write-Host 'Hello2' } }
+
+        $converted = @(ConvertTo-PodeRouteMiddleware -Method Get -Path '/users' -Middleware @($middleware1, $middleware2))
+
+        $converted.Length | Should Be 2
+        $converted[0].Logic.ToString() | Should Be ($middleware1.Logic.ToString())
+        $converted[1].Logic.ToString() | Should Be ($middleware2.Logic.ToString())
+    }
+
+    It 'Converts single scriptblock middleware to hashtable' {
+        $middleware = { Write-Host 'Hello' }
+        $converted = @(ConvertTo-PodeRouteMiddleware -Method Get -Path '/users' -Middleware $middleware)
+        $converted.Length | Should Be 1
+        $converted[0].Logic.ToString() | Should Be ($middleware.ToString())
+    }
+
+    It 'Converts multiple scriptblock middleware to hashtable' {
+        $middleware1 = { Write-Host 'Hello1' }
+        $middleware2 = { Write-Host 'Hello2' }
+
+        $converted = @(ConvertTo-PodeRouteMiddleware -Method Get -Path '/users' -Middleware @($middleware1, $middleware2))
+
+        $converted.Length | Should Be 2
+        $converted[0].Logic.ToString() | Should Be ($middleware1.ToString())
+        $converted[1].Logic.ToString() | Should Be ($middleware2.ToString())
+    }
+
+    It 'Handles a mixture of hashtable and scriptblock' {
+        $middleware1 = @{ Logic = { Write-Host 'Hello1' } }
+        $middleware2 = { Write-Host 'Hello2' }
+
+        $converted = @(ConvertTo-PodeRouteMiddleware -Method Get -Path '/users' -Middleware @($middleware1, $middleware2))
+
+        $converted.Length | Should Be 2
+        $converted[0].Logic.ToString() | Should Be ($middleware1.Logic.ToString())
+        $converted[1].Logic.ToString() | Should Be ($middleware2.ToString())
+    }
+}


### PR DESCRIPTION
### Description of the Change
This adds support onto static routes (created using `Add-PodeStaticRoute`) for middleware; allowing the use of authentication, and all other forms of middleware normally used on standard routes.

To do this, the static middleware that normal returned static content early now only supports public static content (found in the `/public` directory). Custom static routes are now treated in a similar fashion to normal routes - meaning they can also allow query strings, payloads, cookies, etc.

Being added to the `Add-PodeStaticRoute` are the following new parameters:
* Middleware
* ContentType (for payload parsing)
* TransferEncoding (again, for payload parsing)
* PassThru (for OpenAPI definitions)
* ErrorContentType (for custom error pages, like 404 if the static content isn't found)

### Related Issue
Resolves #511 

### Examples
Setting up a static route that requires authentication to be accessed:
```powershell
Start-PodeServer {
    Add-PodeEndpoint -Address * -Port 8085 -Protocol Http

    New-PodeAuthType -Basic -Realm 'Pode Static Page' | Add-PodeAuth -Name 'Validate' -ScriptBlock {
        param($username, $password)
        # validate the user's credentials as normal
    }

    Add-PodeStaticRoute `
        -Path '/assets' `
        -Source './assets' `
        -Middleware (Get-PodeAuthMiddleware -Name 'Validate' -Sessionless)
}
```
