### PR TITLE
Work to help alleviate the pains of scoping issues for Modules, Snapins, Functions, and Variables

### DIFF
--- a/.github/workflows/ci-coverage.yml
+++ b/.github/workflows/ci-coverage.yml
@@ -27,7 +27,7 @@ jobs:
       shell: pwsh
       env:
         PODE_COVERALLS_TOKEN: ${{ secrets.PODE_COVERALLS_TOKEN }}
-        PODE_RUN_CODE_COVERAGE: true
+        PODE_RUN_CODE_COVERAGE: false
       run: |
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
         Invoke-Build Test

--- a/docs/Getting-Started/LocalModules.md
+++ b/docs/Getting-Started/LocalModules.md
@@ -59,4 +59,6 @@ package.json
 
 ## Importing
 
-When the modules have been downloaded, you can utilise them using the  [`Import-PodeModule`](../../Functions/Utilities/Import-PodeModule) function.
+When the modules have been downloaded, you can import them using the [`Import-PodeModule`](../../Functions/Utilities/Import-PodeModule) function.
+
+Unlike `Import-Module`, [`Import-PodeModule`](../../Functions/Utilities/Import-PodeModule) will check if some module is within the `ps_modules` directory first, then it will check the global modules.

--- a/docs/Getting-Started/Migrating/1X-to-2X.md
+++ b/docs/Getting-Started/Migrating/1X-to-2X.md
@@ -71,3 +71,9 @@ On the following functions:
 * `Remove-PodeStaticRoute`
 
 The `-Endpoint` and `-Protocol` parameters have been removed in favour of `-EndpointName`.
+
+### Modules
+
+You can now use `Import-Module` just normally import any modules, and Pode will automatically load these into its runspaces.
+
+[`Import-PodeModule`](../../../Functions/Utilities/Import-PodeModule) still exists, as it supports the use of local modules in `ps_modules`. The only difference is that the `-Now` switch has been removed, and you can now use [`Import-PodeModule`](../../../Functions/Utilities/Import-PodeModule) outside of the [`Start-PodeServer`](../../../Functions/Core/Start-PodeServer) block.

--- a/docs/Tutorials/ImportingModules.md
+++ b/docs/Tutorials/ImportingModules.md
@@ -1,8 +1,8 @@
-# Importing Modules/SnapIns
+# Importing Modules/Snapins
 
-Modules/SnapIns in Pode have recently undergone a change, making them easier to use with Pode's many runspaces. This change means you can use the normal `Import-Module`/`Add-Snapin` at the top of your scripts, and Pode will automatically import them into its runspaces.
+Modules/Snapins in Pode have recently undergone a change, making them easier to use with Pode's many runspaces. This change means you can use the normal `Import-Module`/`Add-PSSnapin` at the top of your scripts, and Pode will automatically import them into its runspaces.
 
-The older [`Import-PodeModule`](../../Functions/Utilities/Import-PodeModule) and [`Import-PodeSnapIn`](../../Functions/Utilities/Import-PodeSnapIn) still exist - but now mostly just directly call the main module/snapin functions.
+The older [`Import-PodeModule`](../../Functions/Utilities/Import-PodeModule) and [`Import-PodeSnapin`](../../Functions/Utilities/Import-PodeSnapin) still exist - but now mostly just directly call the main module/snapin functions.
 
 !!! important
     Snap-ins are only supported in Windows PowerShell.
@@ -33,14 +33,14 @@ Import-PodeModule -Name EPS
 Import-Module -Name EPS
 ```
 
-## SnapIns
+## Snapins
 
 ### Import via Name
 
 The following example will tell Pode to import the `WDeploySnapin3.0` snap-in into all runspaces:
 
 ```powershell
-Import-PodeSnapIn -Name 'WDeploySnapin3.0'
+Import-PodeSnapin -Name 'WDeploySnapin3.0'
 
 # or just:
 Add-Snapin -Name 'WDeploySnapin3.0'

--- a/docs/Tutorials/ImportingModules.md
+++ b/docs/Tutorials/ImportingModules.md
@@ -1,11 +1,8 @@
 # Importing Modules/SnapIns
 
-Modules in Pode have recently undergone a change, making them easier to use with Pode's many runspaces. This change means you can use the normal `Import-Module` at the top of your scripts, and Pode will automatically import them into its runspaces.
+Modules/SnapIns in Pode have recently undergone a change, making them easier to use with Pode's many runspaces. This change means you can use the normal `Import-Module`/`Add-Snapin` at the top of your scripts, and Pode will automatically import them into its runspaces.
 
-Snap-ins still suffer from the same runspace issue, meaning you still have to use the [`Import-PodeSnapIn`](../../Functions/Utilities/Import-PodeSnapIn) function to declare paths/names of snap-ins that need to be imported into all of the runspaces.
-
-
-Because Pode runs most things in isolated runspaces, importing and using modules or snap-ins can be quite bothersome. To overcome this, you can use the [`Import-PodeModule`](../../Functions/Utilities/Import-PodeModule) or [`Import-PodeSnapIn`](../../Functions/Utilities/Import-PodeSnapIn) functions to declare paths/names of modules or snap-ins that need to be imported into all of the runspaces.
+The older [`Import-PodeModule`](../../Functions/Utilities/Import-PodeModule) and [`Import-PodeSnapIn`](../../Functions/Utilities/Import-PodeSnapIn) still exist - but now mostly just directly call the main module/snapin functions.
 
 !!! important
     Snap-ins are only supported in Windows PowerShell.
@@ -43,7 +40,8 @@ Import-Module -Name EPS
 The following example will tell Pode to import the `WDeploySnapin3.0` snap-in into all runspaces:
 
 ```powershell
-Start-PodeServer {
-    Import-PodeSnapIn -Name 'WDeploySnapin3.0'
-}
+Import-PodeSnapIn -Name 'WDeploySnapin3.0'
+
+# or just:
+Add-Snapin -Name 'WDeploySnapin3.0'
 ```

--- a/docs/Tutorials/ImportingModules.md
+++ b/docs/Tutorials/ImportingModules.md
@@ -1,20 +1,25 @@
 # Importing Modules/SnapIns
 
-Because Pode runs most things in isolated runspaces, importing and using modules or snap-ins can be quite bothersome. To overcome this, you can use the  [`Import-PodeModule`](../../Functions/Utilities/Import-PodeModule) or [`Import-PodeSnapIn`](../../Functions/Utilities/Import-PodeSnapIn) functions to declare paths/names of modules or snap-ins that need to be imported into all of the runspaces.
+Modules in Pode have recently undergone a change, making them easier to use with Pode's many runspaces. This change means you can use the normal `Import-Module` at the top of your scripts, and Pode will automatically import them into its runspaces.
+
+Snap-ins still suffer from the same runspace issue, meaning you still have to use the [`Import-PodeSnapIn`](../../Functions/Utilities/Import-PodeSnapIn) function to declare paths/names of snap-ins that need to be imported into all of the runspaces.
+
+
+Because Pode runs most things in isolated runspaces, importing and using modules or snap-ins can be quite bothersome. To overcome this, you can use the [`Import-PodeModule`](../../Functions/Utilities/Import-PodeModule) or [`Import-PodeSnapIn`](../../Functions/Utilities/Import-PodeSnapIn) functions to declare paths/names of modules or snap-ins that need to be imported into all of the runspaces.
 
 !!! important
     Snap-ins are only supported in Windows PowerShell.
 
 ## Modules
 
+Modules in Pode can be imported in the normal manor using `Import-Module`. The [`Import-PodeModule`](../../Functions/Utilities/Import-PodeModule) function can now be used inside and outside of [`Start-PodeServer`](../../Functions/Core/Start-PodeServer), and should be used if you're using local modules via `ps_modules`.
+
 ### Import via Path
 
-The following example will tell Pode that the `tools.psm1` module needs to be imported into all runspaces. This will allow the functions defined within the module to be accessible to all other functions within your server.
+The following example will tell Pode that the `tools.psm1` module needs to be imported. This will allow the functions defined within the module to be accessible to all other functions within your server.
 
 ```powershell
-Start-PodeServer {
-    Import-PodeModule -Path './path/to/tools.psm1'
-}
+Import-PodeModule -Path './path/to/tools.psm1'
 ```
 
 ### Import via Name
@@ -24,9 +29,11 @@ The following example will tell Pode to import the `EPS` module into all runspac
 If you're using [`local modules`](../../Getting-Started/LocalModules) in your `package.json` file, then Pode will first check to see if the EPS module is in the `ps_modules` directory. When Pode can't find the EPS module within the `ps_modules` directory, then it will attempt to import a globally installed version of the EPS module.
 
 ```powershell
-Start-PodeServer {
-    Import-PodeModule -Name EPS
-}
+# if using local modules:
+Import-PodeModule -Name EPS
+
+# if using global modules
+Import-Module -Name EPS
 ```
 
 ## SnapIns

--- a/docs/Tutorials/ImportingModules.md
+++ b/docs/Tutorials/ImportingModules.md
@@ -1,11 +1,11 @@
 # Importing Modules/Snapins
 
-Modules/Snapins in Pode have recently undergone a change, making them easier to use with Pode's many runspaces. This change means you can use the normal `Import-Module`/`Add-PSSnapin` at the top of your scripts, and Pode will automatically import them into its runspaces.
+Modules/Snapins in Pode have recently undergone a change, making them easier to use with Pode's many runspaces. This change means you can use the normal `Import-Module`/`Add-PSSnapin` at the top of your scripts, and Pode will automatically import them into its runspaces. For more information, see the [Scoping](../Scoping) page.
 
 The older [`Import-PodeModule`](../../Functions/Utilities/Import-PodeModule) and [`Import-PodeSnapin`](../../Functions/Utilities/Import-PodeSnapin) still exist - but now mostly just directly call the main module/snapin functions.
 
 !!! important
-    Snap-ins are only supported in Windows PowerShell.
+    Snapins are only supported in Windows PowerShell.
 
 ## Modules
 
@@ -43,5 +43,5 @@ The following example will tell Pode to import the `WDeploySnapin3.0` snap-in in
 Import-PodeSnapin -Name 'WDeploySnapin3.0'
 
 # or just:
-Add-Snapin -Name 'WDeploySnapin3.0'
+Add-PSSnapin -Name 'WDeploySnapin3.0'
 ```

--- a/docs/Tutorials/Routes/Utilities/FunctionsAndModules.md
+++ b/docs/Tutorials/Routes/Utilities/FunctionsAndModules.md
@@ -37,7 +37,7 @@ Add-PodeRoute -Method Post -Path '/Invoke-Expression' -ScriptBlock {
 
 If you have a Module whose exported commands you want to convert into Routes, then you can supply the Module's name to [`ConvertTo-PodeRoute`](../../../../Functions/Routes/ConvertTo-PodeRoute).
 
-Supplying a Module will cause it to be automatically imported into all runspaces, using [`Import-PodeModule`](../../../../Functions/Utilities/Import-PodeModule). This means the Module can be referenced by name, or by path; it also means [`Import-PodeModule`](../../../../Functions/Utilities/Import-PodeModule).supports modules within the `ps_modules` directory.
+Supplying a Module will cause it to be automatically imported using [`Import-PodeModule`](../../../../Functions/Utilities/Import-PodeModule). This means the Module can be referenced by name, or by path, and it supports modules within the `ps_modules` directory.
 
 For example, if you wanted to import all commands from Pester you could do the following:
 

--- a/docs/Tutorials/Scoping.md
+++ b/docs/Tutorials/Scoping.md
@@ -1,0 +1,257 @@
+# Scoping
+
+Scoping in Pode can be a little confusing at times, with everything running in different runspaces it can be hard to keep track of what's available, and what's not.
+
+In 2.0 work was done to help alleviate some of this confusion, mostly around modules; snapins; functions, and variables.
+
+## Modules
+
+Prior to 2.0 you had to use the [`Import-PodeModule`](../../Functions/Utilities/Import-PodeModule) function; but now, you can use the normal `Import-Module` function. Pode will automatically import all currently loaded modules into its runspaces. The [`Import-PodeModule`](../../Functions/Utilities/Import-PodeModule) function still exists though, for support with local modules via `ps_modules` - under the hood however, it now just calls `Import-Module`.
+
+Below, `SomeModule1` and `SomeModule2` will be automatically imported into all of Pode's runspaces, and their functions readily available:
+
+```powershell
+Import-Module SomeModule1, SomeModule2
+
+Start-PodeServer -ScriptBlock {
+    Add-PodeEndpoint -Address localhost -Port 9000 -Protocol Http
+
+    Add-PodeRoute -Method Get -Path '/' -ScriptBlock {
+        Use-SomeModule1Function
+    }
+}
+```
+
+### Disable
+
+If you don't need any modules, or want to stop the auto-importing from occurring, you can use disable it via the `server.psd1` [configuration file](../Configuration):
+
+```powershell
+@{
+    Server = @{
+        AutoImport = @{
+            Modules = @{
+                Enable = $false
+            }
+        }
+    }
+}
+```
+
+### Export
+
+If you want finer control over which modules are auto-imported, then you can set the auto-import to use an export list. To do so, you set Pode to only import exported modules:
+
+```powershell
+@{
+    Server = @{
+        AutoImport = @{
+            Modules = @{
+                Enable = $true
+                ExportOnly = $true
+            }
+        }
+    }
+}
+```
+
+Then you can "export" modules that Pode should import by using [`Export-PodeModule`](../../Functions/AutoImport/Export-PodeModule). Below only `SomeModule2` will be auto-imported into all of Pode's runspaces.
+
+```powershell
+Import-Module SomeModule1, SomeModule2
+
+Start-PodeServer -ScriptBlock {
+    Export-PodeModule SomeModule2
+}
+```
+
+## Snapins
+
+!!! important
+    Snapins are only supported on Windows PowerShell.
+
+Prior to 2.0 you had to use the [`Import-PodeSnapin`](../../Functions/Utilities/Import-PodeSnapin) function; but now, you can use the normal `Add-PSSnapin` function. Pode will automatically import all currently loaded snapins into its runspaces. The [`Import-PodeSnapin`](../../Functions/Utilities/Import-PodeSnapin) function still exists though, just to make transition to 2.0 a little easier - under the hood however, it now just calls `Add-PSSnapin`.
+
+Below, `Some.Snapin.1` and `Some.Snapin.2` will be automatically imported into all of Pode's runspaces, and their functions readily available:
+
+```powershell
+Add-PSSnapin Some.Snapin.1
+Add-PSSnapin Some.Snapin.2
+
+Start-PodeServer -ScriptBlock {
+    Add-PodeEndpoint -Address localhost -Port 9000 -Protocol Http
+
+    Add-PodeRoute -Method Get -Path '/' -ScriptBlock {
+        Use-SomeSnapinFunction
+    }
+}
+```
+
+### Disable
+
+If you don't need any snapins, or want to stop the auto-importing from occurring, you can use disable it via the `server.psd1` [configuration file](../Configuration):
+
+```powershell
+@{
+    Server = @{
+        AutoImport = @{
+            Snapins = @{
+                Enable = $false
+            }
+        }
+    }
+}
+```
+
+### Export
+
+If you want finer control over which snapins are auto-imported, then you can set the auto-import to use an export list. To do so, you set Pode to only import exported snapins:
+
+```powershell
+@{
+    Server = @{
+        AutoImport = @{
+            Snapins = @{
+                Enable = $true
+                ExportOnly = $true
+            }
+        }
+    }
+}
+```
+
+Then you can "export" snapins that Pode should import by using [`Export-PodeSnapin`](../../Functions/AutoImport/Export-PodeSnapin). Below only `Some.Snapin.2` will be auto-imported into all of Pode's runspaces.
+
+```powershell
+Add-PSSnapin 'Some.Snapin.1'
+Add-PSSnapin 'Some.Snapin.2'
+
+Start-PodeServer -ScriptBlock {
+    Export-PodeSnapin 'Some.Snapin.2'
+}
+```
+
+## Functions
+
+Prior to 2.0 if you wanted to use quick local functions in your Routes/etc, you would have needed to put them all into a module file, and then use [`Import-PodeSnapin`](../../Functions/Utilities/Import-PodeSnapin) to load them. But now you can just define your functions in the same ps1 file, and Pode will auto-import them for you.
+
+Below, `Write-HelloResponse` and `Write-ByeResponse` will be automatically imported into all of Pode's runspaces, ready for use:
+
+```powershell
+function Write-HelloResponse
+{
+    Write-PodeJsonResponse -Value @{ Message = 'Hello!' }
+}
+
+Start-PodeServer -ScriptBlock {
+    function Write-ByeResponse
+    {
+        Write-PodeJsonResponse -Value @{ Message = 'Bye!' }
+    }
+
+    Add-PodeEndpoint -Address localhost -Port 9000 -Protocol Http
+
+    Add-PodeRoute -Method Get -Path '/hello' -ScriptBlock {
+        Write-HelloResponse
+    }
+
+    Add-PodeRoute -Method Get -Path '/bye' -ScriptBlock {
+        Write-ByeResponse
+    }
+}
+```
+
+If you store Routes/etc in other files, you can also have local functions in these files as well. However, for Pode to import them you must use [`Use-PodeScript`](../../Functions/Utilities/Use-PodeScript) to dot-source the scripts - this will trigger Pode to scan the file for functions.
+
+### Disable
+
+If you don't need any functions, or want to stop the auto-importing from occurring, you can use disable it via the `server.psd1` [configuration file](../Configuration):
+
+```powershell
+@{
+    Server = @{
+        AutoImport = @{
+            Functions = @{
+                Enable = $false
+            }
+        }
+    }
+}
+```
+
+### Export
+
+If you want finer control over which functions are auto-imported, then you can set the auto-import to use an export list. To do so, you set Pode to only import exported modules:
+
+```powershell
+@{
+    Server = @{
+        AutoImport = @{
+            Functions = @{
+                Enable = $true
+                ExportOnly = $true
+            }
+        }
+    }
+}
+```
+
+Then you can "export" functions that Pode should import by using [`Export-PodeFunction`](../../Functions/AutoImport/Export-PodeFunction). Below only `Write-HelloResponse` will be auto-imported into all of Pode's runspaces.
+
+```powershell
+function Write-HelloResponse
+{
+    Write-PodeJsonResponse -Value @{ Message = 'Hello!' }
+}
+
+Start-PodeServer -ScriptBlock {
+    function Write-ByeResponse
+    {
+        Write-PodeJsonResponse -Value @{ Message = 'Bye!' }
+    }
+
+    Add-PodeEndpoint -Address localhost -Port 9000 -Protocol Http
+
+    Add-PodeRoute -Method Get -Path '/hello' -ScriptBlock {
+        Write-HelloResponse
+    }
+
+    Add-PodeRoute -Method Get -Path '/bye' -ScriptBlock {
+        # this would fail
+        Write-ByeResponse
+    }
+
+    Export-PodeFunction 'Write-HelloResponse'
+}
+```
+
+## Variables
+
+Prior to 2.0 if you wanted to use quick local variables in your Routes/etc, you would have needed to use the [`Set-PodeState`](../../Functions/State/Set-PodeState)/[`Get-PodeState`](../../Functions/State/Get-PodeState) functions. But now you can just define your variables in the same ps1 file, and then reference them in your Routes/etc via the `$using:` syntax.
+
+The `$using:` syntax is supported in almost all `-ScriptBlock` parameters for the likes of:
+
+* Authentication
+* Endware
+* Handlers
+* Logging
+* Middleware
+* Routes
+* Schedules
+* Timers
+
+Below, the `$outer_msg` and `$inner_msg` variables can now be more simply referenced in a Route:
+
+```powershell
+$outer_msg = 'Hello, there'
+
+Start-PodeServer -ScriptBlock {
+    Add-PodeEndpoint -Address localhost -Port 9000 -Protocol Http
+
+    $inner_msg = 'General Kenobi'
+
+    Add-PodeRoute -Method Get -Path '/random' -ScriptBlock {
+        Write-PodeJsonResponse -Value @{ Message = "$($using:outer_msg) ... $($using:inner_msg)" }
+    }
+}
+```

--- a/docs/Tutorials/Views/ThirdParty.md
+++ b/docs/Tutorials/Views/ThirdParty.md
@@ -9,25 +9,26 @@ This custom `scriptblock` will be supplied with two arguments:
 
 ## EPS
 
-If you were to use `EPS` engine, and already have the module installed, then the following server example would work for views and static content:
+If you were to use the `EPS` engine, and already have the module installed, then the following server example would work for views and static content:
 
 ```powershell
+# import the EPS module
+Import-Module -Name EPS
+
 Start-PodeServer {
     Add-PodeEndpoint -Address * -Port 8080 -Protocol Http
-
-    # import the EPS module into the runspaces
-    Import-PodeModule -Name EPS
 
     # set the engine to use and render EPS files
     # (could be index.eps, or for content scripts.css.eps)
     Set-PodeViewEngine -Type EPS -ScriptBlock {
         param($path, $data)
+        $template = Get-Content -Path $path -Raw -Force
 
         if ($null -eq $data) {
-            return (Invoke-EpsTemplate -Path $path)
+            return (Invoke-EpsTemplate -Template $template)
         }
         else {
-            return (Invoke-EpsTemplate -Path $path -Binding $data)
+            return (Invoke-EpsTemplate -Template $template -Binding $data)
         }
     }
 
@@ -53,11 +54,11 @@ The following example structure could be used for the views and static content:
 If you were to use `PSHTML` engine, and already have the module installed, then the following server example would work for views and static content:
 
 ```powershell
+# import the PSHTML module
+Import-Module -Name PSHTML
+
 Start-PodeServer {
     Add-PodeEndpoint -Address * -Port 8080 -Protocol Http
-
-    # import the PSHTML module into the runspaces
-    Import-PodeModule -Name PSHTML
 
     # set the engine to use and render PSHTML (which are just ps1) files
     # (could be index.ps1, or for content scripts.css.ps1)

--- a/examples/external-funcs.ps1
+++ b/examples/external-funcs.ps1
@@ -4,14 +4,14 @@ Import-Module "$($path)/src/Pode.psm1" -Force -ErrorAction Stop
 # or just:
 # Import-Module Pode
 
+# include the external function module
+Import-PodeModule -Path './modules/external-funcs.psm1'
+
 # create a server, and start listening on port 8085
 Start-PodeServer {
 
     # listen on localhost:8085
     Add-PodeEndpoint -Address * -Port 8085 -Protocol Http
-
-    # include the external function module
-    Import-PodeModule -Path './modules/external-funcs.psm1'
 
     # GET request for "localhost:8085/"
     Add-PodeRoute -Method Get -Path '/' -ScriptBlock {

--- a/examples/modules/imported-funcs.ps1
+++ b/examples/modules/imported-funcs.ps1
@@ -1,0 +1,3 @@
+function Get-Greeting {
+    return "Hello, world! [$(Get-Random -Maximum 100)]"
+}

--- a/examples/modules/imported-funcs.ps1
+++ b/examples/modules/imported-funcs.ps1
@@ -1,3 +1,5 @@
-function Get-Greeting {
-    return "Hello, world! [$(Get-Random -Maximum 100)]"
+function Write-MyGreeting {
+    Write-PodeJsonResponse -Value @{ Message = "Hello, world! [$(Get-Random -Maximum 100)]" }
 }
+
+Use-PodeScript -Path (Join-Path $PSScriptRoot .\imported-sub-funcs.ps1)

--- a/examples/modules/imported-funcs.ps1
+++ b/examples/modules/imported-funcs.ps1
@@ -2,4 +2,5 @@ function Write-MyGreeting {
     Write-PodeJsonResponse -Value @{ Message = "Hello, world! [$(Get-Random -Maximum 100)]" }
 }
 
+Export-PodeFunction -Name 'Write-MyGreeting'
 Use-PodeScript -Path (Join-Path $PSScriptRoot .\imported-sub-funcs.ps1)

--- a/examples/modules/imported-sub-funcs.ps1
+++ b/examples/modules/imported-sub-funcs.ps1
@@ -1,3 +1,5 @@
 function Write-MySubGreeting {
     Write-PodeJsonResponse -Value @{ Message = "Mudkipz! [$(Get-Random -Maximum 100)]" }
 }
+
+Export-PodeFunction -Name 'Write-MySubGreeting'

--- a/examples/modules/imported-sub-funcs.ps1
+++ b/examples/modules/imported-sub-funcs.ps1
@@ -1,0 +1,3 @@
+function Write-MySubGreeting {
+    Write-PodeJsonResponse -Value @{ Message = "Mudkipz! [$(Get-Random -Maximum 100)]" }
+}

--- a/examples/modules/route_script.ps1
+++ b/examples/modules/route_script.ps1
@@ -1,3 +1,4 @@
 return {
+    $using:hmm | out-default
     Write-PodeViewResponse -Path 'simple' -Data @{ 'numbers' = @(4, 5, 6); }
 }

--- a/examples/schedules.ps1
+++ b/examples/schedules.ps1
@@ -11,8 +11,9 @@ Start-PodeServer {
     Add-PodeEndpoint -Address * -Port 8085 -Protocol Http
 
     # schedule minutely using predefined cron
+    $message = 'Hello, world!'
     Add-PodeSchedule -Name 'predefined' -Cron '@minutely' -Limit 2 -ScriptBlock {
-        'hello, world!' | Out-Default
+        $using:message | Out-Default
         Get-PodeSchedule -Name 'predefined' | Out-Default
     }
 

--- a/examples/server.psd1
+++ b/examples/server.psd1
@@ -39,5 +39,10 @@
                 Mask = '--MASKED--'
             }
         }
+        AutoImport = @{
+            Functions = @{
+                ExportOnly = $true
+            }
+        }
     }
 }

--- a/examples/timers.ps1
+++ b/examples/timers.ps1
@@ -10,8 +10,11 @@ Start-PodeServer {
     Add-PodeEndpoint -Address * -Port 8081 -Protocol Http
 
     # runs forever, looping every 5secs
+    $message = 'Hello, world'
     Add-PodeTimer -Name 'forever' -Interval 5 -ScriptBlock {
-        'Hello, world' | Out-PodeHost
+        '- - -' | Out-PodeHost
+        $using:message | Out-PodeHost
+        '- - -' | Out-PodeHost
     } -Limit 5
 
     Add-PodeTimer -Name 'from-file' -Interval 2 -FilePath './scripts/timer.ps1'

--- a/examples/web-imports.ps1
+++ b/examples/web-imports.ps1
@@ -9,14 +9,14 @@ Import-Module "$($path)/src/Pode.psm1" -Force -ErrorAction Stop
 # or just:
 # Import-Module Pode
 
+# import modules
+Import-Module -Name EPS
+
 # create a server, and start listening on port 8085
 Start-PodeServer -Threads 2 {
 
     # listen on localhost:8085
     Add-PodeEndpoint -Address localhost -Port $Port -Protocol Http
-
-    # import modules
-    Import-PodeModule -Name EPS
 
     # set view engine to pode renderer
     Set-PodeViewEngine -Type Pode

--- a/examples/web-pages-using.ps1
+++ b/examples/web-pages-using.ps1
@@ -14,6 +14,10 @@ function Write-MyOuterResponse
 
 # create a server, and start listening on port 8085
 Start-PodeServer -Threads 2 {
+    # disable module/snapin loading
+    Disable-PodeModuleImport
+    Disable-PodeSnapinImport
+    Enable-PodeFunctionImport -OnlyExported
 
     # listen on localhost:8090
     Add-PodeEndpoint -Address * -Port 8090 -Protocol Http
@@ -35,6 +39,8 @@ Start-PodeServer -Threads 2 {
     {
         Write-PodeJsonResponse -Value @{ Message = 'From an inner function' }
     }
+
+    Export-PodeFunction -Name 'Write-MyOuterResponse', 'Write-MyInnerResponse'
 
     New-PodeMiddleware -ScriptBlock {
         "M1: $($using:outer_ken) ... $($using:inner_ken)" | Out-Default

--- a/examples/web-pages-using.ps1
+++ b/examples/web-pages-using.ps1
@@ -27,11 +27,11 @@ Start-PodeServer -Threads 2 {
     Add-PodeRoute -Method Get -Path '/' -ScriptBlock {
         param($e)
 
-        $using:innerfoo | out-default
-        $using:outerfoo | out-default
-        $using:innerfoo | out-default
+        $using:innerfoo | Out-Default
+        $using:outerfoo | Out-Default
+        $using:innerfoo | Out-Default
 
-        $e.Method | out-default
+        $e.Method | Out-Default
 
         Write-PodeViewResponse -Path 'simple' -Data @{ 'numbers' = @(1, 2, 3); }
     }

--- a/examples/web-pages-using.ps1
+++ b/examples/web-pages-using.ps1
@@ -5,6 +5,7 @@ Import-Module "$($path)/src/Pode.psm1" -Force -ErrorAction Stop
 # Import-Module Pode
 
 $outerfoo = 'outer-bar'
+$outer_ken = 'Hello, there'
 
 # create a server, and start listening on port 8085
 Start-PodeServer -Threads 2 {
@@ -20,6 +21,7 @@ Start-PodeServer -Threads 2 {
     Set-PodeViewEngine -Type Pode
 
     $innerfoo = 'inner-bar'
+    $inner_ken = 'General Kenobi'
 
     # GET request for web page on "localhost:8090/"
     Add-PodeRoute -Method Get -Path '/' -ScriptBlock {
@@ -27,10 +29,22 @@ Start-PodeServer -Threads 2 {
 
         $using:innerfoo | out-default
         $using:outerfoo | out-default
+        $using:innerfoo | out-default
 
         $e.Method | out-default
 
         Write-PodeViewResponse -Path 'simple' -Data @{ 'numbers' = @(1, 2, 3); }
     }
 
+    Add-PodeRoute -Method Get -Path '/random' -ScriptBlock {
+        Write-PodeJsonResponse -Value @{ Message = "$($using:outer_ken) ... $($using:inner_ken)" }
+    }
+
+    Add-PodeTimer -Name 'empty' -Interval 60 -ScriptBlock {}
+
+    Add-PodeRoute -Method Get -Path '/timer' -ScriptBlock {
+        Add-PodeTimer -Name 'inner_timer' -Interval 5 -ScriptBlock {
+            $using:innerfoo | Out-PodeHost
+        }
+    }
 }

--- a/examples/web-pages-using.ps1
+++ b/examples/web-pages-using.ps1
@@ -14,11 +14,6 @@ function Write-MyOuterResponse
 
 # create a server, and start listening on port 8085
 Start-PodeServer -Threads 2 {
-    # disable module/snapin loading
-    Disable-PodeModuleImport
-    Disable-PodeSnapinImport
-    Enable-PodeFunctionImport -OnlyExported
-
     # listen on localhost:8090
     Add-PodeEndpoint -Address * -Port 8090 -Protocol Http
 

--- a/examples/web-pages-using.ps1
+++ b/examples/web-pages-using.ps1
@@ -1,0 +1,36 @@
+$path = Split-Path -Parent -Path (Split-Path -Parent -Path $MyInvocation.MyCommand.Path)
+Import-Module "$($path)/src/Pode.psm1" -Force -ErrorAction Stop
+
+# or just:
+# Import-Module Pode
+
+$outerfoo = 'outer-bar'
+
+# create a server, and start listening on port 8085
+Start-PodeServer -Threads 2 {
+
+    # listen on localhost:8090
+    Add-PodeEndpoint -Address * -Port 8090 -Protocol Http
+
+    # log requests to the terminal
+    New-PodeLoggingMethod -Terminal -Batch 10 -BatchTimeout 10 | Enable-PodeRequestLogging
+    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+
+    # set view engine to pode renderer
+    Set-PodeViewEngine -Type Pode
+
+    $innerfoo = 'inner-bar'
+
+    # GET request for web page on "localhost:8090/"
+    Add-PodeRoute -Method Get -Path '/' -ScriptBlock {
+        param($e)
+
+        $using:innerfoo | out-default
+        $using:outerfoo | out-default
+
+        $e.Method | out-default
+
+        Write-PodeViewResponse -Path 'simple' -Data @{ 'numbers' = @(1, 2, 3); }
+    }
+
+}

--- a/examples/web-pages-using.ps1
+++ b/examples/web-pages-using.ps1
@@ -23,6 +23,16 @@ Start-PodeServer -Threads 2 {
     $innerfoo = 'inner-bar'
     $inner_ken = 'General Kenobi'
 
+    New-PodeMiddleware -ScriptBlock {
+        "M1: $($using:outer_ken) ... $($using:inner_ken)" | Out-Default
+        return $true
+    } |  Add-PodeMiddleware -Name 'TestUsingMiddleware1'
+
+    Add-PodeMiddleware -Name 'TestUsingMiddleware2' -ScriptBlock {
+        "M2: $($using:outer_ken) ... $($using:inner_ken)" | Out-Default
+        return $true
+    }
+
     # GET request for web page on "localhost:8090/"
     Add-PodeRoute -Method Get -Path '/' -ScriptBlock {
         param($e)

--- a/examples/web-pages.ps1
+++ b/examples/web-pages.ps1
@@ -11,6 +11,8 @@ Import-Module "$($path)/src/Pode.psm1" -Force -ErrorAction Stop
 
 # create a server, and start listening on port 8085
 Start-PodeServer -Threads 2 {
+    # disable module loading
+    Disable-PodeModuleImport
 
     # listen on localhost:8085
     Add-PodeEndpoint -Address * -Port 8090 -Protocol Http -Name '8090Address'

--- a/examples/web-pages.ps1
+++ b/examples/web-pages.ps1
@@ -93,6 +93,7 @@ Start-PodeServer -Threads 2 {
         Write-PodeJsonResponse -Value @{ 'value' = 'works for every hello route' }
     }
 
+    $hmm = 'well well'
     Add-PodeRoute -Method Get -Path '/script' -FilePath './modules/route_script.ps1'
 
 }

--- a/examples/web-pages.ps1
+++ b/examples/web-pages.ps1
@@ -11,9 +11,6 @@ Import-Module "$($path)/src/Pode.psm1" -Force -ErrorAction Stop
 
 # create a server, and start listening on port 8085
 Start-PodeServer -Threads 2 {
-    # disable module loading
-    Disable-PodeModuleImport
-
     # listen on localhost:8085
     Add-PodeEndpoint -Address * -Port 8090 -Protocol Http -Name '8090Address'
     Add-PodeEndpoint -Address * -Port $Port -Protocol Http -Name '8085Address' -RedirectTo '8090Address'

--- a/examples/web-tp-eps.ps1
+++ b/examples/web-tp-eps.ps1
@@ -4,6 +4,8 @@ Import-Module "$($path)/src/Pode.psm1" -Force -ErrorAction Stop
 # or just:
 # Import-Module Pode
 
+Import-Module -Name EPS
+
 # create a server, and start listening on port 8085
 Start-PodeServer -Threads 2 {
 
@@ -13,18 +15,16 @@ Start-PodeServer -Threads 2 {
     # log requests to the terminal
     New-PodeLoggingMethod -Terminal | Enable-PodeRequestLogging
 
-    # import the EPS module to each runspace
-    Import-PodeModule -Name EPS
-
     # set view engine to EPS renderer
     Set-PodeViewEngine -Type EPS -ScriptBlock {
         param($path, $data)
+        $template = Get-Content -Path $path -Raw -Force
 
         if ($null -eq $data) {
-            return (Invoke-EpsTemplate -Path $path)
+            return (Invoke-EpsTemplate -Template $template)
         }
         else {
-            return (Invoke-EpsTemplate -Path $path -Binding $data)
+            return (Invoke-EpsTemplate -Template $template -Binding $data)
         }
     }
 

--- a/examples/web-tp-pshtml.ps1
+++ b/examples/web-tp-pshtml.ps1
@@ -4,6 +4,8 @@ Import-Module "$($path)/src/Pode.psm1" -Force -ErrorAction Stop
 # or just:
 # Import-Module Pode
 
+Import-Module -Name PSHTML
+
 # create a server, and start listening on port 8085
 Start-PodeServer -Threads 2 {
 
@@ -12,9 +14,6 @@ Start-PodeServer -Threads 2 {
 
     # log requests to the terminal
     New-PodeLoggingMethod -Terminal | Enable-PodeRequestLogging
-
-    # import the PSHTML module to each runspace
-    Import-PodeModule -Name PSHTML
 
     # set view engine to PSHTML renderer
     Set-PodeViewEngine -Type PSHTML -Extension PS1 -ScriptBlock {

--- a/src/Pode.psd1
+++ b/src/Pode.psd1
@@ -215,7 +215,18 @@
         # Metrics
         'Get-PodeServerUptime',
         'Get-PodeServerRestartCount',
-        'Get-PodeServerRequestMetric'
+        'Get-PodeServerRequestMetric',
+
+        # AutoImport
+        'Disable-PodeModuleImport',
+        'Enable-PodeModuleImport',
+        'Export-PodeModule',
+        'Disable-PodeSnapinImport',
+        'Enable-PodeSnapinImport',
+        'Export-PodeSnapin',
+        'Disable-PodeFunctionImport',
+        'Enable-PodeFunctionImport',
+        'Export-PodeFunction'
     )
 
     # Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.

--- a/src/Pode.psd1
+++ b/src/Pode.psd1
@@ -218,14 +218,8 @@
         'Get-PodeServerRequestMetric',
 
         # AutoImport
-        'Disable-PodeModuleImport',
-        'Enable-PodeModuleImport',
         'Export-PodeModule',
-        'Disable-PodeSnapinImport',
-        'Enable-PodeSnapinImport',
         'Export-PodeSnapin',
-        'Disable-PodeFunctionImport',
-        'Enable-PodeFunctionImport',
         'Export-PodeFunction'
     )
 

--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -299,6 +299,22 @@ function New-PodeRunspaceState
     $PodeContext.RunspaceState = $state
 }
 
+function Import-PodeFunctionsIntoRunspaceState
+{
+    param(
+        [Parameter(Mandatory=$true)]
+        [scriptblock]
+        $ScriptBlock
+    )
+
+    $funcs = Get-PodeScriptFunctions -ScriptBlock $ScriptBlock
+
+    foreach ($funcName in $funcs.Keys) {
+        $funcDef = [System.Management.Automation.Runspaces.SessionStateFunctionEntry]::new($funcName, $funcs[$funcName].Trim('{}'))
+        $PodeContext.RunspaceState.Commands.Add($funcDef)
+    }
+}
+
 function Import-PodeModulesIntoRunspaceState
 {
     # load modules into runspaces

--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -172,7 +172,8 @@ function New-PodeContext
     $ctx.Server.ViewEngine = @{
         Type = 'html'
         Extension = 'html'
-        Script = $null
+        ScriptBlock = $null
+        UsingVariables = $null
         IsDynamic = $false
     }
 

--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -312,6 +312,16 @@ function Import-PodeModulesIntoRunspaceState
         }
 }
 
+function Import-PodeSnapInsIntoRunspaceState
+{
+    (Get-PSSnapin | Where-Object { !$_.IsDefault }).Name |
+        Sort-Object -Unique |
+        ForEach-Object {
+            $exp = $null
+            $PodeContext.RunspaceState.ImportPSSnapIn($_, ([ref]$exp))
+        }
+}
+
 function New-PodeRunspacePools
 {
     if ($PodeContext.Server.IsServerless) {

--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -78,21 +78,21 @@ function New-PodeContext
     $ctx.Server.Quiet = $Quiet.IsPresent
 
     # auto importing (modules, funcs, snap-ins)
-    $ctx.Server.AutoImporters = @{
+    $ctx.Server.AutoImport = @{
         Modules = @{
             Enabled = $true
-            Exported = @()
-            OnlyExported = $false
+            ExportList = @()
+            ExportOnly = $false
         }
         Snapins = @{
             Enabled = $true
-            Exported = @()
-            OnlyExported = $false
+            ExportList = @()
+            ExportOnly = $false
         }
         Functions = @{
             Enabled = $true
-            Exported = @()
-            OnlyExported = $false
+            ExportList = @()
+            ExportOnly = $false
         }
     }
 
@@ -332,12 +332,12 @@ function Import-PodeFunctionsIntoRunspaceState
     )
 
     # do nothing if disabled
-    if (!$PodeContext.Server.AutoImporters.Functions.Enabled) {
+    if (!$PodeContext.Server.AutoImport.Functions.Enabled) {
         return
     }
 
     # if export only, and there are none, do nothing
-    if ($PodeContext.Server.AutoImporters.Functions.OnlyExported -and ($PodeContext.Server.AutoImporters.Functions.Exported.Length -eq 0)) {
+    if ($PodeContext.Server.AutoImport.Functions.ExportOnly -and ($PodeContext.Server.AutoImport.Functions.ExportList.Length -eq 0)) {
         return
     }
 
@@ -363,7 +363,7 @@ function Import-PodeFunctionsIntoRunspaceState
     # import them, but also check if they're exported
     foreach ($func in $funcs) {
         # only exported funcs? is the func exported?
-        if ($PodeContext.Server.AutoImporters.Functions.OnlyExported -and ($PodeContext.Server.AutoImporters.Functions.Exported -inotcontains $func.Name)) {
+        if ($PodeContext.Server.AutoImport.Functions.ExportOnly -and ($PodeContext.Server.AutoImport.Functions.ExportList -inotcontains $func.Name)) {
             continue
         }
 
@@ -376,12 +376,12 @@ function Import-PodeFunctionsIntoRunspaceState
 function Import-PodeModulesIntoRunspaceState
 {
     # do nothing if disabled
-    if (!$PodeContext.Server.AutoImporters.Modules.Enabled) {
+    if (!$PodeContext.Server.AutoImport.Modules.Enabled) {
         return
     }
 
     # if export only, and there are none, do nothing
-    if ($PodeContext.Server.AutoImporters.Modules.OnlyExported -and ($PodeContext.Server.AutoImporters.Modules.Exported.Length -eq 0)) {
+    if ($PodeContext.Server.AutoImport.Modules.ExportOnly -and ($PodeContext.Server.AutoImport.Modules.ExportList.Length -eq 0)) {
         return
     }
 
@@ -390,7 +390,7 @@ function Import-PodeModulesIntoRunspaceState
 
     foreach ($module in $modules) {
         # only exported modules? is the module exported?
-        if ($PodeContext.Server.AutoImporters.Modules.OnlyExported -and ($PodeContext.Server.AutoImporters.Modules.Exported -inotcontains $module)) {
+        if ($PodeContext.Server.AutoImport.Modules.ExportOnly -and ($PodeContext.Server.AutoImport.Modules.ExportList -inotcontains $module)) {
             continue
         }
 
@@ -407,12 +407,12 @@ function Import-PodeSnapinsIntoRunspaceState
     }
 
     # do nothing if disabled
-    if (!$PodeContext.Server.AutoImporters.Snapins.Enabled) {
+    if (!$PodeContext.Server.AutoImport.Snapins.Enabled) {
         return
     }
 
     # if export only, and there are none, do nothing
-    if ($PodeContext.Server.AutoImporters.Snapins.OnlyExported -and ($PodeContext.Server.AutoImporters.Snapins.Exported.Length -eq 0)) {
+    if ($PodeContext.Server.AutoImport.Snapins.ExportOnly -and ($PodeContext.Server.AutoImport.Snapins.ExportList.Length -eq 0)) {
         return
     }
 
@@ -421,7 +421,7 @@ function Import-PodeSnapinsIntoRunspaceState
 
     foreach ($snapin in $snapins) {
         # only exported snapins? is the snapin exported?
-        if ($PodeContext.Server.AutoImporters.Snapins.OnlyExported -and ($PodeContext.Server.AutoImporters.Snapins.Exported -inotcontains $snapin)) {
+        if ($PodeContext.Server.AutoImport.Snapins.ExportOnly -and ($PodeContext.Server.AutoImport.Snapins.ExportList -inotcontains $snapin)) {
             continue
         }
 
@@ -549,7 +549,7 @@ function Set-PodeServerConfiguration
 
     # logging
     $Context.Server.Logging = @{
-        Enabled = !([bool]$Configuration.Logging.Enable)
+        Enabled = (($null -eq $Configuration.Logging.Enable) -or [bool]$Configuration.Logging.Enable)
         Masking = @{
             Patterns = (Remove-PodeEmptyItemsFromArray -Array @($Configuration.Logging.Masking.Patterns))
             Mask = (Protect-PodeValue -Value $Configuration.Logging.Masking.Mask -Default '********')
@@ -564,6 +564,25 @@ function Set-PodeServerConfiguration
 
     if ([int]$Configuration.ReceiveTimeout -gt 0) {
         $Context.Server.Sockets.ReceiveTimeout = (Protect-PodeValue -Value $Configuration.ReceiveTimeout $Context.Server.Sockets.ReceiveTimeout)
+    }
+
+    # auto-import
+    $Context.Server.AutoImport = @{
+        Modules = @{
+            Enabled = (($null -eq $Configuration.AutoImport.Modules.Enable) -or [bool]$Configuration.AutoImport.Modules.Enable)
+            ExportList = @()
+            ExportOnly = ([bool]$Configuration.AutoImport.Modules.ExportOnly)
+        }
+        Snapins = @{
+            Enabled = (($null -eq $Configuration.AutoImport.Snapins.Enable) -or [bool]$Configuration.AutoImport.Snapins.Enable)
+            ExportList = @()
+            ExportOnly = ([bool]$Configuration.AutoImport.Snapins.ExportOnly)
+        }
+        Functions = @{
+            Enabled = (($null -eq $Configuration.AutoImport.Functions.Enable) -or [bool]$Configuration.AutoImport.Functions.Enable)
+            ExportList = @()
+            ExportOnly = ([bool]$Configuration.AutoImport.Functions.ExportOnly)
+        }
     }
 }
 

--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -301,6 +301,7 @@ function New-PodeRunspaceState
 
 function Import-PodeModulesIntoRunspaceState
 {
+    # load modules into runspaces
     (Get-Module | Where-Object { ($_.ModuleType -ieq 'script') -and ($_.Name -ine 'pode') }).Name |
         Sort-Object -Unique |
         ForEach-Object {
@@ -314,6 +315,12 @@ function Import-PodeModulesIntoRunspaceState
 
 function Import-PodeSnapInsIntoRunspaceState
 {
+    # if non-windows or core, do nothing
+    if ((Test-IsPSCore) -or (Test-IsUnix)) {
+        return
+    }
+
+    # load snapins into runspaces
     (Get-PSSnapin | Where-Object { !$_.IsDefault }).Name |
         Sort-Object -Unique |
         ForEach-Object {

--- a/src/Private/Endware.ps1
+++ b/src/Private/Endware.ps1
@@ -22,7 +22,12 @@ function Invoke-PodeEndware
         }
 
         try {
-            Invoke-PodeScriptBlock -ScriptBlock $eware.Logic -Arguments (@($WebEvent) + @($eware.Arguments)) -Scoped -Splat | Out-Null
+            $_args = @($WebEvent) + @($eware.Arguments)
+            if ($null -ne $eware.UsingVariables) {
+                $_args = @($eware.UsingVariables.Value) + $_args
+            }
+
+            Invoke-PodeScriptBlock -ScriptBlock $eware.Logic -Arguments $_args -Scoped -Splat | Out-Null
         }
         catch {
             $_ | Write-PodeErrorLog

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -2122,8 +2122,8 @@ function Get-PodeScriptFunctions
 
     # get each function in the callstack
     $callstack = Get-PSCallStack
-    if ($callstack.Count -gt 1) {
-        $callstack = ($callstack | Select-Object -Skip 2)
+    if ($callstack.Count -gt 3) {
+        $callstack = ($callstack | Select-Object -Skip 4)
         $flags = [System.Reflection.BindingFlags]'NonPublic, Instance, Static'
 
         foreach ($call in $callstack)

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -1897,7 +1897,11 @@ function Get-PodeWildcardFiles
 
         [Parameter()]
         [string]
-        $Wildcard = '*.*'
+        $Wildcard = '*.*',
+
+        [Parameter()]
+        [string]
+        $RootPath
     )
 
     # if the OriginalPath is a directory, add wildcard
@@ -1907,7 +1911,7 @@ function Get-PodeWildcardFiles
 
     # if path has a *, assume wildcard
     if (Test-PodePathIsWildcard -Path $Path) {
-        $Path = Get-PodeRelativePath -Path $Path -JoinRoot
+        $Path = Get-PodeRelativePath -Path $Path -RootPath $RootPath -JoinRoot
         return @((Get-ChildItem $Path -Recurse -Force).FullName)
     }
 

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -78,7 +78,7 @@ function Get-PodeFileContentUsingViewEngine
 
         default {
             if ($null -ne $PodeContext.Server.ViewEngine.ScriptBlock) {
-                $_args = $Path
+                $_args = @($Path)
                 if (($null -ne $Data) -and ($Data.Count -gt 0)) {
                     $_args = @($Path, $Data)
                 }
@@ -1149,7 +1149,7 @@ function ConvertFrom-PodeRequestContent
         if ($PodeContext.Server.BodyParsers.ContainsKey($MetaData.ContentType)) {
             $parser = $PodeContext.Server.BodyParsers[$MetaData.ContentType]
 
-            $_args = $Content
+            $_args = @($Content)
             if ($null -ne $parser.UsingVariables) {
                 $_args = @($parser.UsingVariables.Value) + $_args
             }
@@ -2090,7 +2090,7 @@ function Convert-PodeQueryStringToHashTable
 function Invoke-PodeUsingScriptConversion
 {
     param(
-        [Parameter(Mandatory=$true)]
+        [Parameter()]
         [scriptblock]
         $ScriptBlock,
 
@@ -2098,6 +2098,11 @@ function Invoke-PodeUsingScriptConversion
         [System.Management.Automation.SessionState]
         $PSSession
     )
+
+    # do nothing if no script
+    if ($null -eq $ScriptBlock) {
+        return @($ScriptBlock, $null)
+    }
 
     # rename any __using_ vars for inner timers, etcs
     $scriptStr = "$($ScriptBlock)"

--- a/src/Private/Logging.ps1
+++ b/src/Private/Logging.ps1
@@ -298,7 +298,12 @@ function Start-PodeLoggingRunspace
             }
 
             # convert to log item into a writable format
-            $result = @(Invoke-PodeScriptBlock -ScriptBlock $logger.ScriptBlock -Arguments (@($log.Item) + @($logger.Arguments)) -Return -Splat)
+            $_args = @($log.Item) + @($logger.Arguments)
+            if ($null -ne $logger.UsingVariables) {
+                $_args = @($logger.UsingVariables.Value) + $_args
+            }
+
+            $result = @(Invoke-PodeScriptBlock -ScriptBlock $logger.ScriptBlock -Arguments $_args -Return -Splat)
 
             # check batching
             $batch = $logger.Method.Batch
@@ -321,7 +326,12 @@ function Start-PodeLoggingRunspace
 
             # send the writable log item off to the log writer
             if ($null -ne $result) {
-                Invoke-PodeScriptBlock -ScriptBlock $logger.Method.ScriptBlock -Arguments (@(,$result) + @($logger.Method.Arguments)) -Splat
+                $_args = @(,$result) + @($logger.Method.Arguments)
+                if ($null -ne $logger.Method.UsingVariables) {
+                    $_args = @($logger.Method.UsingVariables.Value) + $_args
+                }
+
+                Invoke-PodeScriptBlock -ScriptBlock $logger.Method.ScriptBlock -Arguments $_args -Splat
             }
 
             # small sleep to lower cpu usage
@@ -345,7 +355,13 @@ function Test-PodeLoggerBatches
         {
             $result = $batch.Items
             $batch.Items = @()
-            Invoke-PodeScriptBlock -ScriptBlock $logger.Method.ScriptBlock -Arguments (@(,$result) + @($logger.Method.Arguments)) -Splat
+
+            $_args = @(,$result) + @($logger.Method.Arguments)
+            if ($null -ne $logger.Method.UsingVariables) {
+                $_args = @($logger.Method.UsingVariables.Value) + $_args
+            }
+
+            Invoke-PodeScriptBlock -ScriptBlock $logger.Method.ScriptBlock -Arguments $_args -Splat
         }
     }
 }

--- a/src/Private/PodeServer.ps1
+++ b/src/Private/PodeServer.ps1
@@ -143,7 +143,12 @@ function Start-PodeWebServer
                                     }
                                 }
                                 elseif ($null -ne $WebEvent.Route.Logic) {
-                                    Invoke-PodeScriptBlock -ScriptBlock $WebEvent.Route.Logic -Arguments (@($WebEvent) + @($WebEvent.Route.Arguments)) -Scoped -Splat
+                                    $_args = @($WebEvent) + @($WebEvent.Route.Arguments)
+                                    if ($null -ne $WebEvent.Route.UsingVariables) {
+                                        $_args = @($WebEvent.Route.UsingVariables.Value) + $_args
+                                    }
+
+                                    Invoke-PodeScriptBlock -ScriptBlock $WebEvent.Route.Logic -Arguments $_args -Scoped -Splat
                                 }
                             }
                         }

--- a/src/Private/Routes.ps1
+++ b/src/Private/Routes.ps1
@@ -626,7 +626,11 @@ function ConvertTo-PodeRouteMiddleware
 
         [Parameter()]
         [object[]]
-        $Middleware
+        $Middleware,
+
+        [Parameter(Mandatory=$true)]
+        [System.Management.Automation.SessionState]
+        $PSSession
     )
 
     # return if no middleware
@@ -658,8 +662,11 @@ function ConvertTo-PodeRouteMiddleware
 
     for ($i = 0; $i -lt $Middleware.Length; $i++) {
         if ($Middleware[$i] -is [scriptblock]) {
+            $_script, $_usingVars = Invoke-PodeUsingScriptConversion -ScriptBlock $Middleware[$i] -PSSession $PSSession
+
             $Middleware[$i] = @{
-                Logic = $Middleware[$i]
+                Logic = $_script
+                UsingVariables = $_usingVars
             }
         }
     }

--- a/src/Private/Schedules.ps1
+++ b/src/Private/Schedules.ps1
@@ -119,14 +119,23 @@ function Invoke-PodeInternalScheduleLogic
     )
 
     try {
+        # setup event param
         $parameters = @{
             Event = @{
                 Lockable = $PodeContext.Lockable
             }
         }
 
+        # add any custom args as params
         foreach ($key in $Schedule.Arguments.Keys) {
             $parameters[$key] = $Schedule.Arguments[$key]
+        }
+
+        # add any using variables as params
+        if ($null -ne $Schedule.UsingVariables) {
+            foreach ($usingVar in $Schedule.UsingVariables) {
+                $parameters[$usingVar.NewName] = $usingVar.Value
+            }
         }
 
         Add-PodeRunspace -Type Schedules -ScriptBlock (($Schedule.Script).GetNewClosure()) -Parameters $parameters -Forget

--- a/src/Private/Server.ps1
+++ b/src/Private/Server.ps1
@@ -24,6 +24,9 @@ function Start-PodeInternalServer
 
         Invoke-PodeScriptBlock -ScriptBlock $_script -NoNewClosure
 
+        # load any modules
+        Import-PodeModulesIntoRunspaceState
+
         # start the runspace pools for web, schedules, etc
         New-PodeRunspacePools
         Open-PodeRunspacePools

--- a/src/Private/Server.ps1
+++ b/src/Private/Server.ps1
@@ -155,7 +155,8 @@ function Restart-PodeInternalServer
         $PodeContext.Server.ViewEngine = @{
             Type = 'html'
             Extension = 'html'
-            Script = $null
+            ScriptBlock = $null
+            UsingVariables = $null
             IsDynamic = $false
         }
 

--- a/src/Private/Server.ps1
+++ b/src/Private/Server.ps1
@@ -26,6 +26,7 @@ function Start-PodeInternalServer
 
         # load any modules
         Import-PodeModulesIntoRunspaceState
+        Import-PodeSnapInsIntoRunspaceState
 
         # start the runspace pools for web, schedules, etc
         New-PodeRunspacePools

--- a/src/Private/Server.ps1
+++ b/src/Private/Server.ps1
@@ -29,7 +29,7 @@ function Start-PodeInternalServer
 
         # load any modules
         Import-PodeModulesIntoRunspaceState
-        Import-PodeSnapInsIntoRunspaceState
+        Import-PodeSnapinsIntoRunspaceState
 
         # start the runspace pools for web, schedules, etc
         New-PodeRunspacePools
@@ -133,6 +133,11 @@ function Restart-PodeInternalServer
         $PodeContext.Timers.Clear()
         $PodeContext.Schedules.Clear()
         $PodeContext.Server.Logging.Types.Clear()
+
+        # auto-importers
+        $PodeContext.Server.AutoImporters.Modules.Exported = @()
+        $PodeContext.Server.AutoImporters.Snapins.Exported = @()
+        $PodeContext.Server.AutoImporters.Functions.Exported = @()
 
         # clear middle/endware
         $PodeContext.Server.Middleware = @()

--- a/src/Private/Server.ps1
+++ b/src/Private/Server.ps1
@@ -135,9 +135,9 @@ function Restart-PodeInternalServer
         $PodeContext.Server.Logging.Types.Clear()
 
         # auto-importers
-        $PodeContext.Server.AutoImporters.Modules.Exported = @()
-        $PodeContext.Server.AutoImporters.Snapins.Exported = @()
-        $PodeContext.Server.AutoImporters.Functions.Exported = @()
+        $PodeContext.Server.AutoImport.Modules.ExportList = @()
+        $PodeContext.Server.AutoImport.Snapins.ExportList = @()
+        $PodeContext.Server.AutoImport.Functions.ExportList = @()
 
         # clear middle/endware
         $PodeContext.Server.Middleware = @()

--- a/src/Private/Server.ps1
+++ b/src/Private/Server.ps1
@@ -24,12 +24,12 @@ function Start-PodeInternalServer
 
         Invoke-PodeScriptBlock -ScriptBlock $_script -NoNewClosure
 
+        # load any modules/snapins
+        Import-PodeSnapinsIntoRunspaceState
+        Import-PodeModulesIntoRunspaceState
+
         # load any functions
         Import-PodeFunctionsIntoRunspaceState -ScriptBlock $_script
-
-        # load any modules
-        Import-PodeModulesIntoRunspaceState
-        Import-PodeSnapinsIntoRunspaceState
 
         # start the runspace pools for web, schedules, etc
         New-PodeRunspacePools

--- a/src/Private/Server.ps1
+++ b/src/Private/Server.ps1
@@ -24,6 +24,9 @@ function Start-PodeInternalServer
 
         Invoke-PodeScriptBlock -ScriptBlock $_script -NoNewClosure
 
+        # load any functions
+        Import-PodeFunctionsIntoRunspaceState -ScriptBlock $_script
+
         # load any modules
         Import-PodeModulesIntoRunspaceState
         Import-PodeSnapInsIntoRunspaceState

--- a/src/Private/ServiceServer.ps1
+++ b/src/Private/ServiceServer.ps1
@@ -23,7 +23,13 @@ function Start-PodeServiceServer
                 $handlers = Get-PodeHandler -Type Service
                 foreach ($name in $handlers.Keys) {
                     $handler = $handlers[$name]
-                    Invoke-PodeScriptBlock -ScriptBlock $handler.Logic -Arguments (@($ServiceEvent) + @($handler.Arguments)) -Scoped -Splat
+
+                    $_args = @($ServiceEvent) + @($handler.Arguments)
+                    if ($null -ne $handler.UsingVariables) {
+                        $_args = @($handler.UsingVariables.Value) + $_args
+                    }
+
+                    Invoke-PodeScriptBlock -ScriptBlock $handler.Logic -Arguments $_args -Scoped -Splat
                 }
 
                 # sleep before next run

--- a/src/Private/SmtpServer.ps1
+++ b/src/Private/SmtpServer.ps1
@@ -96,7 +96,13 @@ function Start-PodeSmtpServer
                         $handlers = Get-PodeHandler -Type Smtp
                         foreach ($name in $handlers.Keys) {
                             $handler = $handlers[$name]
-                            Invoke-PodeScriptBlock -ScriptBlock $handler.Logic -Arguments (@($TcpEvent) + @($handler.Arguments)) -Scoped -Splat
+
+                            $_args = @($TcpEvent) + @($handler.Arguments)
+                            if ($null -ne $handler.UsingVariables) {
+                                $_args = @($handler.UsingVariables.Value) + $_args
+                            }
+
+                            Invoke-PodeScriptBlock -ScriptBlock $handler.Logic -Arguments $_args -Scoped -Splat
                         }
                     }
                 }

--- a/src/Private/TcpServer.ps1
+++ b/src/Private/TcpServer.ps1
@@ -65,7 +65,13 @@ function Start-PodeTcpServer
                     $handlers = Get-PodeHandler -Type Tcp
                     foreach ($name in $handlers.Keys) {
                         $handler = $handlers[$name]
-                        Invoke-PodeScriptBlock -ScriptBlock $handler.Logic -Arguments (@($TcpEvent) + @($handler.Arguments)) -Scoped -Splat
+
+                        $_args = @($TcpEvent) + @($handler.Arguments)
+                        if ($null -ne $handler.UsingVariables) {
+                            $_args = @($handler.UsingVariables.Value) + $_args
+                        }
+
+                        Invoke-PodeScriptBlock -ScriptBlock $handler.Logic -Arguments $_args -Scoped -Splat
                     }
                 }
 

--- a/src/Private/Timers.ps1
+++ b/src/Private/Timers.ps1
@@ -61,7 +61,12 @@ function Invoke-PodeInternalTimer
 
     try {
         $_event = @{ Lockable = $PodeContext.Lockable }
+
         $_args = @($_event) + @($Timer.Arguments)
+        if ($null -ne $Timer.UsingVariables) {
+            $_args = @($Timer.UsingVariables.Value) + $_args
+        }
+
         Invoke-PodeScriptBlock -ScriptBlock $Timer.Script -Arguments $_args -Scoped -Splat
     }
     catch {

--- a/src/Public/AutoImport.ps1
+++ b/src/Public/AutoImport.ps1
@@ -1,51 +1,5 @@
 <#
 .SYNOPSIS
-Disables Pode's auto-import feature for modules.
-
-.DESCRIPTION
-Disables Pode's auto-import feature for modules into its runspaces.
-
-.EXAMPLE
-Disable-PodeModuleImport
-#>
-function Disable-PodeModuleImport
-{
-    [CmdletBinding()]
-    param()
-
-    $PodeContext.Server.AutoImporters.Modules.Enabled = $false
-}
-
-<#
-.SYNOPSIS
-Enables Pode's auto-import feature for modules.
-
-.DESCRIPTION
-Enables Pode's auto-import feature for modules, with option to only load exported modules.
-
-.PARAMETER OnlyExported
-If supplied, only modules exported via Export-PodeModule will be auto-imported.
-
-.EXAMPLE
-Enable-PodeModuleImport
-
-.EXAMPLE
-Enable-PodeModuleImport -OnlyExported
-#>
-function Enable-PodeModuleImport
-{
-    [CmdletBinding()]
-    param(
-        [switch]
-        $OnlyExported
-    )
-
-    $PodeContext.Server.AutoImporters.Modules.Enabled = $true
-    $PodeContext.Server.AutoImporters.Modules.OnlyExported = $OnlyExported
-}
-
-<#
-.SYNOPSIS
 Exports modules that can be auto-imported by Pode, and into its runspaces.
 
 .DESCRIPTION
@@ -66,50 +20,7 @@ function Export-PodeModule
         $Name
     )
 
-    $PodeContext.Server.AutoImporters.Modules.Exported += @($Name)
-}
-
-<#
-.SYNOPSIS
-Disables Pode's auto-import feature for snapins.
-
-.DESCRIPTION
-Disables Pode's auto-import feature for snapins into its runspaces.
-
-.EXAMPLE
-Disable-PodeSnapinImport
-#>
-function Disable-PodeSnapinImport
-{
-    $PodeContext.Server.AutoImporters.Snapins.Enabled = $false
-}
-
-<#
-.SYNOPSIS
-Enables Pode's auto-import feature for snapins.
-
-.DESCRIPTION
-Enables Pode's auto-import feature for snapins, with option to only load exported snapins.
-
-.PARAMETER OnlyExported
-If supplied, only snapins exported via Export-PodeSnapin will be auto-imported.
-
-.EXAMPLE
-Enable-PodeSnapinImport
-
-.EXAMPLE
-Enable-PodeSnapinImport -OnlyExported
-#>
-function Enable-PodeSnapinImport
-{
-    [CmdletBinding()]
-    param(
-        [switch]
-        $OnlyExported
-    )
-
-    $PodeContext.Server.AutoImporters.Snapins.Enabled = $true
-    $PodeContext.Server.AutoImporters.Snapins.OnlyExported = $OnlyExported
+    $PodeContext.Server.AutoImport.Modules.ExportList += @($Name)
 }
 
 <#
@@ -134,50 +45,12 @@ function Export-PodeSnapin
         $Name
     )
 
-    $PodeContext.Server.AutoImporters.Snapins.Exported += @($Name)
-}
+    # if non-windows or core, fail
+    if ((Test-IsPSCore) -or (Test-IsUnix)) {
+        throw 'Snapins are only supported on Windows PowerShell'
+    }
 
-<#
-.SYNOPSIS
-Disables Pode's auto-import feature for functions.
-
-.DESCRIPTION
-Disables Pode's auto-import feature for functions into its runspaces.
-
-.EXAMPLE
-Disable-PodeFunctionImport
-#>
-function Disable-PodeFunctionImport
-{
-    $PodeContext.Server.AutoImporters.Functions.Enabled = $false
-}
-
-<#
-.SYNOPSIS
-Enables Pode's auto-import feature for functions.
-
-.DESCRIPTION
-Enables Pode's auto-import feature for functions, with option to only load exported functions.
-
-.PARAMETER OnlyExported
-If supplied, only functions exported via Export-PodeFunction will be auto-imported.
-
-.EXAMPLE
-Enable-PodeFunctionImport
-
-.EXAMPLE
-Enable-PodeFunctionImport -OnlyExported
-#>
-function Enable-PodeFunctionImport
-{
-    [CmdletBinding()]
-    param(
-        [switch]
-        $OnlyExported
-    )
-
-    $PodeContext.Server.AutoImporters.Functions.Enabled = $true
-    $PodeContext.Server.AutoImporters.Functions.OnlyExported = $OnlyExported
+    $PodeContext.Server.AutoImport.Snapins.ExportList += @($Name)
 }
 
 <#
@@ -202,5 +75,5 @@ function Export-PodeFunction
         $Name
     )
 
-    $PodeContext.Server.AutoImporters.Functions.Exported += @($Name)
+    $PodeContext.Server.AutoImport.Functions.ExportList += @($Name)
 }

--- a/src/Public/AutoImport.ps1
+++ b/src/Public/AutoImport.ps1
@@ -1,0 +1,206 @@
+<#
+.SYNOPSIS
+Disables Pode's auto-import feature for modules.
+
+.DESCRIPTION
+Disables Pode's auto-import feature for modules into its runspaces.
+
+.EXAMPLE
+Disable-PodeModuleImport
+#>
+function Disable-PodeModuleImport
+{
+    [CmdletBinding()]
+    param()
+
+    $PodeContext.Server.AutoImporters.Modules.Enabled = $false
+}
+
+<#
+.SYNOPSIS
+Enables Pode's auto-import feature for modules.
+
+.DESCRIPTION
+Enables Pode's auto-import feature for modules, with option to only load exported modules.
+
+.PARAMETER OnlyExported
+If supplied, only modules exported via Export-PodeModule will be auto-imported.
+
+.EXAMPLE
+Enable-PodeModuleImport
+
+.EXAMPLE
+Enable-PodeModuleImport -OnlyExported
+#>
+function Enable-PodeModuleImport
+{
+    [CmdletBinding()]
+    param(
+        [switch]
+        $OnlyExported
+    )
+
+    $PodeContext.Server.AutoImporters.Modules.Enabled = $true
+    $PodeContext.Server.AutoImporters.Modules.OnlyExported = $OnlyExported
+}
+
+<#
+.SYNOPSIS
+Exports modules that can be auto-imported by Pode, and into its runspaces.
+
+.DESCRIPTION
+Exports modules that can be auto-imported by Pode, and into its runspaces.
+
+.PARAMETER Name
+The Name(s) of modules to export.
+
+.EXAMPLE
+Export-PodeModule -Name Mod1, Mod2
+#>
+function Export-PodeModule
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [string[]]
+        $Name
+    )
+
+    $PodeContext.Server.AutoImporters.Modules.Exported += @($Name)
+}
+
+<#
+.SYNOPSIS
+Disables Pode's auto-import feature for snapins.
+
+.DESCRIPTION
+Disables Pode's auto-import feature for snapins into its runspaces.
+
+.EXAMPLE
+Disable-PodeSnapinImport
+#>
+function Disable-PodeSnapinImport
+{
+    $PodeContext.Server.AutoImporters.Snapins.Enabled = $false
+}
+
+<#
+.SYNOPSIS
+Enables Pode's auto-import feature for snapins.
+
+.DESCRIPTION
+Enables Pode's auto-import feature for snapins, with option to only load exported snapins.
+
+.PARAMETER OnlyExported
+If supplied, only snapins exported via Export-PodeSnapin will be auto-imported.
+
+.EXAMPLE
+Enable-PodeSnapinImport
+
+.EXAMPLE
+Enable-PodeSnapinImport -OnlyExported
+#>
+function Enable-PodeSnapinImport
+{
+    [CmdletBinding()]
+    param(
+        [switch]
+        $OnlyExported
+    )
+
+    $PodeContext.Server.AutoImporters.Snapins.Enabled = $true
+    $PodeContext.Server.AutoImporters.Snapins.OnlyExported = $OnlyExported
+}
+
+<#
+.SYNOPSIS
+Exports snapins that can be auto-imported by Pode, and into its runspaces.
+
+.DESCRIPTION
+Exports snapins that can be auto-imported by Pode, and into its runspaces.
+
+.PARAMETER Name
+The Name(s) of snapins to export.
+
+.EXAMPLE
+Export-PodeSnapin -Name Mod1, Mod2
+#>
+function Export-PodeSnapin
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [string[]]
+        $Name
+    )
+
+    $PodeContext.Server.AutoImporters.Snapins.Exported += @($Name)
+}
+
+<#
+.SYNOPSIS
+Disables Pode's auto-import feature for functions.
+
+.DESCRIPTION
+Disables Pode's auto-import feature for functions into its runspaces.
+
+.EXAMPLE
+Disable-PodeFunctionImport
+#>
+function Disable-PodeFunctionImport
+{
+    $PodeContext.Server.AutoImporters.Functions.Enabled = $false
+}
+
+<#
+.SYNOPSIS
+Enables Pode's auto-import feature for functions.
+
+.DESCRIPTION
+Enables Pode's auto-import feature for functions, with option to only load exported functions.
+
+.PARAMETER OnlyExported
+If supplied, only functions exported via Export-PodeFunction will be auto-imported.
+
+.EXAMPLE
+Enable-PodeFunctionImport
+
+.EXAMPLE
+Enable-PodeFunctionImport -OnlyExported
+#>
+function Enable-PodeFunctionImport
+{
+    [CmdletBinding()]
+    param(
+        [switch]
+        $OnlyExported
+    )
+
+    $PodeContext.Server.AutoImporters.Functions.Enabled = $true
+    $PodeContext.Server.AutoImporters.Functions.OnlyExported = $OnlyExported
+}
+
+<#
+.SYNOPSIS
+Exports functions that can be auto-imported by Pode, and into its runspaces.
+
+.DESCRIPTION
+Exports functions that can be auto-imported by Pode, and into its runspaces.
+
+.PARAMETER Name
+The Name(s) of functions to export.
+
+.EXAMPLE
+Export-PodeFunction -Name Mod1, Mod2
+#>
+function Export-PodeFunction
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [string[]]
+        $Name
+    )
+
+    $PodeContext.Server.AutoImporters.Functions.Exported += @($Name)
+}

--- a/src/Public/Core.ps1
+++ b/src/Public/Core.ps1
@@ -1251,19 +1251,23 @@ function Edit-PodeTimer
         throw "Timer '$($Name)' does not exist"
     }
 
+    $_timer = $PodeContext.Timers[$Name]
+
     # edit interval if supplied
     if ($Interval -gt 0) {
-        $PodeContext.Timers[$Name].Interval = $Interval
+        $_timer.Interval = $Interval
     }
 
     # edit scriptblock if supplied
     if (!(Test-IsEmpty $ScriptBlock)) {
-        $PodeContext.Timers[$Name].Script = $ScriptBlock
+        $ScriptBlock, $usingVars = Invoke-PodeUsingScriptConversion -ScriptBlock $ScriptBlock -PSSession $PSCmdlet.SessionState
+        $_timer.Script = $ScriptBlock
+        $_timer.UsingVariables = $usingVars
     }
 
     # edit arguments if supplied
     if (!(Test-IsEmpty $ArgumentList)) {
-        $PodeContext.Timers[$Name].Arguments = $ArgumentList
+        $_timer.Arguments = $ArgumentList
     }
 }
 
@@ -1628,7 +1632,9 @@ function Edit-PodeSchedule
 
     # edit scriptblock if supplied
     if (!(Test-IsEmpty $ScriptBlock)) {
+        $ScriptBlock, $usingVars = Invoke-PodeUsingScriptConversion -ScriptBlock $ScriptBlock -PSSession $PSCmdlet.SessionState
         $_schedule.Script = $ScriptBlock
+        $_schedule.UsingVariables = $usingVars
     }
 
     # edit arguments if supplied

--- a/src/Public/Core.ps1
+++ b/src/Public/Core.ps1
@@ -1104,6 +1104,9 @@ function Add-PodeTimer
         $ScriptBlock = Convert-PodeFileToScriptBlock -FilePath $FilePath
     }
 
+    # check if the scriptblock has any using vars
+    $ScriptBlock, $usingVars = Invoke-PodeUsingScriptConversion -ScriptBlock $ScriptBlock -PSSession $PSCmdlet.SessionState
+
     # calculate the next tick time (based on Skip)
     $NextTriggerTime = [DateTime]::Now.AddSeconds($Interval)
     if ($Skip -gt 1) {
@@ -1119,6 +1122,7 @@ function Add-PodeTimer
         Skip = $Skip
         NextTriggerTime = $NextTriggerTime
         Script = $ScriptBlock
+        UsingVariables = $usingVars
         Arguments = $ArgumentList
         OnStart = $OnStart
         Completed = $false
@@ -1420,6 +1424,9 @@ function Add-PodeSchedule
         $ScriptBlock = Convert-PodeFileToScriptBlock -FilePath $FilePath
     }
 
+    # check if the scriptblock has any using vars
+    $ScriptBlock, $usingVars = Invoke-PodeUsingScriptConversion -ScriptBlock $ScriptBlock -PSSession $PSCmdlet.SessionState
+
     # add the schedule
     $parsedCrons = ConvertFrom-PodeCronExpressions -Expressions @($Cron)
     $nextTrigger = Get-PodeCronNextEarliestTrigger -Expressions $parsedCrons -StartTime $StartTime -EndTime $EndTime
@@ -1434,6 +1441,7 @@ function Add-PodeSchedule
         Count = 0
         NextTriggerTime = $nextTrigger
         Script = $ScriptBlock
+        UsingVariables = $usingVars
         Arguments = (Protect-PodeValue -Value $ArgumentList -Default @{})
         OnStart = $OnStart
         Completed = ($null -eq $nextTrigger)

--- a/src/Public/Handlers.ps1
+++ b/src/Public/Handlers.ps1
@@ -78,9 +78,13 @@ function Add-PodeHandler
         $ScriptBlock = [scriptblock](Use-PodeScript -Path $FilePath)
     }
 
+    # check if the scriptblock has any using vars
+    $ScriptBlock, $usingVars = Invoke-PodeUsingScriptConversion -ScriptBlock $ScriptBlock -PSSession $PSCmdlet.SessionState
+
     # add the handler
     $PodeContext.Server.Handlers[$Type][$Name] += @(@{
         Logic = $ScriptBlock
+        UsingVariables = $usingVars
         Arguments = $ArgumentList
     })
 }

--- a/src/Public/Logging.ps1
+++ b/src/Public/Logging.ps1
@@ -157,8 +157,11 @@ function New-PodeLoggingMethod
         }
 
         'custom' {
+            $ScriptBlock, $usingVars = Invoke-PodeUsingScriptConversion -ScriptBlock $ScriptBlock -PSSession $PSCmdlet.SessionState
+
             return @{
                 ScriptBlock = $ScriptBlock
+                UsingVariables = $usingVars
                 Batch = $batchInfo
                 Arguments = $ArgumentList
             }
@@ -375,10 +378,14 @@ function Add-PodeLogger
         throw "The supplied output Method for the '$($Name)' Logging method requires a valid ScriptBlock"
     }
 
+    # check if the scriptblock has any using vars
+    $ScriptBlock, $usingVars = Invoke-PodeUsingScriptConversion -ScriptBlock $ScriptBlock -PSSession $PSCmdlet.SessionState
+
     # add logging method to server
     $PodeContext.Server.Logging.Types[$Name] = @{
         Method = $Method
         ScriptBlock = $ScriptBlock
+        UsingVariables = $usingVars
         Arguments = $ArgumentList
     }
 }

--- a/src/Public/Middleware.ps1
+++ b/src/Public/Middleware.ps1
@@ -619,7 +619,13 @@ function Add-PodeBodyParser
         throw "There is already a body parser defined for the $($ContentType) content-type"
     }
 
-    $PodeContext.Server.BodyParsers[$ContentType] = $ScriptBlock
+    # check if the scriptblock has any using vars
+    $ScriptBlock, $usingVars = Invoke-PodeUsingScriptConversion -ScriptBlock $ScriptBlock -PSSession $PSCmdlet.SessionState
+
+    $PodeContext.Server.BodyParsers[$ContentType] = @{
+        ScriptBlock = $ScriptBlock
+        UsingVariables = $usingVars
+    }
 }
 
 <#

--- a/src/Public/Responses.ps1
+++ b/src/Public/Responses.ps1
@@ -1217,10 +1217,16 @@ function Set-PodeViewEngine
         $Extension = $Type.ToLowerInvariant()
     }
 
+    # check if the scriptblock has any using vars
+    if ($null -ne $ScriptBlock) {
+        $ScriptBlock, $usingVars = Invoke-PodeUsingScriptConversion -ScriptBlock $ScriptBlock -PSSession $PSCmdlet.SessionState
+    }
+
     # setup view engine config
     $PodeContext.Server.ViewEngine.Type = $Type.ToLowerInvariant()
     $PodeContext.Server.ViewEngine.Extension = $Extension
-    $PodeContext.Server.ViewEngine.Script = $ScriptBlock
+    $PodeContext.Server.ViewEngine.ScriptBlock = $ScriptBlock
+    $PodeContext.Server.ViewEngine.UsingVariables = $usingVars
     $PodeContext.Server.ViewEngine.IsDynamic = (@('html', 'md') -inotcontains $Type)
 }
 

--- a/src/Public/Routes.ps1
+++ b/src/Public/Routes.ps1
@@ -159,7 +159,7 @@ function Add-PodeRoute
     $ScriptBlock, $usingVars = Invoke-PodeUsingScriptConversion -ScriptBlock $ScriptBlock -PSSession $PSCmdlet.SessionState
 
     # convert any middleware into valid hashtables
-    $Middleware = @(ConvertTo-PodeRouteMiddleware -Method $Method -Path $Path -Middleware $Middleware)
+    $Middleware = @(ConvertTo-PodeRouteMiddleware -Method $Method -Path $Path -Middleware $Middleware -PSSession $PSCmdlet.SessionState)
 
     # if an auth name was supplied, setup the auth as the first middleware
     if (![string]::IsNullOrWhiteSpace($Authentication)) {
@@ -368,7 +368,7 @@ function Add-PodeStaticRoute
     }
 
     # convert any middleware into valid hashtables
-    $Middleware = @(ConvertTo-PodeRouteMiddleware -Method $Method -Path $Path -Middleware $Middleware)
+    $Middleware = @(ConvertTo-PodeRouteMiddleware -Method $Method -Path $Path -Middleware $Middleware -PSSession $PSCmdlet.SessionState)
 
     # if an auth name was supplied, setup the auth as the first middleware
     if (![string]::IsNullOrWhiteSpace($Authentication)) {

--- a/src/Public/Routes.ps1
+++ b/src/Public/Routes.ps1
@@ -155,6 +155,9 @@ function Add-PodeRoute
         $ScriptBlock = Convert-PodeFileToScriptBlock -FilePath $FilePath
     }
 
+    # check if the scriptblock has any using vars
+    $ScriptBlock, $usingVars = Invoke-PodeUsingScriptConversion -ScriptBlock $ScriptBlock -PSSession $PSCmdlet.SessionState
+
     # convert any middleware into valid hashtables
     $Middleware = @(ConvertTo-PodeRouteMiddleware -Method $Method -Path $Path -Middleware $Middleware)
 
@@ -184,6 +187,7 @@ function Add-PodeRoute
     $newRoutes = @(foreach ($_endpoint in $endpoints) {
         @{
             Logic = $ScriptBlock
+            UsingVariables = $usingVars
             Middleware = $Middleware
             Authentication = $Authentication
             Endpoint = @{

--- a/src/Public/Routes.ps1
+++ b/src/Public/Routes.ps1
@@ -684,7 +684,7 @@ function ConvertTo-PodeRoute
 
     # if a module was supplied, import it - then validate the commands
     if (![string]::IsNullOrWhiteSpace($Module)) {
-        Import-PodeModule -Name $Module -Now
+        Import-PodeModule -Name $Module
 
         Write-Verbose "Getting exported commands from module"
         $ModuleCommands = (Get-Module -Name $Module | Sort-Object -Descending | Select-Object -First 1).ExportedCommands.Keys

--- a/src/Public/Utilities.ps1
+++ b/src/Public/Utilities.ps1
@@ -389,9 +389,13 @@ function Add-PodeEndware
         $ArgumentList
     )
 
+    # check if the scriptblock has any using vars
+    $ScriptBlock, $usingVars = Invoke-PodeUsingScriptConversion -ScriptBlock $ScriptBlock -PSSession $PSCmdlet.SessionState
+
     # add the scriptblock to array of endware that needs to be run
     $PodeContext.Server.Endware += @{
         Logic = $ScriptBlock
+        UsingVariables = $usingVars
         Arguments = $ArgumentList
     }
 }

--- a/src/Public/Utilities.ps1
+++ b/src/Public/Utilities.ps1
@@ -482,9 +482,6 @@ Imports a SnapIn into the current, and all runspaces that Pode uses.
 .PARAMETER Name
 The name of a SnapIn to import.
 
-.PARAMETER Now
-Import the SnapIn now, into the current runspace.
-
 .EXAMPLE
 Import-PodeSnapIn -Name 'WDeploySnapin3.0'
 #>
@@ -494,10 +491,7 @@ function Import-PodeSnapIn
     param (
         [Parameter(Mandatory=$true)]
         [string]
-        $Name,
-
-        [switch]
-        $Now
+        $Name
     )
 
     # if non-windows or core, fail
@@ -505,14 +499,8 @@ function Import-PodeSnapIn
         throw 'SnapIns are only supported on Windows PowerShell'
     }
 
-    # import the snap-in into the runspace state
-    $exp = $null
-    $PodeContext.RunspaceState.ImportPSSnapIn($Name, ([ref]$exp))
-
-    # import the snap-in now, if specified
-    if ($Now) {
-        Add-PSSnapin -Name $Name | Out-Null
-    }
+    # import the snap-in
+    Add-PSSnapin -Name $Name | Out-Null
 }
 
 <#

--- a/src/Public/Utilities.ps1
+++ b/src/Public/Utilities.ps1
@@ -481,18 +481,18 @@ function Import-PodeModule
 
 <#
 .SYNOPSIS
-Imports a SnapIn into the current, and all runspaces that Pode uses.
+Imports a Snapin into the current, and all runspaces that Pode uses.
 
 .DESCRIPTION
-Imports a SnapIn into the current, and all runspaces that Pode uses.
+Imports a Snapin into the current, and all runspaces that Pode uses.
 
 .PARAMETER Name
-The name of a SnapIn to import.
+The name of a Snapin to import.
 
 .EXAMPLE
-Import-PodeSnapIn -Name 'WDeploySnapin3.0'
+Import-PodeSnapin -Name 'WDeploySnapin3.0'
 #>
-function Import-PodeSnapIn
+function Import-PodeSnapin
 {
     [CmdletBinding()]
     param (
@@ -503,7 +503,7 @@ function Import-PodeSnapIn
 
     # if non-windows or core, fail
     if ((Test-IsPSCore) -or (Test-IsUnix)) {
-        throw 'SnapIns are only supported on Windows PowerShell'
+        throw 'Snapins are only supported on Windows PowerShell'
     }
 
     # import the snap-in

--- a/src/Public/Utilities.ps1
+++ b/src/Public/Utilities.ps1
@@ -339,6 +339,9 @@ function Use-PodeScript
 
     # dot-source the script
     . $_path
+
+    # load any functions from the file into pode's runspaces
+    Import-PodeFunctionsIntoRunspaceState -FilePath $_path
 }
 
 <#

--- a/tests/unit/Context.Tests.ps1
+++ b/tests/unit/Context.Tests.ps1
@@ -408,16 +408,12 @@ Describe 'Import-PodeModule' {
 
     Context 'Valid parameters supplied' {
         Mock Resolve-Path { return @{ 'Path' = 'c:/some/file.txt' } }
+        Mock Import-Module { }
         Mock Test-PodePath { return $true }
 
         It 'Returns null for no shared state in context' {
-            $PodeContext = @{ 'RunspaceState' = [initialsessionstate]::CreateDefault() }
-
             Import-PodeModule -Path 'file.txt'
-
-            $modules = @($PodeContext.RunspaceState.Modules)
-            $modules.Length | Should Be 1
-            $modules[0].Name | Should Be 'c:/some/file.txt'
+            Assert-MockCalled Import-Module -Times 1 -Scope It
         }
     }
 }

--- a/tests/unit/Routes.Tests.ps1
+++ b/tests/unit/Routes.Tests.ps1
@@ -1260,25 +1260,27 @@ Describe 'Find-PodeRouteContentType' {
 }
 
 Describe 'ConvertTo-PodeRouteMiddleware' {
+    $_PSSession = @{}
+
     It 'Returns no middleware' {
-        @(ConvertTo-PodeRouteMiddleware -Method Get -Path '/users') | Should Be $null
+        @(ConvertTo-PodeRouteMiddleware -Method Get -Path '/users' -PSSession $_PSSession) | Should Be $null
     }
 
     It 'Errors for invalid middleware type' {
-        { ConvertTo-PodeRouteMiddleware -Method Get -Path '/users' -Middleware 'string' } | Should Throw 'invalid type'
+        { ConvertTo-PodeRouteMiddleware -Method Get -Path '/users' -Middleware 'string' -PSSession $_PSSession } | Should Throw 'invalid type'
     }
 
     It 'Errors for invalid middleware hashtable - no logic' {
-        { ConvertTo-PodeRouteMiddleware -Method Get -Path '/users' -Middleware @{} } | Should Throw 'no logic defined'
+        { ConvertTo-PodeRouteMiddleware -Method Get -Path '/users' -Middleware @{} -PSSession $_PSSession } | Should Throw 'no logic defined'
     }
 
     It 'Errors for invalid middleware hashtable - logic not scriptblock' {
-        { ConvertTo-PodeRouteMiddleware -Method Get -Path '/users' -Middleware @{ Logic = 'string' } } | Should Throw 'invalid logic type'
+        { ConvertTo-PodeRouteMiddleware -Method Get -Path '/users' -Middleware @{ Logic = 'string' } -PSSession $_PSSession } | Should Throw 'invalid logic type'
     }
 
     It 'Returns hashtable for single hashtable middleware' {
         $middleware = @{ Logic = { Write-Host 'Hello' } }
-        $converted = @(ConvertTo-PodeRouteMiddleware -Method Get -Path '/users' -Middleware $middleware)
+        $converted = @(ConvertTo-PodeRouteMiddleware -Method Get -Path '/users' -Middleware $middleware -PSSession $_PSSession)
         $converted.Length | Should Be 1
         $converted[0].Logic.ToString() | Should Be ($middleware.Logic.ToString())
     }
@@ -1287,7 +1289,7 @@ Describe 'ConvertTo-PodeRouteMiddleware' {
         $middleware1 = @{ Logic = { Write-Host 'Hello1' } }
         $middleware2 = @{ Logic = { Write-Host 'Hello2' } }
 
-        $converted = @(ConvertTo-PodeRouteMiddleware -Method Get -Path '/users' -Middleware @($middleware1, $middleware2))
+        $converted = @(ConvertTo-PodeRouteMiddleware -Method Get -Path '/users' -Middleware @($middleware1, $middleware2) -PSSession $_PSSession)
 
         $converted.Length | Should Be 2
         $converted[0].Logic.ToString() | Should Be ($middleware1.Logic.ToString())
@@ -1296,7 +1298,7 @@ Describe 'ConvertTo-PodeRouteMiddleware' {
 
     It 'Converts single scriptblock middleware to hashtable' {
         $middleware = { Write-Host 'Hello' }
-        $converted = @(ConvertTo-PodeRouteMiddleware -Method Get -Path '/users' -Middleware $middleware)
+        $converted = @(ConvertTo-PodeRouteMiddleware -Method Get -Path '/users' -Middleware $middleware -PSSession $_PSSession)
         $converted.Length | Should Be 1
         $converted[0].Logic.ToString() | Should Be ($middleware.ToString())
     }
@@ -1305,7 +1307,7 @@ Describe 'ConvertTo-PodeRouteMiddleware' {
         $middleware1 = { Write-Host 'Hello1' }
         $middleware2 = { Write-Host 'Hello2' }
 
-        $converted = @(ConvertTo-PodeRouteMiddleware -Method Get -Path '/users' -Middleware @($middleware1, $middleware2))
+        $converted = @(ConvertTo-PodeRouteMiddleware -Method Get -Path '/users' -Middleware @($middleware1, $middleware2) -PSSession $_PSSession)
 
         $converted.Length | Should Be 2
         $converted[0].Logic.ToString() | Should Be ($middleware1.ToString())
@@ -1316,7 +1318,7 @@ Describe 'ConvertTo-PodeRouteMiddleware' {
         $middleware1 = @{ Logic = { Write-Host 'Hello1' } }
         $middleware2 = { Write-Host 'Hello2' }
 
-        $converted = @(ConvertTo-PodeRouteMiddleware -Method Get -Path '/users' -Middleware @($middleware1, $middleware2))
+        $converted = @(ConvertTo-PodeRouteMiddleware -Method Get -Path '/users' -Middleware @($middleware1, $middleware2) -PSSession $_PSSession)
 
         $converted.Length | Should Be 2
         $converted[0].Logic.ToString() | Should Be ($middleware1.Logic.ToString())

--- a/tests/unit/Server.Tests.ps1
+++ b/tests/unit/Server.Tests.ps1
@@ -23,7 +23,7 @@ Describe 'Start-PodeInternalServer' {
     Mock Start-PodeWebServer { }
     Mock Start-PodeServiceServer { }
     Mock Import-PodeModulesIntoRunspaceState { }
-    Mock Import-PodeSnapInsIntoRunspaceState { }
+    Mock Import-PodeSnapinsIntoRunspaceState { }
     Mock Import-PodeFunctionsIntoRunspaceState { }
 
     It 'Calls one-off script logic' {
@@ -151,6 +151,11 @@ Describe 'Restart-PodeInternalServer' {
                 }
                 OpenAPI = @{}
                 BodyParsers = @{}
+                AutoImporters = @{
+                    Modules = @{ Exported = @() }
+                    Snapins = @{ Exported = @() }
+                    Functions = @{ Exported = @() }
+                }
             };
             Metrics = @{
                 Server = @{

--- a/tests/unit/Server.Tests.ps1
+++ b/tests/unit/Server.Tests.ps1
@@ -22,6 +22,7 @@ Describe 'Start-PodeInternalServer' {
     Mock Start-PodeTcpServer { }
     Mock Start-PodeWebServer { }
     Mock Start-PodeServiceServer { }
+    Mock Import-PodeModulesIntoRunspaceState { }
 
     It 'Calls one-off script logic' {
         $PodeContext.Server = @{ Type = ([string]::Empty); Logic = {} }

--- a/tests/unit/Server.Tests.ps1
+++ b/tests/unit/Server.Tests.ps1
@@ -177,7 +177,8 @@ Describe 'Restart-PodeInternalServer' {
 
         $PodeContext.Server.ViewEngine.Type | Should Be 'html'
         $PodeContext.Server.ViewEngine.Extension | Should Be 'html'
-        $PodeContext.Server.ViewEngine.Script | Should Be $null
+        $PodeContext.Server.ViewEngine.ScriptBlock | Should Be $null
+        $PodeContext.Server.ViewEngine.UsingVariables | Should Be $null
         $PodeContext.Server.ViewEngine.IsDynamic | Should Be $false
 
         $PodeContext.Metrics.Server.RestartCount | Should Be 1

--- a/tests/unit/Server.Tests.ps1
+++ b/tests/unit/Server.Tests.ps1
@@ -151,7 +151,7 @@ Describe 'Restart-PodeInternalServer' {
                 }
                 OpenAPI = @{}
                 BodyParsers = @{}
-                AutoImporters = @{
+                AutoImport = @{
                     Modules = @{ Exported = @() }
                     Snapins = @{ Exported = @() }
                     Functions = @{ Exported = @() }

--- a/tests/unit/Server.Tests.ps1
+++ b/tests/unit/Server.Tests.ps1
@@ -23,6 +23,8 @@ Describe 'Start-PodeInternalServer' {
     Mock Start-PodeWebServer { }
     Mock Start-PodeServiceServer { }
     Mock Import-PodeModulesIntoRunspaceState { }
+    Mock Import-PodeSnapInsIntoRunspaceState { }
+    Mock Import-PodeFunctionsIntoRunspaceState { }
 
     It 'Calls one-off script logic' {
         $PodeContext.Server = @{ Type = ([string]::Empty); Logic = {} }


### PR DESCRIPTION
### Description of the Change
This is a big change to make scoping in Pode simpler:

* Modules and Snapins can now be imported just by using the `Import-Module` and `Add-PSSnapin` functions
* Local functions are auto-imported into Pode's runspaces
* Local variables can now be referenced in routes/etc via the `$using:` syntax

There is also added config to disable the auto-importing of modules, snapins, and functions. Plus, there's the option to allow the auto-import, but to only import "exported" ones via `Export-PodeModule`, `Export-PodeSnapin`, and `Export-PodeFunction`

### Related Issue
Resolves #577 

### Examples
#### Modules/Snapins
```powershell
Import-Module -Name Pester
Import-PodeModule -Name Az

Start-PodeServer {
    Add-PodeRoute -Method Get -Path '/az' -ScriptBlock {
        # call some function in Az
    }

    Add-PodeRoute -Method Get -Path '/pester' -ScriptBlock {
        # call some function in Pester
    }
}
```
(Snapins are basically the same, just using `Add-PSSnapin` instead)

#### Functions
```powershell
function Write-HelloResponse
{
    Write-PodeJsonResponse -Value @{ Message = 'Hello!' }
}

Start-PodeServer -ScriptBlock {
    function Write-ByeResponse
    {
        Write-PodeJsonResponse -Value @{ Message = 'Bye!' }
    }

    Add-PodeEndpoint -Address localhost -Port 9000 -Protocol Http

    Add-PodeRoute -Method Get -Path '/hello' -ScriptBlock {
        Write-HelloResponse
    }

    Add-PodeRoute -Method Get -Path '/bye' -ScriptBlock {
        Write-ByeResponse
    }
}
```

#### Variables
```powershell
$outer_msg = 'Hello, there'

Start-PodeServer -ScriptBlock {
    $inner_msg = 'General Kenobi'

    Add-PodeRoute -Method Get -Path '/random' -ScriptBlock {
        Write-PodeJsonResponse -Value @{ Message = "$($using:outer_msg) ... $($using:inner_msg)" }
    }
}
```