### PR TITLE
Adds new Quiet mode, fixes DisableTermination, and auto-detects Azure Web Apps

### DIFF
--- a/docs/Hosting/IIS.md
+++ b/docs/Hosting/IIS.md
@@ -112,7 +112,7 @@ If the required header is missing, then Pode responds with a 401. The retrieved 
 !!! note
     If the authenticated user is a Local User, then the following properties will be empty: FQDN, Email, and DistinguishedName
 
-## Azure Web App
+## Azure Web Apps
 
 To host your Pode server under IIS using Azure Web Apps, ensure the OS type is Windows and the framework is .NET Core 2.1/3.0.
 

--- a/docs/Hosting/IIS.md
+++ b/docs/Hosting/IIS.md
@@ -112,6 +112,14 @@ If the required header is missing, then Pode responds with a 401. The retrieved 
 !!! note
     If the authenticated user is a Local User, then the following properties will be empty: FQDN, Email, and DistinguishedName
 
+## Azure Web App
+
+To host your Pode server under IIS using Azure Web Apps, ensure the OS type is Windows and the framework is .NET Core 2.1/3.0.
+
+Your web.config's `processPath` will also need to reference `powershell.exe` not `pwsh.exe`.
+
+Pode can auto-detect if you're using an Azure Web App, but if you're having issues trying setting the `-DisableTermination` and `-Quiet` switches on your [`Start-PodeServer`](../../Functions/Core/Start-PodeServer).
+
 ## Useful Links
 
 * [Host ASP.NET Core on Windows with IIS \| Microsoft Docs](https://docs.microsoft.com/en-us/aspnet/core/host-and-deploy/iis/?view=aspnetcore-3.1)

--- a/src/Pode.psd1
+++ b/src/Pode.psd1
@@ -104,6 +104,7 @@
         'Test-IsPSCore',
         'Test-IsEmpty',
         'Out-PodeHost',
+        'Write-PodeHost',
         'Test-PodeIsIIS',
 
         # routes

--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -130,16 +130,22 @@ function New-PodeContext
         $ctx.Server.Type = 'SERVICE'
     }
 
+    # if it's serverless, also disable termination
     if ($isServerless) {
         $ctx.Server.IsServerless = $isServerless
         $ctx.Server.DisableTermination = $true
     }
 
-    # is the server running under IIS? (also, force the server type to pode)
+    # is the server running under IIS? (also, force the server type to pode, and disable termination)
     $ctx.Server.IsIIS = (!$isServerless -and (!(Test-IsEmpty $env:ASPNETCORE_PORT)) -and (!(Test-IsEmpty $env:ASPNETCORE_TOKEN)))
     if ($ctx.Server.IsIIS) {
         $ctx.Server.Type = 'PODE'
         $ctx.Server.DisableTermination = $true
+
+        # if IIS under and Azure Web App, force quiet
+        if (!(Test-IsEmpty $env:WEBSITE_IIS_SITE_NAME)) {
+            $ctx.Server.Quiet = $true
+        }
     }
 
     # set the IP address details

--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -28,7 +28,13 @@ function New-PodeContext
 
         [Parameter()]
         [string]
-        $ServerType
+        $ServerType,
+
+        [switch]
+        $DisableTermination,
+
+        [switch]
+        $Quiet
     )
 
     # set a random server name if one not supplied
@@ -58,12 +64,14 @@ function New-PodeContext
         Add-Member -MemberType NoteProperty -Name Server -Value @{} -PassThru |
         Add-Member -MemberType NoteProperty -Name Metrics -Value @{} -PassThru
 
-    # set the server name, logic and root
+    # set the server name, logic and root, and other basic properties
     $ctx.Server.Name = $Name
     $ctx.Server.Logic = $ScriptBlock
     $ctx.Server.LogicPath = $FilePath
     $ctx.Server.Interval = $Interval
     $ctx.Server.PodeModulePath = (Get-PodeModulePath)
+    $ctx.Server.DisableTermination = $DisableTermination.IsPresent
+    $ctx.Server.Quiet = $Quiet.IsPresent
 
     # basic logging setup
     $ctx.Server.Logging = @{
@@ -124,12 +132,14 @@ function New-PodeContext
 
     if ($isServerless) {
         $ctx.Server.IsServerless = $isServerless
+        $ctx.Server.DisableTermination = $true
     }
 
     # is the server running under IIS? (also, force the server type to pode)
     $ctx.Server.IsIIS = (!$isServerless -and (!(Test-IsEmpty $env:ASPNETCORE_PORT)) -and (!(Test-IsEmpty $env:ASPNETCORE_TOKEN)))
     if ($ctx.Server.IsIIS) {
         $ctx.Server.Type = 'PODE'
+        $ctx.Server.DisableTermination = $true
     }
 
     # set the IP address details

--- a/src/Private/FileMonitor.ps1
+++ b/src/Private/FileMonitor.ps1
@@ -68,10 +68,12 @@ function Start-PodeFileMonitor
     Register-ObjectEvent -InputObject $timer -EventName 'Elapsed' -SourceIdentifier (Get-PodeFileMonitorTimerName) -Action {
         # if enabled, show the files that triggered the restart
         if ($Event.MessageData.FileSettings.ShowFiles) {
-            Write-Host 'The following files have changed:' -ForegroundColor Magenta
+            if (!$Event.MessageData.Quiet) {
+                Write-Host 'The following files have changed:' -ForegroundColor Magenta
 
-            foreach ($file in $Event.MessageData.FileSettings.Files) {
-                Write-Host "> $($file)" -ForegroundColor Magenta
+                foreach ($file in $Event.MessageData.FileSettings.Files) {
+                    Write-Host "> $($file)" -ForegroundColor Magenta
+                }
             }
 
             $Event.MessageData.FileSettings.Files = @()
@@ -83,6 +85,7 @@ function Start-PodeFileMonitor
     } -MessageData @{
         Tokens = $PodeContext.Tokens
         FileSettings = $PodeContext.Server.FileMonitor
+        Quiet = $PodeContext.Server.Quiet
     } -SupportEvent
 }
 

--- a/src/Private/Gui.ps1
+++ b/src/Private/Gui.ps1
@@ -12,7 +12,7 @@ function Start-PodeGuiRunspace
             if ($null -eq $PodeContext.Server.Gui.Endpoint)
             {
                 if (($PodeContext.Server.Endpoints | Measure-Object).Count -gt 1) {
-                    Write-Host "Multiple endpoints defined, only the first will be used for the GUI" -ForegroundColor Yellow
+                    Write-PodeHost "Multiple endpoints defined, only the first will be used for the GUI" -ForegroundColor Yellow
                 }
             }
 

--- a/src/Private/Logging.ps1
+++ b/src/Private/Logging.ps1
@@ -2,8 +2,13 @@ function Get-PodeLoggingTerminalMethod
 {
     return {
         param($item, $options)
+
+        if ($PodeContext.Server.Quiet) {
+            return
+        }
+
         $item = ($item | Protect-PodeLogItem)
-        $item.ToString() | Out-Default
+        $item.ToString() | Out-PodeHost
     }
 }
 

--- a/src/Private/Server.ps1
+++ b/src/Private/Server.ps1
@@ -91,9 +91,9 @@ function Start-PodeInternalServer
 
         # state what endpoints are being listened on
         if ($endpoints.Length -gt 0) {
-            Write-Host "Listening on the following $($endpoints.Length) endpoint(s) [$($PodeContext.Threads.Web) thread(s)]:" -ForegroundColor Yellow
+            Write-PodeHost "Listening on the following $($endpoints.Length) endpoint(s) [$($PodeContext.Threads.Web) thread(s)]:" -ForegroundColor Yellow
             $endpoints | ForEach-Object {
-                Write-Host "`t- $($_)" -ForegroundColor Yellow
+                Write-PodeHost "`t- $($_)" -ForegroundColor Yellow
             }
         }
     }
@@ -107,7 +107,7 @@ function Restart-PodeInternalServer
     try
     {
         # inform restart
-        Write-Host 'Restarting server...' -NoNewline -ForegroundColor Cyan
+        Write-PodeHost 'Restarting server...' -NoNewline -ForegroundColor Cyan
 
         # cancel the session token
         $PodeContext.Tokens.Cancellation.Cancel()
@@ -180,7 +180,7 @@ function Restart-PodeInternalServer
         # reload the configuration
         $PodeContext.Server.Configuration = Open-PodeConfiguration -Context $PodeContext
 
-        Write-Host " Done" -ForegroundColor Green
+        Write-PodeHost " Done" -ForegroundColor Green
 
         # restart the server
         $PodeContext.Metrics.Server.RestartCount++

--- a/src/Private/Serverless.ps1
+++ b/src/Private/Serverless.ps1
@@ -84,8 +84,8 @@ function Start-PodeAzFuncServer
             }
         }
         catch {
+            $_ | Write-PodeErrorLog
             Set-PodeResponseStatus -Code 500 -Exception $_
-            Write-Host $Error[0]
         }
         finally {
             Update-PodeServerRequestMetrics -WebEvent $WebEvent
@@ -99,7 +99,7 @@ function Start-PodeAzFuncServer
         Push-OutputBinding -Name Response -Value $response
     }
     catch {
-        Write-Host $Error[0]
+        $_ | Write-PodeErrorLog
         throw $_.Exception
     }
 }
@@ -185,8 +185,8 @@ function Start-PodeAwsLambdaServer
             }
         }
         catch {
+            $_ | Write-PodeErrorLog
             Set-PodeResponseStatus -Code 500 -Exception $_
-            Write-Host $Error[0]
         }
         finally {
             Update-PodeServerRequestMetrics -WebEvent $WebEvent
@@ -208,7 +208,7 @@ function Start-PodeAwsLambdaServer
         } | ConvertTo-Json -Depth 10 -Compress) 
     }
     catch {
-        Write-Host $Error[0]
+        $_ | Write-PodeErrorLog
         throw $_.Exception
     }
 }

--- a/src/Private/ServiceServer.ps1
+++ b/src/Private/ServiceServer.ps1
@@ -6,7 +6,7 @@ function Start-PodeServiceServer
     }
 
     # state we're running
-    Write-Host "Server looping every $($PodeContext.Server.Interval)secs" -ForegroundColor Yellow
+    Write-PodeHost "Server looping every $($PodeContext.Server.Interval)secs" -ForegroundColor Yellow
 
     # script for the looping server
     $serverScript = {

--- a/src/Private/Setup.ps1
+++ b/src/Private/Setup.ps1
@@ -45,7 +45,7 @@ function Install-PodeLocalModules
                 $_version = [string]((Find-Module $_name -Repository $_repository -ErrorAction Ignore).Version)
             }
 
-            Write-PodeHost "=> Downloading $($_name)@$($_version) from $($_repository)... " -NoNewline -ForegroundColor Cyan
+            Write-Host "=> Downloading $($_name)@$($_version) from $($_repository)... " -NoNewline -ForegroundColor Cyan
 
             # if the current version exists, do nothing
             if (!(Test-Path (Join-Path $psModules "$($_name)/$($_version)"))) {
@@ -58,10 +58,10 @@ function Install-PodeLocalModules
                 Save-Module -Name $_name -RequiredVersion $_version -Repository $_repository -Path $psModules -Force -ErrorAction Stop | Out-Null
             }
 
-            Write-PodeHost 'Success' -ForegroundColor Green
+            Write-Host 'Success' -ForegroundColor Green
         }
         catch {
-            Write-PodeHost 'Failed' -ForegroundColor Red
+            Write-Host 'Failed' -ForegroundColor Red
             throw "Module or version not found on $($_repository): $($_name)@$($_version)"
         }
     }

--- a/src/Private/Setup.ps1
+++ b/src/Private/Setup.ps1
@@ -45,7 +45,7 @@ function Install-PodeLocalModules
                 $_version = [string]((Find-Module $_name -Repository $_repository -ErrorAction Ignore).Version)
             }
 
-            Write-Host "=> Downloading $($_name)@$($_version) from $($_repository)... " -NoNewline -ForegroundColor Cyan
+            Write-PodeHost "=> Downloading $($_name)@$($_version) from $($_repository)... " -NoNewline -ForegroundColor Cyan
 
             # if the current version exists, do nothing
             if (!(Test-Path (Join-Path $psModules "$($_name)/$($_version)"))) {
@@ -58,10 +58,10 @@ function Install-PodeLocalModules
                 Save-Module -Name $_name -RequiredVersion $_version -Repository $_repository -Path $psModules -Force -ErrorAction Stop | Out-Null
             }
 
-            Write-Host 'Success' -ForegroundColor Green
+            Write-PodeHost 'Success' -ForegroundColor Green
         }
         catch {
-            Write-Host 'Failed' -ForegroundColor Red
+            Write-PodeHost 'Failed' -ForegroundColor Red
             throw "Module or version not found on $($_repository): $($_name)@$($_version)"
         }
     }

--- a/src/Private/Sockets.ps1
+++ b/src/Private/Sockets.ps1
@@ -129,7 +129,7 @@ function Close-PodeSocketListener
         $PodeContext.Server[$Type].Listeners = @()
     }
     catch {
-        $_.Exception | Out-Default
+        $_.Exception | Out-PodeHost
     }
 }
 

--- a/src/Public/Core.ps1
+++ b/src/Public/Core.ps1
@@ -33,6 +33,9 @@ The server type, to define how Pode should run and deal with incoming Requests.
 .PARAMETER DisableTermination
 Disables the ability to terminate the Server.
 
+.PARAMETER Quiet
+Disables any output from the Server.
+
 .PARAMETER Browse
 Open the web Server's default endpoint in your default browser.
 
@@ -88,6 +91,9 @@ function Start-PodeServer
         $DisableTermination,
 
         [switch]
+        $Quiet,
+
+        [switch]
         $Browse,
 
         [Parameter(ParameterSetName='File')]
@@ -127,10 +133,12 @@ function Start-PodeServer
             -Threads $Threads `
             -Interval $Interval `
             -ServerRoot (Protect-PodeValue -Value $RootPath -Default $MyInvocation.PSScriptRoot) `
-            -ServerType $Type
+            -ServerType $Type `
+            -DisableTermination:$DisableTermination `
+            -Quiet:$Quiet
 
-        # set it so ctrl-c can terminate, unless serverless
-        if (!$PodeContext.Server.IsServerless -and !$PodeContext.Server.IsIIS) {
+        # set it so ctrl-c can terminate, unless serverless/iis, or disabled
+        if (!$PodeContext.Server.DisableTermination) {
             [Console]::TreatControlCAsInput = $true
         }
 
@@ -158,7 +166,7 @@ function Start-PodeServer
             }
         }
 
-        Write-Host 'Terminating...' -NoNewline -ForegroundColor Yellow
+        Write-PodeHost 'Terminating...' -NoNewline -ForegroundColor Yellow
         $PodeContext.Tokens.Cancellation.Cancel()
     }
     catch {

--- a/src/Public/Utilities.ps1
+++ b/src/Public/Utilities.ps1
@@ -223,7 +223,7 @@ function Start-PodeStopwatch
     }
     finally {
         $watch.Stop()
-        Out-Default -InputObject "[Stopwatch]: $($watch.Elapsed) [$($Name)]"
+        "[Stopwatch]: $($watch.Elapsed) [$($Name)]" | Out-PodeHost
     }
 }
 
@@ -768,6 +768,7 @@ Outputs an object to the main Host.
 
 .DESCRIPTION
 Due to Pode's use of runspaces, this will output a given object back to the main Host.
+It's advised to use this function, so that any output respects the -Quiet flag of the server.
 
 .PARAMETER InputObject
 The object to output.
@@ -787,7 +788,57 @@ function Out-PodeHost
         $InputObject
     )
 
-    $InputObject | Out-Default
+    if (!$PodeContext.Server.Quiet) {
+        $InputObject | Out-Default
+    }
+}
+
+<#
+.SYNOPSIS
+Writes an object to the Host.
+
+.DESCRIPTION
+Writes an object to the Host.
+It's advised to use this function, so that any output respects the -Quiet flag of the server.
+
+.PARAMETER Object
+The object to write.
+
+.PARAMETER ForegroundColor
+An optional foreground colour.
+
+.PARAMETER NoNewLine
+Whether or not to write a new line.
+
+.EXAMPLE
+'Some output' | Write-PodeHost -ForegroundColor Cyan
+#>
+function Write-PodeHost
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Position=0, ValueFromPipeline=$true)]
+        [object]
+        $Object,
+
+        [Parameter()]
+        [System.ConsoleColor]
+        $ForegroundColor,
+
+        [switch]
+        $NoNewLine
+    )
+
+    if ($PodeContext.Server.Quiet) {
+        return
+    }
+
+    if ($ForegroundColor) {
+        Write-Host -Object $Object -ForegroundColor $ForegroundColor -NoNewline:$NoNewLine
+    }
+    else {
+        Write-Host -Object $Object -NoNewline:$NoNewLine
+    }
 }
 
 <#


### PR DESCRIPTION
### Description of the Change
Fixes a long standing issue with the `-DisableTermination` switch, and adds in a new `-Quiet` switch on the `Start-PodeServer` function. These will allow Pode to better function under certain hosted environments - like Azure Web Apps. (When quiet, all output to the terminal, from Pode, will be disabled)

Also, this change introduces a new check; if Pode detects IIS then it will also check for Azure Web Apps, if detected the new `-Quiet` mode is automatically enabled.

### Related Issue
Resolves #525 
