### PR TITLE
Adds support for client-to-server websockets

### DIFF
--- a/examples/public/scripts/websockets.js
+++ b/examples/public/scripts/websockets.js
@@ -9,10 +9,10 @@ $(document).ready(() => {
         $('#messages').append(`<p>${evt.data}</p>`);
     }
 
-    // send message on the socket
+    // send message on the socket, to all clients
     $('#bc-form').submit(function(e) {
         e.preventDefault();
         ws.send(JSON.stringify({ message: $('#bc-message').val() }));
-        $('input[name=message]').val('')
+        $('input[name=message]').val('');
     })
 })

--- a/examples/public/scripts/websockets.js
+++ b/examples/public/scripts/websockets.js
@@ -1,17 +1,4 @@
 $(document).ready(() => {
-    // bind submit on the form to send message to the server
-    $('#bc-form').submit(function(e) {
-        e.preventDefault();
-
-        $.ajax({
-            url: '/broadcast',
-            type: 'post',
-            data: $('#bc-form').serialize()
-        })
-
-        $('input[name=message]').val('')
-    })
-
     // create the websocket
     var ws = new WebSocket("ws://localhost:8091/");
 
@@ -20,4 +7,11 @@ $(document).ready(() => {
         var data = JSON.parse(evt.data)
         $('#messages').append(`<p>${data.Message}</p>`);
     }
+
+    // send message on the socket
+    $('#bc-form').submit(function(e) {
+        e.preventDefault();
+        ws.send($('#bc-message').val());
+        $('input[name=message]').val('')
+    })
 })

--- a/examples/public/scripts/websockets.js
+++ b/examples/public/scripts/websockets.js
@@ -4,14 +4,15 @@ $(document).ready(() => {
 
     // event for inbound messages to append them
     ws.onmessage = function(evt) {
-        var data = JSON.parse(evt.data)
-        $('#messages').append(`<p>${data.Message}</p>`);
+        //var data = JSON.parse(evt.data)
+        console.log(evt.data);
+        $('#messages').append(`<p>${evt.data}</p>`);
     }
 
     // send message on the socket
     $('#bc-form').submit(function(e) {
         e.preventDefault();
-        ws.send($('#bc-message').val());
+        ws.send(JSON.stringify({ message: $('#bc-message').val() }));
         $('input[name=message]').val('')
     })
 })

--- a/examples/views/websockets.html
+++ b/examples/views/websockets.html
@@ -9,7 +9,7 @@
         <h1>Example of using a WebSockets</h1>
         <p>Clicking submit will broadcast the message to all connected clients - try opening this page on multiple, and different, browsers!</p>
         <form id='bc-form'>
-            <input type='text' name='message' placeholder='Enter any random text' />
+            <input type='text' name='message' id='bc-message' placeholder='Enter any random text' />
             <input type='submit' value='Broadcast!' />
         </form>
 

--- a/examples/web-signal.ps1
+++ b/examples/web-signal.ps1
@@ -23,10 +23,4 @@ Start-PodeServer -Threads 5 {
     Add-PodeRoute -Method Get -Path '/' -ScriptBlock {
         Write-PodeViewResponse -Path 'websockets'
     }
-
-    # POST broadcast a received message back out to ever connected client via websockets
-    Add-PodeRoute -Method Post -Path '/broadcast' -ScriptBlock {
-        param($e)
-        Send-PodeSignal -Value @{ Message = $e.Data['message'] }
-    }
 }

--- a/src/Listener/PodeClientSignal.cs
+++ b/src/Listener/PodeClientSignal.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace Pode
+{
+    public class PodeClientSignal
+    {
+        public PodeWebSocket WebSocket { get; private set; }
+        public string Message { get; private set; }
+        public DateTime Timestamp { get; private set; }
+
+        public PodeClientSignal(PodeWebSocket webSocket, string message)
+        {
+            WebSocket = webSocket;
+            Message = message;
+            Timestamp = DateTime.UtcNow;
+        }
+    }
+}

--- a/src/Listener/PodeListener.cs
+++ b/src/Listener/PodeListener.cs
@@ -16,7 +16,8 @@ namespace Pode
 
         private IList<PodeSocket> Sockets;
         private BlockingCollection<PodeContext> Contexts;
-        private BlockingCollection<PodeSignal> Signals;
+        private BlockingCollection<PodeServerSignal> ServerSignals;
+        private BlockingCollection<PodeClientSignal> ClientSignals;
 
         public PodeListener(CancellationToken cancellationToken, PodeListenerType type = PodeListenerType.Http)
         {
@@ -26,7 +27,8 @@ namespace Pode
             Sockets = new List<PodeSocket>();
             WebSockets = new Dictionary<string, PodeWebSocket>();
             Contexts = new BlockingCollection<PodeContext>();
-            Signals = new BlockingCollection<PodeSignal>();
+            ServerSignals = new BlockingCollection<PodeServerSignal>();
+            ClientSignals = new BlockingCollection<PodeClientSignal>();
         }
 
         public void Add(PodeSocket socket)
@@ -68,21 +70,39 @@ namespace Pode
             }
         }
 
-        public PodeSignal GetSignal(CancellationToken cancellationToken)
+        public PodeServerSignal GetServerSignal(CancellationToken cancellationToken)
         {
-            return Signals.Take(cancellationToken);
+            return ServerSignals.Take(cancellationToken);
         }
 
-        public Task<PodeSignal> GetSignalAsync(CancellationToken cancellationToken)
+        public Task<PodeServerSignal> GetServerSignalAsync(CancellationToken cancellationToken)
         {
-            return Task.Factory.StartNew(() => GetSignal(cancellationToken), cancellationToken);
+            return Task.Factory.StartNew(() => GetServerSignal(cancellationToken), cancellationToken);
         }
 
-        public void AddSignal(string value, string path, string clientId)
+        public void AddServerSignal(string value, string path, string clientId)
         {
-            lock (Signals)
+            lock (ServerSignals)
             {
-                Signals.Add(new PodeSignal(value, path, clientId));
+                ServerSignals.Add(new PodeServerSignal(value, path, clientId));
+            }
+        }
+
+        public PodeClientSignal GetClientSignal(CancellationToken cancellationToken)
+        {
+            return ClientSignals.Take(cancellationToken);
+        }
+
+        public Task<PodeClientSignal> GetClientSignalAsync(CancellationToken cancellationToken)
+        {
+            return Task.Factory.StartNew(() => GetClientSignal(cancellationToken), cancellationToken);
+        }
+
+        public void AddClientSignal(PodeClientSignal signal)
+        {
+            lock (ClientSignals)
+            {
+                ClientSignals.Add(signal);
             }
         }
 

--- a/src/Listener/PodeRequest.cs
+++ b/src/Listener/PodeRequest.cs
@@ -31,6 +31,17 @@ namespace Pode
             RemoteEndPoint = socket.RemoteEndPoint;
         }
 
+        public PodeRequest(PodeRequest request)
+        {
+            IsSsl = request.IsSsl;
+            InputStream = request.InputStream;
+            IsKeepAlive = request.IsKeepAlive;
+            Socket = request.Socket;
+            RemoteEndPoint = Socket.RemoteEndPoint;
+            Error = request.Error;
+            Context = request.Context;
+        }
+
         public void Open(X509Certificate certificate, SslProtocols protocols)
         {
             // ssl or not?
@@ -97,7 +108,7 @@ namespace Pode
             Context = context;
         }
 
-        public void Dispose()
+        public virtual void Dispose()
         {
             if (Socket != default(Socket))
             {

--- a/src/Listener/PodeResponse.cs
+++ b/src/Listener/PodeResponse.cs
@@ -105,7 +105,7 @@ namespace Pode
             }
         }
 
-        public void SendSignal(PodeSignal signal)
+        public void SendSignal(PodeServerSignal signal)
         {
             Write(signal.Value);
         }

--- a/src/Listener/PodeResponse.cs
+++ b/src/Listener/PodeResponse.cs
@@ -112,17 +112,23 @@ namespace Pode
 
         public void Write(string message, bool flush = false)
         {
-            var msgBytes = Encoding.GetBytes(message);
-
             // simple messages
             if (!Context.IsWebSocket)
             {
-                Write(msgBytes, flush);
-                return;
+                Write(Encoding.GetBytes(message), flush);
             }
 
             // web socket message
-            var buffer = new List<byte>() { (byte)((byte)0x80 | (byte)1) };
+            else
+            {
+                WriteFrame(message, PodeWsOpCode.Text, flush);
+            }
+        }
+
+        public void WriteFrame(string message, PodeWsOpCode opCode = PodeWsOpCode.Text, bool flush = false)
+        {
+            var msgBytes = Encoding.GetBytes(message);
+            var buffer = new List<byte>() { (byte)((byte)0x80 | (byte)opCode) };
 
             if (msgBytes.Length < 126)
             {

--- a/src/Listener/PodeServerSignal.cs
+++ b/src/Listener/PodeServerSignal.cs
@@ -2,14 +2,14 @@ using System;
 
 namespace Pode
 {
-    public class PodeSignal
+    public class PodeServerSignal
     {
         public string Value { get; private set; }
         public string Path { get; private set; }
         public string ClientId { get; private set; }
         public DateTime Timestamp { get; private set; }
 
-        public PodeSignal(string value, string path, string clientId)
+        public PodeServerSignal(string value, string path, string clientId)
         {
             Value = value;
             Path = path;

--- a/src/Listener/PodeSocket.cs
+++ b/src/Listener/PodeSocket.cs
@@ -214,11 +214,12 @@ namespace Pode
                     process = false;
                 }
 
-                // if it's a websocket, upgrade it
-                else if (context.IsWebSocket)
+                // if it's a websocket, upgrade it, then add context back for re-receiving
+                else if (context.IsWebSocket && !context.IsWebSocketUpgraded)
                 {
                     context.UpgradeWebSocket();
                     process = false;
+                    context.Dispose();
                 }
 
                 // if it's an email, re-receive unless processable
@@ -234,7 +235,15 @@ namespace Pode
                 // add the context for processing
                 if (process)
                 {
-                    Listener.AddContext(context);
+                    if (context.IsWebSocket)
+                    {
+                        Listener.AddClientSignal(context.HttpRequest.NewClientSignal());
+                        context.Dispose();
+                    }
+                    else
+                    {
+                        Listener.AddContext(context);
+                    }
                 }
             }
             catch (Exception ex)

--- a/src/Listener/PodeSocket.cs
+++ b/src/Listener/PodeSocket.cs
@@ -237,7 +237,7 @@ namespace Pode
                 {
                     if (context.IsWebSocket)
                     {
-                        Listener.AddClientSignal(context.HttpRequest.NewClientSignal());
+                        Listener.AddClientSignal(context.WsRequest.NewClientSignal());
                         context.Dispose();
                     }
                     else

--- a/src/Listener/PodeWsOpCode.cs
+++ b/src/Listener/PodeWsOpCode.cs
@@ -1,0 +1,12 @@
+namespace Pode
+{
+    public enum PodeWsOpCode
+    {
+        Fragment = 0,
+        Text = 1,
+        Binary = 2,
+        Close = 8,
+        Ping = 9,
+        Pong = 10
+    }
+}

--- a/src/Listener/PodeWsRequest.cs
+++ b/src/Listener/PodeWsRequest.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Net.WebSockets;
+
+namespace Pode
+{
+    public class PodeWsRequest : PodeRequest
+    {
+        public PodeWsOpCode OpCode { get; private set; }
+        public string Body { get; private set; }
+        public byte[] RawBody { get; private set; }
+        public PodeWebSocket WebSocket { get; set; }
+
+        private WebSocketCloseStatus _closeStatus = WebSocketCloseStatus.Empty;
+        public WebSocketCloseStatus CloseStatus
+        {
+            get => _closeStatus;
+        }
+
+        private string _closeDescription = string.Empty;
+        public string CloseDescription
+        {
+            get => _closeDescription;
+        }
+
+        public override bool CloseImmediately
+        {
+            get => (OpCode == PodeWsOpCode.Close);
+        }
+
+        public PodeWsRequest(PodeRequest request)
+            : base(request)
+        {
+            IsKeepAlive = true;
+        }
+
+        public PodeClientSignal NewClientSignal()
+        {
+            return new PodeClientSignal(WebSocket, Body);
+        }
+
+        protected override void Parse(byte[] bytes)
+        {
+            // get the length and op-code
+            var dataLength = bytes[1] - 128;
+            OpCode = (PodeWsOpCode)(bytes[0] & 0b00001111);
+            var offset = 0;
+
+            // set the offset relevant to the data's length
+            if (dataLength < 126)
+            {
+                offset = 2;
+            }
+            else if (dataLength == 126)
+            {
+                dataLength = BitConverter.ToInt16(new byte[] { bytes[3], bytes[2] }, 0);
+                offset = 4;
+            }
+            else
+            {
+                dataLength = (int)BitConverter.ToInt64(new byte[] { bytes[9], bytes[8], bytes[7], bytes[6], bytes[5], bytes[4], bytes[3], bytes[2] }, 0);
+                offset = 10;
+            }
+
+            // read in the mask
+            var mask = new byte[] { bytes[offset], bytes[offset + 1], bytes[offset + 2], bytes[offset + 3] };
+            offset += 4;
+
+            // build the decoded message
+            var decoded = new byte[dataLength];
+            for (var i = 0; i < dataLength; ++i)
+            {
+                decoded[i] = (byte)(bytes[offset + i] ^ mask[i % 4]);
+            }
+
+            // set the raw/body
+            RawBody = bytes;
+            Body = Encoding.GetString(decoded);
+
+            // get the close status and description
+            if (OpCode == PodeWsOpCode.Close)
+            {
+                _closeStatus = WebSocketCloseStatus.Empty;
+                _closeDescription = string.Empty;
+
+                if (dataLength >= 2)
+                {
+                    Array.Reverse(decoded, 0, 2);
+                    var code = (int)BitConverter.ToUInt16(decoded, 0);
+
+                    _closeStatus = Enum.IsDefined(typeof(WebSocketCloseStatus), code)
+                        ? (WebSocketCloseStatus)code
+                        : WebSocketCloseStatus.Empty;
+
+                    var descCount = dataLength - 2;
+                    if (descCount > 0)
+                    {
+                        _closeDescription = Encoding.GetString(decoded, 2, descCount);
+                    }
+                }
+            }
+
+            // send back a pong
+            if (OpCode == PodeWsOpCode.Ping)
+            {
+                Context.Response.WriteFrame(string.Empty, PodeWsOpCode.Pong);
+            }
+        }
+
+        public override void Dispose()
+        {
+            // send close frame, remove client, and dispose
+            Context.Response.WriteFrame(string.Empty, PodeWsOpCode.Close);
+            Context.Listener.WebSockets.Remove(WebSocket.ClientId);
+            base.Dispose();
+        }
+
+    }
+}

--- a/src/Private/SignalServer.ps1
+++ b/src/Private/SignalServer.ps1
@@ -53,7 +53,7 @@ function Start-PodeSignalServer
         try {
             while ($Listener.IsListening -and !$PodeContext.Tokens.Cancellation.IsCancellationRequested)
             {
-                $message = (Wait-PodeTask -Task $Listener.GetSignalAsync($PodeContext.Tokens.Cancellation.Token))
+                $message = (Wait-PodeTask -Task $Listener.GetServerSignalAsync($PodeContext.Tokens.Cancellation.Token))
 
                 # get the sockets for the message
                 $sockets = @()

--- a/src/Private/SignalServer.ps1
+++ b/src/Private/SignalServer.ps1
@@ -115,7 +115,7 @@ function Start-PodeSignalServer
             {
                 $context = (Wait-PodeTask -Task $Listener.GetClientSignalAsync($PodeContext.Tokens.Cancellation.Token))
                 $context = ($context.Message | ConvertFrom-Json)
-                Send-PodeSignal -Value $context.message
+                Send-PodeSignal -Value $context.message -Path $context.path -ClientId $context.clientId
             }
         }
         catch [System.OperationCanceledException] {}

--- a/src/Public/Responses.ps1
+++ b/src/Public/Responses.ps1
@@ -1340,5 +1340,5 @@ function Send-PodeSignal
         }
     }
 
-    $PodeContext.Server.WebSockets.Listener.AddSignal($Value, $Path, $ClientId)
+    $PodeContext.Server.WebSockets.Listener.AddServerSignal($Value, $Path, $ClientId)
 }


### PR DESCRIPTION
### Description of the Change
Adds support for client-to-server websockets - allowing clients to send messages to the Pode server, and Pode automatically re-broadcasts to signal back out to connected clients.

### Related Issue
Resolves #585

### Examples
There isn't really a decent example, as it's mostly all backend, but `.send` on a websocket is now supported:

```javascript
ws.send(JSON.stringify({
    message: $('input[name=message]').val()
}));
```

Also, messages sent must be of JSON format, as follows:

```json
{
    "message": "some message",
    "path": "/",
    "clientId": ""
}
```

Only `"message"` is mandatory.