### PR TITLE
Adds Include, Exclude, and Scope from filtering state saves

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 pode_modules/
 ps_modules/
 docs/[Ff]unctions/
+examples/state.json
 
 
 # Code Runner

--- a/docs/Tutorials/SharedState.md
+++ b/docs/Tutorials/SharedState.md
@@ -1,24 +1,24 @@
 # Shared State
 
-Most things in Pode all run in isolated runspaces, which means you can't create a variable in a timer and then access that variable in a route. To overcome this limitation you can use the State functions, which allows you to set/get variables on a state shared between all runspaces. This means you can create a variable in a timer and set it against the shared state; then you can retrieve the variable from the state in a route.
+Most things in Pode run in isolated runspaces: routes, middleware, schedules - to name a few. This means you can't create a variable in a timer, or in the base server scope, and then access that variable in a route. To overcome this limitation you can use the Shared State feature within Pode, which allows you to set/get variables on a state shared between all runspaces. This lets you can create a variable in a timer and store it within the shared state; then you can retrieve the variable from the state in a route.
 
 You also have the option of saving the current state to a file, and then restoring the state back on server start. This way you won't lose state between server restarts.
 
-To do this, you use the State functions in combination with the  [`Lock-PodeObject`](../../Functions/Utilities/Lock-PodeObject) function to ensure thread safety.
+You can also use the State in combination with the [`Lock-PodeObject`](../../Functions/Utilities/Lock-PodeObject) function to ensure thread safety - if needed.
 
 !!! tip
-    It's wise to use the State functions in conjunction with the  [`Lock-PodeObject`](../../Functions/Utilities/Lock-PodeObject) function, to ensure thread safety between runspaces. The event argument supplied to the Routes, Handlers, Timers, Schedules, Middleware, Endware and Loggers each contain a `.Lockable` resource that can be supplied to the  [`Lock-PodeObject`](../../Functions/Utilities/Lock-PodeObject) function.
+    It's wise to use the State in conjunction with the [`Lock-PodeObject`](../../Functions/Utilities/Lock-PodeObject) function, to ensure thread safety between runspaces. The event argument supplied to Routes, Handlers, Timers, Schedules, Middleware, Endware and Loggers each contain a `.Lockable` resource that can be supplied to the [`Lock-PodeObject`](../../Functions/Utilities/Lock-PodeObject) function.
 
 !!! warning
-    If you omit the use of  [`Lock-PodeObject`](../../Functions/Utilities/Lock-PodeObject), you will run into errors due to multi-threading. Only omit if you are *absolutely confident* you do not need locking. (ie: you set in state once and then only ever retrieve, never updating the variable).
+    If you omit the use of [`Lock-PodeObject`](../../Functions/Utilities/Lock-PodeObject), you will run into errors due to multi-threading. Only omit if you are *absolutely confident* you do not need locking. (ie: you set in state once and then only ever retrieve, never updating the variable).
 
 ## Usage
 
 ### Set
 
-The  [`Set-PodeState`](../../Functions/State/Set-PodeState) function will create/update a variable on the shared state. You need to supply a name and a value to set on the state.
+The [`Set-PodeState`](../../Functions/State/Set-PodeState) function will create/update a variable in the state. You need to supply a name and a value to set on the state, there's also an optional scope that can be supplied - which lets you save specific state objects with a certain scope.
 
-An example of setting a shared hashtable variable is as follows:
+An example of setting a hashtable variable in the state is as follows:
 
 ```powershell
 Start-PodeServer {
@@ -34,9 +34,9 @@ Start-PodeServer {
 
 ### Get
 
-The  [`Get-PodeState`](../../Functions/State/Get-PodeState) function will return the value currently stored on the shared state for a variable. If the variable doesn't exist then `$null` is returned.
+The [`Get-PodeState`](../../Functions/State/Get-PodeState) function will return the value currently stored in the state for a variable. If the variable doesn't exist then `$null` is returned.
 
-An example of retrieving the value from the shared state is as follows:
+An example of retrieving a value from the state is as follows:
 
 ```powershell
 Start-PodeServer {
@@ -55,9 +55,9 @@ Start-PodeServer {
 
 ### Remove
 
-The  [`Remove-PodeState`](../../Functions/State/Remove-PodeState) function will remove a variable from the shared state. It will also return the value stored in the state before removing the variable.
+The [`Remove-PodeState`](../../Functions/State/Remove-PodeState) function will remove a variable from the state. It will also return the value stored in the state before removing the variable.
 
-An example of removing a variable from the shared state is as follows:
+An example of removing a variable from the state is as follows:
 
 ```powershell
 Start-PodeServer {
@@ -73,7 +73,7 @@ Start-PodeServer {
 
 ### Save
 
-The  [`Save-PodeState`](../../Functions/State/Save-PodeState) function will save the current state, as JSON, to the specified file. The file path can either be relative, or a literal path. When saving the state, it's recommended to wrap the function within a  [`Lock-PodeObject`](../../Functions/Utilities/Lock-PodeObject).
+The [`Save-PodeState`](../../Functions/State/Save-PodeState) function will save the current state, as JSON, to the specified file. The file path can either be relative, or literal. When saving the state, it's recommended to wrap the function within [`Lock-PodeObject`](../../Functions/Utilities/Lock-PodeObject).
 
 An example of saving the current state every hour is as follows:
 
@@ -87,9 +87,13 @@ Start-PodeServer {
 }
 ```
 
+When saving the state, you can also use the `-Exclude` or `-Include` parameters to exclude/include certain state objects from being saved. Saving also has a `-Scope` parameter, which allows you so save only state objects created with the specified scope(s).
+
+You can use all the above 3 parameter in conjunction, with `-Exclude` having the highest precedence and `-Scope` having the lowest.
+
 ### Restore
 
-The  [`Restore-PodeState`](../../Functions/State/Restore-PodeState) function will restore the current state from the specified file. The file path can either be relative, or a literal path. if you're restoring the state immediately on server start, you don't need to use  [`Lock-PodeObject`](../../Functions/Utilities/Lock-PodeObject).
+The [`Restore-PodeState`](../../Functions/State/Restore-PodeState) function will restore the current state from the specified file. The file path can either be relative, or a literal path. if you're restoring the state immediately on server start, you don't need to use [`Lock-PodeObject`](../../Functions/Utilities/Lock-PodeObject).
 
 An example of restore the current state on server start is as follows:
 

--- a/examples/shared-state.ps1
+++ b/examples/shared-state.ps1
@@ -9,13 +9,19 @@ Start-PodeServer {
 
     Add-PodeEndpoint -Address * -Port 8085 -Protocol Http
     New-PodeLoggingMethod -Terminal | Enable-PodeRequestLogging
+    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
 
     # re-initialise the state
     Restore-PodeState -Path './state.json'
 
     # initialise if there was no file
-    if ($null -eq ($hash = (Get-PodeState -Name 'hash'))) {
-        $hash = Set-PodeState -Name 'hash' -Value @{}
+    if ($null -eq ($hash = (Get-PodeState -Name 'hash1'))) {
+        $hash = Set-PodeState -Name 'hash1' -Value @{}
+        $hash['values'] = @()
+    }
+
+    if ($null -eq ($hash = (Get-PodeState -Name 'hash2'))) {
+        $hash = Set-PodeState -Name 'hash2' -Value @{}
         $hash['values'] = @()
     }
 
@@ -25,9 +31,9 @@ Start-PodeServer {
         $hash = $null
 
         Lock-PodeObject -Object $session.Lockable {
-            $hash = (Get-PodeState -Name 'hash')
+            $hash = (Get-PodeState -Name 'hash1')
             $hash.values += (Get-Random -Minimum 0 -Maximum 10)
-            Save-PodeState -Path './state.json'
+            Save-PodeState -Path './state.json' -Exclude 'hash2'
         }
     }
 
@@ -36,7 +42,7 @@ Start-PodeServer {
         param($session)
 
         Lock-PodeObject -Object $session.Lockable {
-            $hash = (Get-PodeState 'hash')
+            $hash = (Get-PodeState 'hash1')
             Write-PodeJsonResponse -Value $hash
         }
     }

--- a/examples/shared-state.ps1
+++ b/examples/shared-state.ps1
@@ -7,7 +7,7 @@ Import-Module "$($path)/src/Pode.psm1" -Force -ErrorAction Stop
 # create a basic server
 Start-PodeServer {
 
-    Add-PodeEndpoint -Address * -Port 8085 -Protocol Http
+    Add-PodeEndpoint -Address * -Port 8090 -Protocol Http
     New-PodeLoggingMethod -Terminal | Enable-PodeRequestLogging
     New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
 
@@ -16,12 +16,12 @@ Start-PodeServer {
 
     # initialise if there was no file
     if ($null -eq ($hash = (Get-PodeState -Name 'hash1'))) {
-        $hash = Set-PodeState -Name 'hash1' -Value @{}
+        $hash = Set-PodeState -Name 'hash1' -Value @{} -Scope Scope0, Scope1
         $hash['values'] = @()
     }
 
     if ($null -eq ($hash = (Get-PodeState -Name 'hash2'))) {
-        $hash = Set-PodeState -Name 'hash2' -Value @{}
+        $hash = Set-PodeState -Name 'hash2' -Value @{} -Scope Scope0, Scope2
         $hash['values'] = @()
     }
 
@@ -33,7 +33,7 @@ Start-PodeServer {
         Lock-PodeObject -Object $session.Lockable {
             $hash = (Get-PodeState -Name 'hash1')
             $hash.values += (Get-Random -Minimum 0 -Maximum 10)
-            Save-PodeState -Path './state.json' -Exclude 'hash2'
+            Save-PodeState -Path './state.json' -Scope Scope1 #-Exclude 'hash1'
         }
     }
 

--- a/src/Public/State.ps1
+++ b/src/Public/State.ps1
@@ -137,7 +137,7 @@ Saves the current shared state to a supplied JSON file. When using this function
 The path to a JSON file which the current state will be saved to.
 
 .PARAMETER Scope
-An optional array of scopes for state objects that should be saved. (This has a higher precedence than Exclude/Include)
+An optional array of scopes for state objects that should be saved. (This has a lower precedence than Exclude/Include)
 
 .PARAMETER Exclude
 An optional array of state object names to exclude from being saved. (This has a higher precedence than Include)

--- a/tests/unit/State.Tests.ps1
+++ b/tests/unit/State.Tests.ps1
@@ -15,7 +15,8 @@ Describe 'Set-PodeState' {
         $result = Set-PodeState -Name 'test' -Value 7
 
         $result | Should Be 7
-        $PodeContext.Server.State['test'] | Should Be 7
+        $PodeContext.Server.State['test'].Value | Should Be 7
+        $PodeContext.Server.State['test'].Scope | Should Be @()
     }
 }
 
@@ -26,7 +27,8 @@ Describe 'Get-PodeState' {
     }
 
     It 'Gets an object from the state' {
-        $PodeContext.Server = @{ 'State' = @{ 'test' = 8 } }
+        $PodeContext.Server = @{ 'State' = @{} }
+        Set-PodeState -Name 'test' -Value 8
         Get-PodeState -Name 'test' | Should Be 8
     }
 }
@@ -38,7 +40,8 @@ Describe 'Remove-PodeState' {
     }
 
     It 'Removes an object from the state' {
-        $PodeContext.Server = @{ 'State' = @{ 'test' = 8 } }
+        $PodeContext.Server = @{ 'State' = @{} }
+        Set-PodeState -Name 'test' -Value 8
         Remove-PodeState -Name 'test' | Should Be 8
         $PodeContext.Server.State['test'] | Should Be $null
     }
@@ -54,7 +57,8 @@ Describe 'Save-PodeState' {
         Mock Get-PodeRelativePath { return $Path }
         Mock Out-File {}
 
-        $PodeContext.Server = @{ 'State' = @{ 'test' = 8 } }
+        $PodeContext.Server = @{ 'State' = @{} }
+        Set-PodeState -Name 'test' -Value 8
         Save-PodeState -Path './state.json'
 
         Assert-MockCalled Out-File -Times 1 -Scope It
@@ -64,7 +68,8 @@ Describe 'Save-PodeState' {
         Mock Get-PodeRelativePath { return $Path }
         Mock Out-File {}
 
-        $PodeContext.Server = @{ 'State' = @{ 'test' = 8 } }
+        $PodeContext.Server = @{ 'State' = @{} }
+        Set-PodeState -Name 'test' -Value 8
         Save-PodeState -Path './state.json' -Include 'test'
 
         Assert-MockCalled Out-File -Times 1 -Scope It
@@ -74,7 +79,8 @@ Describe 'Save-PodeState' {
         Mock Get-PodeRelativePath { return $Path }
         Mock Out-File {}
 
-        $PodeContext.Server = @{ 'State' = @{ 'test' = 8 } }
+        $PodeContext.Server = @{ 'State' = @{} }
+        Set-PodeState -Name 'test' -Value 8
         Save-PodeState -Path './state.json' -Exclude 'test'
 
         Assert-MockCalled Out-File -Times 1 -Scope It
@@ -105,12 +111,14 @@ Describe 'Test-PodeState' {
     }
 
     It 'Returns true for an object being in the state' {
-        $PodeContext.Server = @{ 'State' = @{ 'test' = 8 } }
+        $PodeContext.Server = @{ 'State' = @{} }
+        Set-PodeState -Name 'test' -Value 8
         Test-PodeState -Name 'test' | Should Be $true
     }
 
     It 'Returns false for an object not being in the state' {
-        $PodeContext.Server = @{ 'State' = @{ 'test' = 8 } }
+        $PodeContext.Server = @{ 'State' = @{} }
+        Set-PodeState -Name 'test' -Value 8
         Test-PodeState -Name 'tests' | Should Be $false
     }
 }

--- a/tests/unit/State.Tests.ps1
+++ b/tests/unit/State.Tests.ps1
@@ -59,6 +59,26 @@ Describe 'Save-PodeState' {
 
         Assert-MockCalled Out-File -Times 1 -Scope It
     }
+
+    It 'Saves the state to file with Include' {
+        Mock Get-PodeRelativePath { return $Path }
+        Mock Out-File {}
+
+        $PodeContext.Server = @{ 'State' = @{ 'test' = 8 } }
+        Save-PodeState -Path './state.json' -Include 'test'
+
+        Assert-MockCalled Out-File -Times 1 -Scope It
+    }
+
+    It 'Saves the state to file with Exclude' {
+        Mock Get-PodeRelativePath { return $Path }
+        Mock Out-File {}
+
+        $PodeContext.Server = @{ 'State' = @{ 'test' = 8 } }
+        Save-PodeState -Path './state.json' -Exclude 'test'
+
+        Assert-MockCalled Out-File -Times 1 -Scope It
+    }
 }
 
 Describe 'Restore-PodeState' {


### PR DESCRIPTION
### Description of the Change
* Adds 3 new parameters to `Save-PodeState`: `-Scope`, `-Exclude`, and `-Include`.
* Also adds a new `-Scope` parameter to `Set-PodeState`

All 3 of the new parameters allow an array of strings. The Exclude and Include restrict/allow state objects by name, while the Scope while saving restricts to state objects set with that scope.

Because the scope needs to be saved to the state file, this change also has a small migration script on `Restore-PodeState` to map old state files into a new scoped format - using a default scope of no-scope (empty).

### Related Issue
Resolves #533

### Examples
Save state objects using Scope:
```powershell
Set-PodeState -Name 'state1' -Value 'value1' -Scope 'scope1'
Set-PodeState -Name 'state2' -Value 'value2' -Scope 'scope1'
Set-PodeState -Name 'state3' -Value 'value3' -Scope 'scope2'

# will only save state1 and state2
Save-PodeState -Path ./state.json -Scope scope1
```

Save state objects using Include:
```powershell
Set-PodeState -Name 'state1' -Value 'value1'
Set-PodeState -Name 'state2' -Value 'value2'
Set-PodeState -Name 'state3' -Value 'value3'

# will only save state1 and state3
Save-PodeState -Path ./state.json -Include state1, state3
```

Save state objects using Exclude:
```powershell
Set-PodeState -Name 'state1' -Value 'value1'
Set-PodeState -Name 'state2' -Value 'value2'
Set-PodeState -Name 'state3' -Value 'value3'

# will only save state2 and state3
Save-PodeState -Path ./state.json -Exclude state1
```