### PR TITLE
Adds functions to get Schedules

### DIFF
--- a/docs/Tutorials/Schedules.md
+++ b/docs/Tutorials/Schedules.md
@@ -1,6 +1,6 @@
 # Schedules
 
-A Schedule in Pode is a long-running async task, and unlike timers, when they trigger they are run in their own separate runspace - so they don't affect each other if they take a while to process. By default up to a maximum of 10 schedules can run concurrently, this can be changed by using the [`Set-PodeScheduleConcurrency`](../../Functions/Core/Set-PodeScheduleConcurrency) function.
+A Schedule in Pode is a long-running async task, and unlike timers, when they trigger they are run in their own separate runspace - so they don't affect each other if they take a while to process. By default up to a maximum of 10 schedules can run concurrently, but this can be changed by using the [`Set-PodeScheduleConcurrency`](../../Functions/Core/Set-PodeScheduleConcurrency) function.
 
 Schedule triggers are defined using [`cron expressions`](../Misc/CronExpressions), basic syntax is supported as well as some predefined expressions. Schedules can start immediately, have a delayed start time, and also have a defined end time.
 
@@ -44,6 +44,9 @@ Add-PodeSchedule -Name 'date' -Cron '@minutely' -ArgumentList @{ Name = 'Rick'; 
 }
 ```
 
+!!! important
+    In schedules, your scriptblock parameter names must be exact - including case-sensitivity. This is because the arguments are splatted into a runspace. If you pass in an argument called "Names", the param-block must have `$Names` exactly. Furthermore, the event parameter *must* be called `$Event`.
+
 ## Delayed Start
 
 The `-StartTime <datetime>` parameter will cause the Schedule to only be triggered after the date/time defined. For example, if you have a schedule set to trigger at 00:05 every Tuesday, and you pass `-StartTime [DateTime]::Now.AddMonths(2)`, then the schedule will only start trigger on Tuesdays in 2 months time.
@@ -85,7 +88,42 @@ For example, to create a schedule from a file that will output `Hello, world` ev
 }
 ```
 
-* Timer
+* Schedule
 ```powershell
 Add-PodeSchedule -Name 'from-file' -Cron '@minutely' -FilePath './Schedules/File.ps1'
 ```
+
+## Getting Schedules
+
+The [`Get-PodeSchedule`] helper function will allow you to retrieve a list of schedules configured within Pode. You can use it to retrieve all of the schedules, or supply filters to retrieve specific ones.
+
+To retrieve all of the schedules, you can call the function will no parameters. To filter, here are some examples:
+
+```powershell
+# one schedule by name
+Get-PodeSchedule -Name Name1
+
+# multiple schedules by name
+Get-PodeSchedule -Name Name1, Name2
+```
+
+## Schedule Object
+
+!!! warning
+    Be careful if you choose to edit these objects, as they will affect the server.
+
+The following is the structure of the Schedule object internally, as well as the object that is returned from [`Get-PodeSchedule`]:
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| Name | string | The name of the Schedule |
+| StartTime | datetime | The delayed start time of the Schedule - null if run at server start |
+| EndTime | datetime | The end time of the Schedule - null if running indefinitely |
+| Crons | hashtable[] | The cron expressions of the Schedule, but parsed into an internal format |
+| CronsRaw | string[] | The raw cron expressions that were supplied |
+| Limit | int | The number of times the Schedule should run - 0 if running indefinitely |
+| Count | int | The number of times the Schedule has run - this will only increment if the Schedule is limited |
+| Script | scriptblock | The scriptblock of the Schedule |
+| Arguments | hashtable | The arguments supplied from ArgumentList |
+| OnStart | bool | Should the Schedule run once when the server is starting, or once the server has fully loaded |
+| Completed | bool | Has the Schedule completed all of its runs - only set if the Schedule is limited |

--- a/docs/Tutorials/Timers.md
+++ b/docs/Tutorials/Timers.md
@@ -1,9 +1,9 @@
 # Timers
 
-A Timer in Pode is a short-running async task. All timers in Pode run in the same separate runspace along side your main server logic. Timers have unique names, and iterate on a defined number of seconds.
+A Timer in Pode is a short-running async task. All timers in Pode run in the same runspace along side your main server logic - so aim to keep them as short running as possible. Timers have unique names, and iterate on a defined number of seconds.
 
 !!! warning
-    Since all timers are run within the same runspace, it is wise to keep them as short-running as possible. If you require something long-running we recommend you use [Schedules](../Schedules).
+    Since all timers are run within the same runspace, it is wise to keep them as short running as possible. If you require a long-running task we recommend you use [Schedules](../Schedules) instead.
 
 ## Create a Timer
 
@@ -58,3 +58,37 @@ For example, to create a timer from a file that will output `Hello, world` every
 ```powershell
 Add-PodeTimer -Name 'from-file' -Interval 2 -FilePath './Timers/File.ps1'
 ```
+
+## Getting Timers
+
+The [`Get-PodeTimer`] helper function will allow you to retrieve a list of timers configured within Pode. You can use it to retrieve all of the timers, or supply filters to retrieve specific ones.
+
+To retrieve all of the timers, you can call the function will no parameters. To filter, here are some examples:
+
+```powershell
+# one timer by name
+Get-PodeTimer -Name Name1
+
+# multiple timers by name
+Get-PodeTimer -Name Name1, Name2
+```
+
+## Timer Object
+
+!!! warning
+    Be careful if you choose to edit these objects, as they will affect the server.
+
+The following is the structure of the Timer object internally, as well as the object that is returned from [`Get-PodeTimer`]:
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| Name | string | The name of the Timer |
+| Interval | int | How often the Timer runs, defined in seconds |
+| Limit | int | The number of times the Timer should run - 0 if running indefinitely |
+| Skip | int | The number of times the Timer should skip being triggered |
+| Count | int | The number of times the Timer has run - this will only increment if the Timer is limited |
+| NextTick | datetime | The datetime the Timer will next be triggered |
+| Script | scriptblock | The scriptblock of the Timer |
+| Arguments | object[] | The arguments supplied from ArgumentList |
+| OnStart | bool | Should the Timer run once when the server is starting, or once the server has fully loaded |
+| Completed | bool | Has the Timer completed all of its runs - only set if the Timer is limited |

--- a/src/Pode.psd1
+++ b/src/Pode.psd1
@@ -131,6 +131,7 @@
         'Invoke-PodeSchedule',
         'Edit-PodeSchedule',
         'Set-PodeScheduleConcurrency',
+        'Get-PodeSchedule',
 
         # timers
         'Add-PodeTimer',
@@ -138,6 +139,7 @@
         'Clear-PodeTimers',
         'Invoke-PodeTimer',
         'Edit-PodeTimer',
+        'Get-PodeTimer',
 
         # middleware
         'Add-PodeMiddleware',

--- a/src/Private/Schedules.ps1
+++ b/src/Private/Schedules.ps1
@@ -1,6 +1,6 @@
-function Get-PodeSchedule
+function Find-PodeSchedule
 {
-    param (
+    param(
         [Parameter(Mandatory=$true)]
         [ValidateNotNullOrEmpty()]
         [string]

--- a/src/Private/Timers.ps1
+++ b/src/Private/Timers.ps1
@@ -1,4 +1,4 @@
-function Get-PodeTimer
+function Find-PodeTimer
 {
     param (
         [Parameter(Mandatory=$true)]

--- a/src/Public/Core.ps1
+++ b/src/Public/Core.ps1
@@ -1236,6 +1236,50 @@ function Edit-PodeTimer
 
 <#
 .SYNOPSIS
+Returns any defined timers.
+
+.DESCRIPTION
+Returns any defined timers, with support for filtering.
+
+.PARAMETER Name
+Any timer Names to filter the timers.
+
+.EXAMPLE
+Get-PodeTimer
+
+.EXAMPLE
+Get-PodeTimer -Name Name1, Name2
+#>
+function Get-PodeTimer
+{
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [string[]]
+        $Name
+    )
+
+    $timers = $PodeContext.Timers.Values
+
+    # further filter by timer names
+    if (($null -ne $Name) -and ($Name.Length -gt 0)) {
+        $timers = @(foreach ($_name in $Name) {
+            foreach ($timer in $timers) {
+                if ($timer.Name -ine $_name) {
+                    continue
+                }
+
+                $timer
+            }
+        })
+    }
+
+    # return
+    return $timers
+}
+
+<#
+.SYNOPSIS
 Adds a new Schedule with logic to periodically invoke, defined using Cron Expressions.
 
 .DESCRIPTION
@@ -1353,6 +1397,7 @@ function Add-PodeSchedule
         StartTime = $StartTime
         EndTime = $EndTime
         Crons = (ConvertFrom-PodeCronExpressions -Expressions @($Cron))
+        CronsRaw = @($Cron)
         Limit = $Limit
         Count = 0
         Countable = ($Limit -gt 0)
@@ -1546,6 +1591,50 @@ function Edit-PodeSchedule
     if (!(Test-IsEmpty $ArgumentList)) {
         $PodeContext.Schedules[$Name].Arguments = $ArgumentList
     }
+}
+
+<#
+.SYNOPSIS
+Returns any defined schedules.
+
+.DESCRIPTION
+Returns any defined schedules, with support for filtering.
+
+.PARAMETER Name
+Any schedule Names to filter the schedules.
+
+.EXAMPLE
+Get-PodeSchedule
+
+.EXAMPLE
+Get-PodeSchedule -Name Name1, Name2
+#>
+function Get-PodeSchedule
+{
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [string[]]
+        $Name
+    )
+
+    $schedules = $PodeContext.Schedules.Values
+
+    # further filter by schedule names
+    if (($null -ne $Name) -and ($Name.Length -gt 0)) {
+        $schedules = @(foreach ($_name in $Name) {
+            foreach ($schedule in $schedules) {
+                if ($schedule.Name -ine $_name) {
+                    continue
+                }
+
+                $schedule
+            }
+        })
+    }
+
+    # return
+    return $schedules
 }
 
 <#

--- a/tests/unit/Schedules.Tests.ps1
+++ b/tests/unit/Schedules.Tests.ps1
@@ -2,26 +2,26 @@ $path = $MyInvocation.MyCommand.Path
 $src = (Split-Path -Parent -Path $path) -ireplace '[\\/]tests[\\/]unit', '/src/'
 Get-ChildItem "$($src)/*.ps1" -Recurse | Resolve-Path | ForEach-Object { . $_ }
 
-Describe 'Get-PodeSchedule' {
+Describe 'Find-PodeSchedule' {
     Context 'Invalid parameters supplied' {
         It 'Throw null name parameter error' {
-            { Get-PodeSchedule -Name $null } | Should Throw 'The argument is null or empty'
+            { Find-PodeSchedule -Name $null } | Should Throw 'The argument is null or empty'
         }
 
         It 'Throw empty name parameter error' {
-            { Get-PodeSchedule -Name ([string]::Empty) } | Should Throw 'The argument is null or empty'
+            { Find-PodeSchedule -Name ([string]::Empty) } | Should Throw 'The argument is null or empty'
         }
     }
 
     Context 'Valid values supplied' {
         It 'Returns null as the schedule does not exist' {
             $PodeContext = @{ 'Schedules' = @{}; }
-            Get-PodeSchedule -Name 'test' | Should Be $null
+            Find-PodeSchedule -Name 'test' | Should Be $null
         }
 
         It 'Returns schedule for name' {
             $PodeContext = @{ 'Schedules' = @{ 'test' = @{ 'Name' = 'test'; }; }; }
-            $result = (Get-PodeSchedule -Name 'test')
+            $result = (Find-PodeSchedule -Name 'test')
 
             $result | Should BeOfType System.Collections.Hashtable
             $result.Name | Should Be 'test'
@@ -129,6 +129,55 @@ Describe 'Add-PodeSchedule' {
         $schedule.Script | Should Not Be $null
         $schedule.Script.ToString() | Should Be ({ Write-Host 'hello' }).ToString()
         $schedule.Crons.Length | Should Be 2
+    }
+}
+
+Describe 'Get-PodeSchedule' {
+    It 'Returns no schedules' {
+        $PodeContext = @{ Schedules = @{} }
+        $schedules = Get-PodeSchedule
+        $schedules.Length | Should Be 0
+    }
+
+    It 'Returns 1 schedule by name' {
+        $PodeContext = @{ Schedules = @{} }
+        $start = ([DateTime]::Now.AddHours(3))
+        $end = ([DateTime]::Now.AddHours(5))
+
+        Add-PodeSchedule -Name 'test1' -Cron '@hourly' -ScriptBlock { Write-Host 'hello' } -StartTime $start -EndTime $end
+        $schedules = Get-PodeSchedule
+        $schedules.Length | Should Be 1
+
+        $schedules.Name | Should Be 'test1'
+        $schedules.StartTime | Should Be $start
+        $schedules.EndTime | Should Be $end
+        $schedules.Limit | Should Be 0
+    }
+
+    It 'Returns 2 schedules by name' {
+        $PodeContext = @{ Schedules = @{} }
+        $start = ([DateTime]::Now.AddHours(3))
+        $end = ([DateTime]::Now.AddHours(5))
+
+        Add-PodeSchedule -Name 'test1' -Cron '@hourly' -ScriptBlock { Write-Host 'hello' } -StartTime $start -EndTime $end
+        Add-PodeSchedule -Name 'test2' -Cron '@hourly' -ScriptBlock { Write-Host 'hello' } -StartTime $start -EndTime $end
+        Add-PodeSchedule -Name 'test3' -Cron '@hourly' -ScriptBlock { Write-Host 'hello' } -StartTime $start -EndTime $end
+
+        $schedules = Get-PodeSchedule -Name test1, test2
+        $schedules.Length | Should Be 2
+    }
+
+    It 'Returns all schedules' {
+        $PodeContext = @{ Schedules = @{} }
+        $start = ([DateTime]::Now.AddHours(3))
+        $end = ([DateTime]::Now.AddHours(5))
+
+        Add-PodeSchedule -Name 'test1' -Cron '@hourly' -ScriptBlock { Write-Host 'hello' } -StartTime $start -EndTime $end
+        Add-PodeSchedule -Name 'test2' -Cron '@hourly' -ScriptBlock { Write-Host 'hello' } -StartTime $start -EndTime $end
+        Add-PodeSchedule -Name 'test3' -Cron '@hourly' -ScriptBlock { Write-Host 'hello' } -StartTime $start -EndTime $end
+
+        $schedules = Get-PodeSchedule
+        $schedules.Length | Should Be 3
     }
 }
 

--- a/tests/unit/Timers.Tests.ps1
+++ b/tests/unit/Timers.Tests.ps1
@@ -2,26 +2,26 @@ $path = $MyInvocation.MyCommand.Path
 $src = (Split-Path -Parent -Path $path) -ireplace '[\\/]tests[\\/]unit', '/src/'
 Get-ChildItem "$($src)/*.ps1" -Recurse | Resolve-Path | ForEach-Object { . $_ }
 
-Describe 'Get-PodeTimer' {
+Describe 'Find-PodeTimer' {
     Context 'Invalid parameters supplied' {
         It 'Throw null name parameter error' {
-            { Get-PodeTimer -Name $null } | Should Throw 'The argument is null or empty'
+            { Find-PodeTimer -Name $null } | Should Throw 'The argument is null or empty'
         }
 
         It 'Throw empty name parameter error' {
-            { Get-PodeTimer -Name ([string]::Empty) } | Should Throw 'The argument is null or empty'
+            { Find-PodeTimer -Name ([string]::Empty) } | Should Throw 'The argument is null or empty'
         }
     }
 
     Context 'Valid values supplied' {
         It 'Returns null as the timer does not exist' {
             $PodeContext = @{ 'Timers' = @{}; }
-            Get-PodeTimer -Name 'test' | Should Be $null
+            Find-PodeTimer -Name 'test' | Should Be $null
         }
 
         It 'Returns timer for name' {
             $PodeContext = @{ 'Timers' = @{ 'test' = @{ 'Name' = 'test'; }; }; }
-            $result = (Get-PodeTimer -Name 'test')
+            $result = (Find-PodeTimer -Name 'test')
 
             $result | Should BeOfType System.Collections.Hashtable
             $result.Name | Should Be 'test'
@@ -87,6 +87,49 @@ Describe 'Add-PodeTimer' {
         $timer.NextTick | Should BeOfType System.DateTime
         $timer.Script | Should Not Be $null
         $timer.Script.ToString() | Should Be ({ Write-Host 'hello' }).ToString()
+    }
+}
+
+Describe 'Get-PodeTimer' {
+    It 'Returns no timers' {
+        $PodeContext = @{ Timers = @{} }
+        $timers = Get-PodeTimer
+        $timers.Length | Should Be 0
+    }
+
+    It 'Returns 1 timer by name' {
+        $PodeContext = @{ Timers = @{} }
+
+        Add-PodeTimer -Name 'test1' -Interval 1 -ScriptBlock { Write-Host 'hello' } -Limit 0 -Skip 1
+        $timers = Get-PodeTimer
+        $timers.Length | Should Be 1
+
+        $timers.Name | Should Be 'test1'
+        $timers.Interval | Should Be 1
+        $timers.Skip | Should Be 1
+        $timers.Limit | Should Be 0
+    }
+
+    It 'Returns 2 timers by name' {
+        $PodeContext = @{ Timers = @{} }
+
+        Add-PodeTimer -Name 'test1' -Interval 1 -ScriptBlock { Write-Host 'hello' } -Limit 0 -Skip 1
+        Add-PodeTimer -Name 'test2' -Interval 1 -ScriptBlock { Write-Host 'hello' } -Limit 0 -Skip 1
+        Add-PodeTimer -Name 'test3' -Interval 1 -ScriptBlock { Write-Host 'hello' } -Limit 0 -Skip 1
+
+        $timers = Get-PodeTimer -Name test1, test2
+        $timers.Length | Should Be 2
+    }
+
+    It 'Returns all timers' {
+        $PodeContext = @{ Timers = @{} }
+
+        Add-PodeTimer -Name 'test1' -Interval 1 -ScriptBlock { Write-Host 'hello' } -Limit 0 -Skip 1
+        Add-PodeTimer -Name 'test2' -Interval 1 -ScriptBlock { Write-Host 'hello' } -Limit 0 -Skip 1
+        Add-PodeTimer -Name 'test3' -Interval 1 -ScriptBlock { Write-Host 'hello' } -Limit 0 -Skip 1
+
+        $timers = Get-PodeTimer
+        $timers.Length | Should Be 3
     }
 }
 


### PR DESCRIPTION
### Description of the Change
Akin to Routes and Endpoints, this adds new functions to be able to retrieve both Schedules and Timers - with support for filtering by names.

### Related Issue
Resolves #548

### Examples
Schedules:
```powershell
# all schedules
Get-PodeSchedule

# one schedule by name
Get-PodeSchedule -Name Name1

# multiple schedules by name
Get-PodeSchedule -Name Name1, Name2
```

Timers:
```powershell
# all timers
Get-PodeTimer

# one timer by name
Get-PodeTimer -Name Name1

# multiple timers by name
Get-PodeTimer -Name Name1, Name2
```
