### PR TITLE
Adds client certificate authentication support

### DIFF
--- a/docs/Getting-Started/Migrating/1X-to-2X.md
+++ b/docs/Getting-Started/Migrating/1X-to-2X.md
@@ -59,6 +59,8 @@ There's also a new [`Add-PodeAuthMiddleware`](../../../Functions/Authentication/
 
 Furthermore, the OpenAPI functions for `Set-PodeOAAuth` and `Set-PodeOAGlobalAuth` have been removed. The new [`Add-PodeAuthMiddleware`](../../../Functions/Authentication/Add-PodeAuthMiddleware) function and `-Authentication` parameter on [`Add-PodeRoute`](../../../Functions/Routes/Add-PodeRoute) set these up for you automatically in OpenAPI.
 
+On `Add-PodeAuth`, `Add-PodeAuthWindowsAd`, and `Add-PodeAuthUserFile` the `-Type` parameter has been renamed to `-Scheme`. If you have always piped `New-PodeAuthScheme` (formally `New-PodeAuthType`) into them, then this won't affect you.
+
 ### Endpoint and Protocol
 
 On the following functions:

--- a/docs/Tutorials/Authentication/Methods/ClientCertificate.md
+++ b/docs/Tutorials/Authentication/Methods/ClientCertificate.md
@@ -2,6 +2,8 @@
 
 Client Certificate Authentication is when the server requires the client to supply a certificate on the request, to verify themselves with the server. This only works over HTTPS connections.
 
+If at any point to you need to access the client's certificate outside of this validator, then it can be found on the web event object at `Request.ClientCertificate`.
+
 ## Setup
 
 To setup and start using Client Certificate Authentication in Pode you use the `New-PodeAuthScheme -ClientCertificate` function, and then pipe this into the [`Add-PodeAuth`](../../../../Functions/Authentication/Add-PodeAuth) function. The [`Add-PodeAuth`](../../../../Functions/Authentication/Add-PodeAuth) function's ScriptBlock is supplied the client's certificate, and any SSL errors that may have occurred (like chain issues, etc).

--- a/docs/Tutorials/Authentication/Methods/ClientCertificate.md
+++ b/docs/Tutorials/Authentication/Methods/ClientCertificate.md
@@ -1,0 +1,86 @@
+# Client Certificate
+
+Client Certificate Authentication is when the server requires the client to supply a certificate on the request, to verify themselves with the server. This only works over HTTPS connections.
+
+## Setup
+
+To setup and start using Client Certificate Authentication in Pode you use the `New-PodeAuthScheme -ClientCertificate` function, and then pipe this into the [`Add-PodeAuth`](../../../../Functions/Authentication/Add-PodeAuth) function. The [`Add-PodeAuth`](../../../../Functions/Authentication/Add-PodeAuth) function's ScriptBlock is supplied the client's certificate, and any SSL errors that may have occurred (like chain issues, etc).
+
+You will also need to supply `-AllowClientCertificate` to [`Add-PodeEndpoint`], and ensure the `-Protocol` is HTTPS:
+
+```powershell
+Start-PodeServer {
+    Add-PodeEndpoint -Address * -Port 8443 -Protocol Https -SelfSigned -AllowClientCertificate
+
+    New-PodeAuthScheme -ClientCertificate | Add-PodeAuth -Name 'Login' -Sessionless -ScriptBlock {
+        param($cert, $errors)
+
+        # check if the client's cert is valid
+
+        return @{ User = $user }
+    }
+}
+```
+
+By default, Pode will ensure a certificate was supplied, and also ensure the certificate's Before/After dates are valid - if not, a 401 response will be returned.
+
+## Middleware
+
+Once configured you can start using Client Certificate Authentication to validate incoming Requests. You can either configure the validation to happen on every Route as global Middleware, or as custom Route Middleware.
+
+The following will use Client Certificate Authentication to validate every request on every Route:
+
+```powershell
+Start-PodeServer {
+    Add-PodeAuthMiddleware -Name 'GlobalAuthValidation' -Authentication 'Login'
+}
+```
+
+Whereas the following example will use Client Certificate authentication to only validate requests on specific a Route:
+
+```powershell
+Start-PodeServer {
+    Add-PodeRoute -Method Get -Path '/info' -Authentication 'Login' -ScriptBlock {
+        # logic
+    }
+}
+```
+
+## Full Example
+
+The following full example of Basic authentication will setup and configure authentication, validate that a users username/password is valid, and then validate on a specific Route:
+
+```powershell
+Start-PodeServer {
+    Add-PodeEndpoint -Address * -Port 8443 -Protocol Https -SelfSigned -AllowClientCertificate
+
+    # setup client cert authentication to validate a user
+    New-PodeAuthScheme -ClientCertificate | Add-PodeAuth -Name 'Login' -Sessionless -ScriptBlock {
+        param($cert, $errors)
+
+        # validate the thumbprint - here you would check a real cert store, or database
+        if ($cert.Thumbprint -ieq '3571B3BE3CA202FA56F73691FC258E653D0874C1') {
+            return @{
+                User = @{
+                    ID ='M0R7Y302'
+                    Name = 'Morty'
+                    Type = 'Human'
+                }
+            }
+        }
+
+        # an invalid cert
+        return @{ Message = 'Invalid certificate supplied' }
+    }
+
+    # check the request on this route against the authentication
+    Add-PodeRoute -Method Get -Path '/cpu' -Authentication 'Login' -ScriptBlock {
+        Write-PodeJsonResponse -Value @{ 'cpu' = 82 }
+    }
+
+    # this route will not be validated against the authentication
+    Add-PodeRoute -Method Get -Path '/memory' -ScriptBlock {
+        Write-PodeJsonResponse -Value @{ 'memory' = 14 }
+    }
+}
+```

--- a/docs/Tutorials/Authentication/Methods/Custom.md
+++ b/docs/Tutorials/Authentication/Methods/Custom.md
@@ -1,6 +1,6 @@
 # Custom
 
-Custom authentication works much like the inbuilt types (Basic/Form/etc), but allows you to specify your own parsing logic, as well as any custom options that might be required.
+Custom authentication works much like the inbuilt schemes (Basic/Form/etc), but allows you to specify your own parsing logic, as well as any custom options that might be required.
 
 ## Setup and Parsing
 
@@ -12,8 +12,8 @@ The `-ScriptBlock` on [`New-PodeAuthScheme`](../../../../Functions/Authenticatio
 
 ```powershell
 Start-PodeServer {
-    # define a new custom authentication type
-    $custom_type = New-PodeAuthScheme -Custom -ScriptBlock {
+    # define a new custom authentication scheme
+    $custom_scheme = New-PodeAuthScheme -Custom -ScriptBlock {
         param($e, $opts)
 
         # get client/user/password field names
@@ -30,8 +30,8 @@ Start-PodeServer {
         return @($client, $username, $password)
     }
 
-    # now, add a new custom authentication method using the type you created above
-    $custom_type | Add-PodeAuth -Name 'Login' -ScriptBlock {
+    # now, add a new custom authentication validator using the scheme you created above
+    $custom_scheme | Add-PodeAuth -Name 'Login' -ScriptBlock {
         param($client, $username, $password)
 
         # check if the client is valid in some database
@@ -47,9 +47,9 @@ Start-PodeServer {
 
 ## Post Validation
 
-The typical setup of authentication is that you create some type to parse the request ([`New-PodeAuthScheme`](../../../../Functions/Authentication/New-PodeAuthScheme)), and then you pipe this into a validator/method to validate the parsed user's credentials ([`Add-PodeAuth`](../../../../Functions/Authentication/Add-PodeAuth)).
+The typical setup of authentication is that you create some scheme to parse the request ([`New-PodeAuthScheme`](../../../../Functions/Authentication/New-PodeAuthScheme)), and then you pipe this into a validator to validate the parsed user's credentials ([`Add-PodeAuth`](../../../../Functions/Authentication/Add-PodeAuth)).
 
-There is however also an optional `-PostValidator` ScriptBlock that can be passed to your Custom Authentication type on the [`New-PodeAuthScheme`](../../../../Functions/Authentication/New-PodeAuthScheme) function. This `-PostValidator` script runs after normal user validation, and is supplied the current [web event](../../../WebEvent), the original splatted array returned from the [`New-PodeAuthScheme`](../../../../Functions/Authentication/New-PodeAuthScheme) ScriptBlock, the result HashTable from the user validator from `Add-PodeAuth`, and the `-ArgumentList` HashTable from `New-PodeAuthScheme`. You can use this script to re-generate any hashes for further validation, but if successful you *must* return the User object again (ie: re-return the last parameter which is the original validation result).
+There is however also an optional `-PostValidator` ScriptBlock that can be passed to your Custom Authentication scheme on the [`New-PodeAuthScheme`](../../../../Functions/Authentication/New-PodeAuthScheme) function. This `-PostValidator` script runs after normal user validation, and is supplied the current [web event](../../../WebEvent), the original splatted array returned from the [`New-PodeAuthScheme`](../../../../Functions/Authentication/New-PodeAuthScheme) ScriptBlock, the result HashTable from the user validator from `Add-PodeAuth`, and the `-ArgumentList` HashTable from `New-PodeAuthScheme`. You can use this script to re-generate any hashes for further validation, but if successful you *must* return the User object again (ie: re-return the last parameter which is the original validation result).
 
 For example, if you have a post validator script for the above Client Custom Authentication, then it would be supplied the following parameters:
 
@@ -59,14 +59,14 @@ For example, if you have a post validator script for the above Client Custom Aut
 * Password
 * ClientName
 * Validation Result
-* Type ArgumentsList
+* Scheme ArgumentsList
 
 For example:
 
 ```powershell
 Start-PodeServer {
-    # define a new custom authentication type
-    $custom_type = New-PodeAuthScheme -Custom -ScriptBlock {
+    # define a new custom authentication scheme
+    $custom_scheme = New-PodeAuthScheme -Custom -ScriptBlock {
         param($e, $opts)
 
         # get client/user/password field names
@@ -91,8 +91,8 @@ Start-PodeServer {
         return $result
     }
 
-    # now, add a new custom authentication method using the type you created above
-    $custom_type | Add-PodeAuth -Name 'Login' -ScriptBlock {
+    # now, add a new custom authentication method using the scheme you created above
+    $custom_scheme | Add-PodeAuth -Name 'Login' -ScriptBlock {
         param($client, $username, $password)
 
         # check if the client is valid in some database
@@ -133,8 +133,8 @@ The following full example of Custom authentication will setup and configure aut
 Start-PodeServer {
     Add-PodeEndpoint -Address * -Port 8080 -Protocol Http
 
-    # define a new custom authentication type
-    $custom_type = New-PodeAuthScheme -Custom -ScriptBlock {
+    # define a new custom authentication scheme
+    $custom_scheme = New-PodeAuthScheme -Custom -ScriptBlock {
         param($e, $opts)
 
         # get client/user/pass field names to get from payload
@@ -152,7 +152,7 @@ Start-PodeServer {
     }
 
     # now, add a new custom authentication method
-    $custom_type | Add-PodeAuth -Name 'Login' -Sessionless -ScriptBlock {
+    $custom_scheme | Add-PodeAuth -Name 'Login' -Sessionless -ScriptBlock {
         param($client, $username, $password)
 
         # check if the client is valid

--- a/docs/Tutorials/WebEvent.md
+++ b/docs/Tutorials/WebEvent.md
@@ -43,3 +43,5 @@ Add-PodeRoute -Method Get -Path '/' -ScriptBlock {
 ## Customise
 
 The web event itself is just a HashTable, which means you can add your own properties to it within Middleware for further use in other Middleware down the flow, or in the Route itself.
+
+Make sure these custom properties have a unique name, so as to not clash with already existing properties.

--- a/examples/web-auth-clientcert.ps1
+++ b/examples/web-auth-clientcert.ps1
@@ -1,0 +1,48 @@
+$path = Split-Path -Parent -Path (Split-Path -Parent -Path $MyInvocation.MyCommand.Path)
+Import-Module "$($path)/src/Pode.psm1" -Force -ErrorAction Stop
+
+# or just:
+# Import-Module Pode
+
+# create a server, flagged to generate a self-signed cert for dev/testing, but allow client certs for auth
+Start-PodeServer {
+
+    # bind to ip/port and set as https with self-signed cert
+    Add-PodeEndpoint -Address * -Port 8443 -Protocol Https -SelfSigned -AllowClientCertificate
+
+    # set view engine for web pages
+    Set-PodeViewEngine -Type Pode
+
+    # setup client cert auth
+    New-PodeAuthScheme -ClientCertificate | Add-PodeAuth -Name 'Validate' -Sessionless -ScriptBlock {
+        param($cert, $errors)
+
+        # validate the thumbprint - here you would check a real cert store, or database
+        if ($cert.Thumbprint -ieq '2561B2BD3CF292FF55F72692FB252E6B3D9879C2') {
+            return @{
+                User = @{
+                    ID ='M0R7Y302'
+                    Name = 'Morty'
+                    Type = 'Human'
+                }
+            }
+        }
+
+        # an invalid cert
+        return @{ Message = 'Invalid certificate supplied' }
+    }
+
+    # GET request for web page at "/"
+    Add-PodeRoute -Method Get -Path '/' -Authentication 'Validate' -ScriptBlock {
+        param($e)
+        #$e.Request.ClientCertificate | out-default
+        Write-PodeViewResponse -Path 'simple' -Data @{ 'numbers' = @(1, 2, 3); }
+    }
+
+    # GET request throws fake "500" server error status code
+    Add-PodeRoute -Method Get -Path '/error' -Authentication 'Validate' -ScriptBlock {
+        param($e)
+        Set-PodeResponseStatus -Code 500
+    }
+
+}

--- a/examples/web-auth-clientcert.ps1
+++ b/examples/web-auth-clientcert.ps1
@@ -18,7 +18,7 @@ Start-PodeServer {
         param($cert, $errors)
 
         # validate the thumbprint - here you would check a real cert store, or database
-        if ($cert.Thumbprint -ieq '2561B2BD3CF292FF55F72692FB252E6B3D9879C2') {
+        if ($cert.Thumbprint -ieq '3571B3BE3CA202FA56F73691FC258E653D0874C1') {
             return @{
                 User = @{
                     ID ='M0R7Y302'

--- a/examples/web-pages-https.ps1
+++ b/examples/web-pages-https.ps1
@@ -21,13 +21,13 @@ Start-PodeServer {
 
     # GET request for web page at "/"
     Add-PodeRoute -Method Get -Path '/' -ScriptBlock {
-        param($session)
+        param($e)
         Write-PodeViewResponse -Path 'simple' -Data @{ 'numbers' = @(1, 2, 3); }
     }
 
     # GET request throws fake "500" server error status code
     Add-PodeRoute -Method Get -Path '/error' -ScriptBlock {
-        param($session)
+        param($e)
         Set-PodeResponseStatus -Code 500
     }
 

--- a/src/Listener/PodeContext.cs
+++ b/src/Listener/PodeContext.cs
@@ -112,7 +112,7 @@ namespace Pode
             // attempt to open the request stream
             try
             {
-                Request.Open(PodeSocket.Certificate, PodeSocket.Protocols);
+                Request.Open(PodeSocket.Certificate, PodeSocket.Protocols, PodeSocket.AllowClientCertificate);
                 State = PodeContextState.Open;
             }
             catch

--- a/src/Listener/PodeSocket.cs
+++ b/src/Listener/PodeSocket.cs
@@ -15,6 +15,7 @@ namespace Pode
         public int Port { get; private set; }
         public IPEndPoint Endpoint { get; private set; }
         public X509Certificate Certificate { get; private set; }
+        public bool AllowClientCertificate { get; private set; }
         public SslProtocols Protocols { get; private set; }
         public Socket Socket { get; private set; }
 
@@ -35,11 +36,12 @@ namespace Pode
             set => Socket.ReceiveTimeout = value;
         }
 
-        public PodeSocket(IPAddress ipAddress, int port, SslProtocols protocols, X509Certificate certificate = null)
+        public PodeSocket(IPAddress ipAddress, int port, SslProtocols protocols, X509Certificate certificate = null, bool allowClientCertificate = false)
         {
             IPAddress = ipAddress;
             Port = port;
             Certificate = certificate;
+            AllowClientCertificate = allowClientCertificate;
             Protocols = protocols;
             Endpoint = new IPEndPoint(ipAddress, port);
 

--- a/src/Private/Authentication.ps1
+++ b/src/Private/Authentication.ps1
@@ -669,18 +669,23 @@ function Get-PodeAuthMiddlewareScript
         }
 
         try {
-            # run auth type script to parse request for data
-            $_args = @($e) + @($auth.Type.Arguments)
-            if ($null -ne $auth.Type.ScriptBlock.UsingVariables) {
-                $_args = @($auth.Type.ScriptBlock.UsingVariables.Value) + $_args
+            # run auth scheme script to parse request for data
+            $_args = @($e) + @($auth.Scheme.Arguments)
+            if ($null -ne $auth.Scheme.ScriptBlock.UsingVariables) {
+                $_args = @($auth.Scheme.ScriptBlock.UsingVariables.Value) + $_args
             }
 
-            $result = (Invoke-PodeScriptBlock -ScriptBlock $auth.Type.ScriptBlock.Script -Arguments $_args -Return -Splat)
+            $result = (Invoke-PodeScriptBlock -ScriptBlock $auth.Scheme.ScriptBlock.Script -Arguments $_args -Return -Splat)
 
             # if data is a hashtable, then don't call validator (parser either failed, or forced a success)
             if ($result -isnot [hashtable]) {
                 $original = $result
+
                 $_args = @($result) + @($auth.Arguments)
+                if ($auth.PassEvent) {
+                    $_args = @($e) + $_args
+                }
+
                 if ($null -ne $auth.UsingVariables) {
                     $_args = @($auth.UsingVariables.Value) + $_args
                 }
@@ -688,13 +693,13 @@ function Get-PodeAuthMiddlewareScript
                 $result = (Invoke-PodeScriptBlock -ScriptBlock $auth.ScriptBlock -Arguments $_args -Return -Splat)
 
                 # if we have user, then run post validator if present
-                if ([string]::IsNullOrWhiteSpace($result.Code) -and !(Test-PodeIsEmpty $auth.Type.PostValidator.Script)) {
-                    $_args = @($e) + @($original) + @($result) + @($auth.Type.Arguments)
-                    if ($null -ne $auth.Type.PostValidator.UsingVariables) {
-                        $_args = @($auth.Type.PostValidator.UsingVariables.Value) + $_args
+                if ([string]::IsNullOrWhiteSpace($result.Code) -and !(Test-PodeIsEmpty $auth.Scheme.PostValidator.Script)) {
+                    $_args = @($e) + @($original) + @($result) + @($auth.Scheme.Arguments)
+                    if ($null -ne $auth.Scheme.PostValidator.UsingVariables) {
+                        $_args = @($auth.Scheme.PostValidator.UsingVariables.Value) + $_args
                     }
 
-                    $result = (Invoke-PodeScriptBlock -ScriptBlock $auth.Type.PostValidator.Script -Arguments $_args -Return -Splat)
+                    $result = (Invoke-PodeScriptBlock -ScriptBlock $auth.Scheme.PostValidator.Script -Arguments $_args -Return -Splat)
                 }
             }
         }
@@ -712,7 +717,7 @@ function Get-PodeAuthMiddlewareScript
             $validHeaders = (($null -eq $result.Headers) -or !$result.Headers.ContainsKey('WWW-Authenticate'))
 
             if ($validCode -and $validHeaders) {
-                $_wwwHeader = Get-PodeAuthWwwHeaderValue -Name $auth.Type.Name -Realm $auth.Type.Realm -Challenge $result.Challenge
+                $_wwwHeader = Get-PodeAuthWwwHeaderValue -Name $auth.Scheme.Name -Realm $auth.Scheme.Realm -Challenge $result.Challenge
                 if (![string]::IsNullOrWhiteSpace($_wwwHeader)) {
                     Set-PodeHeader -Name 'WWW-Authenticate' -Value $_wwwHeader
                 }

--- a/src/Private/PodeServer.ps1
+++ b/src/Private/PodeServer.ps1
@@ -33,6 +33,7 @@ function Start-PodeWebServer
             Address = $_ip
             Port = $_.Port
             Certificate = $_.Certificate.Raw
+            AllowClientCertificate = $_.Certificate.AllowClientCertificate
             HostName = $_.Url
         }
     }
@@ -45,7 +46,7 @@ function Start-PodeWebServer
     {
         # register endpoints on the listener
         $endpoints | ForEach-Object {
-            $socket = [PodeSocket]::new($_.Address, $_.Port, $PodeContext.Server.Sockets.Ssl.Protocols, $_.Certificate)
+            $socket = [PodeSocket]::new($_.Address, $_.Port, $PodeContext.Server.Sockets.Ssl.Protocols, $_.Certificate, $_.AllowClientCertificate)
             $socket.ReceiveTimeout = $PodeContext.Server.Sockets.ReceiveTimeout
             $listener.Add($socket)
         }

--- a/src/Private/SignalServer.ps1
+++ b/src/Private/SignalServer.ps1
@@ -15,6 +15,7 @@ function Start-PodeSignalServer
             Address = $_ip
             Port = $_.Port
             Certificate = $_.Certificate.Raw
+            AllowClientCertificate = $_.Certificate.AllowClientCertificate
             HostName = $_.Url
         }
     }
@@ -27,7 +28,7 @@ function Start-PodeSignalServer
     {
         # register endpoints on the listener
         $endpoints | ForEach-Object {
-            $socket = [PodeSocket]::new($_.Address, $_.Port, $PodeContext.Server.Sockets.Ssl.Protocols, $_.Certificate)
+            $socket = [PodeSocket]::new($_.Address, $_.Port, $PodeContext.Server.Sockets.Ssl.Protocols, $_.Certificate, $_.AllowClientCertificate)
             $socket.ReceiveTimeout = $PodeContext.Server.Sockets.ReceiveTimeout
             $listener.Add($socket)
         }

--- a/src/Public/Authentication.ps1
+++ b/src/Public/Authentication.ps1
@@ -50,6 +50,9 @@ If supplied, will use the inbuilt Digest Authentication credentials retriever.
 .PARAMETER Bearer
 If supplied, will use the inbuilt Bearer Authentication token retriever.
 
+.PARAMETER ClientCertificate
+If supplied, will use the inbuilt Client Certificate Authentication validation.
+
 .PARAMETER Scope
 An optional array of Scopes for Bearer Authentication. (These are case-sensitive)
 
@@ -135,6 +138,10 @@ function New-PodeAuthScheme
         [switch]
         $Bearer,
 
+        [Parameter(ParameterSetName='ClientCertificate')]
+        [switch]
+        $ClientCertificate,
+
         [Parameter(ParameterSetName='Bearer')]
         [string[]]
         $Scope
@@ -159,6 +166,20 @@ function New-PodeAuthScheme
                     HeaderTag = (Protect-PodeValue -Value $HeaderTag -Default 'Basic')
                     Encoding = (Protect-PodeValue -Value $Encoding -Default 'ISO-8859-1')
                 }
+            }
+        }
+
+        'clientcertificate' {
+            return @{
+                Name = 'Mutual'
+                Realm = (Protect-PodeValue -Value $Realm -Default $_realm)
+                ScriptBlock = @{
+                    Script = (Get-PodeAuthClientCertificateType)
+                    UsingVariables = $null
+                }
+                PostValidator = $null
+                Scheme = 'http'
+                Arguments = @{}
             }
         }
 

--- a/src/Public/Core.ps1
+++ b/src/Public/Core.ps1
@@ -651,6 +651,9 @@ Ignore Adminstrator checks for non-localhost endpoints.
 .PARAMETER SelfSigned
 Create and bind a self-signed certifcate for HTTPS endpoints.
 
+.PARAMETER AllowClientCertificate
+Allow for client certificates to be sent on requests.
+
 .EXAMPLE
 Add-PodeEndpoint -Address localhost -Port 8090 -Protocol Http
 
@@ -718,7 +721,10 @@ function Add-PodeEndpoint
 
         [Parameter(ParameterSetName='CertSelf')]
         [switch]
-        $SelfSigned
+        $SelfSigned,
+
+        [switch]
+        $AllowClientCertificate
     )
 
     # error if serverless
@@ -771,6 +777,7 @@ function Add-PodeEndpoint
         Certificate = @{
             Raw = $X509Certificate
             SelfSigned = $SelfSigned
+            AllowClientCertificate = $AllowClientCertificate
         }
     }
 

--- a/src/Public/Core.ps1
+++ b/src/Public/Core.ps1
@@ -762,6 +762,11 @@ function Add-PodeEndpoint
         throw "An endpoint with the name '$($Name)' has already been defined"
     }
 
+    # protocol must be https for client certs
+    if (($Protocol -ine 'https') -and $AllowClientCertificate) {
+        throw "Client certificates are only supported on HTTPS endpoints"
+    }
+
     # new endpoint object
     $obj = @{
         Name = $Name


### PR DESCRIPTION
### Description of the Change
Adds client certificate authentication support, as well as just generally allowing client certificates to be sent on requests and retrieved.

There's a new `-AllowClientCertificate` switch on `Add-PodeEndpoint` for HTTPS endpoints. When supplied, any requests to the server will accept a client certificate to be sent. This certificate is then available in the `Request` object under `ClientCertificate`, which is accessible from the current web event.

There's also a new `-ClientCertificate` switch on `New-PodeAuthScheme`; the appropriate scriptblock from `Add-PodeAuth` will be supplied with the client's certificate and any errors.

### Related Issue
Resolves #472 

### Examples
```powershell
Start-PodeServer {
    Add-PodeEndpoint -Address * -Port 8443 -Protocol Https -SelfSigned -AllowClientCertificate

    New-PodeAuthScheme -ClientCertificate | Add-PodeAuth -Name 'Login' -Sessionless -ScriptBlock {
        param($cert, $errors)

        # check if the client's cert is valid

        return @{ User = $user }
    }
}
```

By default, Pode will validate the certificate is present, and the Before/After dates - if not valid a 401 response is returned.