### PR TITLE
Adds optional parameter to toggle stack traces in status pages

### DIFF
--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -30,6 +30,10 @@ function New-PodeContext
         [string]
         $ServerType,
 
+        [Parameter()]
+        [string]
+        $StatusPageExceptions,
+
         [switch]
         $DisableTermination,
 
@@ -117,6 +121,15 @@ function New-PodeContext
 
     # check if there is any global configuration
     $ctx.Server.Configuration = Open-PodeConfiguration -ServerRoot $ServerRoot -Context $ctx
+
+    # over status page exceptions
+    if (!(Test-IsEmpty $StatusPageExceptions)) {
+        if ($null -eq $ctx.Server.Web) {
+            $ctx.Server.Web = @{ ErrorPages = @{} }
+        }
+
+        $ctx.Server.Web.ErrorPages.ShowExceptions = ($StatusPageExceptions -eq 'show')
+    }
 
     # configure the server's root path
     $ctx.Server.Root = $ServerRoot

--- a/src/Public/Core.ps1
+++ b/src/Public/Core.ps1
@@ -30,6 +30,10 @@ Intended for Serverless environments, this is Requests details that Pode can par
 .PARAMETER Type
 The server type, to define how Pode should run and deal with incoming Requests.
 
+.PARAMETER StatusPageExceptions
+An optional value of Show/Hide to control where Stacktraces are shown in the Status Pages.
+If supplied this value will override the ShowExceptions setting in the server.psd1 file.
+
 .PARAMETER DisableTermination
 Disables the ability to terminate the Server.
 
@@ -87,6 +91,11 @@ function Start-PodeServer
         [string]
         $Type = [string]::Empty,
 
+        [Parameter()]
+        [ValidateSet('', 'Hide', 'Show')]
+        [string]
+        $StatusPageExceptions = [string]::Empty,
+
         [switch]
         $DisableTermination,
 
@@ -134,6 +143,7 @@ function Start-PodeServer
             -Interval $Interval `
             -ServerRoot (Protect-PodeValue -Value $RootPath -Default $MyInvocation.PSScriptRoot) `
             -ServerType $Type `
+            -StatusPageExceptions $StatusPageExceptions `
             -DisableTermination:$DisableTermination `
             -Quiet:$Quiet
 


### PR DESCRIPTION
### Description of the Change
Adds a new optional parameter to `Start-PodeServer` to toggle showing Exceptions/Stack Traces on the Status Page. This value, if supplied, will override the ShowExceptions value in the server.psd1

### Related Issue
Resolves #542 

### Examples
```powershell
Start-PodeServer -StatusPageExceptions Show -ScriptBlock {}
```
