### PR TITLE
Fixes 2 bugs in the OpenAPI functions

### DIFF
--- a/examples/web-rest-openapi-shared.ps1
+++ b/examples/web-rest-openapi-shared.ps1
@@ -30,6 +30,10 @@ Start-PodeServer {
         ))
     }
 
+    New-PodeOAIntProperty -Name 'userId' -Required |
+        ConvertTo-PodeOAParameter -In Path |
+        Add-PodeOAComponentParameter -Name 'UserId'
+
 
     Get-PodeAuthMiddleware -Name 'Validate' -Sessionless | Add-PodeMiddleware -Name 'AuthMiddleware' -Route '/api/*'
     Set-PodeOAGlobalAuth -Name 'Validate'
@@ -55,7 +59,7 @@ Start-PodeServer {
     } -PassThru |
         Set-PodeOARouteInfo -Summary 'A cool summary' -Tags 'Users' -PassThru |
         Set-PodeOARequest -Parameters @(
-            (New-PodeOAIntProperty -Name 'userId' -Required | ConvertTo-PodeOAParameter -In Path)
+            (ConvertTo-PodeOAParameter -Reference 'UserId')
         ) -PassThru |
         Add-PodeOAResponse -StatusCode 200 -Reference 'OK'
 

--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -237,18 +237,7 @@ function New-PodeContext
     $ctx.Server.Sessions = @{}
 
     # swagger and openapi
-    $ctx.Server.OpenAPI = @{
-        Path = $null
-        Title = $null
-        components = @{
-            schemas = @{}
-            responses = @{}
-            securitySchemas = @{}
-            requestBodies = @{}
-            parameters = @{}
-        }
-        security = @()
-    }
+    $ctx.Server.OpenAPI = Get-PodeOABaseObject
 
     # server metrics
     $ctx.Metrics = @{

--- a/src/Private/OpenApi.ps1
+++ b/src/Private/OpenApi.ps1
@@ -343,3 +343,19 @@ function ConvertTo-PodeOAPropertyFromCmdletParameter
 
     New-PodeOAStringProperty -Name $Parameter.Name
 }
+
+function Get-PodeOABaseObject
+{
+    return @{
+        Path = $null
+        Title = $null
+        components = @{
+            schemas = @{}
+            responses = @{}
+            securitySchemas = @{}
+            requestBodies = @{}
+            parameters = @{}
+        }
+        security = @()
+    }
+}

--- a/src/Private/Server.ps1
+++ b/src/Private/Server.ps1
@@ -142,7 +142,7 @@ function Restart-PodeInternalServer
         $PodeContext.Server.Endpoints = @()
 
         # clear openapi
-        $PodeContext.Server.OpenAPI.Clear()
+        $PodeContext.Server.OpenAPI = Get-PodeOABaseObject
 
         # clear the sockets
         $PodeContext.Server.Sockets.Listeners = @()

--- a/src/Public/OpenApi.ps1
+++ b/src/Public/OpenApi.ps1
@@ -700,7 +700,7 @@ function Add-PodeOAComponentParameter
         $Name = $Parameter.name
     }
 
-    $PodeContext.Server.OpenAPI.components.responses[$Name] = $Parameter
+    $PodeContext.Server.OpenAPI.components.parameters[$Name] = $Parameter
 }
 
 <#

--- a/src/Public/OpenApi.ps1
+++ b/src/Public/OpenApi.ps1
@@ -575,7 +575,7 @@ function New-PodeOARequestBody
                 throw "The OpenApi component request body doesn't exist: $($Reference)"
             }
 
-            return = @{
+            return @{
                 '$ref' = "#/components/requestBodies/$($Reference)"
             }
         }
@@ -1252,7 +1252,7 @@ function ConvertTo-PodeOAParameter
             throw "The OpenApi component request parameter doesn't exist: $($Reference)"
         }
 
-        return = @{
+        return @{
             '$ref' = "#/components/parameters/$($Reference)"
         }
     }


### PR DESCRIPTION
### Description of the Change
Fixes two bugs in the OpenAPI functions:

1. two rogue `=` after a `return`
2. storing component parameters in responses, rather than as parameters

### Related Issue
Resolves #578 
