### PR TITLE
Added Support for IIS based Windows Authentication in trusted domains

### DIFF
--- a/src/Private/Authentication.ps1
+++ b/src/Private/Authentication.ps1
@@ -465,28 +465,34 @@ function Get-PodeAuthWindowsADIISMethod
             if (![string]::IsNullOrWhiteSpace($domain) -and (@('.', $env:COMPUTERNAME) -inotcontains $domain)) {
                 # get the server's fdqn (and name/email)
                 try {
-                    $ad = [adsi]"LDAP://<SID=$($winIdentity.User.Value.ToString())>"
-                    $user.DistinguishedName = @($ad.distinguishedname)[0]
-                    $user.Name = @($ad.name)[0]
-                    $user.Email = @($ad.mail)[0]
+                    $searcher = [adsisearcher]""
+                    $searcher.SearchRoot = [adsi]"LDAP://$($domain)"
+                    $searcher.Filter = "ObjectSid=$($winIdentity.User.Value.ToString())"
+
+                    $ad = $searcher.FindOne()
+                    
+                    $user.DistinguishedName = @($ad.Properties.distinguishedname)[0]
+                    $user.Name = @($ad.Properties.name)[0]
+                    $user.Email = @($ad.Properties.mail)[0]
                     $user.Fqdn = (Get-PodeADServerFromDistinguishedName -DistinguishedName $user.DistinguishedName)
                 }
                 finally {
-                    Close-PodeDisposable -Disposable $ad -Close
+                    Close-PodeDisposable -Disposable $searcher
                 }
 
                 try {
-                    # open a new connection
-                    $result = (Open-PodeAuthADConnection -Server $user.Fqdn -Domain $domain)
-                    if (!$result.Success) {
-                        return @{ Message = 'Failed to connect to Domain Server' }
-                    }
-
-                    # get the connection
-                    $connection = $result.Connection
-
-                    # get the users groups
                     if (!$options.NoGroups) {
+
+                        # open a new connection
+                        $result = (Open-PodeAuthADConnection -Server $user.Fqdn -Domain $domain)
+                        if (!$result.Success) {
+                            return @{ Message = "Failed to connect to Domain Server '$($user.Fqdn)' of $domain for $($user.DistinguishedName)." }
+                        }
+
+                        # get the connection
+                        $connection = $result.Connection
+
+                        # get the users groups
                         $user.Groups = (Get-PodeAuthADGroups -Connection $connection -DistinguishedName $user.DistinguishedName)
                     }
                 }

--- a/src/Private/Authentication.ps1
+++ b/src/Private/Authentication.ps1
@@ -465,12 +465,15 @@ function Get-PodeAuthWindowsADIISMethod
             if (![string]::IsNullOrWhiteSpace($domain) -and (@('.', $env:COMPUTERNAME) -inotcontains $domain)) {
                 # get the server's fdqn (and name/email)
                 try {
+                    # Open ADSISearcher and change context to given domain
                     $searcher = [adsisearcher]""
                     $searcher.SearchRoot = [adsi]"LDAP://$($domain)"
                     $searcher.Filter = "ObjectSid=$($winIdentity.User.Value.ToString())"
 
+                    # Query the ADSISearcher for the above defined SID
                     $ad = $searcher.FindOne()
                     
+                    # Save it to our existing array for later usage
                     $user.DistinguishedName = @($ad.Properties.distinguishedname)[0]
                     $user.Name = @($ad.Properties.name)[0]
                     $user.Email = @($ad.Properties.mail)[0]


### PR DESCRIPTION
### Description of the Change
Adds domain and server context to the ADSISearcher so it queries the domain of the user, this way we can handle users from trusted domains.

### Related Issue
Fixes #534 

### Additional Context
Group Support is also given, however it only returns the groups of the user in its respective domain. Querying all domains and resolving foreign security principals takes too long, even with ADSISearcher - I know that from another project.

ADSISearcher sometimes doesn't handle AD Sites and Services properly resulting in using a Domain Controller in another (possibly far away) site.
To handle this it is possible to query the destination DCs latency before. I don't think this should be handled by Pode but instead by the application on it.
Examples can be found in this snippet [Get-ActiveDirectoryWebservices](https://github.com/RobinBeismann/PowerShell-Scripts/blob/master/Scripts/MS-AD/Migrate-AADIdentity.ps1).
