### PR TITLE
Add support for rate limiting routes and endpoints

### DIFF
--- a/docs/Getting-Started/Migrating/1X-to-2X.md
+++ b/docs/Getting-Started/Migrating/1X-to-2X.md
@@ -74,7 +74,7 @@ On the following functions:
 
 The `-Endpoint` and `-Protocol` parameters have been removed in favour of `-EndpointName`.
 
-Further to this, if no `-Name` is supplied to [`Add-PodeEndpoint`] then a random GUID is used instead. To get the name back you can use `-PassThru` for the endpoint to be returned.
+Further to this, if no `-Name` is supplied to [`Add-PodeEndpoint`](../../../Functions/Core/Add-PodeEndpoint) then a random GUID is used instead. To get the name back you can use `-PassThru` for the endpoint to be returned.
 
 ### Scoping and Auto-Importing
 

--- a/docs/Getting-Started/Migrating/1X-to-2X.md
+++ b/docs/Getting-Started/Migrating/1X-to-2X.md
@@ -74,6 +74,8 @@ On the following functions:
 
 The `-Endpoint` and `-Protocol` parameters have been removed in favour of `-EndpointName`.
 
+Further to this, if no `-Name` is supplied to [`Add-PodeEndpoint`] then a random GUID is used instead. To get the name back you can use `-PassThru` for the endpoint to be returned.
+
 ### Scoping and Auto-Importing
 
 The 2.0 release sees a big change to some scoping issues in Pode, around modules/snapins/functions and variables. For more information, see the new page on [Scoping](../../../Tutorials/Scoping).

--- a/docs/Tutorials/Authentication/Methods/ClientCertificate.md
+++ b/docs/Tutorials/Authentication/Methods/ClientCertificate.md
@@ -8,7 +8,7 @@ If at any point to you need to access the client's certificate outside of this v
 
 To setup and start using Client Certificate Authentication in Pode you use the `New-PodeAuthScheme -ClientCertificate` function, and then pipe this into the [`Add-PodeAuth`](../../../../Functions/Authentication/Add-PodeAuth) function. The [`Add-PodeAuth`](../../../../Functions/Authentication/Add-PodeAuth) function's ScriptBlock is supplied the client's certificate, and any SSL errors that may have occurred (like chain issues, etc).
 
-You will also need to supply `-AllowClientCertificate` to [`Add-PodeEndpoint`], and ensure the `-Protocol` is HTTPS:
+You will also need to supply `-AllowClientCertificate` to [`Add-PodeEndpoint`](../../../../Functions/Core/Add-PodeEndpoint), and ensure the `-Protocol` is HTTPS:
 
 ```powershell
 Start-PodeServer {

--- a/docs/Tutorials/Middleware/Types/AccessRules.md
+++ b/docs/Tutorials/Middleware/Types/AccessRules.md
@@ -4,7 +4,7 @@ Access rules in Pode are inbuilt Middleware that allow you to specify allow/deny
 
 ## Usage
 
-To setup access rules in Pode you use the  [`Add-PodeAccessRule`](../../../../Functions/Middleware/Add-PodeAccessRule) function.
+To setup access rules in Pode you use the [`Add-PodeAccessRule`](../../../../Functions/Middleware/Add-PodeAccessRule) function.
 
 You can either put a rule in for a specific IP address/subnet mask, or for every address (using `all`). You can also supply an array of addresses/subnets as well, rather than one at a time.
 
@@ -14,40 +14,32 @@ You can either put a rule in for a specific IP address/subnet mask, or for every
 The following example will allow access for requests from localhost:
 
 ```powershell
-Start-PodeServer {
-    Add-PodeAccessRule -Access Allow -Type IP -Values 127.0.0.1
-}
+Add-PodeAccessRule -Access Allow -Type IP -Values 127.0.0.1
 ```
 
 Whereas the following example will deny access to requests from a subnet:
 
 ```powershell
-Start-PodeServer {
-    Add-PodeAccessRule -Access Deny -Type IP -Values 10.10.0.0/24
-}
+Add-PodeAccessRule -Access Deny -Type IP -Values 10.10.0.0/24
 ```
 
 To allow access to requests from multiple addresses in one line, the following example will work:
 
 ```powershell
-Start-PodeServer {
-    Add-PodeAccessRule -Access Allow -Type IP -Values @('192.168.1.1', '192.168.1.2')
-}
+Add-PodeAccessRule -Access Allow -Type IP -Values @('192.168.1.1', '192.168.1.2')
 ```
 
 Finally, to allow or deny access to requests from every address you can use the `all` keyword:
 
 ```powershell
-Start-PodeServer {
-    Add-PodeAccessRule -Access Deny -Type IP -Values 'all'
-}
+Add-PodeAccessRule -Access Deny -Type IP -Values 'all'
 ```
 
 ## Overriding
 
 Since access rules are an inbuilt Middleware in Pode, then when you setup rules the point at which the rules are checked on the request lifecycle is fixed (see [here](../../Overview/#order-of-running)).
 
-This means you can override the inbuilt access rule logic with your own custom logic, using the  [`Add-PodeMiddleware`](../../../../Functions/Core/Add-PodeMiddleware) function. To override the access rule logic you can pass `__pode_mw_access__` to the `-Name` parameter of the  [`Add-PodeMiddleware`](../../../../Functions/Core/Add-PodeMiddleware) function.
+This means you can override the inbuilt access rule logic with your own custom logic, using the  [`Add-PodeMiddleware`](../../../../Functions/Core/Add-PodeMiddleware) function. To override the access rule logic you can pass `__pode_mw_access__` to the `-Name` parameter of the [`Add-PodeMiddleware`](../../../../Functions/Core/Add-PodeMiddleware) function.
 
 The following example uses access rules, and defines Middleware that will override the inbuilt access logic:
 

--- a/docs/Tutorials/Middleware/Types/RateLimiting.md
+++ b/docs/Tutorials/Middleware/Types/RateLimiting.md
@@ -1,10 +1,14 @@
 # Rate Limiting
 
-Rate limiting in Pode is inbuilt Middleware, that allows you to specify a maximum number of requests, per second, for an IP address or subnet mask. When rate limiting a subnet you can choose to either individually limit each IP address in a subnet, or you can group all IPs in a subnet together under a single limit.
+Rate limiting in Pode is inbuilt Middleware, that allows you to specify a maximum number of requests, per second, for an IP, Route, or Endpoint.
+
+When rate limiting a subnet you can choose to either individually limit each IP address in a subnet, or you can group all IPs in a subnet together under a single limit.
 
 ## Usage
 
-To setup rate limiting in Pode you use the  [`Add-PodeLimitRule`](../../../../Functions/Middleware/Add-PodeLimitRule) function.
+To setup rate limiting in Pode you use the [`Add-PodeLimitRule`](../../../../Functions/Middleware/Add-PodeLimitRule) function.
+
+### IP Address
 
 You can either rate limit a specific IP address, a subnet mask, or every address using `all`. You can also supply an array of addresses/subnets as well, rather than one at a time.
 
@@ -14,48 +18,57 @@ You can either rate limit a specific IP address, a subnet mask, or every address
 The following example will limit requests from localhost to 5 requests per second:
 
 ```powershell
-Start-PodeServer {
-    Add-PodeLimitRule -Type IP -Values 127.0.0.1 -Limit 5 -Seconds 1
-}
+Add-PodeLimitRule -Type IP -Values 127.0.0.1 -Limit 5 -Seconds 1
 ```
 
 Whereas the following example will rate limit requests from a subnet. By default each IP address within the subnet are limited to 5 requests per second:
 
 ```powershell
-Start-PodeServer {
-    Add-PodeLimitRule -Type IP -Values 10.10.0.0/24 -Limit 5 -Seconds 1
-}
+Add-PodeLimitRule -Type IP -Values 10.10.0.0/24 -Limit 5 -Seconds 1
 ```
 
 To treat all IP addresses within by a subnet as one, using a shared limit, you can supply the `-Group` switch:
 
 ```powershell
-Start-PodeServer {
-    Add-PodeLimitRule -Type IP -Values 10.10.0.0/24 -Limit 5 -Seconds 1 -Group
-}
+Add-PodeLimitRule -Type IP -Values 10.10.0.0/24 -Limit 5 -Seconds 1 -Group
 ```
 
 To rate limit requests from multiple addresses in one line, the following example will work:
 
 ```powershell
-Start-PodeServer {
-    Add-PodeLimitRule -Type IP -Values @('192.168.1.1', '192.168.1.2') -Limit 5 -Seconds 1
-}
+Add-PodeLimitRule -Type IP -Values @('192.168.1.1', '192.168.1.2') -Limit 5 -Seconds 1
 ```
 
 Finally, to rate limit requests from every address you can use the `all` keyword:
 
 ```powershell
-Start-PodeServer {
-    Add-PodeLimitRule -Type IP -Values all -Limit 5 -Seconds 1
-}
+Add-PodeLimitRule -Type IP -Values all -Limit 5 -Seconds 1
+```
+
+### Routes
+
+To assign rate limiting to a specific route, you can pass its path to [`Add-PodeLimitRule`](../../../../Functions/Middleware/Add-PodeLimitRule). The following with limit the `/downloads` route to 5 requests every second:
+
+```powershell
+Add-PodeLimitRule -Type Route -Values '/downloads' -Limit 5 -Seconds 1
+```
+
+### Endpoints
+
+To assign rate limiting to a specific endpoint, you can pass an enpoint's name to [`Add-PodeLimitRule`](../../../../Functions/Middleware/Add-PodeLimitRule). The following with limit the `User` endpoint to 5 requests every second:
+
+```powershell
+Add-PodeEndpoint -Address 127.0.0.2 -Port 8090 -Protocol Http -Name 'Admin'
+Add-PodeEndpoint -Address 127.0.0.3 -Port 8090 -Protocol Http -Name 'User'
+
+Add-PodeLimitRule -Type Endpoint -Values 'User' -Limit 5 -Seconds 1
 ```
 
 ## Overriding
 
-Since rate limiting is an inbuilt Middleware, then when you setup rules via the  [`Add-PodeLimitRule`](../../../../Functions/Middleware/Add-PodeLimitRule) function the point at which the limit is checked on the request lifecycle is fixed (see [here](../../Overview/#order-of-running)).
+Since rate limiting is an inbuilt Middleware, then when you setup rules via the [`Add-PodeLimitRule`](../../../../Functions/Middleware/Add-PodeLimitRule) function the point at which the limit is checked on the request lifecycle is fixed (see [here](../../Overview/#order-of-running)).
 
-This means you can override the inbuilt rate limiting logic, with your own custom logic, using the  [`Add-PodeMiddleware`](../../../../Functions/Core/Add-PodeMiddleware) function. To override the rate limiting logic you can pass `__pode_mw_rate_limit__` to the `-Name` parameter of the  [`Add-PodeMiddleware`](../../../../Functions/Core/Add-PodeMiddleware) function.
+This means you can override the inbuilt rate limiting logic, with your own custom logic, using the  [`Add-PodeMiddleware`](../../../../Functions/Core/Add-PodeMiddleware) function. To override the rate limiting logic you can pass `__pode_mw_rate_limit__` to the `-Name` parameter of the [`Add-PodeMiddleware`](../../../../Functions/Core/Add-PodeMiddleware) function.
 
 The following example uses rate limiting, and defines Middleware that will override the inbuilt limiting logic:
 

--- a/examples/web-route-endpoints.ps1
+++ b/examples/web-route-endpoints.ps1
@@ -32,7 +32,7 @@ Start-PodeServer {
 
     # ALL requests for 127.0.0.2 to 127.0.0.1
     Add-PodeRoute -Method * -Path * -EndpointName Endpoint2 -ScriptBlock {
-        Move-PodeResponseUrl -Domain 127.0.0.1
+        Move-PodeResponseUrl -Address 127.0.0.1
     }
 
 }

--- a/src/Private/Authentication.ps1
+++ b/src/Private/Authentication.ps1
@@ -840,7 +840,7 @@ function Set-PodeAuthStatus
         $Description = (Protect-PodeValue -Value $Failure.Message -Default $Description)
 
         # add error to flash
-        if (!$Sessionless -and ![string]::IsNullOrWhiteSpace($Description)) {
+        if ($LoginRoute -and !$Sessionless -and ![string]::IsNullOrWhiteSpace($Description)) {
             Add-PodeFlashMessage -Name 'auth-error' -Message $Description
         }
 

--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -172,7 +172,8 @@ function New-PodeContext
     }
 
     # set the IP address details
-    $ctx.Server.Endpoints = @()
+    $ctx.Server.Endpoints = @{}
+    $ctx.Server.EndpointsMap = @{}
 
     # general encoding for the server
     $ctx.Server.Encoding = New-Object System.Text.UTF8Encoding
@@ -689,28 +690,4 @@ function New-PodeAutoRestartServer
             $PodeContext.Tokens.Restart.Cancel()
         }
     }
-}
-
-function Get-PodeEndpoints
-{
-    param(
-        [Parameter(Mandatory=$true)]
-        [ValidateSet('Http', 'Ws')]
-        [string]
-        $Type
-    )
-
-    $endpoints = $null
-
-    switch ($Type.ToLowerInvariant()) {
-        'http' {
-            $endpoints = @($PodeContext.Server.Endpoints | Where-Object { @('http', 'https') -icontains $_.Protocol })
-        }
-
-        'ws' {
-            $endpoints = @($PodeContext.Server.Endpoints | Where-Object { @('ws', 'wss') -icontains $_.Protocol })
-        }
-    }
-
-    return $endpoints
 }

--- a/src/Private/Endpoints.ps1
+++ b/src/Private/Endpoints.ps1
@@ -1,0 +1,145 @@
+function Find-PodeEndpoints
+{
+    param(
+        [Parameter()]
+        [ValidateSet('', 'Http', 'Https')]
+        [string]
+        $Protocol,
+
+        [Parameter()]
+        [string]
+        $Address,
+
+        [Parameter()]
+        [string[]]
+        $EndpointName
+    )
+
+    $endpoints = @()
+
+    # just use a single endpoint/protocol
+    if ([string]::IsNullOrWhiteSpace($EndpointName)) {
+        $endpoints += @{
+            Protocol = $Protocol
+            Address = $Address
+            Name = [string]::Empty
+        }
+    }
+
+    # get all defined endpoints by name
+    else {
+        foreach ($name in @($EndpointName)) {
+            $_endpoint = Get-PodeEndpointByName -Name $name -ThrowError
+            if ($null -ne $_endpoint) {
+                $endpoints += @{
+                    Protocol = $_endpoint.Protocol
+                    Address = $_endpoint.RawAddress
+                    Name = $name
+                }
+            }
+        }
+    }
+
+    # convert the endpoint's address into host:port format
+    foreach ($_endpoint in $endpoints) {
+        if (![string]::IsNullOrWhiteSpace($_endpoint.Address)) {
+            $_addr = Get-PodeEndpointInfo -Address $_endpoint.Address -AnyPortOnZero
+            $_endpoint.Address = "$($_addr.Host):$($_addr.Port)"
+        }
+    }
+
+    return $endpoints
+}
+
+function Get-PodeEndpoints
+{
+    param(
+        [Parameter(Mandatory=$true)]
+        [ValidateSet('Http', 'Ws')]
+        [string]
+        $Type
+    )
+
+    $endpoints = $null
+
+    switch ($Type.ToLowerInvariant()) {
+        'http' {
+            $endpoints = @($PodeContext.Server.Endpoints.Values | Where-Object { @('http', 'https') -icontains $_.Protocol })
+        }
+
+        'ws' {
+            $endpoints = @($PodeContext.Server.Endpoints.Values | Where-Object { @('ws', 'wss') -icontains $_.Protocol })
+        }
+    }
+
+    return $endpoints
+}
+
+function Find-PodeEndpointName
+{
+    param(
+        [Parameter()]
+        [string]
+        $Protocol,
+
+        [Parameter()]
+        [string]
+        $Address,
+
+        [switch]
+        $ThrowError
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Protocol) -or [string]::IsNullOrWhiteSpace($Address)) {
+        return $null
+    }
+
+    # try and find endpoint
+    $key = "$($Protocol)|$($Address)"
+    $key = @(foreach ($k in $PodeContext.Server.EndpointsMap.Keys) {
+        if ($key -ilike $k) {
+            $k
+            break
+        }
+    })[0]
+
+    if (![string]::IsNullOrWhiteSpace($key) -and $PodeContext.Server.EndpointsMap.ContainsKey($key)) {
+        return $PodeContext.Server.EndpointsMap[$key]
+    }
+
+    # error?
+    if ($ThrowError) {
+        throw "Endpoint with protocol '$($Protocol)' and address '$($Address)' does not exist"
+    }
+
+    return $null
+}
+
+function Get-PodeEndpointByName
+{
+    param (
+        [Parameter()]
+        [string]
+        $Name,
+
+        [switch]
+        $ThrowError
+    )
+
+    # if an EndpointName was supplied, find it and use it
+    if ([string]::IsNullOrWhiteSpace($Name)) {
+        return $null
+    }
+
+    # ensure it exists
+    if ($PodeContext.Server.Endpoints.ContainsKey($Name)) {
+        return $PodeContext.Server.Endpoints[$Name]
+    }
+
+    # error?
+    if ($ThrowError) {
+        throw "Endpoint with name '$($Name)' does not exist"
+    }
+
+    return $null
+}

--- a/src/Private/Gui.ps1
+++ b/src/Private/Gui.ps1
@@ -11,7 +11,7 @@ function Start-PodeGuiRunspace {
         try {
             # if there are multiple endpoints, flag warning we're only using the first - unless explicitly set
             if ($null -eq $PodeContext.Server.Gui.Endpoint) {
-                if (($PodeContext.Server.Endpoints | Measure-Object).Count -gt 1) {
+                if ($PodeContext.Server.Endpoints.Values.Count -gt 1) {
                     Write-PodeHost "Multiple endpoints defined, only the first will be used for the GUI" -ForegroundColor Yellow
                 }
             }

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -1956,9 +1956,9 @@ function Get-PodeEndpointUrl
         $Endpoint
     )
 
-    # get the endpoint on which we're currently listening - use first if there are many
+    # get the endpoint on which we're currently listening - use first http/https if there are many
     if ($null -eq $Endpoint) {
-        $Endpoint = @($PodeContext.Server.Endpoints.Values)[0]
+        $Endpoint = @($PodeContext.Server.Endpoints.Values | Where-Object { $_.Protocol -iin @('http', 'https') })[0]
     }
 
     $url = $Endpoint.Url

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -1958,7 +1958,7 @@ function Get-PodeEndpointUrl
 
     # get the endpoint on which we're currently listening - use first if there are many
     if ($null -eq $Endpoint) {
-        $Endpoint = $PodeContext.Server.Endpoints[0]
+        $Endpoint = @($PodeContext.Server.Endpoints.Values)[0]
     }
 
     $url = $Endpoint.Url

--- a/src/Private/Middleware.ps1
+++ b/src/Private/Middleware.ps1
@@ -142,13 +142,18 @@ function Get-PodeAccessMiddleware
     return (Get-PodeInbuiltMiddleware -Name '__pode_mw_access__' -ScriptBlock {
         param($e)
 
+        # are there any rules?
+        if (($PodeContext.Server.Access.Allow.Count -eq 0) -and ($PodeContext.Server.Access.Deny.Count -eq 0)) {
+            return $true
+        }
+
         # ensure the request IP address is allowed
         if (!(Test-PodeIPAccess -IP $e.Request.RemoteEndPoint.Address)) {
             Set-PodeResponseStatus -Code 403
             return $false
         }
 
-        # IP address is allowed
+        # request is allowed
         return $true
     })
 }
@@ -158,26 +163,28 @@ function Get-PodeLimitMiddleware
     return (Get-PodeInbuiltMiddleware -Name '__pode_mw_rate_limit__' -ScriptBlock {
         param($e)
 
+        # are there any rules?
+        if ($PodeContext.Server.Limits.Rules.Count -eq 0) {
+            return $true
+        }
+
         # check the request IP address has not hit a rate limit
         if (!(Test-PodeIPLimit -IP $e.Request.RemoteEndPoint.Address)) {
             Set-PodeResponseStatus -Code 429
             return $false
         }
 
-        #TODO: check the route
+        # check the route
         if (!(Test-PodeRouteLimit -Path $e.Path)) {
             Set-PodeResponseStatus -Code 429
             return $false
         }
 
-        #TODO: check the endpoint
-        if (!(Test-PodeEndpointLimit -Protocol $e.Endpoint.Protocol -Address $e.Endpoint.Address)) {
+        # check the endpoint
+        if (!(Test-PodeEndpointLimit -EndpointName $e.Endpoint.Name)) {
             Set-PodeResponseStatus -Code 429
             return $false
         }
-
-        #TODO: can we shrink proto/addr searches by doing a one off "what's the endpoint name search?"
-        # - might increase perf else where
 
         # request is allowed
         return $true
@@ -214,9 +221,9 @@ function Get-PodeRouteValidateMiddleware
             param($e)
 
             # check if the path is static route first, then check the main routes
-            $route = Find-PodeStaticRoute -Path $e.Path -Protocol $e.Endpoint.Protocol -Address $e.Endpoint.Address
+            $route = Find-PodeStaticRoute -Path $e.Path -EndpointName $e.Endpoint.Name
             if ($null -eq $route) {
-                $route = Find-PodeRoute -Method $e.Method -Path $e.Path -Protocol $e.Endpoint.Protocol -Address $e.Endpoint.Address -CheckWildMethod
+                $route = Find-PodeRoute -Method $e.Method -Path $e.Path -EndpointName $e.Endpoint.Name -CheckWildMethod
             }
 
             # if there's no route defined, it's a 404 - or a 405 if a route exists for any other method
@@ -224,7 +231,7 @@ function Get-PodeRouteValidateMiddleware
                 # check if a route exists for another method
                 $methods = @('DELETE', 'GET', 'HEAD', 'MERGE', 'OPTIONS', 'PATCH', 'POST', 'PUT', 'TRACE')
                 $diff_route = @(foreach ($method in $methods) {
-                    $r = Find-PodeRoute -Method $method -Path $e.Path -Protocol $e.Endpoint.Protocol -Address $e.Endpoint.Address
+                    $r = Find-PodeRoute -Method $method -Path $e.Path -EndpointName $e.Endpoint.Name
                     if ($null -ne $r) {
                         $r
                         break

--- a/src/Private/Middleware.ps1
+++ b/src/Private/Middleware.ps1
@@ -158,13 +158,28 @@ function Get-PodeLimitMiddleware
     return (Get-PodeInbuiltMiddleware -Name '__pode_mw_rate_limit__' -ScriptBlock {
         param($e)
 
-        # ensure the request IP address has not hit a rate limit
+        # check the request IP address has not hit a rate limit
         if (!(Test-PodeIPLimit -IP $e.Request.RemoteEndPoint.Address)) {
             Set-PodeResponseStatus -Code 429
             return $false
         }
 
-        # IP address is allowed
+        #TODO: check the route
+        if (!(Test-PodeRouteLimit -Path $e.Path)) {
+            Set-PodeResponseStatus -Code 429
+            return $false
+        }
+
+        #TODO: check the endpoint
+        if (!(Test-PodeEndpointLimit -Protocol $e.Endpoint.Protocol -Address $e.Endpoint.Address)) {
+            Set-PodeResponseStatus -Code 429
+            return $false
+        }
+
+        #TODO: can we shrink proto/addr searches by doing a one off "what's the endpoint name search?"
+        # - might increase perf else where
+
+        # request is allowed
         return $true
     })
 }

--- a/src/Private/PodeServer.ps1
+++ b/src/Private/PodeServer.ps1
@@ -100,6 +100,7 @@ function Start-PodeWebServer
                             Endpoint = @{
                                 Protocol = $Request.Url.Scheme
                                 Address = $Request.Host
+                                Name = $null
                             }
                             ContentType = $Request.ContentType
                             ErrorType = $null
@@ -119,6 +120,9 @@ function Start-PodeWebServer
                         # accept/transfer encoding
                         $WebEvent.TransferEncoding = (Get-PodeTransferEncoding -TransferEncoding (Get-PodeHeader -Name 'Transfer-Encoding') -ThrowError)
                         $WebEvent.AcceptEncoding = (Get-PodeAcceptEncoding -AcceptEncoding (Get-PodeHeader -Name 'Accept-Encoding') -ThrowError)
+
+                        # endpoint name
+                        $WebEvent.Endpoint.Name = (Find-PodeEndpointName -Protocol $WebEvent.Endpoint.Protocol -Address $WebEvent.Endpoint.Address)
 
                         # add logging endware for post-request
                         Add-PodeRequestLogEndware -WebEvent $WebEvent

--- a/src/Private/Security.ps1
+++ b/src/Private/Security.ps1
@@ -250,6 +250,118 @@ function Add-PodeIPLimit
     })
 }
 
+function Add-PodeRouteLimit
+{
+    param (
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNull()]
+        [string]
+        $Path,
+
+        [Parameter(Mandatory=$true)]
+        [int]
+        $Limit,
+
+        [Parameter(Mandatory=$true)]
+        [int]
+        $Seconds,
+
+        [switch]
+        $Group
+    )
+
+    # current limit type
+    $type = 'Route'
+
+    # ensure limit and seconds are non-zero and negative
+    if ($Limit -le 0) {
+        throw "Limit value cannot be 0 or less for $($IP)"
+    }
+
+    if ($Seconds -le 0) {
+        throw "Seconds value cannot be 0 or less for $($IP)"
+    }
+
+    # get current rules
+    $rules = $PodeContext.Server.Limits.Rules[$type]
+
+    # setup up perm type
+    if ($null -eq $rules) {
+        $PodeContext.Server.Limits.Rules[$type] = @{}
+        $PodeContext.Server.Limits.Active[$type] = @{}
+        $rules = $PodeContext.Server.Limits.Rules[$type]
+    }
+
+    # have we already added the route?
+    elseif ($rules.ContainsKey($Path)) {
+        return
+    }
+
+    # add limit rule for the route
+    $rules.Add($Path, @{
+        Limit = $Limit
+        Seconds = $Seconds
+        Grouped = [bool]$Group
+        Path = $Path
+    })
+}
+
+function Add-PodeEndpointLimit
+{
+    param (
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNull()]
+        [string]
+        $EndpointName,
+
+        [Parameter(Mandatory=$true)]
+        [int]
+        $Limit,
+
+        [Parameter(Mandatory=$true)]
+        [int]
+        $Seconds,
+
+        [switch]
+        $Group
+    )
+
+    # current limit type
+    $type = 'Endpoint'
+
+    # ensure limit and seconds are non-zero and negative
+    if ($Limit -le 0) {
+        throw "Limit value cannot be 0 or less for $($IP)"
+    }
+
+    if ($Seconds -le 0) {
+        throw "Seconds value cannot be 0 or less for $($IP)"
+    }
+
+    # get current rules
+    $rules = $PodeContext.Server.Limits.Rules[$type]
+
+    # setup up perm type
+    if ($null -eq $rules) {
+        $PodeContext.Server.Limits.Rules[$type] = @{}
+        $PodeContext.Server.Limits.Active[$type] = @{}
+        $rules = $PodeContext.Server.Limits.Rules[$type]
+    }
+
+    # have we already added the endpoint?
+    elseif ($rules.ContainsKey($EndpointName)) {
+        return
+    }
+
+    # add limit rule for the endpoint
+    $rules.Add($Path, @{
+        Limit = $Limit
+        Seconds = $Seconds
+        Grouped = [bool]$Group
+        EndpointName = $EndpointName
+    })
+}
+
 function Add-PodeIPAccess
 {
     param (

--- a/src/Private/Server.ps1
+++ b/src/Private/Server.ps1
@@ -147,7 +147,8 @@ function Restart-PodeInternalServer
         $PodeContext.Server.BodyParsers.Clear()
 
         # clear endpoints
-        $PodeContext.Server.Endpoints = @()
+        $PodeContext.Server.Endpoints.Clear()
+        $PodeContext.Server.EndpointsMap.Clear()
 
         # clear openapi
         $PodeContext.Server.OpenAPI = Get-PodeOABaseObject

--- a/src/Private/SmtpServer.ps1
+++ b/src/Private/SmtpServer.ps1
@@ -7,11 +7,14 @@ function Start-PodeSmtpServer
         throw 'No SMTP handlers have been defined'
     }
 
+    # the endpoint to listen on
+    $endpoint = @($PodeContext.Server.Endpoints.Values)[0]
+
     # grab the relavant port
-    $port = $PodeContext.Server.Endpoints[0].Port
+    $port = $endpoint.Port
 
     # get the IP address for the server
-    $ipAddress = $PodeContext.Server.Endpoints[0].Address
+    $ipAddress = $endpoint.Address
     if (Test-PodeHostname -Hostname $ipAddress) {
         $ipAddress = (Get-PodeIPAddressesForHostname -Hostname $ipAddress -Type All | Select-Object -First 1)
         $ipAddress = (Get-PodeIPAddress $ipAddress)
@@ -26,7 +29,7 @@ function Start-PodeSmtpServer
         # register endpoint on the listener
         $socket = [PodeSocket]::new($ipAddress, $port, $PodeContext.Server.Sockets.Ssl.Protocols, $null)
         $socket.ReceiveTimeout = $PodeContext.Server.Sockets.ReceiveTimeout
-        $socket.Hostname = $PodeContext.Server.Endpoints[0].HostName
+        $socket.Hostname = $endpoint.HostName
         $listener.Add($socket)
         $listener.Start()
     }
@@ -152,5 +155,5 @@ function Start-PodeSmtpServer
     Add-PodeRunspace -Type 'Main' -ScriptBlock $waitScript -Parameters @{ 'Listener' = $listener }
 
     # state where we're running
-    return @("smtp://$($PodeContext.Server.Endpoints[0].HostName):$($port)")
+    return @("smtp://$($endpoint.HostName):$($port)")
 }

--- a/src/Private/TcpServer.ps1
+++ b/src/Private/TcpServer.ps1
@@ -5,11 +5,14 @@ function Start-PodeTcpServer
         throw 'No TCP handlers have been defined'
     }
 
+    # the endpoint to listen on
+    $endpoint = @($PodeContext.Server.Endpoints.Values)[0]
+
     # grab the relavant port
-    $port = $PodeContext.Server.Endpoints[0].Port
+    $port = $endpoint.Port
 
     # get the IP address for the server
-    $ipAddress = $PodeContext.Server.Endpoints[0].Address
+    $ipAddress = $endpoint.Address
     if (Test-PodeHostname -Hostname $ipAddress) {
         $ipAddress = (Get-PodeIPAddressesForHostname -Hostname $ipAddress -Type All | Select-Object -First 1)
         $ipAddress = (Get-PodeIPAddress $ipAddress)
@@ -122,5 +125,5 @@ function Start-PodeTcpServer
     Add-PodeRunspace -Type 'Main' -ScriptBlock $waitScript -Parameters @{ 'Listener' = $listener }
 
     # state where we're running
-    return @("tcp://$($PodeContext.Server.Endpoints[0].HostName):$($port)")
+    return @("tcp://$($endpoint.HostName):$($port)")
 }

--- a/src/Public/Core.ps1
+++ b/src/Public/Core.ps1
@@ -650,6 +650,9 @@ Create and bind a self-signed certifcate for HTTPS endpoints.
 .PARAMETER AllowClientCertificate
 Allow for client certificates to be sent on requests.
 
+.PARAMETER PassThru
+If supplied, the endpoint created will be returned.
+
 .EXAMPLE
 Add-PodeEndpoint -Address localhost -Port 8090 -Protocol Http
 

--- a/src/Public/Middleware.ps1
+++ b/src/Public/Middleware.ps1
@@ -55,13 +55,13 @@ function Add-PodeAccessRule
 
 <#
 .SYNOPSIS
-Adds rate limiting rules for an IP address.
+Adds rate limiting rules for an IP addresses, Routes, or Endpoints.
 
 .DESCRIPTION
-Adds rate limiting rules for an IP address.
+Adds rate limiting rules for an IP addresses, Routes, or Endpoints.
 
 .PARAMETER Type
-What type of request are we limiting?
+What type of request is being rate limited: IP, Route, or Endpoint?
 
 .PARAMETER Values
 A single, or an array of values.
@@ -73,13 +73,16 @@ The maximum number of requests to allow.
 The number of seconds to count requests before restarting the count.
 
 .PARAMETER Group
-If supplied, groups of IPs in a subnet will be concidered as one IP.
+If supplied, groups of IPs in a subnet will be considered as one IP.
 
 .EXAMPLE
 Add-PodeLimitRule -Type IP -Values '127.0.0.1' -Limit 10 -Seconds 1
 
 .EXAMPLE
 Add-PodeLimitRule -Type IP -Values @('192.168.1.1', '10.10.1.0/24') -Limit 50 -Seconds 1 -Group
+
+.EXAMPLE
+Add-PodeLimitRule -Type Route -Values '/downloads' -Limit 5 -Seconds 1
 #>
 function Add-PodeLimitRule
 {

--- a/src/Public/Middleware.ps1
+++ b/src/Public/Middleware.ps1
@@ -86,7 +86,7 @@ function Add-PodeLimitRule
     [CmdletBinding()]
     param (
         [Parameter(Mandatory=$true)]
-        [ValidateSet('IP')]
+        [ValidateSet('IP', 'Route', 'Endpoint')]
         [string]
         $Type,
 
@@ -106,15 +106,22 @@ function Add-PodeLimitRule
         $Group
     )
 
-    # error if serverless
-    Test-PodeIsServerless -FunctionName 'Add-PodeLimitRule' -ThrowError
-
     # call the appropriate limit method
-    switch ($Type.ToLowerInvariant())
+    foreach ($value in $Values)
     {
-        'ip' {
-            foreach ($ip in $Values) {
-                Add-PodeIPLimit -IP $ip -Limit $Limit -Seconds $Seconds -Group:$Group
+        switch ($Type.ToLowerInvariant())
+        {
+            'ip' {
+                Test-PodeIsServerless -FunctionName 'Add-PodeLimitRule' -ThrowError
+                Add-PodeIPLimit -IP $value -Limit $Limit -Seconds $Seconds -Group:$Group
+            }
+
+            'route' {
+                Add-PodeRouteLimit -Path $value -Limit $Limit -Seconds $Seconds -Group:$Group
+            }
+
+            'endpoint' {
+                Add-PodeEndpointLimit -EndpointName $value -Limit $Limit -Seconds $Seconds -Group:$Group
             }
         }
     }

--- a/src/Public/OpenApi.ps1
+++ b/src/Public/OpenApi.ps1
@@ -94,6 +94,7 @@ function Enable-PodeOpenApi
             -RouteFilter $meta.RouteFilter `
             -Protocol $e.Endpoint.Protocol `
             -Address $e.Endpoint.Address `
+            -EndpointName $e.Endpoint.Name `
             -RestrictRoutes:$strict
 
         # write the openapi definition
@@ -164,6 +165,7 @@ function Get-PodeOpenApiDefinition
         -RouteFilter $RouteFilter `
         -Protocol $WebEvent.Endpoint.Protocol `
         -Address $WebEvent.Endpoint.Address `
+        -EndpointName $WebEvent.Endpoint.Name `
         -RestrictRoutes:$RestrictRoutes)
 }
 

--- a/tests/unit/Context.Tests.ps1
+++ b/tests/unit/Context.Tests.ps1
@@ -26,256 +26,285 @@ Describe 'Add-PodeEndpoint' {
         Mock Test-PodeIsAdminUser { return $true }
 
         It 'Set just a Hostname address' {
-            $PodeContext.Server = @{ 'Endpoints' = @(); 'Type' = $null }
+            $PodeContext.Server = @{ Endpoints = @{}; EndpointsMap = @{}; 'Type' = $null }
             Add-PodeEndpoint -Address 'foo.com' -Protocol 'HTTP'
 
             $PodeContext.Server.Type | Should Be 'HTTP'
             $PodeContext.Server.Endpoints | Should Not Be $null
-            $PodeContext.Server.Endpoints.Length | Should Be 1
-            $PodeContext.Server.Endpoints[0].Port | Should Be 8080
-            $PodeContext.Server.Endpoints[0].Name | Should Be ([string]::Empty)
-            $PodeContext.Server.Endpoints[0].HostName | Should Be 'foo.com'
-            $PodeContext.Server.Endpoints[0].Address.ToString() | Should Be 'foo.com'
-            $PodeContext.Server.Endpoints[0].RawAddress | Should Be 'foo.com:0'
+            $PodeContext.Server.Endpoints.Count | Should Be 1
+
+            $endpoint = ($PodeContext.Server.Endpoints.Values | Select-Object -First 1)
+            $endpoint.Port | Should Be 8080
+            $endpoint.Name | Should Not Be ([string]::Empty)
+            $endpoint.HostName | Should Be 'foo.com'
+            $endpoint.Address.ToString() | Should Be 'foo.com'
+            $endpoint.RawAddress | Should Be 'foo.com:8080'
         }
 
         It 'Set Hostname address with a Name' {
-            $PodeContext.Server = @{ 'Endpoints' = @(); 'Type' = $null }
+            $PodeContext.Server = @{ Endpoints = @{}; EndpointsMap = @{}; 'Type' = $null }
             Add-PodeEndpoint -Address 'foo.com' -Protocol 'HTTP' -Name 'Example'
 
             $PodeContext.Server.Type | Should Be 'HTTP'
             $PodeContext.Server.Endpoints | Should Not Be $null
-            $PodeContext.Server.Endpoints.Length | Should Be 1
-            $PodeContext.Server.Endpoints[0].Port | Should Be 8080
-            $PodeContext.Server.Endpoints[0].Name | Should Be 'Example'
-            $PodeContext.Server.Endpoints[0].HostName | Should Be 'foo.com'
-            $PodeContext.Server.Endpoints[0].Address.ToString() | Should Be 'foo.com'
+            $PodeContext.Server.Endpoints.Count | Should Be 1
+
+            $endpoint = ($PodeContext.Server.Endpoints.Values | Select-Object -First 1)
+            $endpoint.Port | Should Be 8080
+            $endpoint.Name | Should Be 'Example'
+            $endpoint.HostName | Should Be 'foo.com'
+            $endpoint.Address.ToString() | Should Be 'foo.com'
         }
 
         It 'Set just a Hostname address with colon' {
-            $PodeContext.Server = @{ 'Endpoints' = @(); 'Type' = $null }
+            $PodeContext.Server = @{ Endpoints = @{}; EndpointsMap = @{}; 'Type' = $null }
             Add-PodeEndpoint -Address 'foo.com' -Protocol 'HTTP'
 
             $PodeContext.Server.Type | Should Be 'HTTP'
             $PodeContext.Server.Endpoints | Should Not Be $null
-            $PodeContext.Server.Endpoints.Length | Should Be 1
-            $PodeContext.Server.Endpoints[0].Port | Should Be 8080
-            $PodeContext.Server.Endpoints[0].HostName | Should Be 'foo.com'
-            $PodeContext.Server.Endpoints[0].Address.ToString() | Should Be 'foo.com'
-            $PodeContext.Server.Endpoints[0].RawAddress | Should Be 'foo.com:0'
+            $PodeContext.Server.Endpoints.Count | Should Be 1
+
+            $endpoint = ($PodeContext.Server.Endpoints.Values | Select-Object -First 1)
+            $endpoint.Port | Should Be 8080
+            $endpoint.HostName | Should Be 'foo.com'
+            $endpoint.Address.ToString() | Should Be 'foo.com'
+            $endpoint.RawAddress | Should Be 'foo.com:8080'
         }
 
         It 'Set both the Hostname address and port' {
-            $PodeContext.Server = @{ 'Endpoints' = @(); 'Type' = $null }
+            $PodeContext.Server = @{ Endpoints = @{}; EndpointsMap = @{}; 'Type' = $null }
             Add-PodeEndpoint -Address 'foo.com' -Port 80 -Protocol 'HTTP'
 
             $PodeContext.Server.Type | Should Be 'HTTP'
             $PodeContext.Server.Endpoints | Should Not Be $null
-            $PodeContext.Server.Endpoints.Length | Should Be 1
-            $PodeContext.Server.Endpoints[0].Port | Should Be 80
-            $PodeContext.Server.Endpoints[0].HostName | Should Be 'foo.com'
-            $PodeContext.Server.Endpoints[0].Address.ToString() | Should Be 'foo.com'
+            $PodeContext.Server.Endpoints.Count | Should Be 1
+
+            $endpoint = ($PodeContext.Server.Endpoints.Values | Select-Object -First 1)
+            $endpoint.Port | Should Be 80
+            $endpoint.HostName | Should Be 'foo.com'
+            $endpoint.Address.ToString() | Should Be 'foo.com'
         }
 
         It 'Set just an IPv4 address' {
-            $PodeContext.Server = @{ 'Endpoints' = @(); 'Type' = $null }
+            $PodeContext.Server = @{ Endpoints = @{}; EndpointsMap = @{}; 'Type' = $null }
             Add-PodeEndpoint -Address '127.0.0.1' -Protocol 'HTTP'
 
             $PodeContext.Server.Type | Should Be 'HTTP'
             $PodeContext.Server.Endpoints | Should Not Be $null
-            $PodeContext.Server.Endpoints.Length | Should Be 1
-            $PodeContext.Server.Endpoints[0].Port | Should Be 8080
-            $PodeContext.Server.Endpoints[0].HostName | Should Be 'localhost'
-            $PodeContext.Server.Endpoints[0].Address.ToString() | Should Be '127.0.0.1'
+            $PodeContext.Server.Endpoints.Count | Should Be 1
+
+            $endpoint = ($PodeContext.Server.Endpoints.Values | Select-Object -First 1)
+            $endpoint.Port | Should Be 8080
+            $endpoint.HostName | Should Be 'localhost'
+            $endpoint.Address.ToString() | Should Be '127.0.0.1'
         }
 
         It 'Set just an IPv4 address for all' {
-            $PodeContext.Server = @{ 'Endpoints' = @(); 'Type' = $null }
+            $PodeContext.Server = @{ Endpoints = @{}; EndpointsMap = @{}; 'Type' = $null }
             Add-PodeEndpoint -Address 'all' -Protocol 'HTTP'
 
             $PodeContext.Server.Type | Should Be 'HTTP'
             $PodeContext.Server.Endpoints | Should Not Be $null
-            $PodeContext.Server.Endpoints.Length | Should Be 1
-            $PodeContext.Server.Endpoints[0].Port | Should Be 8080
-            $PodeContext.Server.Endpoints[0].HostName | Should Be 'localhost'
-            $PodeContext.Server.Endpoints[0].Address.ToString() | Should Be '0.0.0.0'
-            $PodeContext.Server.Endpoints[0].RawAddress | Should Be 'all:0'
+            $PodeContext.Server.Endpoints.Count | Should Be 1
+
+            $endpoint = ($PodeContext.Server.Endpoints.Values | Select-Object -First 1)
+            $endpoint.Port | Should Be 8080
+            $endpoint.HostName | Should Be 'localhost'
+            $endpoint.Address.ToString() | Should Be '0.0.0.0'
+            $endpoint.RawAddress | Should Be 'all:8080'
         }
 
         It 'Set just an IPv4 address with colon' {
-            $PodeContext.Server = @{ 'Endpoints' = @(); 'Type' = $null }
+            $PodeContext.Server = @{ Endpoints = @{}; EndpointsMap = @{}; 'Type' = $null }
             Add-PodeEndpoint -Address '127.0.0.1' -Protocol 'HTTP'
 
             $PodeContext.Server.Type | Should Be 'HTTP'
             $PodeContext.Server.Endpoints | Should Not Be $null
-            $PodeContext.Server.Endpoints.Length | Should Be 1
-            $PodeContext.Server.Endpoints[0].Port | Should Be 8080
-            $PodeContext.Server.Endpoints[0].HostName | Should Be 'localhost'
-            $PodeContext.Server.Endpoints[0].Address.ToString() | Should Be '127.0.0.1'
+            $PodeContext.Server.Endpoints.Count | Should Be 1
+
+            $endpoint = ($PodeContext.Server.Endpoints.Values | Select-Object -First 1)
+            $endpoint.Port | Should Be 8080
+            $endpoint.HostName | Should Be 'localhost'
+            $endpoint.Address.ToString() | Should Be '127.0.0.1'
         }
 
         It 'Set just a port' {
-            $PodeContext.Server = @{ 'Endpoints' = @(); 'Type' = $null }
+            $PodeContext.Server = @{ Endpoints = @{}; EndpointsMap = @{}; 'Type' = $null }
             Add-PodeEndpoint -Port 80 -Protocol 'HTTP'
 
             $PodeContext.Server.Type | Should Be 'HTTP'
             $PodeContext.Server.Endpoints | Should Not Be $null
-            $PodeContext.Server.Endpoints.Length | Should Be 1
-            $PodeContext.Server.Endpoints[0].Port | Should Be 80
-            $PodeContext.Server.Endpoints[0].HostName | Should Be 'localhost'
-            $PodeContext.Server.Endpoints[0].Address.ToString() | Should Be 'localhost'
+            $PodeContext.Server.Endpoints.Count | Should Be 1
+
+            $endpoint = ($PodeContext.Server.Endpoints.Values | Select-Object -First 1)
+            $endpoint.Port | Should Be 80
+            $endpoint.HostName | Should Be 'localhost'
+            $endpoint.Address.ToString() | Should Be 'localhost'
         }
 
         It 'Set just a port with colon' {
-            $PodeContext.Server = @{ 'Endpoints' = @(); 'Type' = $null }
+            $PodeContext.Server = @{ Endpoints = @{}; EndpointsMap = @{}; 'Type' = $null }
             Add-PodeEndpoint -Port 80 -Protocol 'HTTP'
 
             $PodeContext.Server.Type | Should Be 'HTTP'
             $PodeContext.Server.Endpoints | Should Not Be $null
-            $PodeContext.Server.Endpoints.Length | Should Be 1
-            $PodeContext.Server.Endpoints[0].Port | Should Be 80
-            $PodeContext.Server.Endpoints[0].HostName | Should Be 'localhost'
-            $PodeContext.Server.Endpoints[0].Address.ToString() | Should Be 'localhost'
+            $PodeContext.Server.Endpoints.Count | Should Be 1
+
+            $endpoint = ($PodeContext.Server.Endpoints.Values | Select-Object -First 1)
+            $endpoint.Port | Should Be 80
+            $endpoint.HostName | Should Be 'localhost'
+            $endpoint.Address.ToString() | Should Be 'localhost'
         }
 
         It 'Set both IPv4 address and port' {
-            $PodeContext.Server = @{ 'Endpoints' = @(); 'Type' = $null }
+            $PodeContext.Server = @{ Endpoints = @{}; EndpointsMap = @{}; 'Type' = $null }
             Add-PodeEndpoint -Address '127.0.0.1' -Port 80 -Protocol 'HTTP'
 
             $PodeContext.Server.Type | Should Be 'HTTP'
             $PodeContext.Server.Endpoints | Should Not Be $null
-            $PodeContext.Server.Endpoints.Length | Should Be 1
-            $PodeContext.Server.Endpoints[0].Port | Should Be 80
-            $PodeContext.Server.Endpoints[0].HostName | Should Be 'localhost'
-            $PodeContext.Server.Endpoints[0].Address.ToString() | Should Be '127.0.0.1'
+            $PodeContext.Server.Endpoints.Count | Should Be 1
+
+            $endpoint = ($PodeContext.Server.Endpoints.Values | Select-Object -First 1)
+            $endpoint.Port | Should Be 80
+            $endpoint.HostName | Should Be 'localhost'
+            $endpoint.Address.ToString() | Should Be '127.0.0.1'
         }
 
         It 'Set both IPv4 address and port for all' {
-            $PodeContext.Server = @{ 'Endpoints' = @(); 'Type' = $null }
+            $PodeContext.Server = @{ Endpoints = @{}; EndpointsMap = @{}; 'Type' = $null }
             Add-PodeEndpoint -Address '*' -Port 80 -Protocol 'HTTP'
 
             $PodeContext.Server.Type | Should Be 'HTTP'
             $PodeContext.Server.Endpoints | Should Not Be $null
-            $PodeContext.Server.Endpoints.Length | Should Be 1
-            $PodeContext.Server.Endpoints[0].Port | Should Be 80
-            $PodeContext.Server.Endpoints[0].HostName | Should Be 'localhost'
-            $PodeContext.Server.Endpoints[0].Address.ToString() | Should Be '0.0.0.0'
-            $PodeContext.Server.Endpoints[0].RawAddress | Should Be '*:80'
+            $PodeContext.Server.Endpoints.Count | Should Be 1
+
+            $endpoint = ($PodeContext.Server.Endpoints.Values | Select-Object -First 1)
+            $endpoint.Port | Should Be 80
+            $endpoint.HostName | Should Be 'localhost'
+            $endpoint.Address.ToString() | Should Be '0.0.0.0'
+            $endpoint.RawAddress | Should Be '*:80'
         }
 
         It 'Throws error for an invalid IPv4' {
-            $PodeContext.Server = @{ 'Endpoints' = @(); 'Type' = $null }
+            $PodeContext.Server = @{ Endpoints = @{}; EndpointsMap = @{}; 'Type' = $null }
             { Add-PodeEndpoint -Address '256.0.0.1' -Protocol 'HTTP' } | Should Throw 'Invalid IP Address'
 
             $PodeContext.Server.Type | Should Be $null
-            $PodeContext.Server.Endpoints | Should Be $null
+            $PodeContext.Server.Endpoints.Count | Should Be 0
         }
 
         It 'Throws error for an invalid IPv4 address with port' {
-            $PodeContext.Server = @{ 'Endpoints' = @(); 'Type' = $null }
+            $PodeContext.Server = @{ Endpoints = @{}; EndpointsMap = @{}; 'Type' = $null }
             { Add-PodeEndpoint -Address '256.0.0.1' -Port 80 -Protocol 'HTTP' } | Should Throw 'Invalid IP Address'
 
             $PodeContext.Server.Type | Should Be $null
-            $PodeContext.Server.Endpoints | Should Be $null
+            $PodeContext.Server.Endpoints.Count | Should Be 0
         }
 
         It 'Add two endpoints to listen on, of the same type' {
-            $PodeContext.Server = @{ 'Endpoints' = @(); 'Type' = $null }
-            Add-PodeEndpoint -Address '127.0.0.1' -Port 80 -Protocol 'HTTP'
-            Add-PodeEndpoint -Address 'pode.foo.com' -Port 80 -Protocol 'HTTP'
+            $PodeContext.Server = @{ Endpoints = @{}; EndpointsMap = @{}; 'Type' = $null }
+            $ep1 = (Add-PodeEndpoint -Address '127.0.0.1' -Port 80 -Protocol 'HTTP' -PassThru)
+            $ep2 = (Add-PodeEndpoint -Address 'pode.foo.com' -Port 80 -Protocol 'HTTP' -PassThru)
 
             $PodeContext.Server.Type | Should Be 'HTTP'
             $PodeContext.Server.Endpoints | Should Not Be $null
-            $PodeContext.Server.Endpoints.Length | Should Be 2
+            $PodeContext.Server.Endpoints.Count | Should Be 2
 
-            $PodeContext.Server.Endpoints[0].Port | Should Be 80
-            $PodeContext.Server.Endpoints[0].HostName | Should Be 'localhost'
-            $PodeContext.Server.Endpoints[0].Address.ToString() | Should Be '127.0.0.1'
+            $endpoint = $PodeContext.Server.Endpoints[$ep1.Name]
+            $endpoint.Port | Should Be 80
+            $endpoint.HostName | Should Be 'localhost'
+            $endpoint.Address.ToString() | Should Be '127.0.0.1'
 
-            $PodeContext.Server.Endpoints[1].Port | Should Be 80
-            $PodeContext.Server.Endpoints[1].HostName | Should Be 'pode.foo.com'
-            $PodeContext.Server.Endpoints[1].Address.ToString() | Should Be 'pode.foo.com'
+            $endpoint = $PodeContext.Server.Endpoints[$ep2.Name]
+            $endpoint.Port | Should Be 80
+            $endpoint.HostName | Should Be 'pode.foo.com'
+            $endpoint.Address.ToString() | Should Be 'pode.foo.com'
         }
 
         It 'Add two endpoints to listen on, with different names' {
-            $PodeContext.Server = @{ 'Endpoints' = @(); 'Type' = $null }
+            $PodeContext.Server = @{ Endpoints = @{}; EndpointsMap = @{}; 'Type' = $null }
             Add-PodeEndpoint -Address '127.0.0.1' -Port 80 -Protocol 'HTTP' -Name 'Example1'
             Add-PodeEndpoint -Address 'pode.foo.com' -Port 80 -Protocol 'HTTP' -Name 'Example2'
 
             $PodeContext.Server.Type | Should Be 'HTTP'
             $PodeContext.Server.Endpoints | Should Not Be $null
-            $PodeContext.Server.Endpoints.Length | Should Be 2
+            $PodeContext.Server.Endpoints.Count | Should Be 2
 
-            $PodeContext.Server.Endpoints[0].Port | Should Be 80
-            $PodeContext.Server.Endpoints[0].Name | Should Be 'Example1'
-            $PodeContext.Server.Endpoints[0].HostName | Should Be 'localhost'
-            $PodeContext.Server.Endpoints[0].Address.ToString() | Should Be '127.0.0.1'
+            $endpoint = $PodeContext.Server.Endpoints['Example1']
+            $endpoint.Port | Should Be 80
+            $endpoint.Name | Should Be 'Example1'
+            $endpoint.HostName | Should Be 'localhost'
+            $endpoint.Address.ToString() | Should Be '127.0.0.1'
 
-            $PodeContext.Server.Endpoints[1].Port | Should Be 80
-            $PodeContext.Server.Endpoints[1].Name | Should Be 'Example2'
-            $PodeContext.Server.Endpoints[1].HostName | Should Be 'pode.foo.com'
-            $PodeContext.Server.Endpoints[1].Address.ToString() | Should Be 'pode.foo.com'
+            $endpoint = $PodeContext.Server.Endpoints['Example2']
+            $endpoint.Port | Should Be 80
+            $endpoint.Name | Should Be 'Example2'
+            $endpoint.HostName | Should Be 'pode.foo.com'
+            $endpoint.Address.ToString() | Should Be 'pode.foo.com'
         }
 
         It 'Add two endpoints to listen on, one of HTTP and one of HTTPS' {
-            $PodeContext.Server = @{ 'Endpoints' = @(); 'Type' = $null }
-            Add-PodeEndpoint -Address '127.0.0.1' -Port 80 -Protocol 'HTTP'
-            Add-PodeEndpoint -Address 'pode.foo.com' -Port 80 -Protocol 'HTTPS'
+            $PodeContext.Server = @{ Endpoints = @{}; EndpointsMap = @{}; 'Type' = $null }
+            Add-PodeEndpoint -Address '127.0.0.1' -Port 80 -Protocol 'HTTP' -Name 'Http'
+            Add-PodeEndpoint -Address 'pode.foo.com' -Port 80 -Protocol 'HTTPS' -Name 'Https'
 
             $PodeContext.Server.Type | Should Be 'HTTP'
             $PodeContext.Server.Endpoints | Should Not Be $null
-            $PodeContext.Server.Endpoints.Length | Should Be 2
+            $PodeContext.Server.Endpoints.Count | Should Be 2
 
-            $PodeContext.Server.Endpoints[0].Port | Should Be 80
-            $PodeContext.Server.Endpoints[0].HostName | Should Be 'localhost'
-            $PodeContext.Server.Endpoints[0].Address.ToString() | Should Be '127.0.0.1'
+            $endpoint = $PodeContext.Server.Endpoints['Http']
+            $endpoint.Port | Should Be 80
+            $endpoint.HostName | Should Be 'localhost'
+            $endpoint.Address.ToString() | Should Be '127.0.0.1'
 
-            $PodeContext.Server.Endpoints[1].Port | Should Be 80
-            $PodeContext.Server.Endpoints[1].HostName | Should Be 'pode.foo.com'
-            $PodeContext.Server.Endpoints[1].Address.ToString() | Should Be 'pode.foo.com'
+            $endpoint = $PodeContext.Server.Endpoints['Https']
+            $endpoint.Port | Should Be 80
+            $endpoint.HostName | Should Be 'pode.foo.com'
+            $endpoint.Address.ToString() | Should Be 'pode.foo.com'
         }
 
         It 'Add two endpoints to listen on, but one added as they are the same' {
-            $PodeContext.Server = @{ 'Endpoints' = @(); 'Type' = $null }
+            $PodeContext.Server = @{ Endpoints = @{}; EndpointsMap = @{}; 'Type' = $null }
             Add-PodeEndpoint -Address '127.0.0.1' -Port 80 -Protocol 'HTTP'
             Add-PodeEndpoint -Address '127.0.0.1' -Port 80 -Protocol 'HTTP'
 
             $PodeContext.Server.Type | Should Be 'HTTP'
             $PodeContext.Server.Endpoints | Should Not Be $null
-            $PodeContext.Server.Endpoints.Length | Should Be 1
+            $PodeContext.Server.Endpoints.Count | Should Be 1
 
-            $PodeContext.Server.Endpoints[0].Port | Should Be 80
-            $PodeContext.Server.Endpoints[0].HostName | Should Be 'localhost'
-            $PodeContext.Server.Endpoints[0].Address.ToString() | Should Be '127.0.0.1'
+            $endpoint = @($PodeContext.Server.Endpoints.Values)[0]
+            $endpoint.Port | Should Be 80
+            $endpoint.HostName | Should Be 'localhost'
+            $endpoint.Address.ToString() | Should Be '127.0.0.1'
         }
 
         It 'Throws error when adding two endpoints of different types' {
-            $PodeContext.Server = @{ 'Endpoints' = @(); 'Type' = $null }
+            $PodeContext.Server = @{ Endpoints = @{}; EndpointsMap = @{}; 'Type' = $null }
             Add-PodeEndpoint -Address '127.0.0.1' -Port 80 -Protocol 'HTTP'
             { Add-PodeEndpoint -Address 'pode.foo.com' -Port 80 -Protocol 'SMTP' } | Should Throw 'cannot add smtp endpoint'
         }
 
         It 'Throws error when adding two endpoints with the same name' {
-            $PodeContext.Server = @{ 'Endpoints' = @(); 'Type' = $null }
+            $PodeContext.Server = @{ Endpoints = @{}; EndpointsMap = @{}; 'Type' = $null }
             Add-PodeEndpoint -Address '127.0.0.1' -Port 80 -Protocol 'HTTP' -Name 'Example'
             { Add-PodeEndpoint -Address 'pode.foo.com' -Port 80 -Protocol 'HTTP' -Name 'Example' } | Should Throw 'already been defined'
         }
 
         It 'Throws error when adding two SMTP endpoints' {
-            $PodeContext.Server = @{ 'Endpoints' = @(); 'Type' = $null }
+            $PodeContext.Server = @{ Endpoints = @{}; EndpointsMap = @{}; 'Type' = $null }
             Add-PodeEndpoint -Address '127.0.0.1' -Port 80 -Protocol 'SMTP'
             { Add-PodeEndpoint -Address 'pode.foo.com' -Port 80 -Protocol 'SMTP' } | Should Throw 'already been defined'
         }
 
         It 'Throws error when adding two TCP endpoints' {
-            $PodeContext.Server = @{ 'Endpoints' = @(); 'Type' = $null }
+            $PodeContext.Server = @{ Endpoints = @{}; EndpointsMap = @{}; 'Type' = $null }
             Add-PodeEndpoint -Address '127.0.0.1' -Port 80 -Protocol 'TCP'
             { Add-PodeEndpoint -Address 'pode.foo.com' -Port 80 -Protocol 'TCP' } | Should Throw 'already been defined'
         }
 
         It 'Throws an error for not running as admin' {
             Mock Test-PodeIsAdminUser { return $false }
-            $PodeContext.Server = @{ 'Endpoints' = @(); 'Type' = $null }
+            $PodeContext.Server = @{ Endpoints = @{}; EndpointsMap = @{}; 'Type' = $null }
             { Add-PodeEndpoint -Address 'foo.com' -Protocol 'HTTP' } | Should Throw 'Must be running with admin'
         }
     }
@@ -286,13 +315,13 @@ Describe 'Get-PodeEndpoint' {
     Mock Test-PodeIsAdminUser { return $true }
 
     It 'Returns no Endpoints' {
-        $PodeContext.Server = @{ Endpoints = @(); Type = $null }
+        $PodeContext.Server = @{ Endpoints = @{}; EndpointsMap = @{}; Type = $null }
         $endpoints = Get-PodeEndpoint
         $endpoints.Length | Should Be 0
     }
 
     It 'Returns all Endpoints' {
-        $PodeContext.Server = @{ Endpoints = @(); Type = $null }
+        $PodeContext.Server = @{ Endpoints = @{}; EndpointsMap = @{}; Type = $null }
 
         Add-PodeEndpoint -Address '127.0.0.1' -Port 80 -Protocol 'HTTP'
         Add-PodeEndpoint -Address 'pode.foo.com' -Port 80 -Protocol 'HTTP'
@@ -303,7 +332,7 @@ Describe 'Get-PodeEndpoint' {
     }
 
     It 'Returns 1 endpoint by address' {
-        $PodeContext.Server = @{ Endpoints = @(); Type = $null }
+        $PodeContext.Server = @{ Endpoints = @{}; EndpointsMap = @{}; Type = $null }
 
         Add-PodeEndpoint -Address '127.0.0.1' -Port 80 -Protocol 'HTTP'
         Add-PodeEndpoint -Address 'pode.foo.com' -Port 80 -Protocol 'HTTP'
@@ -314,7 +343,7 @@ Describe 'Get-PodeEndpoint' {
     }
 
     It 'Returns 2 endpoints by address' {
-        $PodeContext.Server = @{ Endpoints = @(); Type = $null }
+        $PodeContext.Server = @{ Endpoints = @{}; EndpointsMap = @{}; Type = $null }
 
         Add-PodeEndpoint -Address '127.0.0.1' -Port 80 -Protocol 'HTTP'
         Add-PodeEndpoint -Address 'pode.foo.com' -Port 80 -Protocol 'HTTP'
@@ -325,7 +354,7 @@ Describe 'Get-PodeEndpoint' {
     }
 
     It 'Returns 2 endpoints by port' {
-        $PodeContext.Server = @{ Endpoints = @(); Type = $null }
+        $PodeContext.Server = @{ Endpoints = @{}; EndpointsMap = @{}; Type = $null }
 
         Add-PodeEndpoint -Address '127.0.0.1' -Port 80 -Protocol 'HTTP'
         Add-PodeEndpoint -Address 'pode.foo.com' -Port 80 -Protocol 'HTTP'
@@ -336,7 +365,7 @@ Describe 'Get-PodeEndpoint' {
     }
 
     It 'Returns all endpoints by protocol' {
-        $PodeContext.Server = @{ Endpoints = @(); Type = $null }
+        $PodeContext.Server = @{ Endpoints = @{}; EndpointsMap = @{}; Type = $null }
 
         Add-PodeEndpoint -Address '127.0.0.1' -Port 80 -Protocol 'HTTP'
         Add-PodeEndpoint -Address 'pode.foo.com' -Port 80 -Protocol 'HTTP'
@@ -347,7 +376,7 @@ Describe 'Get-PodeEndpoint' {
     }
 
     It 'Returns 2 endpoints by name' {
-        $PodeContext.Server = @{ Endpoints = @(); Type = $null }
+        $PodeContext.Server = @{ Endpoints = @{}; EndpointsMap = @{}; Type = $null }
 
         Add-PodeEndpoint -Address '127.0.0.1' -Port 80 -Protocol 'HTTP' -Name 'Admin'
         Add-PodeEndpoint -Address 'pode.foo.com' -Port 80 -Protocol 'HTTP' -Name 'User'
@@ -358,7 +387,7 @@ Describe 'Get-PodeEndpoint' {
     }
 
     It 'Returns 1 endpoint using everything' {
-        $PodeContext.Server = @{ Endpoints = @(); Type = $null }
+        $PodeContext.Server = @{ Endpoints = @{}; EndpointsMap = @{}; Type = $null }
 
         Add-PodeEndpoint -Address '127.0.0.1' -Port 80 -Protocol 'HTTP' -Name 'Admin'
         Add-PodeEndpoint -Address 'pode.foo.com' -Port 80 -Protocol 'HTTP' -Name 'User'
@@ -369,7 +398,7 @@ Describe 'Get-PodeEndpoint' {
     }
 
     It 'Returns endpoint set using wildcard' {
-        $PodeContext.Server = @{ Endpoints = @(); Type = $null }
+        $PodeContext.Server = @{ Endpoints = @{}; EndpointsMap = @{}; Type = $null }
 
         Add-PodeEndpoint -Address '*' -Port 80 -Protocol 'HTTP'
 
@@ -378,7 +407,7 @@ Describe 'Get-PodeEndpoint' {
     }
 
     It 'Returns endpoint set using localhost' {
-        $PodeContext.Server = @{ Endpoints = @(); Type = $null }
+        $PodeContext.Server = @{ Endpoints = @{}; EndpointsMap = @{}; Type = $null }
 
         Add-PodeEndpoint -Address 'localhost' -Port 80 -Protocol 'HTTP'
 

--- a/tests/unit/Helpers.Tests.ps1
+++ b/tests/unit/Helpers.Tests.ps1
@@ -1199,11 +1199,13 @@ Describe 'Close-PodeServerInternal' {
 Describe 'Get-PodeEndpointUrl' {
     It 'Returns default endpoint url' {
         $PodeContext = @{ Server = @{
-            Endpoints = @(@{
-                Port = 6000
-                Hostname = 'thing.com'
-                Protocol = 'https'
-            })
+            Endpoints = @{
+                Example1 = @{
+                    Port = 6000
+                    Hostname = 'thing.com'
+                    Protocol = 'https'
+                }
+            }
         } }
 
         Get-PodeEndpointUrl | Should Be 'https://thing.com:6000'

--- a/tests/unit/Middleware.Tests.ps1
+++ b/tests/unit/Middleware.Tests.ps1
@@ -253,7 +253,25 @@ Describe 'Get-PodeAccessMiddleware' {
         }) | Should Be $true
     }
 
+    It 'Returns a ScriptBlock and invokes it as true, no rule' {
+        $r = Get-PodeAccessMiddleware
+        $r.Name | Should Be '__pode_mw_access__'
+        $r.Logic | Should Not Be $null
+
+        (. $r.Logic @{
+            'Request' = @{ 'RemoteEndPoint' = @{ 'Address' = 'localhost' } }
+        }) | Should Be $true
+    }
+
     It 'Returns a ScriptBlock and invokes it as false' {
+        $PodeContext = @{
+            Server = @{
+                Access = @{
+                    Allow = @{ Key = 'Value' }
+                }
+            }
+        }
+
         $r = Get-PodeAccessMiddleware
         $r.Name | Should Be '__pode_mw_access__'
         $r.Logic | Should Not Be $null
@@ -283,7 +301,25 @@ Describe 'Get-PodeLimitMiddleware' {
         }) | Should Be $true
     }
 
+    It 'Returns a ScriptBlock and invokes it as true, no rules' {
+        $r = Get-PodeLimitMiddleware
+        $r.Name | Should Be '__pode_mw_rate_limit__'
+        $r.Logic | Should Not Be $null
+
+        (. $r.Logic @{
+            'Request' = @{ 'RemoteEndPoint' = @{ 'Address' = 'localhost' } }
+        }) | Should Be $true
+    }
+
     It 'Returns a ScriptBlock and invokes it as false' {
+        $PodeContext = @{
+            Server = @{
+                Limits = @{
+                    Rules = @{ Key = 'Value' }
+                }
+            }
+        }
+
         $r = Get-PodeLimitMiddleware
         $r.Name | Should Be '__pode_mw_rate_limit__'
         $r.Logic | Should Not Be $null

--- a/tests/unit/Server.Tests.ps1
+++ b/tests/unit/Server.Tests.ps1
@@ -124,6 +124,8 @@ Describe 'Restart-PodeInternalServer' {
                     Types = @{ 'key' = 'value' };
                 };
                 Middleware = @{ 'key' = 'value' };
+                Endpoints = @{ 'key' = 'value' };
+                EndpointsMap = @{ 'key' = 'value' };
                 Endware = @{ 'key' = 'value' };
                 ViewEngine = @{
                     Type = 'pode';


### PR DESCRIPTION
### Description of the Change
This adds support for rate limiting Routes and Endpoints. It also refactors the logic around finding routes based on the current endpoint - so that the endpoint is looked up once, instead of numerous times.

Endpoints now also have a random name assigned, if one isn't specified on `Add-PodeEndpoint` - this name is a GUID. To get this name, there's a new `-PassThru` switch as well.

### Related Issue
Resolves #524 

### Examples
To limit some `/download` Route to 5 req/s:
```powershell
Add-PodeLimitRule -Type Route -Values '/downloads' -Limit 5 -Seconds 1
```

To limit an endpoint with name `User` to 5 req/s:
```powershell
Add-PodeEndpoint -Address 127.0.0.3 -Port 8090 -Protocol Http -Name 'User'
Add-PodeLimitRule -Type Endpoint -Values 'User' -Limit 5 -Seconds 1
```
