### PR TITLE
Adds NextTriggerTime support for Schedules

### DIFF
--- a/.github/workflows/ci-coverage.yml
+++ b/.github/workflows/ci-coverage.yml
@@ -19,11 +19,15 @@ jobs:
 
     - name: Install Invoke-Build
       shell: pwsh
-      run: Install-Module -Name InvokeBuild -RequiredVersion '5.5.1' -Force
+      run: |
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+        Install-Module -Name InvokeBuild -RequiredVersion '5.5.1' -Force
 
     - name: Run Pester Tests
       shell: pwsh
       env:
         PODE_COVERALLS_TOKEN: ${{ secrets.PODE_COVERALLS_TOKEN }}
         PODE_RUN_CODE_COVERAGE: true
-      run: Invoke-Build Test
+      run: |
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+        Invoke-Build Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,12 @@ jobs:
 
     - name: Install Invoke-Build
       shell: pwsh
-      run: Install-Module -Name InvokeBuild -RequiredVersion '5.5.1' -Force
+      run: |
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+        Install-Module -Name InvokeBuild -RequiredVersion '5.5.1' -Force
 
     - name: Run Pester Tests
       shell: pwsh
-      run: Invoke-Build Test
+      run: |
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+        Invoke-Build Test

--- a/docs/Tutorials/Misc/CronExpressions.md
+++ b/docs/Tutorials/Misc/CronExpressions.md
@@ -19,7 +19,7 @@ For example, if you wanted to run a schedule that triggers every midnight on a T
 Whereas if you wanted a schedule to trigger on the 15th of each month, at 1am:
 
 ```plain
-0 1 15 * * *
+0 1 15 * *
 ```
 
 ## Predefined
@@ -33,7 +33,7 @@ The following table outlines some of the predefined cron expressions supported b
 | @daily | `0 0 * * *` |
 | @weekly | `0 0 * * 0` |
 | @monthly | `0 0 1 * *` |
-| @quarterly | `0 0 1 1,4,8,7,10` |
+| @quarterly | `0 0 1 1,4,8,7,10 *` |
 | @yearly | `0 0 1 1 *` |
 | @annually | `0 0 1 1 *` |
 | @twice-hourly | `0,30 * * * *` |

--- a/docs/Tutorials/Schedules.md
+++ b/docs/Tutorials/Schedules.md
@@ -95,7 +95,7 @@ Add-PodeSchedule -Name 'from-file' -Cron '@minutely' -FilePath './Schedules/File
 
 ## Getting Schedules
 
-The [`Get-PodeSchedule`] helper function will allow you to retrieve a list of schedules configured within Pode. You can use it to retrieve all of the schedules, or supply filters to retrieve specific ones.
+The [`Get-PodeSchedule`](../../Functions/Core/Get-PodeSchedule) helper function will allow you to retrieve a list of schedules configured within Pode. You can use it to retrieve all of the schedules, or supply filters to retrieve specific ones.
 
 To retrieve all of the schedules, you can call the function will no parameters. To filter, here are some examples:
 
@@ -107,23 +107,38 @@ Get-PodeSchedule -Name Name1
 Get-PodeSchedule -Name Name1, Name2
 ```
 
+## Next Trigger Time
+
+When you retrieve a Schedule using [`Get-PodeSchedule`](../../Functions/Core/Get-PodeSchedule), each Schedule object will already have its next trigger time as `NextTriggerTime`. However, if you want to get a trigger time further ino the future than this, then you can use the [`Get-PodeScheduleNextTrigger`](../../Functions/Core/Get-PodeScheduleNextTrigger) function.
+
+This function takes the Name of a Schedule, as well as a custom DateTime and will return the next trigger time after that DateTime. If no DateTime is supplied, then the Schedule's StartTime is used (or the current time if no StartTime).
+
+```powershell
+# just get the next time
+$time = Get-PodeScheduleNextTrigger -Name Schedule1
+
+# get the next time after a date
+$time = Get-PodeScheduleTriggerTime -Name Schedule1 -DateTime [datetime]::new(2020, 3, 20)
+```
+
 ## Schedule Object
 
 !!! warning
     Be careful if you choose to edit these objects, as they will affect the server.
 
-The following is the structure of the Schedule object internally, as well as the object that is returned from [`Get-PodeSchedule`]:
+The following is the structure of the Schedule object internally, as well as the object that is returned from [`Get-PodeSchedule`](../../Functions/Core/Get-PodeSchedule):
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
 | Name | string | The name of the Schedule |
-| StartTime | datetime | The delayed start time of the Schedule - null if run at server start |
-| EndTime | datetime | The end time of the Schedule - null if running indefinitely |
+| StartTime | datetime | The delayed start time of the Schedule |
+| EndTime | datetime | The end time of the Schedule |
 | Crons | hashtable[] | The cron expressions of the Schedule, but parsed into an internal format |
 | CronsRaw | string[] | The raw cron expressions that were supplied |
-| Limit | int | The number of times the Schedule should run - 0 if running indefinitely |
-| Count | int | The number of times the Schedule has run - this will only increment if the Schedule is limited |
+| Limit | int | The number of times the Schedule should run - 0 if running infinitely |
+| Count | int | The number of times the Schedule has run |
+| NextTriggerTime | datetime | The datetime the Schedule will next be triggered |
 | Script | scriptblock | The scriptblock of the Schedule |
 | Arguments | hashtable | The arguments supplied from ArgumentList |
 | OnStart | bool | Should the Schedule run once when the server is starting, or once the server has fully loaded |
-| Completed | bool | Has the Schedule completed all of its runs - only set if the Schedule is limited |
+| Completed | bool | Has the Schedule completed all of its runs |

--- a/docs/Tutorials/Timers.md
+++ b/docs/Tutorials/Timers.md
@@ -84,11 +84,11 @@ The following is the structure of the Timer object internally, as well as the ob
 | ---- | ---- | ----------- |
 | Name | string | The name of the Timer |
 | Interval | int | How often the Timer runs, defined in seconds |
-| Limit | int | The number of times the Timer should run - 0 if running indefinitely |
+| Limit | int | The number of times the Timer should run - 0 if running forever |
 | Skip | int | The number of times the Timer should skip being triggered |
-| Count | int | The number of times the Timer has run - this will only increment if the Timer is limited |
-| NextTick | datetime | The datetime the Timer will next be triggered |
+| Count | int | The number of times the Timer has run |
+| NextTriggerTime | datetime | The datetime the Timer will next be triggered |
 | Script | scriptblock | The scriptblock of the Timer |
 | Arguments | object[] | The arguments supplied from ArgumentList |
 | OnStart | bool | Should the Timer run once when the server is starting, or once the server has fully loaded |
-| Completed | bool | Has the Timer completed all of its runs - only set if the Timer is limited |
+| Completed | bool | Has the Timer completed all of its runs |

--- a/docs/Tutorials/Timers.md
+++ b/docs/Tutorials/Timers.md
@@ -61,7 +61,7 @@ Add-PodeTimer -Name 'from-file' -Interval 2 -FilePath './Timers/File.ps1'
 
 ## Getting Timers
 
-The [`Get-PodeTimer`] helper function will allow you to retrieve a list of timers configured within Pode. You can use it to retrieve all of the timers, or supply filters to retrieve specific ones.
+The [`Get-PodeTimer`](../../Functions/Core/Get-PodeTimer) helper function will allow you to retrieve a list of timers configured within Pode. You can use it to retrieve all of the timers, or supply filters to retrieve specific ones.
 
 To retrieve all of the timers, you can call the function will no parameters. To filter, here are some examples:
 
@@ -78,7 +78,7 @@ Get-PodeTimer -Name Name1, Name2
 !!! warning
     Be careful if you choose to edit these objects, as they will affect the server.
 
-The following is the structure of the Timer object internally, as well as the object that is returned from [`Get-PodeTimer`]:
+The following is the structure of the Timer object internally, as well as the object that is returned from [`Get-PodeTimer`](../../Functions/Core/Get-PodeTimer):
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |

--- a/examples/schedules.ps1
+++ b/examples/schedules.ps1
@@ -13,6 +13,7 @@ Start-PodeServer {
     # schedule minutely using predefined cron
     Add-PodeSchedule -Name 'predefined' -Cron '@minutely' -Limit 2 -ScriptBlock {
         'hello, world!' | Out-Default
+        Get-PodeSchedule -Name 'predefined' | Out-Default
     }
 
     Add-PodeSchedule -Name 'from-file' -Cron '@minutely' -FilePath './scripts/schedule.ps1'
@@ -28,7 +29,7 @@ Start-PodeServer {
     }
 
     # schedule to run every 5 past the hour, starting in 2hrs
-    Add-PodeSchedule -Name 'hourly-start' -Cron '5 * * * *' -ScriptBlock {
+    Add-PodeSchedule -Name 'hourly-start' -Cron '5,7,9 * * * *' -ScriptBlock {
         # logic
     } -StartTime ([DateTime]::Now.AddHours(2))
 

--- a/examples/schedules.ps1
+++ b/examples/schedules.ps1
@@ -21,6 +21,7 @@ Start-PodeServer {
     # schedule defined using two cron expressions
     Add-PodeSchedule -Name 'two-crons' -Cron @('0/3 * * * *', '0/5 * * * *') -ScriptBlock {
         'double cron' | Out-Default
+        Get-PodeSchedule -Name 'two-crons' | Out-Default
     }
 
     # schedule to run every tuesday at midnight

--- a/examples/timers.ps1
+++ b/examples/timers.ps1
@@ -18,13 +18,14 @@ Start-PodeServer {
 
     # runs forever, but skips the first 3 "loops" - is paused for 15secs then loops every 5secs
     Add-PodeTimer -Name 'pause-first-3' -Interval 5 -ScriptBlock {
-        # logic
+        'Skip 3 then run' | Out-PodeHost
     } -Skip 3
 
-    # runs every 5secs, but only runs for 10 "loops" (ie, 50secs)
-    Add-PodeTimer -Name 'run-10-times' -Interval 5 -ScriptBlock {
-        # logic
-    } -Limit 10
+    # runs every 5secs, but only runs for 3 "loops" (ie, 15secs)
+    Add-PodeTimer -Name 'run-3-times' -Interval 5 -ScriptBlock {
+        'Only run 3 times' | Out-PodeHost
+        Get-PodeTimer -Name 'run-3-times' | Out-Default
+    } -Limit 3
 
     # skip the first 2 loops, then run for 15 loops
     Add-PodeTimer -Name 'pause-then-limit' -Interval 5 -ScriptBlock {
@@ -32,8 +33,8 @@ Start-PodeServer {
     } -Skip 2 -Limit 15
 
     # run once after 2mins
-    Add-PodeTimer -Name 'run-once' -Interval 120 -ScriptBlock {
-        # logic
+    Add-PodeTimer -Name 'run-once' -Interval 20 -ScriptBlock {
+        'Ran once' | Out-PodeHost
     } -Skip 1 -Limit 1
 
     # create a new timer via a route

--- a/pode.build.ps1
+++ b/pode.build.ps1
@@ -103,13 +103,13 @@ function Invoke-PodeBuildInstall($name, $version)
 
 function Install-PodeBuildModule($name)
 {
-    if ($null -ne ((Get-Module -ListAvailable $name) | Where-Object { $_.Version -ieq $Versions.$name })) {
+    if ($null -ne ((Get-Module -ListAvailable $name) | Where-Object { $_.Version -ieq $Versions[$name] })) {
         return
     }
 
-    Write-Host "Installing $($name)"
+    Write-Host "Installing $($name) v$($Versions[$name])"
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-    Install-Module -Name $name -Scope CurrentUser -RequiredVersion $Versions.$name -Force -SkipPublisherCheck
+    Install-Module -Name "$($name)" -Scope CurrentUser -RequiredVersion "$($Versions[$name])" -Force -SkipPublisherCheck
 }
 
 

--- a/pode.build.ps1
+++ b/pode.build.ps1
@@ -101,6 +101,17 @@ function Invoke-PodeBuildInstall($name, $version)
     }
 }
 
+function Install-PodeBuildModule($name)
+{
+    if ($null -ne ((Get-Module -ListAvailable $name) | Where-Object { $_.Version -ieq $Versions.$name })) {
+        return
+    }
+
+    Write-Host "Installing $($name)"
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    Install-Module -Name $name -Scope CurrentUser -RequiredVersion $Versions.$name -Force -SkipPublisherCheck
+}
+
 
 <#
 # Helper Tasks
@@ -152,18 +163,12 @@ task PackDeps -If (Test-PodeBuildIsWindows) ChocoDeps, {
 # Synopsis: Install dependencies for running tests
 task TestDeps {
     # install pester
-    if (((Get-Module -ListAvailable Pester) | Where-Object { $_.Version -ieq $Versions.Pester }) -eq $null) {
-        Write-Host 'Installing Pester'
-        Install-Module -Name Pester -Scope CurrentUser -RequiredVersion $Versions.Pester -Force -SkipPublisherCheck
-    }
+    Install-PodeBuildModule Pester
 
     # install PSCoveralls
     if (Test-PodeBuildCanCodeCoverage)
     {
-        if (((Get-Module -ListAvailable PSCoveralls) | Where-Object { $_.Version -ieq $Versions.PSCoveralls }) -eq $null) {
-            Write-Host 'Installing PSCoveralls'
-            Install-Module -Name PSCoveralls -Scope CurrentUser -RequiredVersion $Versions.PSCoveralls -Force -SkipPublisherCheck
-        }
+        Install-PodeBuildModule PSCoveralls
     }
 }
 
@@ -180,10 +185,7 @@ task DocsDeps ChocoDeps, {
     }
 
     # install platyps
-    if (((Get-Module -ListAvailable PlatyPS) | Where-Object { $_.Version -ieq $Versions.PlatyPS }) -eq $null) {
-        Write-Host 'Installing PlatyPS'
-        Install-Module -Name PlatyPS -Scope CurrentUser -RequiredVersion $Versions.PlatyPS -Force -SkipPublisherCheck
-    }
+    Install-PodeBuildModule PlatyPS
 }
 
 

--- a/src/Pode.psd1
+++ b/src/Pode.psd1
@@ -132,6 +132,7 @@
         'Edit-PodeSchedule',
         'Set-PodeScheduleConcurrency',
         'Get-PodeSchedule',
+        'Get-PodeScheduleNextTrigger',
 
         # timers
         'Add-PodeTimer',

--- a/src/Private/CronParser.ps1
+++ b/src/Private/CronParser.ps1
@@ -433,7 +433,7 @@ function Get-PodeCronNextTrigger
         return $NextTime
     }
 
-    # functions for getting values
+    # functions for getting the closest value
     function Get-ClosestValue($AtomContraint, $NowValue) {
         $_values = $AtomContraint.Values
         if ($null -eq $_values) {
@@ -533,11 +533,11 @@ function Get-PodeCronNextTrigger
 
     # before we return, make sure the time is valid
     if (!(Test-PodeCronExpression -Expression $Expression -DateTime $NextTime)) {
-        throw "Looks like something went wrong trying to calculate the next trigger datetime"
+        throw "Looks like something went wrong trying to calculate the next trigger datetime: $($NextTime)"
     }
 
     # if before the start or after end then return null
-    if (($NextTime -lt $StartTime) -or (($null -ne $EndTime) -and ($NextTime -ge $EndTime))) {
+    if (($NextTime -lt $StartTime) -or (($null -ne $EndTime) -and ($NextTime -gt $EndTime))) {
         return $null
     }
 

--- a/src/Private/Schedules.ps1
+++ b/src/Private/Schedules.ps1
@@ -24,13 +24,11 @@ function Start-PodeScheduleRunspace
             Where-Object {
                 $_.OnStart
             } | ForEach-Object {
-                if (Invoke-PodeInternalSchedule -Schedule $_) {
-                    $_.Completed = $true
-                }
+                Invoke-PodeInternalSchedule -Schedule $_
             }
 
-        # remove any schedules
-        Remove-PodeInternalSchedules -Now $_now
+        # complete any schedules
+        Complete-PodeInternalSchedules -Now $_now
 
         # first, sleep for a period of time to get to 00 seconds (start of minute)
         Start-Sleep -Seconds (60 - [DateTime]::Now.Second)
@@ -46,13 +44,11 @@ function Start-PodeScheduleRunspace
                     (($null -eq $_.EndTime) -or ($_.EndTime -ge $_now)) -and
                     (Test-PodeCronExpressions -Expressions $_.Crons -DateTime $_now) -and !$_.Completed
                 } | ForEach-Object {
-                    if (Invoke-PodeInternalSchedule -Schedule $_) {
-                        $_.Completed = $true
-                    }
+                    Invoke-PodeInternalSchedule -Schedule $_
                 }
 
-            # remove any schedules
-            Remove-PodeInternalSchedules -Now $_now
+            # complete any schedules
+            Complete-PodeInternalSchedules -Now $_now
 
             # cron expression only goes down to the minute, so sleep for 1min
             Start-Sleep -Seconds (60 - [DateTime]::Now.Second)
@@ -62,7 +58,7 @@ function Start-PodeScheduleRunspace
     Add-PodeRunspace -Type 'Main' -ScriptBlock $script
 }
 
-function Remove-PodeInternalSchedules
+function Complete-PodeInternalSchedules
 {
     param(
         [Parameter(Mandatory=$true)]
@@ -92,25 +88,22 @@ function Invoke-PodeInternalSchedule
     )
 
     $Schedule.OnStart = $false
-    $remove = $false
 
     # increment total number of triggers for the schedule
-    if ($Schedule.Countable) {
-        $Schedule.Count++
-        $Schedule.Countable = ($Schedule.Count -lt $Schedule.Limit)
-    }
+    $Schedule.Count++
 
     # check if we have hit the limit, and remove
-    if (($Schedule.Limit -ne 0) -and ($Schedule.Count -ge $Schedule.Limit)) {
-        $remove = $true
+    if (($Schedule.Limit -gt 0) -and ($Schedule.Count -ge $Schedule.Limit)) {
+        $Schedule.Completed = $true
     }
 
     # trigger the schedules logic
     Invoke-PodeInternalScheduleLogic -Schedule $Schedule
 
     # reset the cron if it's random
-    $Schedule.Crons = Reset-PodeRandomCronExpressions -Expressions $Schedule.Crons
-    return $remove
+    if (!$Schedule.Completed) {
+        $Schedule.Crons = Reset-PodeRandomCronExpressions -Expressions $Schedule.Crons
+    }
 }
 
 function Invoke-PodeInternalScheduleLogic

--- a/src/Private/Schedules.ps1
+++ b/src/Private/Schedules.ps1
@@ -103,6 +103,10 @@ function Invoke-PodeInternalSchedule
     # reset the cron if it's random
     if (!$Schedule.Completed) {
         $Schedule.Crons = Reset-PodeRandomCronExpressions -Expressions $Schedule.Crons
+        $Schedule.NextTriggerTime = Get-PodeCronNextEarliestTrigger -Expressions $Schedule.Crons -EndTime $Schedule.EndTime
+    }
+    else {
+        $Schedule.NextTriggerTime = $null
     }
 }
 

--- a/src/Private/Schedules.ps1
+++ b/src/Private/Schedules.ps1
@@ -40,9 +40,10 @@ function Start-PodeScheduleRunspace
             # select the schedules that need triggering
             $PodeContext.Schedules.Values |
                 Where-Object {
+                    !$_.Completed -and
                     (($null -eq $_.StartTime) -or ($_.StartTime -le $_now)) -and
                     (($null -eq $_.EndTime) -or ($_.EndTime -ge $_now)) -and
-                    (Test-PodeCronExpressions -Expressions $_.Crons -DateTime $_now) -and !$_.Completed
+                    (Test-PodeCronExpressions -Expressions $_.Crons -DateTime $_now)
                 } | ForEach-Object {
                     Invoke-PodeInternalSchedule -Schedule $_
                 }

--- a/src/Private/Timers.ps1
+++ b/src/Private/Timers.ps1
@@ -40,6 +40,9 @@ function Start-PodeTimerRunspace
                 if (!$_.Completed) {
                     $_.NextTriggerTime = $_now.AddSeconds($_.Interval)
                 }
+                else {
+                    $_.NextTriggerTime = $null
+                }
             }
 
             Start-Sleep -Seconds 1

--- a/src/Private/Timers.ps1
+++ b/src/Private/Timers.ps1
@@ -21,29 +21,25 @@ function Start-PodeTimerRunspace
         {
             $_now = [DateTime]::Now
 
+            # only run timers that haven't completed, and have a next trigger in the past
             $PodeContext.Timers.Values | Where-Object {
-                ($_.OnStart -or ($_.NextTick -le $_now)) -and !$_.Completed
+                !$_.Completed -and ($_.OnStart -or ($_.NextTriggerTime -le $_now))
             } | ForEach-Object {
-                $run = $true
                 $_.OnStart = $false
+                $_.Count++
 
-                # increment total number of runs for timer (do we still need to count?)
-                if ($_.Countable) {
-                    $_.Count++
-                    $_.Countable = ($_.Count -le $_.Limit)
-                }
-
-                # check if we have hit the limit, and remove
-                if ($run -and ($_.Limit -ne 0) -and ($_.Count -gt $_.Limit)) {
-                    $run = $false
+                # has the timer completed?
+                if (($_.Limit -gt 0) -and ($_.Count -ge $_.Limit)) {
                     $_.Completed = $true
                 }
 
-                if ($run) {
-                    Invoke-PodeInternalTimer -Timer $_
-                }
+                # run the timer
+                Invoke-PodeInternalTimer -Timer $_
 
-                $_.NextTick = $_now.AddSeconds($_.Interval)
+                # next trigger
+                if (!$_.Completed) {
+                    $_.NextTriggerTime = $_now.AddSeconds($_.Interval)
+                }
             }
 
             Start-Sleep -Seconds 1

--- a/src/Public/Core.ps1
+++ b/src/Public/Core.ps1
@@ -1075,9 +1075,9 @@ function Add-PodeTimer
     }
 
     # calculate the next tick time (based on Skip)
-    $NextTick = [DateTime]::Now.AddSeconds($Interval)
+    $NextTriggerTime = [DateTime]::Now.AddSeconds($Interval)
     if ($Skip -gt 1) {
-        $NextTick = $NextTick.AddSeconds($Interval * $Skip)
+        $NextTriggerTime = $NextTriggerTime.AddSeconds($Interval * $Skip)
     }
 
     # add the timer
@@ -1087,8 +1087,7 @@ function Add-PodeTimer
         Limit = $Limit
         Count = 0
         Skip = $Skip
-        Countable = ($Limit -gt 0)
-        NextTick = $NextTick
+        NextTriggerTime = $NextTriggerTime
         Script = $ScriptBlock
         Arguments = $ArgumentList
         OnStart = $OnStart
@@ -1400,7 +1399,6 @@ function Add-PodeSchedule
         CronsRaw = @($Cron)
         Limit = $Limit
         Count = 0
-        Countable = ($Limit -gt 0)
         Script = $ScriptBlock
         Arguments = (Protect-PodeValue -Value $ArgumentList -Default @{})
         OnStart = $OnStart

--- a/tests/integration/Authentication.Tests.ps1
+++ b/tests/integration/Authentication.Tests.ps1
@@ -50,7 +50,7 @@ Describe 'Authentication Requests' {
             }
         }
 
-        Start-Sleep -Seconds 8
+        Start-Sleep -Seconds 10
     }
 
     AfterAll {

--- a/tests/integration/Endpoints.Tests.ps1
+++ b/tests/integration/Endpoints.Tests.ps1
@@ -33,7 +33,7 @@ Describe 'Endpoint Requests' {
             }
         }
 
-        Start-Sleep -Seconds 8
+        Start-Sleep -Seconds 10
     }
 
     AfterAll {

--- a/tests/integration/RestApi.Tests.ps1
+++ b/tests/integration/RestApi.Tests.ps1
@@ -77,7 +77,7 @@ Describe 'REST API Requests' {
             }
         }
 
-        Start-Sleep -Seconds 8
+        Start-Sleep -Seconds 10
     }
 
     AfterAll {

--- a/tests/integration/Schedules.Tests.ps1
+++ b/tests/integration/Schedules.Tests.ps1
@@ -41,7 +41,7 @@ Describe 'Schedules' {
             }
         }
 
-        Start-Sleep -Seconds 8
+        Start-Sleep -Seconds 10
     }
 
     AfterAll {

--- a/tests/integration/Sessions.Tests.ps1
+++ b/tests/integration/Sessions.Tests.ps1
@@ -38,7 +38,7 @@ Describe 'Session Requests' {
             }
         }
 
-        Start-Sleep -Seconds 8
+        Start-Sleep -Seconds 10
     }
 
     AfterAll {

--- a/tests/integration/Timers.Tests.ps1
+++ b/tests/integration/Timers.Tests.ps1
@@ -27,7 +27,7 @@ Describe 'Timers' {
             }
         }
 
-        Start-Sleep -Seconds 8
+        Start-Sleep -Seconds 10
     }
 
     AfterAll {

--- a/tests/integration/WebPages.Tests.ps1
+++ b/tests/integration/WebPages.Tests.ps1
@@ -35,7 +35,7 @@ Describe 'Web Page Requests' {
             }
         }
 
-        Start-Sleep -Seconds 8
+        Start-Sleep -Seconds 10
     }
 
     AfterAll {

--- a/tests/unit/CronParser.Tests.ps1
+++ b/tests/unit/CronParser.Tests.ps1
@@ -48,7 +48,7 @@ Describe 'Get-PodeCronPredefined' {
         $values['@daily'] | Should Be '0 0 * * *'
         $values['@weekly'] | Should Be '0 0 * * 0'
         $values['@monthly'] | Should Be '0 0 1 * *'
-        $values['@quarterly'] | Should Be '0 0 1 1,4,7,10'
+        $values['@quarterly'] | Should Be '0 0 1 1,4,7,10 *'
         $values['@yearly'] | Should Be '0 0 1 1 *'
         $values['@annually'] | Should Be '0 0 1 1 *'
         $values['@twice-hourly'] | Should Be '0,30 * * * *'
@@ -487,7 +487,74 @@ Describe 'Test-PodeCronExpression'{
     }
 }
 
+Describe 'Get-PodeCronNextTrigger' {
+    $inputDate = [datetime]::new(2020, 1, 1)
 
+    It 'Returns the next minute' {
+        $exp = '* * * * *'
+        $cron = ConvertFrom-PodeCronExpressions -Expressions $exp
+        Get-PodeCronNextTrigger -Expression $cron -DateTime $inputDate | Should Be ([datetime]::new(2020, 1, 1, 0, 1, 0))
+    }
 
+    It 'Returns the next hour' {
+        $exp = '0 * * * *'
+        $cron = ConvertFrom-PodeCronExpressions -Expressions $exp
+        Get-PodeCronNextTrigger -Expression $cron -DateTime $inputDate | Should Be ([datetime]::new(2020, 1, 1, 1, 0, 0))
+    }
 
+    It 'Returns the next day' {
+        $exp = '0 0 * * *'
+        $cron = ConvertFrom-PodeCronExpressions -Expressions $exp
+        Get-PodeCronNextTrigger -Expression $cron -DateTime $inputDate | Should Be ([datetime]::new(2020, 1, 2, 0, 0, 0))
+    }
 
+    It 'Returns the next month' {
+        $exp = '0 0 1 * *'
+        $cron = ConvertFrom-PodeCronExpressions -Expressions $exp
+        Get-PodeCronNextTrigger -Expression $cron -DateTime $inputDate | Should Be ([datetime]::new(2020, 2, 1, 0, 0, 0))
+    }
+
+    It 'Returns the next year' {
+        $exp = '0 0 1 1 *'
+        $cron = ConvertFrom-PodeCronExpressions -Expressions $exp
+        Get-PodeCronNextTrigger -Expression $cron -DateTime $inputDate | Should Be ([datetime]::new(2021, 1, 1, 0, 0, 0))
+    }
+
+    It 'Returns the friday 3rd' {
+        $exp = '0 0 * 1 FRI'
+        $cron = ConvertFrom-PodeCronExpressions -Expressions $exp
+        Get-PodeCronNextTrigger -Expression $cron -DateTime $inputDate | Should Be ([datetime]::new(2020, 1, 3, 0, 0, 0))
+    }
+
+    It 'Returns the 2023 friday' {
+        $exp = '0 0 13 1 FRI'
+        $cron = ConvertFrom-PodeCronExpressions -Expressions $exp
+        Get-PodeCronNextTrigger -Expression $cron -DateTime $inputDate | Should Be ([datetime]::new(2023, 1, 13, 0, 0, 0))
+    }
+
+    $inputDate = [datetime]::new(2020, 1, 15, 2, 30, 0)
+
+    It 'Returns the minute but next hour' {
+        $exp = '20 * * * *'
+        $cron = ConvertFrom-PodeCronExpressions -Expressions $exp
+        Get-PodeCronNextTrigger -Expression $cron -DateTime $inputDate | Should Be ([datetime]::new(2020, 1, 15, 3, 20, 0))
+    }
+
+    It 'Returns the later minute but same hour' {
+        $exp = '20,40 * * * *'
+        $cron = ConvertFrom-PodeCronExpressions -Expressions $exp
+        Get-PodeCronNextTrigger -Expression $cron -DateTime $inputDate | Should Be ([datetime]::new(2020, 1, 15, 2, 40, 0))
+    }
+
+    It 'Returns the next minute but same hour' {
+        $exp = '20-40 * * * *'
+        $cron = ConvertFrom-PodeCronExpressions -Expressions $exp
+        Get-PodeCronNextTrigger -Expression $cron -DateTime $inputDate | Should Be ([datetime]::new(2020, 1, 15, 2, 31, 0))
+    }
+
+    It 'Returns the a very specific date' {
+        $exp = '37 13 5 2 FRI'
+        $cron = ConvertFrom-PodeCronExpressions -Expressions $exp
+        Get-PodeCronNextTrigger -Expression $cron -DateTime $inputDate | Should Be ([datetime]::new(2021, 2, 5, 13, 37, 0))
+    }
+}

--- a/tests/unit/CronParser.Tests.ps1
+++ b/tests/unit/CronParser.Tests.ps1
@@ -493,43 +493,50 @@ Describe 'Get-PodeCronNextTrigger' {
     It 'Returns the next minute' {
         $exp = '* * * * *'
         $cron = ConvertFrom-PodeCronExpressions -Expressions $exp
-        Get-PodeCronNextTrigger -Expression $cron -DateTime $inputDate | Should Be ([datetime]::new(2020, 1, 1, 0, 1, 0))
+        Get-PodeCronNextTrigger -Expression $cron -StartTime $inputDate | Should Be ([datetime]::new(2020, 1, 1, 0, 1, 0))
     }
 
     It 'Returns the next hour' {
         $exp = '0 * * * *'
         $cron = ConvertFrom-PodeCronExpressions -Expressions $exp
-        Get-PodeCronNextTrigger -Expression $cron -DateTime $inputDate | Should Be ([datetime]::new(2020, 1, 1, 1, 0, 0))
+        Get-PodeCronNextTrigger -Expression $cron -StartTime $inputDate | Should Be ([datetime]::new(2020, 1, 1, 1, 0, 0))
     }
 
     It 'Returns the next day' {
         $exp = '0 0 * * *'
         $cron = ConvertFrom-PodeCronExpressions -Expressions $exp
-        Get-PodeCronNextTrigger -Expression $cron -DateTime $inputDate | Should Be ([datetime]::new(2020, 1, 2, 0, 0, 0))
+        Get-PodeCronNextTrigger -Expression $cron -StartTime $inputDate | Should Be ([datetime]::new(2020, 1, 2, 0, 0, 0))
     }
 
     It 'Returns the next month' {
         $exp = '0 0 1 * *'
         $cron = ConvertFrom-PodeCronExpressions -Expressions $exp
-        Get-PodeCronNextTrigger -Expression $cron -DateTime $inputDate | Should Be ([datetime]::new(2020, 2, 1, 0, 0, 0))
+        Get-PodeCronNextTrigger -Expression $cron -StartTime $inputDate | Should Be ([datetime]::new(2020, 2, 1, 0, 0, 0))
     }
 
     It 'Returns the next year' {
         $exp = '0 0 1 1 *'
         $cron = ConvertFrom-PodeCronExpressions -Expressions $exp
-        Get-PodeCronNextTrigger -Expression $cron -DateTime $inputDate | Should Be ([datetime]::new(2021, 1, 1, 0, 0, 0))
+        Get-PodeCronNextTrigger -Expression $cron -StartTime $inputDate | Should Be ([datetime]::new(2021, 1, 1, 0, 0, 0))
     }
 
     It 'Returns the friday 3rd' {
         $exp = '0 0 * 1 FRI'
         $cron = ConvertFrom-PodeCronExpressions -Expressions $exp
-        Get-PodeCronNextTrigger -Expression $cron -DateTime $inputDate | Should Be ([datetime]::new(2020, 1, 3, 0, 0, 0))
+        Get-PodeCronNextTrigger -Expression $cron -StartTime $inputDate | Should Be ([datetime]::new(2020, 1, 3, 0, 0, 0))
     }
 
     It 'Returns the 2023 friday' {
         $exp = '0 0 13 1 FRI'
         $cron = ConvertFrom-PodeCronExpressions -Expressions $exp
-        Get-PodeCronNextTrigger -Expression $cron -DateTime $inputDate | Should Be ([datetime]::new(2023, 1, 13, 0, 0, 0))
+        Get-PodeCronNextTrigger -Expression $cron -StartTime $inputDate | Should Be ([datetime]::new(2023, 1, 13, 0, 0, 0))
+    }
+
+    It 'Returns the null for after end time' {
+        $exp = '0 0 20 1 FRI'
+        $end = [datetime]::new(2020, 1, 19)
+        $cron = ConvertFrom-PodeCronExpressions -Expressions $exp
+        Get-PodeCronNextTrigger -Expression $cron -StartTime $inputDate -EndTime $end | Should Be $null
     }
 
     $inputDate = [datetime]::new(2020, 1, 15, 2, 30, 0)
@@ -537,24 +544,57 @@ Describe 'Get-PodeCronNextTrigger' {
     It 'Returns the minute but next hour' {
         $exp = '20 * * * *'
         $cron = ConvertFrom-PodeCronExpressions -Expressions $exp
-        Get-PodeCronNextTrigger -Expression $cron -DateTime $inputDate | Should Be ([datetime]::new(2020, 1, 15, 3, 20, 0))
+        Get-PodeCronNextTrigger -Expression $cron -StartTime $inputDate | Should Be ([datetime]::new(2020, 1, 15, 3, 20, 0))
     }
 
     It 'Returns the later minute but same hour' {
         $exp = '20,40 * * * *'
         $cron = ConvertFrom-PodeCronExpressions -Expressions $exp
-        Get-PodeCronNextTrigger -Expression $cron -DateTime $inputDate | Should Be ([datetime]::new(2020, 1, 15, 2, 40, 0))
+        Get-PodeCronNextTrigger -Expression $cron -StartTime $inputDate | Should Be ([datetime]::new(2020, 1, 15, 2, 40, 0))
     }
 
     It 'Returns the next minute but same hour' {
         $exp = '20-40 * * * *'
         $cron = ConvertFrom-PodeCronExpressions -Expressions $exp
-        Get-PodeCronNextTrigger -Expression $cron -DateTime $inputDate | Should Be ([datetime]::new(2020, 1, 15, 2, 31, 0))
+        Get-PodeCronNextTrigger -Expression $cron -StartTime $inputDate | Should Be ([datetime]::new(2020, 1, 15, 2, 31, 0))
     }
 
     It 'Returns the a very specific date' {
         $exp = '37 13 5 2 FRI'
         $cron = ConvertFrom-PodeCronExpressions -Expressions $exp
-        Get-PodeCronNextTrigger -Expression $cron -DateTime $inputDate | Should Be ([datetime]::new(2021, 2, 5, 13, 37, 0))
+        Get-PodeCronNextTrigger -Expression $cron -StartTime $inputDate | Should Be ([datetime]::new(2021, 2, 5, 13, 37, 0))
+    }
+
+    It 'Returns the 30 March' {
+        $inputDate = [datetime]::new(2020, 1, 31, 0, 0, 0)
+        $cron = ConvertFrom-PodeCronExpressions -Expressions '* * 30 * *'
+        Get-PodeCronNextTrigger -Expression $cron -StartTime $inputDate | Should Be ([datetime]::new(2020, 3, 30, 0, 0, 0))
+    }
+
+    It 'Returns the 28 Feb' {
+        $inputDate = [datetime]::new(2020, 1, 31, 0, 0, 0)
+        $cron = ConvertFrom-PodeCronExpressions -Expressions '* * 28 * *'
+        Get-PodeCronNextTrigger -Expression $cron -StartTime $inputDate | Should Be ([datetime]::new(2020, 2, 28, 0, 0, 0))
+    }
+}
+
+Describe 'Get-PodeCronNextEarliestTrigger' {
+    $inputDate = [datetime]::new(2020, 1, 1)
+
+    It 'Returns the earliest trigger when both valid' {
+        $crons = ConvertFrom-PodeCronExpressions -Expressions '* * 11 * FRI', '* * 10 * WED'
+        Get-PodeCronNextEarliestTrigger -Expressions $crons -StartTime $inputDate | Should Be ([datetime]::new(2020, 6, 10, 0, 0, 0))
+    }
+
+    It 'Returns the earliest trigger when one after end time' {
+        $end = [datetime]::new(2020, 1, 9)
+        $crons = ConvertFrom-PodeCronExpressions -Expressions '* * 8 * WED', '* * 10 * FRi'
+        Get-PodeCronNextEarliestTrigger -Expressions $crons -StartTime $inputDate -EndTime $end | Should Be ([datetime]::new(2020, 1, 8, 0, 0, 0))
+    }
+
+    It 'Returns the null when all after end time' {
+        $end = [datetime]::new(2020, 1, 7)
+        $crons = ConvertFrom-PodeCronExpressions -Expressions '* * 8 * WED', '* * 10 * FRi'
+        Get-PodeCronNextEarliestTrigger -Expressions $crons -StartTime $inputDate -EndTime $end | Should Be $null
     }
 }

--- a/tests/unit/Schedules.Tests.ps1
+++ b/tests/unit/Schedules.Tests.ps1
@@ -155,6 +155,81 @@ Describe 'Get-PodeSchedule' {
         $schedules.Limit | Should Be 0
     }
 
+    It 'Returns 1 schedule by start time' {
+        $PodeContext = @{ Schedules = @{} }
+        $start = ([DateTime]::Now.AddHours(3))
+        $end = ([DateTime]::Now.AddHours(5))
+
+        Add-PodeSchedule -Name 'test1' -Cron '@hourly' -ScriptBlock { Write-Host 'hello' } -StartTime $start -EndTime $end
+        $schedules = Get-PodeSchedule -StartTime $start.AddHours(1)
+        $schedules.Length | Should Be 1
+
+        $schedules.Name | Should Be 'test1'
+        $schedules.StartTime | Should Be $start
+        $schedules.EndTime | Should Be $end
+        $schedules.Limit | Should Be 0
+    }
+
+    It 'Returns 1 schedule by end time' {
+        $PodeContext = @{ Schedules = @{} }
+        $start = ([DateTime]::Now.AddHours(3))
+        $end = ([DateTime]::Now.AddHours(5))
+
+        Add-PodeSchedule -Name 'test1' -Cron '@hourly' -ScriptBlock { Write-Host 'hello' } -StartTime $start -EndTime $end
+        $schedules = Get-PodeSchedule -EndTime $end
+        $schedules.Length | Should Be 1
+
+        $schedules.Name | Should Be 'test1'
+        $schedules.StartTime | Should Be $start
+        $schedules.EndTime | Should Be $end
+        $schedules.Limit | Should Be 0
+    }
+
+    It 'Returns 1 schedule by both start and end time' {
+        $PodeContext = @{ Schedules = @{} }
+        $start = ([DateTime]::Now.AddHours(3))
+        $end = ([DateTime]::Now.AddHours(5))
+
+        Add-PodeSchedule -Name 'test1' -Cron '@hourly' -ScriptBlock { Write-Host 'hello' } -StartTime $start -EndTime $end
+        $schedules = Get-PodeSchedule -StartTime $start.AddHours(1) -EndTime $end
+        $schedules.Length | Should Be 1
+
+        $schedules.Name | Should Be 'test1'
+        $schedules.StartTime | Should Be $start
+        $schedules.EndTime | Should Be $end
+        $schedules.Limit | Should Be 0
+    }
+
+    It 'Returns no schedules by end time before start' {
+        $PodeContext = @{ Schedules = @{} }
+        $start = ([DateTime]::Now.AddHours(3))
+        $end = ([DateTime]::Now.AddHours(5))
+
+        Add-PodeSchedule -Name 'test1' -Cron '@hourly' -ScriptBlock { Write-Host 'hello' } -StartTime $start -EndTime $end
+        $schedules = Get-PodeSchedule -EndTime $start.AddHours(-1)
+        $schedules.Length | Should Be 0
+    }
+
+    It 'Returns no schedules by start time after end' {
+        $PodeContext = @{ Schedules = @{} }
+        $start = ([DateTime]::Now.AddHours(3))
+        $end = ([DateTime]::Now.AddHours(5))
+
+        Add-PodeSchedule -Name 'test1' -Cron '@hourly' -ScriptBlock { Write-Host 'hello' } -StartTime $start -EndTime $end
+        $schedules = Get-PodeSchedule -StartTime $end.AddHours(1)
+        $schedules.Length | Should Be 0
+    }
+
+    It 'Returns no schedules by where end just before end' {
+        $PodeContext = @{ Schedules = @{} }
+        $start = ([DateTime]::Now.AddHours(3))
+        $end = ([DateTime]::Now.AddHours(5))
+
+        Add-PodeSchedule -Name 'test1' -Cron '@hourly' -ScriptBlock { Write-Host 'hello' } -StartTime $start -EndTime $end
+        $schedules = Get-PodeSchedule -StartTime $start.AddHours(1).AddMinutes(1) -EndTime $end.AddHours(-1).AddMinutes(-1)
+        $schedules.Length | Should Be 0
+    }
+
     It 'Returns 2 schedules by name' {
         $PodeContext = @{ Schedules = @{} }
         $start = ([DateTime]::Now.AddHours(3))

--- a/tests/unit/Timers.Tests.ps1
+++ b/tests/unit/Timers.Tests.ps1
@@ -66,8 +66,7 @@ Describe 'Add-PodeTimer' {
         $timer.Limit | Should Be 0
         $timer.Count | Should Be 0
         $timer.Skip | Should Be 1
-        $timer.Countable | Should Be $false
-        $timer.NextTick | Should BeOfType System.DateTime
+        $timer.NextTriggerTime | Should BeOfType System.DateTime
         $timer.Script | Should Not Be $null
         $timer.Script.ToString() | Should Be ({ Write-Host 'hello' }).ToString()
     }
@@ -83,8 +82,7 @@ Describe 'Add-PodeTimer' {
         $timer.Limit | Should Be 2
         $timer.Count | Should Be 0
         $timer.Skip | Should Be 1
-        $timer.Countable | Should Be $true
-        $timer.NextTick | Should BeOfType System.DateTime
+        $timer.NextTriggerTime | Should BeOfType System.DateTime
         $timer.Script | Should Not Be $null
         $timer.Script.ToString() | Should Be ({ Write-Host 'hello' }).ToString()
     }


### PR DESCRIPTION
### Description of the Change
Adds new logic to work out the next trigger datetime of a cron expression for a schedule. Schedules automatically work this out, and now have a new property of `NextTriggerTime` on the object returned from `Get-PodeSchedule`.

There's also a new `Get-PodeScheduleNextTrigger` which will either return the next trigger datetime, or will return the next trigger from a specified datetime.

### Related Issue
Resolves #549 
