### PR TITLE
Adds a new -Enum parameter to OpenAPI property functions

### DIFF
--- a/docs/Tutorials/OpenAPI.md
+++ b/docs/Tutorials/OpenAPI.md
@@ -359,8 +359,8 @@ New-PodeOAIntProperty -Name 'userId'
 # a float number with a max value of 100
 New-PodeOANumberProperty -Name 'ratio' -Format Float -Maximum 100
 
-# a string with a default value
-New-PodeOAStringProperty -Name 'type' -Default 'admin'
+# a string with a default value, and enum of options
+New-PodeOAStringProperty -Name 'type' -Default 'admin' -Enum @('admin', 'user')
 
 # a boolean that's required
 New-PodeOABoolProperty -Name 'enabled' -Required
@@ -370,7 +370,7 @@ On their own, like above, the simple properties don't really do much. However, y
 
 ### Arrays
 
-There isn't a dedicated function to create an array property, instead there is an `-Array` swicth on each of the propery functions - both Object and the above simple properties.
+There isn't a dedicated function to create an array property, instead there is an `-Array` switch on each of the property functions - both Object and the above simple properties.
 
 If you supply the `-Array` switch to any of the above simple properties, this will define an array of that type - the `-Name` parameter can also be omitted if only a simple array if required.
 

--- a/examples/web-rest-openapi-simple.ps1
+++ b/examples/web-rest-openapi-simple.ps1
@@ -25,7 +25,7 @@ Start-PodeServer {
         Write-PodeJsonResponse -Value @{ Name = 'Rick'; UserId = $e.Parameters['userId'] }
     } -PassThru |
         Set-PodeOARequest -Parameters @(
-            (New-PodeOAIntProperty -Name 'userId' -Required | ConvertTo-PodeOAParameter -In Path)
+            (New-PodeOAIntProperty -Name 'userId' -Enum @(100,300,999) -Required | ConvertTo-PodeOAParameter -In Path)
         )
 
 

--- a/src/Public/OpenApi.ps1
+++ b/src/Public/OpenApi.ps1
@@ -731,6 +731,9 @@ The integer must be in multiples of the supplied value.
 .PARAMETER Description
 A Description of the property.
 
+.PARAMETER Enum
+An optional array of values that this property can only be set to.
+
 .PARAMETER Required
 If supplied, the object will be treated as Required where supported.
 
@@ -851,6 +854,9 @@ The number must be in multiples of the supplied value.
 
 .PARAMETER Description
 A Description of the property.
+
+.PARAMETER Enum
+An optional array of values that this property can only be set to.
 
 .PARAMETER Required
 If supplied, the object will be treated as Required where supported.
@@ -976,6 +982,9 @@ A Regex pattern that the string must match.
 .PARAMETER Description
 A Description of the property.
 
+.PARAMETER Enum
+An optional array of values that this property can only be set to.
+
 .PARAMETER Required
 If supplied, the object will be treated as Required where supported.
 
@@ -1093,6 +1102,9 @@ The default value of the property. (Default: $false)
 
 .PARAMETER Description
 A Description of the property.
+
+.PARAMETER Enum
+An optional array of values that this property can only be set to.
 
 .PARAMETER Required
 If supplied, the object will be treated as Required where supported.

--- a/src/Public/OpenApi.ps1
+++ b/src/Public/OpenApi.ps1
@@ -779,6 +779,10 @@ function New-PodeOAIntProperty
         [string]
         $Description,
 
+        [Parameter()]
+        [int[]]
+        $Enum,
+
         [switch]
         $Required,
 
@@ -801,6 +805,7 @@ function New-PodeOAIntProperty
         deprecated = $Deprecated.IsPresent
         description = $Description
         format = $Format.ToLowerInvariant()
+        enum = $Enum
         default = $Default
     }
 
@@ -895,6 +900,10 @@ function New-PodeOANumberProperty
         [string]
         $Description,
 
+        [Parameter()]
+        [double[]]
+        $Enum,
+
         [switch]
         $Required,
 
@@ -917,6 +926,7 @@ function New-PodeOANumberProperty
         deprecated = $Deprecated.IsPresent
         description = $Description
         format = $Format.ToLowerInvariant()
+        enum = $Enum
         default = $Default
     }
 
@@ -1021,6 +1031,10 @@ function New-PodeOAStringProperty
         [string]
         $Description,
 
+        [Parameter()]
+        [string[]]
+        $Enum,
+
         [switch]
         $Required,
 
@@ -1048,6 +1062,7 @@ function New-PodeOAStringProperty
         deprecated = $Deprecated.IsPresent
         description = $Description
         format = $_format.ToLowerInvariant()
+        enum = $Enum
         pattern = $Pattern
         default = $Default
     }
@@ -1110,6 +1125,10 @@ function New-PodeOABoolProperty
         [string]
         $Description,
 
+        [Parameter()]
+        [bool[]]
+        $Enum,
+
         [switch]
         $Required,
 
@@ -1131,6 +1150,7 @@ function New-PodeOABoolProperty
         required = $Required.IsPresent
         deprecated = $Deprecated.IsPresent
         description = $Description
+        enum = $Enum
         default = $Default
     }
 
@@ -1272,6 +1292,7 @@ function ConvertTo-PodeOAParameter
         schema = @{
             type = $Property.type
             format = $Property.format
+            enum = $Property.enum
         }
     }
 


### PR DESCRIPTION
### Description of the Change
Adds a new `-Enum` array parameter to each of the following OpenAPI functions:

* `New-PodeOAIntProperty`
* `New-PodeOABoolProperty`
* `New-PodeOANumberProperty`
* `New-PodeOAStringProperty`

### Related Issue
Resolves #603

### Examples
```powershell
Add-PodeRoute -Method Get -Path '/api/users/:userId' -ScriptBlock {
        param($e)
        Write-PodeJsonResponse -Value @{ Name = 'Rick'; UserId = $e.Parameters['userId'] }
    } -PassThru |
        Set-PodeOARequest -Parameters @(
            (New-PodeOAIntProperty -Name 'userId' -Enum @(100,300,999) -Required | ConvertTo-PodeOAParameter -In Path)
        )
```

