### PR TITLE
Show-PodeGui: Support for a modern Browser

### DIFF
--- a/docs/Tutorials/Misc/DesktopApp.md
+++ b/docs/Tutorials/Misc/DesktopApp.md
@@ -60,6 +60,13 @@ In order to switch to [`CefSharp`](http://cefsharp.github.io/), either compile o
 
 Pode will automatically switch to CefSharp, if the binaries are loaded into the Powershell Session before the Pode Module itself gets initialized.
 
+The required packages are the following and can be compiled from scratch or downloaded from the Nuget Repository:
+```
+[`cef.redist.x64`](https://www.nuget.org/packages/cef.redist.x64/)
+[`cefsharp.common`](https://www.nuget.org/packages/cefsharp.common)
+[`cefsharp.wpf`](https://www.nuget.org/packages/cefsharp.wpf)
+```
+
 This example shows how to load them:
 
 ```Powershell

--- a/docs/Tutorials/Misc/DesktopApp.md
+++ b/docs/Tutorials/Misc/DesktopApp.md
@@ -3,7 +3,8 @@
 Normally in Pode you define a server and run it, however if you use the [`Show-PodeGui`](../../../Functions/Core/Show-PodeGui) function Pode will serve the server up as a desktop application.
 
 !!! warning
-Currently only supported in Windows PowerShell, and PowerShell 7 on Windows due to using WPF.
+    Currently only supported in Windows PowerShell, and PowerShell 7 on Windows due to using WPF.
+
 
 ## Setting Server to run as Application
 
@@ -52,7 +53,7 @@ exit
 
 ## Using Chromium instead of Internet Explorer
 
-The default WPF Browser Element used by Pode is based on the system internal Internet Explorer API which is also bound to the same Javascript and Webbrowser Limitations as Internet Explorer itself.
+The default WPF Browser Element used by Pode is based on the system internal Internet Explorer API, which is also bound to the same Javascript and Webbrowser Limitations as Internet Explorer itself.
 
 To utilize Chromium in WPF, Pode offers support for CefSharp which adds a Chromium Web Element to WPF.
 In order to switch to [`CefSharp`](http://cefsharp.github.io/), either compile or download its precompiled binaries.

--- a/docs/Tutorials/Misc/DesktopApp.md
+++ b/docs/Tutorials/Misc/DesktopApp.md
@@ -61,11 +61,10 @@ In order to switch to [`CefSharp`](http://cefsharp.github.io/), either compile o
 Pode will automatically switch to CefSharp, if the binaries are loaded into the Powershell Session before the Pode Module itself gets initialized.
 
 The required packages are the following and can be compiled from scratch or downloaded from the Nuget Repository:
-```
-[`cef.redist.x64`](https://www.nuget.org/packages/cef.redist.x64/)
-[`cefsharp.common`](https://www.nuget.org/packages/cefsharp.common)
-[`cefsharp.wpf`](https://www.nuget.org/packages/cefsharp.wpf)
-```
+- [`cef.redist.x64`](https://www.nuget.org/packages/cef.redist.x64/)
+- [`cefsharp.common`](https://www.nuget.org/packages/cefsharp.common)
+- [`cefsharp.wpf`](https://www.nuget.org/packages/cefsharp.wpf)
+
 
 This example shows how to load them:
 

--- a/docs/Tutorials/Misc/DesktopApp.md
+++ b/docs/Tutorials/Misc/DesktopApp.md
@@ -1,15 +1,15 @@
 # Desktop Application
 
-Normally in Pode you define a server and run it, however if you use the  [`Show-PodeGui`](../../../Functions/Core/Show-PodeGui) function Pode will serve the server up as a desktop application.
+Normally in Pode you define a server and run it, however if you use the [`Show-PodeGui`](../../../Functions/Core/Show-PodeGui) function Pode will serve the server up as a desktop application.
 
 !!! warning
-    Currently only supported in Windows PowerShell, and PowerShell 7 on Windows due to using WPF.
+Currently only supported in Windows PowerShell, and PowerShell 7 on Windows due to using WPF.
 
 ## Setting Server to run as Application
 
-To serve up you server as a desktop application you can just write you Pode server script as normal. The only difference is you can use the  [`Show-PodeGui`](../../../Functions/Core/Show-PodeGui) function to display the application.
+To serve up you server as a desktop application you can just write you Pode server script as normal. The only difference is you can use the [`Show-PodeGui`](../../../Functions/Core/Show-PodeGui) function to display the application.
 
-The  [`Show-PodeGui`](../../../Functions/Core/Show-PodeGui) function *must* have a Title supplied - this is the title of the application's window.
+The [`Show-PodeGui`](../../../Functions/Core/Show-PodeGui) function _must_ have a Title supplied - this is the title of the application's window.
 
 The following will create a basic web server with a single page, but when the server is run it will pop up as a desktop application:
 
@@ -29,13 +29,13 @@ The page used is as follows:
 
 ```html
 <html>
-    <head>
-        <link rel="stylesheet" type="text/css" href="/styles/main.css">
-    </head>
-    <body>
-        <h1>Hello, world!</h1>
-        <p>Welcome to a very simple desktop app!</p>
-    </body>
+  <head>
+    <link rel="stylesheet" type="text/css" href="/styles/main.css" />
+  </head>
+  <body>
+    <h1>Hello, world!</h1>
+    <p>Welcome to a very simple desktop app!</p>
+  </body>
 </html>
 ```
 
@@ -48,4 +48,20 @@ The following is a basic example of a `.bat` file which could be double-clicked 
 ```batch
 powershell.exe -noprofile -windowstyle hidden -command .\you-server-script.ps1
 exit
+```
+
+## Using Chromium instead of Internet Explorer
+
+The default WPF Browser Element used by Pode is based on the system internal Internet Explorer API which is also bound to the same Javascript and Webbrowser Limitations as Internet Explorer itself.
+
+To utilize Chromium in WPF, Pode offers support for CefSharp which adds a Chromium Web Element to WPF.
+In order to switch to [`CefSharp`](http://cefsharp.github.io/), either compile or download its precompiled binaries.
+
+Pode will automatically switch to CefSharp, if the binaries are loaded into the Powershell Session before the Pode Module itself gets initialized.
+
+This example shows how to load them:
+
+```Powershell
+Import-Module -Name "$PSScriptRoot\lib\cefsharp\CefSharp.dll"
+Import-Module -Name "$PSScriptRoot\lib\cefsharp\CefSharp.Wpf.dll"
 ```

--- a/src/Private/Gui.ps1
+++ b/src/Private/Gui.ps1
@@ -51,7 +51,7 @@ function Start-PodeGuiRunspace
 
             # setup the WPF XAML for the server
             
-            #Check for CefSharp and used Chromium based WPF if Modules exists
+            # Check for CefSharp and used Chromium based WPF if Modules exists
             if(Get-Module -Name "CefSharp" -ErrorAction SilentlyContinue){
                 $gui_browser = "
                 <Window

--- a/src/Private/Gui.ps1
+++ b/src/Private/Gui.ps1
@@ -1,5 +1,4 @@
-function Start-PodeGuiRunspace
-{
+function Start-PodeGuiRunspace {
     # do nothing if gui not enabled, or running as serverless
     if (!$PodeContext.Server.Gui.Enabled -or
         $PodeContext.Server.IsServerless -or
@@ -9,11 +8,9 @@ function Start-PodeGuiRunspace
     }
 
     $script = {
-        try
-        {
+        try {
             # if there are multiple endpoints, flag warning we're only using the first - unless explicitly set
-            if ($null -eq $PodeContext.Server.Gui.Endpoint)
-            {
+            if ($null -eq $PodeContext.Server.Gui.Endpoint) {
                 if (($PodeContext.Server.Endpoints | Measure-Object).Count -gt 1) {
                     Write-PodeHost "Multiple endpoints defined, only the first will be used for the GUI" -ForegroundColor Yellow
                 }
@@ -50,19 +47,11 @@ function Start-PodeGuiRunspace
             [System.Reflection.Assembly]::LoadWithPartialName('PresentationCore') | Out-Null
 
             # Check for CefSharp
-            $loadCef = $false
-            if (
-                # This seems to be the safest method to detect if it is loaded or not, feel free to suggest a better one
-                ([AppDomain]::CurrentDomain.GetAssemblies() | Where-Object { $_.FullName.StartsWith("CefSharp.Wpf,") })
-            ) {
-                $loadCef = $true
-            }
+            $loadCef = [bool]([AppDomain]::CurrentDomain.GetAssemblies() | Where-Object { $_.FullName.StartsWith("CefSharp.Wpf,") })
 
             # setup the WPF XAML for the server          
             # Check for CefSharp and used Chromium based WPF if Modules exists
-            if (
-                $loadCef
-            ){
+            if ($loadCef) {
                 $gui_browser = "
                 <Window
                     xmlns=`"http://schemas.microsoft.com/winfx/2006/xaml/presentation`"
@@ -82,7 +71,8 @@ function Start-PodeGuiRunspace
                             <wpf:ChromiumWebBrowser x:Name=`"Browser`" Address=`"$endpoint`"/>
                         </Border>
                 </Window>"
-            }else{
+            }
+            else {
                 # Fall back to the IE based WPF Browser
                 $gui_browser = "
                     <Window
@@ -121,7 +111,7 @@ function Start-PodeGuiRunspace
             }
 
             # get the browser object from XAML and navigate to base page if Cef is not loaded
-            if(!$loadCef){
+            if (!$loadCef) {
                 $form.FindName("WebBrowser").Navigate($endpoint)
             }
 

--- a/src/Private/Gui.ps1
+++ b/src/Private/Gui.ps1
@@ -52,7 +52,10 @@ function Start-PodeGuiRunspace
             # setup the WPF XAML for the server
             
             # Check for CefSharp and used Chromium based WPF if Modules exists
-            if(Get-Module -Name "CefSharp" -ErrorAction SilentlyContinue){
+            if(
+                # This seems to be the safest method to detect if it is loaded or not, feel free to suggest a better one
+                ([AppDomain]::CurrentDomain.GetAssemblies() | Where-Object { $_.FullName.StartsWith("CefSharp.Wpf,") })
+            ){
                 $gui_browser = "
                 <Window
                     xmlns=`"http://schemas.microsoft.com/winfx/2006/xaml/presentation`"

--- a/src/Private/Gui.ps1
+++ b/src/Private/Gui.ps1
@@ -50,9 +50,13 @@ function Start-PodeGuiRunspace
             [System.Reflection.Assembly]::LoadWithPartialName('PresentationCore') | Out-Null
 
             # setup the WPF XAML for the server
-            $gui_browser = "
+            
+            #Check for CefSharp and used Chromium based WPF if Modules exists
+            if(Get-Module -Name "CefSharp" -ErrorAction SilentlyContinue){
+                $gui_browser = "
                 <Window
                     xmlns=`"http://schemas.microsoft.com/winfx/2006/xaml/presentation`"
+                    xmlns:wpf=`"clr-namespace:CefSharp.Wpf;assembly=CefSharp.Wpf`"
                     xmlns:x=`"http://schemas.microsoft.com/winfx/2006/xaml`"
                     Title=`"$($PodeContext.Server.Gui.Title)`"
                     Height=`"$($PodeContext.Server.Gui.Height)`"
@@ -64,8 +68,29 @@ function Start-PodeGuiRunspace
                         <Window.TaskbarItemInfo>
                             <TaskbarItemInfo />
                         </Window.TaskbarItemInfo>
-                        <WebBrowser Name=`"WebBrowser`"></WebBrowser>
+                        <Border Grid.Row=`"1`" BorderBrush=`"Gray`" BorderThickness=`"0,1`">
+                            <wpf:ChromiumWebBrowser x:Name=`"Browser`" Address=`"$endpoint`"/>
+                        </Border>
                 </Window>"
+            }else{
+                # Fall back to the IE based WPF Browser
+                $gui_browser = "
+                    <Window
+                        xmlns=`"http://schemas.microsoft.com/winfx/2006/xaml/presentation`"
+                        xmlns:x=`"http://schemas.microsoft.com/winfx/2006/xaml`"
+                        Title=`"$($PodeContext.Server.Gui.Title)`"
+                        Height=`"$($PodeContext.Server.Gui.Height)`"
+                        Width=`"$($PodeContext.Server.Gui.Width)`"
+                        ResizeMode=`"$($PodeContext.Server.Gui.ResizeMode)`"
+                        WindowStartupLocation=`"CenterScreen`"
+                        ShowInTaskbar = `"$($PodeContext.Server.Gui.ShowInTaskbar)`"
+                        WindowStyle = `"$($PodeContext.Server.Gui.WindowStyle)`">
+                            <Window.TaskbarItemInfo>
+                                <TaskbarItemInfo />
+                            </Window.TaskbarItemInfo>
+                            <WebBrowser Name=`"WebBrowser`"></WebBrowser>
+                    </Window>"
+            }
 
             # read in the XAML
             $reader = [System.Xml.XmlNodeReader]::new([xml]$gui_browser)

--- a/src/Private/Gui.ps1
+++ b/src/Private/Gui.ps1
@@ -49,12 +49,19 @@ function Start-PodeGuiRunspace
             [System.Reflection.Assembly]::LoadWithPartialName('PresentationFramework') | Out-Null
             [System.Reflection.Assembly]::LoadWithPartialName('PresentationCore') | Out-Null
 
-            # setup the WPF XAML for the server
-            
-            # Check for CefSharp and used Chromium based WPF if Modules exists
-            if(
+            # Check for CefSharp
+            $loadCef = $false
+            if (
                 # This seems to be the safest method to detect if it is loaded or not, feel free to suggest a better one
                 ([AppDomain]::CurrentDomain.GetAssemblies() | Where-Object { $_.FullName.StartsWith("CefSharp.Wpf,") })
+            ) {
+                $loadCef = $true
+            }
+
+            # setup the WPF XAML for the server          
+            # Check for CefSharp and used Chromium based WPF if Modules exists
+            if (
+                $loadCef
             ){
                 $gui_browser = "
                 <Window
@@ -113,8 +120,10 @@ function Start-PodeGuiRunspace
                 $form.WindowState = $PodeContext.Server.Gui.WindowState
             }
 
-            # get the browser object from XAML and navigate to base page
-            $form.FindName("WebBrowser").Navigate($endpoint)
+            # get the browser object from XAML and navigate to base page if Cef is not loaded
+            if(!$loadCef){
+                $form.FindName("WebBrowser").Navigate($endpoint)
+            }
 
             # display the form
             $form.ShowDialog() | Out-Null

--- a/src/Private/Gui.ps1
+++ b/src/Private/Gui.ps1
@@ -17,14 +17,14 @@ function Start-PodeGuiRunspace {
             }
 
             # get the endpoint on which we're currently listening, or use explicitly passed one
-            $endpoint = (Get-PodeEndpointUrl -Endpoint $PodeContext.Server.Gui.Endpoint)
+            $uri = (Get-PodeEndpointUrl -Endpoint $PodeContext.Server.Gui.Endpoint)
 
             # poll the server for a response
             $count = 0
 
             while ($true) {
                 try {
-                    Invoke-WebRequest -Method Get -Uri $endpoint -UseBasicParsing -ErrorAction Stop | Out-Null
+                    Invoke-WebRequest -Method Get -Uri $uri -UseBasicParsing -ErrorAction Stop | Out-Null
                     if (!$?) {
                         throw
                     }
@@ -37,7 +37,7 @@ function Start-PodeGuiRunspace {
                         Start-Sleep -Milliseconds 200
                     }
                     else {
-                        throw "Failed to connect to URL: $($endpoint)"
+                        throw "Failed to connect to URL: $($uri)"
                     }
                 }
             }
@@ -68,7 +68,7 @@ function Start-PodeGuiRunspace {
                             <TaskbarItemInfo />
                         </Window.TaskbarItemInfo>
                         <Border Grid.Row=`"1`" BorderBrush=`"Gray`" BorderThickness=`"0,1`">
-                            <wpf:ChromiumWebBrowser x:Name=`"Browser`" Address=`"$endpoint`"/>
+                            <wpf:ChromiumWebBrowser x:Name=`"Browser`" Address=`"$uri`"/>
                         </Border>
                 </Window>"
             }
@@ -112,7 +112,7 @@ function Start-PodeGuiRunspace {
 
             # get the browser object from XAML and navigate to base page if Cef is not loaded
             if (!$loadCef) {
-                $form.FindName("WebBrowser").Navigate($endpoint)
+                $form.FindName("WebBrowser").Navigate($uri)
             }
 
             # display the form


### PR DESCRIPTION
### Description of the Change
Adds support for CefSharp into Pode. Automatic Failback to the default IE based WPF Browser Element incase CefSharp is not loaded.

### Related Issue
Fixes #589 
