### PR TITLE
Fixes an issue in getting the Function Name of an Azure Function

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+## v1.8.4
+
+```plain
+### Bugs
+* #615: Fixes a bug with Azure Functions V3, where the sys property has now been removed
+```
+
 ## v1.8.3
 
 ```plain

--- a/src/Private/Serverless.ps1
+++ b/src/Private/Serverless.ps1
@@ -57,7 +57,12 @@ function Start-PodeAzFuncServer
                 $WebEvent.Path = $request.Query['static-file']
             }
             else {
-                $WebEvent.Path = "/api/$($Data.sys.MethodName)"
+                $funcName = $Data.sys.MethodName
+                if ([string]::IsNullOrWhiteSpace($funcName)) {
+                    $funcName = $Data.FunctionName
+                }
+
+                $WebEvent.Path = "/api/$($funcName)"
             }
 
             $WebEvent.Path = [System.Web.HttpUtility]::UrlDecode($WebEvent.Path)


### PR DESCRIPTION
### Description of the Change
In Functions 3, the sys property appears to have now been removed, meaning retrieving the function name failed. for 3, the name is now in a FunctionName property.

### Related Issue
#615 
