### PR TITLE
Adds better support for Hostnames on Endpoints

### DIFF
--- a/docs/Getting-Started/Migrating/1X-to-2X.md
+++ b/docs/Getting-Started/Migrating/1X-to-2X.md
@@ -15,6 +15,8 @@ With the dropping of HttpListener, the `-Certificate` parameter is now the old `
 The `-CertificateThumbprint` parameter remains the same, and only works on Windows.
 The `-Certificate` parameter is now the `-CertificateName` parameter, and also only works on Windows.
 
+There is a new `-Hostname` parameter to specify a hostname for your endpoint. Using `-Address` still works for ease, and the IP for the hostname by default is `127.0.0.1`. If you used a host file/DNS entry for your hostname address, then supplying `-LookupHostname` will source the IP for your hostname appropriately.
+
 ### Configuration
 
 Settings that use to be under `Server > Pode` are now just under `Server`. For example, SSL protocols have moved from:

--- a/docs/Tutorials/Endpoints/Basics.md
+++ b/docs/Tutorials/Endpoints/Basics.md
@@ -1,20 +1,49 @@
 # Basics
 
-Endpoints in Pode are used to bind your server to specific IPs and ports, over specific protocols (such as HTTP or HTTPS). Endpoints can have unique names, so you can bind Routes to certain endpoints only.
+Endpoints in Pode are used to bind your server to specific IPs, Hostnames and ports, over specific protocols (such as HTTP or HTTPS). Endpoints can have unique names, so you can bind Routes to certain endpoints only.
 
 ## Usage
 
-To add new endpoints to your server, you can use the [`Add-PodeEndpoint`](../../../Functions/Core/Add-PodeEndpoint) function. A quick and simple example is the following, which will bind your server to `http://localhost:8080`:
+To add new endpoints to your server, you can use [`Add-PodeEndpoint`](../../../Functions/Core/Add-PodeEndpoint). A quick and simple example is the following, which will bind your server to `http://localhost:8080`:
 
 ```powershell
 Start-PodeServer {
-    Add-PodeEndpoint -Address * -Port 8080 -Protocol Http
+    Add-PodeEndpoint -Address localhost -Port 8080 -Protocol Http
 }
 ```
 
-The `-Address` can be local or private IP address, or a hostname that is bound to an IP address (either in the hosts file, or in DNS). The `-Port` is any valid port number, and the `-Protocol` defines which protocol the endpoint will use: HTTP, HTTPS, SMTP, TCP, WS and WSS.
+The `-Address` can be local or private IP address. The `-Port` is any valid port number, and the `-Protocol` defines which protocol the endpoint will use: HTTP, HTTPS, SMTP, TCP, WS and WSS.
 
 You can also supply an optional unique `-Name` to your endpoint. This name will allow you to bind routes to certain endpoints; so if you have endpoint A and B, and you bind some route to endpoint A, then it won't be accessible over endpoint B.
+
+## Hostnames
+
+You can specify a `-Hostname` for an endpoint, in doing so you can only access routes via the specified hostname. Using a hostname will allow you to have multiple endpoints all using the same IP/Port, but with different hostnames.
+
+The following will create an endpoint with hostname `example.pode.com`, bound to `127.0.0.1:8080`:
+
+```powershell
+Add-PodeEndpoint -Hostname example.pode.com -Port 8080 -Protocol Http
+```
+
+To bind a hostname to a specific IP you can use `-Address`:
+
+```powershell
+Add-PodeEndpoint -Address 127.0.0.2 -Hostname example.pode.com -Port 8080 -Protocol Http
+```
+
+or, lookup the hostnames IP from host file or DNS:
+
+```powershell
+Add-PodeEndpoint -Hostname example.pode.com -Port 8080 -Protocol Http -LookupHostname
+```
+
+Finally, you can bind multiple hostnames to one IP/Port:
+
+```powershell
+Add-PodeEndpoint -Address 127.0.0.3 -Hostname one.pode.com -Port 8080 -Protocol Http
+Add-PodeEndpoint -Address 127.0.0.3 -Hostname two.pode.com -Port 8080 -Protocol Http
+```
 
 ## Certificates
 
@@ -81,6 +110,7 @@ The following is the structure of the Endpoint object internally, as well as the
 | Port | int | The port the Endpoint will use |
 | IsIPAddress | bool | Whether or not the listener will bind using Hostname or IP address |
 | Hostname | string | The hostname of the Endpoint |
+| FriendlyName | string | A user friendly hostname to use when generating internal URLs |
 | Url | string | The full base URL of the Endpoint |
 | Ssl | bool | Whether or not this Endpoint support support SSL |
 | Protocol | string | The protocol of the Endpoint |

--- a/docs/Tutorials/Endpoints/External.md
+++ b/docs/Tutorials/Endpoints/External.md
@@ -37,18 +37,27 @@ Invoke-RestMethod -Uri 'http://10.10.1.5:8080'
 
 The final way to expose your server externally is to allow only specific hostnames bound to the server's Private/Public IP address - something like SNI in IIS.
 
-To do this, let's say you want to allow only `one.pode.com` and `two.pode.com` on a server with IP `10.10.1.5`. The first thing to do is add the hostnames to the server's hosts file (or dns):
+To do this, let's say you want to allow only `one.pode.com` and `two.pode.com` on a server with IP `10.10.1.5`. There are two way of doing this:
+
+1. Specify the hostname/address directly on [`Add-PodeEndpoint`]:
+
+```powershell
+Add-PodeEndpoint -Address 10.10.1.5 -Hostname 'one.pode.com' -Port 8080 -Protocol Http
+Add-PodeEndpoint -Address 10.10.1.5 -Hostname 'two.pode.com' -Port 8080 -Protocol Http
+```
+
+2. Add the hostnames to the server's hosts file (or dns):
 
 ```plain
 10.10.1.5   one.pode.com
 10.10.1.5   two.pode.com
 ```
 
-Then, create the endpoints within your server:
+Then, create the endpoints within your server using the `-LookupHostname` switch:
 
 ```powershell
-Add-PodeEndpoint -Address 'one.pode.com' -Port 8080 -Protocol Http
-Add-PodeEndpoint -Address 'two.pode.com' -Port 8080 -Protocol Http
+Add-PodeEndpoint -Hostname 'one.pode.com' -Port 8080 -Protocol Http -LookupHostname
+Add-PodeEndpoint -Hostname 'two.pode.com' -Port 8080 -Protocol Http -LookupHostname
 ```
 
 Next, make sure to add the hostnames into your hosts file, or into DNS.

--- a/examples/web-hostname-kestrel.ps1
+++ b/examples/web-hostname-kestrel.ps1
@@ -1,0 +1,46 @@
+param (
+    [int]
+    $Port = 8085
+)
+
+$path = Split-Path -Parent -Path (Split-Path -Parent -Path $MyInvocation.MyCommand.Path)
+Import-Module "$($path)/src/Pode.psm1" -Force -ErrorAction Stop
+
+# or just:
+# Import-Module Pode
+
+# you will require the Pode.Kestrel module for this example
+Import-Module Pode.Kestrel
+
+# create a server, and start listening on port 8085 at pode.foo.com
+# -- You will need to add "127.0.0.1  pode.foo.com" to your hosts file
+Start-PodeServer -Threads 2 -ListenerType Kestrel {
+
+    # listen on localhost:8085
+    Add-PodeEndpoint -Address pode3.foo.com -Port $Port -Protocol Http
+    Add-PodeEndpoint -Address pode2.foo.com -Port $Port -Protocol Http
+    Add-PodeEndpoint -Address 127.0.0.1 -Hostname pode.foo.com -Port $Port -Protocol Http
+    Add-PodeEndpoint -Hostname pode4.foo.com -Port $Port -Protocol Http -LookupHostname
+
+    # logging
+    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+
+    # set view engine to pode renderer
+    Set-PodeViewEngine -Type Pode
+
+    # STATIC asset folder route
+    Add-PodeStaticRoute -Path '/assets' -Source './assets' -Defaults @('index.html')
+
+    # GET request for web page on "localhost:8085/"
+    Add-PodeRoute -Method Get -Path '/' -ScriptBlock {
+        param($session)
+        Write-PodeViewResponse -Path 'web-static' -Data @{ 'numbers' = @(1, 2, 3); }
+    }
+
+    # GET request to download a file from static route
+    Add-PodeRoute -Method Get -Path '/download' -ScriptBlock {
+        param($session)
+        Set-PodeResponseAttachment -Path '/assets/images/Fry.png'
+    }
+
+}

--- a/examples/web-hostname.ps1
+++ b/examples/web-hostname.ps1
@@ -17,6 +17,7 @@ Start-PodeServer -Threads 2 {
     Add-PodeEndpoint -Address pode3.foo.com -Port $Port -Protocol Http
     Add-PodeEndpoint -Address pode2.foo.com -Port $Port -Protocol Http
     Add-PodeEndpoint -Address 127.0.0.1 -Hostname pode.foo.com -Port $Port -Protocol Http
+    Add-PodeEndpoint -Hostname pode4.foo.com -Port $Port -Protocol Http -LookupHostname
 
     # logging
     New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging

--- a/examples/web-hostname.ps1
+++ b/examples/web-hostname.ps1
@@ -15,6 +15,10 @@ Start-PodeServer -Threads 2 {
 
     # listen on localhost:8085
     Add-PodeEndpoint -Address pode.foo.com -Port $Port -Protocol Http
+    #Add-PodeEndpoint -Address pode2.foo.com -Port $Port -Protocol Http
+
+    # logging
+    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
 
     # set view engine to pode renderer
     Set-PodeViewEngine -Type Pode

--- a/examples/web-hostname.ps1
+++ b/examples/web-hostname.ps1
@@ -14,8 +14,9 @@ Import-Module "$($path)/src/Pode.psm1" -Force -ErrorAction Stop
 Start-PodeServer -Threads 2 {
 
     # listen on localhost:8085
-    Add-PodeEndpoint -Address pode.foo.com -Port $Port -Protocol Http
-    #Add-PodeEndpoint -Address pode2.foo.com -Port $Port -Protocol Http
+    Add-PodeEndpoint -Address pode3.foo.com -Port $Port -Protocol Http
+    Add-PodeEndpoint -Address pode2.foo.com -Port $Port -Protocol Http
+    Add-PodeEndpoint -Address 127.0.0.1 -Hostname pode.foo.com -Port $Port -Protocol Http
 
     # logging
     New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging

--- a/src/Listener/PodeHttpRequest.cs
+++ b/src/Listener/PodeHttpRequest.cs
@@ -119,6 +119,17 @@ namespace Pode
                 Headers.Add(h_name, h_value);
             }
 
+            // build required URI details
+            var _proto = (IsSsl ? "https" : "http");
+            Host = $"{Headers["Host"]}";
+            Url = new Uri($"{_proto}://{Host}{reqQuery}");
+
+            // check the host header
+            if (!Context.PodeSocket.CheckHostname(Host))
+            {
+                throw new HttpRequestException($"Invalid request Host: {Host}");
+            }
+
             // get the content length
             var strContentLength = $"{Headers["Content-Length"]}";
             if (string.IsNullOrWhiteSpace(strContentLength))
@@ -196,7 +207,6 @@ namespace Pode
             }
 
             // set values from headers
-            Host = $"{Headers["Host"]}";
             UrlReferrer = $"{Headers["Referer"]}";
             UserAgent = $"{Headers["User-Agent"]}";
             ContentType = $"{Headers["Content-Type"]}";
@@ -223,10 +233,6 @@ namespace Pode
                     }
                 }
             }
-
-            // build required URI details
-            var _proto = (IsSsl ? "https" : "http");
-            Url = new Uri($"{_proto}://{Host}{reqQuery}");
         }
     }
 }

--- a/src/Listener/PodeListener.cs
+++ b/src/Listener/PodeListener.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
@@ -33,6 +34,18 @@ namespace Pode
 
         public void Add(PodeSocket socket)
         {
+            // if this socket has a hostname, try to re-use an existing socket
+            if (socket.HasHostnames)
+            {
+                var foundSocket = Sockets.FirstOrDefault(x => x.Equals(socket));
+                if (foundSocket != default(PodeSocket))
+                {
+                    foundSocket.Hostnames.AddRange(socket.Hostnames);
+                    socket.Dispose();
+                    return;
+                }
+            }
+
             socket.BindListener(this);
             Sockets.Add(socket);
         }

--- a/src/Listener/PodeSmtpRequest.cs
+++ b/src/Listener/PodeSmtpRequest.cs
@@ -52,7 +52,7 @@ namespace Pode
 
         public void SendAck()
         {
-            Context.Response.WriteLine($"220 {Context.PodeSocket.Hostname} -- Pode Proxy Server", true);
+            Context.Response.WriteLine($"220 {Context.PodeSocket.Hostnames[0]} -- Pode Proxy Server", true);
         }
 
         protected override void Parse(byte[] bytes)

--- a/src/Listener/PodeSocket.cs
+++ b/src/Listener/PodeSocket.cs
@@ -324,6 +324,16 @@ namespace Pode
             }
         }
 
+        public bool CheckHostname(string hostname)
+        {
+            if (string.IsNullOrWhiteSpace(Hostname))
+            {
+                return true;
+            }
+
+            return Hostname.Equals(hostname.Split(':')[0], StringComparison.InvariantCultureIgnoreCase);
+        }
+
         public void Dispose()
         {
             CloseSocket(Socket);

--- a/src/Listener/PodeSocket.cs
+++ b/src/Listener/PodeSocket.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Net;
+using System.Linq;
 using System.Net.Sockets;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
@@ -11,7 +12,7 @@ namespace Pode
     public class PodeSocket : IDisposable
     {
         public IPAddress IPAddress { get; private set; }
-        public string Hostname { get; set; }
+        public List<string> Hostnames { get; private set; }
         public int Port { get; private set; }
         public IPEndPoint Endpoint { get; private set; }
         public X509Certificate Certificate { get; private set; }
@@ -36,6 +37,8 @@ namespace Pode
             set => Socket.ReceiveTimeout = value;
         }
 
+        public bool HasHostnames => Hostnames.Any();
+
         public PodeSocket(IPAddress ipAddress, int port, SslProtocols protocols, X509Certificate certificate = null, bool allowClientCertificate = false)
         {
             IPAddress = ipAddress;
@@ -43,6 +46,7 @@ namespace Pode
             Certificate = certificate;
             AllowClientCertificate = allowClientCertificate;
             Protocols = protocols;
+            Hostnames = new List<string>();
             Endpoint = new IPEndPoint(ipAddress, port);
 
             AcceptConnections = new ConcurrentQueue<SocketAsyncEventArgs>();
@@ -326,12 +330,13 @@ namespace Pode
 
         public bool CheckHostname(string hostname)
         {
-            if (string.IsNullOrWhiteSpace(Hostname))
+            if (!HasHostnames)
             {
                 return true;
             }
 
-            return Hostname.Equals(hostname.Split(':')[0], StringComparison.InvariantCultureIgnoreCase);
+            var _name = hostname.Split(':')[0];
+            return Hostnames.Any(x => x.Equals(_name, StringComparison.InvariantCultureIgnoreCase));
         }
 
         public void Dispose()
@@ -362,6 +367,12 @@ namespace Pode
         {
             e.AcceptSocket = default(Socket);
             e.UserToken = default(object);
+        }
+
+        public new bool Equals(object obj)
+        {
+            var _socket = (PodeSocket)obj;
+            return (Endpoint.ToString() == _socket.Endpoint.ToString() && Port == _socket.Port);
         }
     }
 }

--- a/src/Private/Endpoints.ps1
+++ b/src/Private/Endpoints.ps1
@@ -95,7 +95,12 @@ function Find-PodeEndpointName
     }
 
     # try and find endpoint
+    if ($Address -ilike 'localhost:*') {
+        $Address = ($Address -ireplace 'localhost\:', '127.0.0.1:')
+    }
+
     $key = "$($Protocol)|$($Address)"
+
     $key = @(foreach ($k in $PodeContext.Server.EndpointsMap.Keys) {
         if ($key -ilike $k) {
             $k

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -309,7 +309,7 @@ function Get-PodeIPAddressesForHostname
         $ips = @([System.Net.Dns]::GetHostAddresses($Hostname))
     }
     catch {
-        return '0.0.0.0'
+        return '127.0.0.1'
     }
 
     # return ips based on type

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -1978,7 +1978,7 @@ function Get-PodeEndpointUrl
 
     $url = $Endpoint.Url
     if ([string]::IsNullOrWhiteSpace($url)) {
-        $url = "$($Endpoint.Protocol)://$($Endpoint.HostName):$($Endpoint.Port)"
+        $url = "$($Endpoint.Protocol)://$($Endpoint.FriendlyName):$($Endpoint.Port)"
     }
 
     return $url

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -305,7 +305,12 @@ function Get-PodeIPAddressesForHostname
     }
 
     # get the ip addresses for the hostname
-    $ips = @([System.Net.Dns]::GetHostAddresses($Hostname))
+    try {
+        $ips = @([System.Net.Dns]::GetHostAddresses($Hostname))
+    }
+    catch {
+        return '0.0.0.0'
+    }
 
     # return ips based on type
     switch ($Type.ToLowerInvariant())

--- a/src/Private/PodeServer.ps1
+++ b/src/Private/PodeServer.ps1
@@ -31,10 +31,12 @@ function Start-PodeWebServer
         # add endpoint to list
         $endpoints += @{
             Address = $_ip
+            Hostname = $_.HostName
+            IsIPAddress = $_.IsIPAddress
             Port = $_.Port
             Certificate = $_.Certificate.Raw
             AllowClientCertificate = $_.Certificate.AllowClientCertificate
-            HostName = $_.Url
+            Url = $_.Url
         }
     }
 
@@ -48,6 +50,11 @@ function Start-PodeWebServer
         $endpoints | ForEach-Object {
             $socket = (. ([scriptblock]::Create("New-Pode$($PodeContext.Server.ListenerType)ListenerSocket -Address `$_.Address -Port `$_.Port -SslProtocols `$PodeContext.Server.Sockets.Ssl.Protocols -Certificate `$_.Certificate -AllowClientCertificate `$_.AllowClientCertificate")))
             $socket.ReceiveTimeout = $PodeContext.Server.Sockets.ReceiveTimeout
+
+            if (!$_.IsIPAddress) {
+                $socket.Hostname = $_.HostName
+            }
+
             $listener.Add($socket)
         }
 
@@ -227,10 +234,10 @@ function Start-PodeWebServer
 
     # browse to the first endpoint, if flagged
     if ($Browse) {
-        Start-Process $endpoints[0].HostName
+        Start-Process $endpoints[0].Url
     }
 
-    return @($endpoints.HostName)
+    return @($endpoints.Url)
 }
 
 function New-PodeListener

--- a/src/Private/PodeServer.ps1
+++ b/src/Private/PodeServer.ps1
@@ -52,7 +52,7 @@ function Start-PodeWebServer
             $socket.ReceiveTimeout = $PodeContext.Server.Sockets.ReceiveTimeout
 
             if (!$_.IsIPAddress) {
-                $socket.Hostname = $_.HostName
+                $socket.Hostnames.Add($_.HostName)
             }
 
             $listener.Add($socket)

--- a/src/Private/SignalServer.ps1
+++ b/src/Private/SignalServer.ps1
@@ -34,7 +34,7 @@ function Start-PodeSignalServer
             $socket.ReceiveTimeout = $PodeContext.Server.Sockets.ReceiveTimeout
 
             if (!$_.IsIPAddress) {
-                $socket.Hostname = $_.HostName
+                $socket.Hostnames.Add($_.HostName)
             }
 
             $listener.Add($socket)

--- a/src/Private/SignalServer.ps1
+++ b/src/Private/SignalServer.ps1
@@ -13,10 +13,12 @@ function Start-PodeSignalServer
         # add endpoint to list
         $endpoints += @{
             Address = $_ip
+            Hostname = $_.HostName
+            IsIPAddress = $_.IsIPAddress
             Port = $_.Port
             Certificate = $_.Certificate.Raw
             AllowClientCertificate = $_.Certificate.AllowClientCertificate
-            HostName = $_.Url
+            Url = $_.Url
         }
     }
 
@@ -30,6 +32,11 @@ function Start-PodeSignalServer
         $endpoints | ForEach-Object {
             $socket = [PodeSocket]::new($_.Address, $_.Port, $PodeContext.Server.Sockets.Ssl.Protocols, $_.Certificate, $_.AllowClientCertificate)
             $socket.ReceiveTimeout = $PodeContext.Server.Sockets.ReceiveTimeout
+
+            if (!$_.IsIPAddress) {
+                $socket.Hostname = $_.HostName
+            }
+
             $listener.Add($socket)
         }
 
@@ -154,5 +161,5 @@ function Start-PodeSignalServer
     }
 
     Add-PodeRunspace -Type 'Signals' -ScriptBlock $waitScript -Parameters @{ 'Listener' = $listener }
-    return @($endpoints.HostName)
+    return @($endpoints.Url)
 }

--- a/src/Private/SmtpServer.ps1
+++ b/src/Private/SmtpServer.ps1
@@ -29,7 +29,7 @@ function Start-PodeSmtpServer
         # register endpoint on the listener
         $socket = [PodeSocket]::new($ipAddress, $port, $PodeContext.Server.Sockets.Ssl.Protocols, $null)
         $socket.ReceiveTimeout = $PodeContext.Server.Sockets.ReceiveTimeout
-        $socket.Hostname = $endpoint.HostName
+        $socket.Hostnames.Add($endpoint.HostName)
         $listener.Add($socket)
         $listener.Start()
     }

--- a/src/Private/SmtpServer.ps1
+++ b/src/Private/SmtpServer.ps1
@@ -155,5 +155,5 @@ function Start-PodeSmtpServer
     Add-PodeRunspace -Type 'Main' -ScriptBlock $waitScript -Parameters @{ 'Listener' = $listener }
 
     # state where we're running
-    return @("smtp://$($endpoint.HostName):$($port)")
+    return @("smtp://$($endpoint.FriendlyName):$($port)")
 }

--- a/src/Private/TcpServer.ps1
+++ b/src/Private/TcpServer.ps1
@@ -125,5 +125,5 @@ function Start-PodeTcpServer
     Add-PodeRunspace -Type 'Main' -ScriptBlock $waitScript -Parameters @{ 'Listener' = $listener }
 
     # state where we're running
-    return @("tcp://$($endpoint.HostName):$($port)")
+    return @("tcp://$($endpoint.FriendlyName):$($port)")
 }

--- a/src/Public/Core.ps1
+++ b/src/Public/Core.ps1
@@ -662,6 +662,9 @@ Allow for client certificates to be sent on requests.
 .PARAMETER PassThru
 If supplied, the endpoint created will be returned.
 
+.PARAMETER LookupHostname
+If supplied, a supplied Hostname will have its IP Address looked up from host file or DNS.
+
 .EXAMPLE
 Add-PodeEndpoint -Address localhost -Port 8090 -Protocol Http
 
@@ -742,7 +745,10 @@ function Add-PodeEndpoint
         $AllowClientCertificate,
 
         [switch]
-        $PassThru
+        $PassThru,
+
+        [switch]
+        $LookupHostname
     )
 
     # error if serverless
@@ -779,6 +785,10 @@ function Add-PodeEndpoint
     if ((Test-PodeHostname -Hostname $Address) -and ($Address -inotin @('localhost', 'all'))) {
         $Hostname = $Address
         $Address = 'localhost'
+    }
+
+    if (![string]::IsNullOrWhiteSpace($Hostname) -and $LookupHostname) {
+        $Address = (Get-PodeIPAddressesForHostname -Hostname $Hostname -Type All | Select-Object -First 1)
     }
 
     $_endpoint = Get-PodeEndpointInfo -Address "$($Address):$($Port)"

--- a/src/Public/Core.ps1
+++ b/src/Public/Core.ps1
@@ -615,10 +615,13 @@ Bind an endpoint to listen for incoming Requests.
 Bind an endpoint to listen for incoming Requests. The endpoints can be HTTP, HTTPS, TCP or SMTP, with the option to bind certificates.
 
 .PARAMETER Address
-The IP/Hostname of the endpoint.
+The IP/Hostname of the endpoint (Default: localhost).
 
 .PARAMETER Port
 The Port number of the endpoint.
+
+.PARAMETER Hostname
+An optional hostname for the endpoint, specifying a hostname restricts access to just the hostname.
 
 .PARAMETER Protocol
 The protocol of the supplied endpoint.
@@ -667,6 +670,9 @@ Add-PodeEndpoint -Address localhost -Protocol Smtp
 
 .EXAMPLE
 Add-PodeEndpoint -Address dev.pode.com -Port 8443 -Protocol Https -SelfSigned
+
+.EXAMPLE
+Add-PodeEndpoint -Address 127.0.0.2 -Hostname dev.pode.com -Port 8443 -Protocol Https -SelfSigned
 
 .EXAMPLE
 Add-PodeEndpoint -Address live.pode.com -Protocol Https -CertificateThumbprint '2A9467F7D3940243D6C07DE61E7FCCE292'
@@ -940,6 +946,9 @@ An Address to filter the endpoints.
 
 .PARAMETER Port
 A Port to filter the endpoints.
+
+.PARAMETER Hostname
+A Hostname to filter the endpoints.
 
 .PARAMETER Protocol
 A Protocol to filter the endpoints.

--- a/src/Public/Core.ps1
+++ b/src/Public/Core.ps1
@@ -684,6 +684,10 @@ function Add-PodeEndpoint
         $Port = 0,
 
         [Parameter()]
+        [string]
+        $Hostname,
+
+        [Parameter()]
         [ValidateSet('Http', 'Https', 'Smtp', 'Tcp', 'Ws', 'Wss')]
         [string]
         $Protocol,
@@ -748,6 +752,7 @@ function Add-PodeEndpoint
     if ($isIIS) {
         $Port = [int]$env:ASPNETCORE_PORT
         $Address = '127.0.0.1'
+        $Hostname = [string]::Empty
         $Protocol = 'Http'
     }
 
@@ -756,12 +761,21 @@ function Add-PodeEndpoint
     if ($isHeroku) {
         $Port = [int]$env:PORT
         $Address = '0.0.0.0'
+        $Hostname = [string]::Empty
         $Protocol = 'Http'
     }
 
     # parse the endpoint for host/port info
-    $FullAddress = "$($Address):$($Port)"
-    $_endpoint = Get-PodeEndpointInfo -Address $FullAddress
+    if (![string]::IsNullOrWhiteSpace($Hostname) -and !(Test-PodeHostname -Hostname $Hostname)) {
+        throw "Invalid hostname supplied: $($Hostname)"
+    }
+
+    if ((Test-PodeHostname -Hostname $Address) -and ($Address -inotin @('localhost', 'all'))) {
+        $Hostname = $Address
+        $Address = 'localhost'
+    }
+
+    $_endpoint = Get-PodeEndpointInfo -Address "$($Address):$($Port)"
 
     # if no name, set to guid, then check uniqueness
     if ([string]::IsNullOrWhiteSpace($Name)) {
@@ -782,10 +796,11 @@ function Add-PodeEndpoint
         Name = $Name
         Description = $Description
         Address = $null
-        RawAddress = $FullAddress
+        RawAddress = $null
         Port = $null
         IsIPAddress = $true
-        HostName = 'localhost'
+        HostName = $Hostname
+        FriendlyName = $Hostname
         Url = $null
         Ssl = (@('https', 'wss') -icontains $Protocol)
         Protocol = $Protocol.ToLowerInvariant()
@@ -798,21 +813,30 @@ function Add-PodeEndpoint
 
     # set the ip for the context (force to localhost for IIS)
     $obj.Address = (Get-PodeIPAddress $_endpoint.Host)
-    if (!(Test-PodeIPAddressLocalOrAny -IP $obj.Address)) {
-        $obj.HostName = "$($obj.Address)"
-    }
+    $obj.IsIPAddress = [string]::IsNullOrWhiteSpace($obj.HostName)
 
-    $obj.IsIPAddress = (Test-PodeIPAddress -IP $obj.Address -IPOnly)
+    if ($obj.IsIPAddress) {
+        $obj.FriendlyName = 'localhost'
+        if (!(Test-PodeIPAddressLocalOrAny -IP $obj.Address)) {
+            $obj.FriendlyName = "$($obj.Address)"
+        }
+    }
 
     # set the port for the context, if 0 use a default port for protocol
     $obj.Port = $_endpoint.Port
     if (([int]$obj.Port) -eq 0) {
         $obj.Port = Get-PodeDefaultPort -Protocol $Protocol
-        $obj.RawAddress = "$($Address):$($obj.Port)"
+    }
+
+    if ($obj.IsIPAddress) {
+        $obj.RawAddress = "$($obj.Address):$($obj.Port)"
+    }
+    else {
+        $obj.RawAddress = "$($obj.FriendlyName):$($obj.Port)"
     }
 
     # set the url of this endpoint
-    $obj.Url = "$($obj.Protocol)://$($obj.HostName):$($obj.Port)/"
+    $obj.Url = "$($obj.Protocol)://$($obj.FriendlyName):$($obj.Port)/"
 
     # if the address is non-local, then check admin privileges
     if (!$Force -and !(Test-PodeIPAddressLocal -IP $obj.Address) -and !(Test-PodeIsAdminUser)) {
@@ -821,7 +845,7 @@ function Add-PodeEndpoint
 
     # has this endpoint been added before? (for http/https we can just not add it again)
     $exists = ($PodeContext.Server.Endpoints.Values | Where-Object {
-        ($_.Address -eq $obj.Address) -and ($_.Port -eq $obj.Port) -and ($_.Ssl -eq $obj.Ssl)
+        ($_.FriendlyName -eq $obj.FriendlyName) -and ($_.Port -eq $obj.Port) -and ($_.Ssl -eq $obj.Ssl)
     } | Measure-Object).Count
 
     # if we're dealing with a certificate, attempt to import it
@@ -945,6 +969,10 @@ function Get-PodeEndpoint
         $Port = 0,
 
         [Parameter()]
+        [string]
+        $Hostname,
+
+        [Parameter()]
         [ValidateSet('', 'Http', 'Https', 'Smtp', 'Tcp', 'Ws', 'Wss')]
         [string]
         $Protocol,
@@ -953,6 +981,11 @@ function Get-PodeEndpoint
         [string[]]
         $Name
     )
+
+    if ((Test-PodeHostname -Hostname $Address) -and ($Address -inotin @('localhost', 'all'))) {
+        $Hostname = $Address
+        $Address = 'localhost'
+    }
 
     $endpoints = $PodeContext.Server.Endpoints.Values
 
@@ -968,6 +1001,17 @@ function Get-PodeEndpoint
 
         $endpoints = @(foreach ($endpoint in $endpoints) {
             if ($endpoint.Address.ToString() -ine $Address) {
+                continue
+            }
+
+            $endpoint
+        })
+    }
+
+    # if we have a hostname, filter
+    if (![string]::IsNullOrWhiteSpace($Hostname)) {
+        $endpoints = @(foreach ($endpoint in $endpoints) {
+            if ($endpoint.Hostname.ToString() -ine $Hostname) {
                 continue
             }
 

--- a/tests/unit/Context.Tests.ps1
+++ b/tests/unit/Context.Tests.ps1
@@ -25,7 +25,7 @@ Describe 'Add-PodeEndpoint' {
         Mock Test-PodeIPAddress { return $true }
         Mock Test-PodeIsAdminUser { return $true }
 
-        It 'Set just a Hostname address' {
+        It 'Set just a Hostname address - old' {
             $PodeContext.Server = @{ Endpoints = @{}; EndpointsMap = @{}; 'Type' = $null }
             Add-PodeEndpoint -Address 'foo.com' -Protocol 'HTTP'
 
@@ -37,7 +37,24 @@ Describe 'Add-PodeEndpoint' {
             $endpoint.Port | Should Be 8080
             $endpoint.Name | Should Not Be ([string]::Empty)
             $endpoint.HostName | Should Be 'foo.com'
-            $endpoint.Address.ToString() | Should Be 'foo.com'
+            $endpoint.Address.ToString() | Should Be '127.0.0.1'
+            $endpoint.Hostname.ToString() | Should Be 'foo.com'
+            $endpoint.RawAddress | Should Be 'foo.com:8080'
+        }
+
+        It 'Set just a Hostname address - new' {
+            $PodeContext.Server = @{ Endpoints = @{}; EndpointsMap = @{}; 'Type' = $null }
+            Add-PodeEndpoint -Hostname 'foo.com' -Protocol 'HTTP'
+
+            $PodeContext.Server.Type | Should Be 'HTTP'
+            $PodeContext.Server.Endpoints | Should Not Be $null
+            $PodeContext.Server.Endpoints.Count | Should Be 1
+
+            $endpoint = ($PodeContext.Server.Endpoints.Values | Select-Object -First 1)
+            $endpoint.Port | Should Be 8080
+            $endpoint.Name | Should Not Be ([string]::Empty)
+            $endpoint.HostName | Should Be 'foo.com'
+            $endpoint.Address.ToString() | Should Be '127.0.0.1'
             $endpoint.RawAddress | Should Be 'foo.com:8080'
         }
 
@@ -53,7 +70,7 @@ Describe 'Add-PodeEndpoint' {
             $endpoint.Port | Should Be 8080
             $endpoint.Name | Should Be 'Example'
             $endpoint.HostName | Should Be 'foo.com'
-            $endpoint.Address.ToString() | Should Be 'foo.com'
+            $endpoint.Address.ToString() | Should Be '127.0.0.1'
         }
 
         It 'Set just a Hostname address with colon' {
@@ -67,7 +84,7 @@ Describe 'Add-PodeEndpoint' {
             $endpoint = ($PodeContext.Server.Endpoints.Values | Select-Object -First 1)
             $endpoint.Port | Should Be 8080
             $endpoint.HostName | Should Be 'foo.com'
-            $endpoint.Address.ToString() | Should Be 'foo.com'
+            $endpoint.Address.ToString() | Should Be '127.0.0.1'
             $endpoint.RawAddress | Should Be 'foo.com:8080'
         }
 
@@ -82,7 +99,22 @@ Describe 'Add-PodeEndpoint' {
             $endpoint = ($PodeContext.Server.Endpoints.Values | Select-Object -First 1)
             $endpoint.Port | Should Be 80
             $endpoint.HostName | Should Be 'foo.com'
-            $endpoint.Address.ToString() | Should Be 'foo.com'
+            $endpoint.Address.ToString() | Should Be '127.0.0.1'
+        }
+
+        It 'Set all the Hostname, ip and port' {
+            $PodeContext.Server = @{ Endpoints = @{}; EndpointsMap = @{}; 'Type' = $null }
+            Add-PodeEndpoint -Address '127.0.0.2' -Hostname 'foo.com' -Port 80 -Protocol 'HTTP'
+
+            $PodeContext.Server.Type | Should Be 'HTTP'
+            $PodeContext.Server.Endpoints | Should Not Be $null
+            $PodeContext.Server.Endpoints.Count | Should Be 1
+
+            $endpoint = ($PodeContext.Server.Endpoints.Values | Select-Object -First 1)
+            $endpoint.Port | Should Be 80
+            $endpoint.HostName | Should Be 'foo.com'
+            $endpoint.Address.ToString() | Should Be '127.0.0.2'
+            $endpoint.RawAddress | Should Be 'foo.com:80'
         }
 
         It 'Set just an IPv4 address' {
@@ -95,7 +127,7 @@ Describe 'Add-PodeEndpoint' {
 
             $endpoint = ($PodeContext.Server.Endpoints.Values | Select-Object -First 1)
             $endpoint.Port | Should Be 8080
-            $endpoint.HostName | Should Be 'localhost'
+            $endpoint.HostName | Should Be ''
             $endpoint.Address.ToString() | Should Be '127.0.0.1'
         }
 
@@ -109,9 +141,9 @@ Describe 'Add-PodeEndpoint' {
 
             $endpoint = ($PodeContext.Server.Endpoints.Values | Select-Object -First 1)
             $endpoint.Port | Should Be 8080
-            $endpoint.HostName | Should Be 'localhost'
+            $endpoint.HostName | Should Be ''
             $endpoint.Address.ToString() | Should Be '0.0.0.0'
-            $endpoint.RawAddress | Should Be 'all:8080'
+            $endpoint.RawAddress | Should Be '0.0.0.0:8080'
         }
 
         It 'Set just an IPv4 address with colon' {
@@ -124,7 +156,7 @@ Describe 'Add-PodeEndpoint' {
 
             $endpoint = ($PodeContext.Server.Endpoints.Values | Select-Object -First 1)
             $endpoint.Port | Should Be 8080
-            $endpoint.HostName | Should Be 'localhost'
+            $endpoint.HostName | Should Be ''
             $endpoint.Address.ToString() | Should Be '127.0.0.1'
         }
 
@@ -138,7 +170,7 @@ Describe 'Add-PodeEndpoint' {
 
             $endpoint = ($PodeContext.Server.Endpoints.Values | Select-Object -First 1)
             $endpoint.Port | Should Be 80
-            $endpoint.HostName | Should Be 'localhost'
+            $endpoint.HostName | Should Be ''
             $endpoint.Address.ToString() | Should Be '127.0.0.1'
         }
 
@@ -152,7 +184,7 @@ Describe 'Add-PodeEndpoint' {
 
             $endpoint = ($PodeContext.Server.Endpoints.Values | Select-Object -First 1)
             $endpoint.Port | Should Be 80
-            $endpoint.HostName | Should Be 'localhost'
+            $endpoint.HostName | Should Be ''
             $endpoint.Address.ToString() | Should Be '127.0.0.1'
         }
 
@@ -166,7 +198,7 @@ Describe 'Add-PodeEndpoint' {
 
             $endpoint = ($PodeContext.Server.Endpoints.Values | Select-Object -First 1)
             $endpoint.Port | Should Be 80
-            $endpoint.HostName | Should Be 'localhost'
+            $endpoint.HostName | Should Be ''
             $endpoint.Address.ToString() | Should Be '127.0.0.1'
         }
 
@@ -180,9 +212,10 @@ Describe 'Add-PodeEndpoint' {
 
             $endpoint = ($PodeContext.Server.Endpoints.Values | Select-Object -First 1)
             $endpoint.Port | Should Be 80
-            $endpoint.HostName | Should Be 'localhost'
+            $endpoint.HostName | Should Be ''
+            $endpoint.FriendlyName | Should Be 'localhost'
             $endpoint.Address.ToString() | Should Be '0.0.0.0'
-            $endpoint.RawAddress | Should Be '*:80'
+            $endpoint.RawAddress | Should Be '0.0.0.0:80'
         }
 
         It 'Throws error for an invalid IPv4' {
@@ -212,13 +245,13 @@ Describe 'Add-PodeEndpoint' {
 
             $endpoint = $PodeContext.Server.Endpoints[$ep1.Name]
             $endpoint.Port | Should Be 80
-            $endpoint.HostName | Should Be 'localhost'
+            $endpoint.HostName | Should Be ''
             $endpoint.Address.ToString() | Should Be '127.0.0.1'
 
             $endpoint = $PodeContext.Server.Endpoints[$ep2.Name]
             $endpoint.Port | Should Be 80
             $endpoint.HostName | Should Be 'pode.foo.com'
-            $endpoint.Address.ToString() | Should Be 'pode.foo.com'
+            $endpoint.Address.ToString() | Should Be '127.0.0.1'
         }
 
         It 'Add two endpoints to listen on, with different names' {
@@ -233,14 +266,14 @@ Describe 'Add-PodeEndpoint' {
             $endpoint = $PodeContext.Server.Endpoints['Example1']
             $endpoint.Port | Should Be 80
             $endpoint.Name | Should Be 'Example1'
-            $endpoint.HostName | Should Be 'localhost'
+            $endpoint.HostName | Should Be ''
             $endpoint.Address.ToString() | Should Be '127.0.0.1'
 
             $endpoint = $PodeContext.Server.Endpoints['Example2']
             $endpoint.Port | Should Be 80
             $endpoint.Name | Should Be 'Example2'
             $endpoint.HostName | Should Be 'pode.foo.com'
-            $endpoint.Address.ToString() | Should Be 'pode.foo.com'
+            $endpoint.Address.ToString() | Should Be '127.0.0.1'
         }
 
         It 'Add two endpoints to listen on, one of HTTP and one of HTTPS' {
@@ -254,13 +287,13 @@ Describe 'Add-PodeEndpoint' {
 
             $endpoint = $PodeContext.Server.Endpoints['Http']
             $endpoint.Port | Should Be 80
-            $endpoint.HostName | Should Be 'localhost'
+            $endpoint.HostName | Should Be ''
             $endpoint.Address.ToString() | Should Be '127.0.0.1'
 
             $endpoint = $PodeContext.Server.Endpoints['Https']
             $endpoint.Port | Should Be 80
             $endpoint.HostName | Should Be 'pode.foo.com'
-            $endpoint.Address.ToString() | Should Be 'pode.foo.com'
+            $endpoint.Address.ToString() | Should Be '127.0.0.1'
         }
 
         It 'Add two endpoints to listen on, but one added as they are the same' {
@@ -274,7 +307,7 @@ Describe 'Add-PodeEndpoint' {
 
             $endpoint = @($PodeContext.Server.Endpoints.Values)[0]
             $endpoint.Port | Should Be 80
-            $endpoint.HostName | Should Be 'localhost'
+            $endpoint.HostName | Should Be ''
             $endpoint.Address.ToString() | Should Be '127.0.0.1'
         }
 
@@ -305,7 +338,7 @@ Describe 'Add-PodeEndpoint' {
         It 'Throws an error for not running as admin' {
             Mock Test-PodeIsAdminUser { return $false }
             $PodeContext.Server = @{ Endpoints = @{}; EndpointsMap = @{}; 'Type' = $null }
-            { Add-PodeEndpoint -Address 'foo.com' -Protocol 'HTTP' } | Should Throw 'Must be running with admin'
+            { Add-PodeEndpoint -Address '127.0.0.2' -Protocol 'HTTP' } | Should Throw 'Must be running with admin'
         }
     }
 }
@@ -331,7 +364,7 @@ Describe 'Get-PodeEndpoint' {
         $endpoints.Length | Should Be 3
     }
 
-    It 'Returns 1 endpoint by address' {
+    It 'Returns 3 endpoints by address - combination of ip/hostname' {
         $PodeContext.Server = @{ Endpoints = @{}; EndpointsMap = @{}; Type = $null }
 
         Add-PodeEndpoint -Address '127.0.0.1' -Port 80 -Protocol 'HTTP'
@@ -339,10 +372,24 @@ Describe 'Get-PodeEndpoint' {
         Add-PodeEndpoint -Address 'pode.foo.com' -Port 8080 -Protocol 'HTTP'
 
         $endpoints = Get-PodeEndpoint -Address '127.0.0.1'
-        $endpoints.Length | Should Be 1
+        $endpoints.Length | Should Be 3
     }
 
-    It 'Returns 2 endpoints by address' {
+    It 'Returns 2 endpoints by hostname, and 3 by ip' {
+        $PodeContext.Server = @{ Endpoints = @{}; EndpointsMap = @{}; Type = $null }
+
+        Add-PodeEndpoint -Address '127.0.0.1' -Port 80 -Protocol 'HTTP'
+        Add-PodeEndpoint -Address 'pode.foo.com' -Port 80 -Protocol 'HTTP'
+        Add-PodeEndpoint -Address 'pode.foo.com' -Port 8080 -Protocol 'HTTP'
+
+        $endpoints = Get-PodeEndpoint -Hostname 'pode.foo.com'
+        $endpoints.Length | Should Be 2
+
+        $endpoints = Get-PodeEndpoint -Address '127.0.0.1'
+        $endpoints.Length | Should Be 3
+    }
+
+    It 'Returns 2 endpoints by hostname - old' {
         $PodeContext.Server = @{ Endpoints = @{}; EndpointsMap = @{}; Type = $null }
 
         Add-PodeEndpoint -Address '127.0.0.1' -Port 80 -Protocol 'HTTP'
@@ -393,7 +440,7 @@ Describe 'Get-PodeEndpoint' {
         Add-PodeEndpoint -Address 'pode.foo.com' -Port 80 -Protocol 'HTTP' -Name 'User'
         Add-PodeEndpoint -Address 'pode.foo.com' -Port 8080 -Protocol 'HTTP' -Name 'Dev'
 
-        $endpoints = Get-PodeEndpoint -Address 'pode.foo.com' -Port 80 -Protocol Http -Name User
+        $endpoints = Get-PodeEndpoint -Hostname 'pode.foo.com' -Port 80 -Protocol Http -Name User
         $endpoints.Length | Should Be 1
     }
 

--- a/tests/unit/Helpers.Tests.ps1
+++ b/tests/unit/Helpers.Tests.ps1
@@ -1202,6 +1202,8 @@ Describe 'Get-PodeEndpointUrl' {
             Endpoints = @{
                 Example1 = @{
                     Port = 6000
+                    Address = '127.0.0.1'
+                    FriendlyName = 'thing.com'
                     Hostname = 'thing.com'
                     Protocol = 'https'
                 }
@@ -1214,6 +1216,8 @@ Describe 'Get-PodeEndpointUrl' {
     It 'Returns a passed endpoint url' {
         $endpoint = @{
             Port = 7000
+            Address = '127.0.0.1'
+            FriendlyName = 'stuff.com'
             Hostname = 'stuff.com'
             Protocol = 'http'
         }
@@ -1224,6 +1228,8 @@ Describe 'Get-PodeEndpointUrl' {
     It 'Returns a passed endpoint url, with default port for http' {
         $endpoint = @{
             Port = 8080
+            Address = '127.0.0.1'
+            FriendlyName = 'stuff.com'
             Hostname = 'stuff.com'
             Protocol = 'http'
         }
@@ -1234,6 +1240,8 @@ Describe 'Get-PodeEndpointUrl' {
     It 'Returns a passed endpoint url, with default port for https' {
         $endpoint = @{
             Port = 8443
+            Address = '127.0.0.1'
+            FriendlyName = 'stuff.com'
             Hostname = 'stuff.com'
             Protocol = 'https'
         }


### PR DESCRIPTION
### Description of the Change
Far better support for hostnames on endpoints, meaning you can binding multiple hostnames to one IP/Port. There's now a new `-Hostname` parameter on `Add-PodeEndpoint` to let you specify the hostname. Specifying a hostname restricts access to just that hostname, anything else will produce a 400.

You can also specify `-Address` and `-Hostname` together, letting you bind a hostname to an IP from within Pode. Not specifying an `-Address` will default to localhost.

If the hostnames IP address is in a DNS/Host file, then you can use the new `-LookupHostname` switch on `Add-PodeEndpoint` and it will autodetect the address to use.

(Older logic, where you can pass the hostname as `-Address` still functions, but the IP is defaulted to localhost).

### Related Issue
Resolves #619 

### Examples
* Multiple hostnames, one IP/Port:
```powershell
Add-PodeEndpoint -Hostname pode3.foo.com -Port 8080 -Protocol Http
Add-PodeEndpoint -Hostname pode2.foo.com -Port 8080 -Protocol Http
```

* Specify the address:
```powershell
Add-PodeEndpoint -Address 127.0.0.1 -Hostname pode.foo.com -Port $Port -Protocol Http
```

* Lookup the address:
```powershell
Add-PodeEndpoint -Hostname pode4.foo.com -Port $Port -Protocol Http -LookupHostname
```
