### PR TITLE
Bump Docker to PS7.0.1

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug Report
-about: Create a report to help us improve
+about: Create a bug report to help us improve
 title: ''
 labels: 'bug :bug:'
 assignees: ''
@@ -25,8 +25,10 @@ If applicable, add screenshots to help explain your problem.
 
 ### Platform
  - OS: [e.g. iOS, Windows]
- - Browser [e.g. Chrome, Safari]
- - Version [e.g. PS6.2.1]
+ - Browser: [e.g. Chrome, Safari]
+ - Versions:
+   - Pode: [e.g. Pode v1.7.3]
+   - PowerShell: [e.g. PS6.2.1]
 
 ### Additional Context
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/packaging-request.md
+++ b/.github/ISSUE_TEMPLATE/packaging-request.md
@@ -1,0 +1,11 @@
+---
+name: Packaging Request
+about: Suggest an improvement for the packaging of Pode, such as a new version of software.
+title: ''
+labels: 'packaging :package:'
+assignees: ''
+
+---
+
+### Describe the Change
+A clear and concise description of what you want to happen.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/powershell:7.0.0-ubuntu-16.04
+FROM mcr.microsoft.com/powershell:7.0.1-ubuntu-16.04
 LABEL maintainer="Matthew Kelly (Badgerati)"
 RUN mkdir -p /usr/local/share/powershell/Modules/Pode
 COPY ./src/ /usr/local/share/powershell/Modules/Pode

--- a/arm32.dockerfile
+++ b/arm32.dockerfile
@@ -1,4 +1,4 @@
-FROM badgerati/ps-core:7.0.0-arm32
+FROM badgerati/ps-core:7.0.1-arm32
 LABEL maintainer="Matthew Kelly (Badgerati)"
 RUN mkdir -p /usr/local/share/powershell/Modules/Pode
 COPY ./src/ /usr/local/share/powershell/Modules/Pode

--- a/packers/docker/arm32/Dockerfile
+++ b/packers/docker/arm32/Dockerfile
@@ -1,6 +1,6 @@
 FROM arm32v7/ubuntu:bionic
 
-ENV PS_VERSION=7.0.0
+ENV PS_VERSION=7.0.1
 ENV PS_PACKAGE=powershell-${PS_VERSION}-linux-arm32.tar.gz
 ENV PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/${PS_PACKAGE}
 


### PR DESCRIPTION
### Description of the Change
Bumps the PowerShell version in Docker to 7.0.1

### Related Issue
Resolves #567 
