### PR TITLE
Fixes sessions to use ScriptBlocks, stopping crashes and improved performance

### DIFF
--- a/examples/web-auth-bearer.ps1
+++ b/examples/web-auth-bearer.ps1
@@ -10,6 +10,8 @@ Start-PodeServer -Threads 2 {
     # listen on localhost:8085
     Add-PodeEndpoint -Address * -Port 8085 -Protocol Http
 
+    New-PodeLoggingMethod -File -Name 'requests' | Enable-PodeRequestLogging
+
     # setup bearer auth
     New-PodeAuthType -Bearer -Scope write | Add-PodeAuth -Name 'Validate' -ScriptBlock {
         param($token)
@@ -22,7 +24,7 @@ Start-PodeServer -Threads 2 {
                     Name = 'Morty'
                     Type = 'Human'
                 }
-                Scope = 'read'
+                Scope = 'write'
             }
         }
 


### PR DESCRIPTION
### Description of the Change
Fixes an issue with sessions, where by using ScriptMethod types in a PSObject caused sessions to be slow and crash the server.

The fix is to change the ScriptMethod members to a NoteProperty member of ScriptBlocks. Then, we can use the `Invoke-PodeScriptBlock` to invoke the script. Before doing this, logic is in place to check the member type - so backwards compat is supported.

The change not only stop the server crashing, but also improves the performance of sessions dramatically!

### Related Issue
Resolves #509
