### PR TITLE
Adds a new Remove-PodeOAResponse function

### DIFF
--- a/docs/Tutorials/OpenAPI.md
+++ b/docs/Tutorials/OpenAPI.md
@@ -84,7 +84,7 @@ Each of the following OpenAPI functions have a `-PassThru` switch, allowing you 
 
 ### Responses
 
-You can define multiple responses for a route, but only one of each status code, using the [`Add-PodeOAResponse`](../../Functions/OpenApi/Add-PodeOAResponse) function. You can either just define the response and status code; with a custom description; or with a schema defining the payload of the response.
+You can define multiple responses for a route, but only one of each status code, using the [`Add-PodeOAResponse`](../../Functions/OpenApi/Add-PodeOAResponse) function. You can either just define the response and status code, with a custom description, or with a schema defining the payload of the response.
 
 The following is an example of defining simple 200 and 404 responses on a route:
 
@@ -121,6 +121,15 @@ the JSON response payload defined is as follows:
     "Name": [string],
     "UserId": [integer]
 }
+```
+
+Internally, each route is created with an empty default 200 and 500 response. You can remove these, or other added responses, by using [`Remove-PodeOAResponse`](../../Functions/OpenApi/Add-PodeOAResponse):
+
+```powershell
+Add-PodeRoute -Method Get -Path "/api/user/:userId" -ScriptBlock {
+    # logic
+} -PassThru |
+    Remove-PodeOAResponse -StatusCode 200
 ```
 
 ### Requests

--- a/src/Pode.psd1
+++ b/src/Pode.psd1
@@ -194,6 +194,7 @@
         'Enable-PodeOpenApi',
         'Get-PodeOpenApiDefinition',
         'Add-PodeOAResponse',
+        'Remove-PodeOAResponse',
         'Add-PodeOAComponentResponse',
         'Set-PodeOAAuth',
         'Set-PodeOAGlobalAuth',

--- a/src/Public/OpenApi.ps1
+++ b/src/Public/OpenApi.ps1
@@ -303,6 +303,69 @@ function Add-PodeOAResponse
 
 <#
 .SYNOPSIS
+Remove a response definition from the supplied route.
+
+.DESCRIPTION
+Remove a response definition from the supplied route.
+
+.PARAMETER Route
+The route to remove the response definition, usually from -PassThru on Add-PodeRoute.
+
+.PARAMETER StatusCode
+The HTTP StatusCode for the response to remove.
+
+.PARAMETER Default
+If supplied, the response will be used as a default response - this overrides the StatusCode supplied.
+
+.PARAMETER PassThru
+If supplied, the route passed in will be returned for further chaining.
+
+.EXAMPLE
+Add-PodeRoute -PassThru | Remove-PodeOAResponse -StatusCode 200
+
+.EXAMPLE
+Add-PodeRoute -PassThru | Remove-PodeOAResponse -StatusCode 201 -Default
+#>
+function Remove-PodeOAResponse
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [hashtable[]]
+        $Route,
+
+        [Parameter(Mandatory=$true)]
+        [int]
+        $StatusCode,
+
+        [switch]
+        $Default,
+
+        [switch]
+        $PassThru
+    )
+
+    # override status code with default
+    $code = "$($StatusCode)"
+    if ($Default) {
+        $code = 'default'
+    }
+
+    # remove the respones from the routes
+    foreach ($r in @($Route)) {
+        if ($r.OpenApi.Responses.ContainsKey($code)) {
+            $r.OpenApi.Responses.Remove($code) | Out-Null
+        }
+    }
+
+    if ($PassThru) {
+        return $Route
+    }
+}
+
+<#
+.SYNOPSIS
 Adds a reusable component for responses.
 
 .DESCRIPTION


### PR DESCRIPTION
### Description of the Change
Adds a new `Remove-PodeOAResponse` function, so that response - such as the internal 200 default - can be removed.

### Related Issue
Resolves #602

### Examples
```powershell
Add-PodeRoute -Method Get -Path "/api/user/:userId" -ScriptBlock {
    # logic
} -PassThru |
    Remove-PodeOAResponse -StatusCode 200
```