### PR TITLE
Allow support for a server to run endpoints of different protocols

### DIFF
--- a/docs/Getting-Started/Migrating/1X-to-2X.md
+++ b/docs/Getting-Started/Migrating/1X-to-2X.md
@@ -8,6 +8,8 @@ In Pode v2.X the Server got the biggest overhaul with the dropping of HttpListen
 
 If you were previously specifying `-Type Pode` on your [`Start-PodeServer`](../../../Functions/Core/Start-PodeServer), then you no longer need to - all servers now default to using Pode new .NET Core socket listener.
 
+Furthermore, the `-Type` parameter has been renamed to `-ServerlessType`.
+
 ## Web Event
 
 Originally the Web Event object was the first parameter supplied to the ScriptBlocks of Routes, Middleware, and Endware. These already all had access to the main `$WebEvent` object, including Authentication, without the need to supply it as a parameter.

--- a/docs/Hosting/AwsLambda.md
+++ b/docs/Hosting/AwsLambda.md
@@ -48,7 +48,7 @@ Here, the `/{proxy+}` will enable one Function for all routes - which can be con
 With the above being done, your Pode `server` can be created as follows. The `$LambdaInput` is a parameter supplied to your Function by AWS:
 
 ```powershell
-Start-PodeServer -Request $LambdaInput -Type 'AwsLambda' {
+Start-PodeServer -Request $LambdaInput -ServerlessType AwsLambda {
     # logic
 }
 ```
@@ -63,7 +63,7 @@ The following script would be a simple example of using Pode to aid with routing
 #Requires -Modules @{ModuleName='AWSPowerShell.NetCore';ModuleVersion='3.3.509.0'}
 #Requires -Modules @{ModuleName='Pode';ModuleVersion='<version>'}
 
-Start-PodeServer -Request $LambdaInput -Type 'AwsLambda' {
+Start-PodeServer -Request $LambdaInput -ServerlessType AwsLambda {
     # get some user data
     Add-PodeRoute -Method Get -Path '/users' -ScriptBlock {
         Write-PodeJsonResponse -Value @{ 'Users' = @() }
@@ -88,7 +88,7 @@ Then within your Function script, you need to read in the data from your S3 buck
 
 Read-S3Object -BucketName '<bucket-name>' -KeyPrefix '<dir-name>' -Folder '/tmp/www' | Out-Null
 
-Start-PodeServer -Request $LambdaInput -Type 'AwsLambda' -RootPath '/tmp/www' {
+Start-PodeServer -Request $LambdaInput -ServerlessType AwsLambda -RootPath '/tmp/www' {
     # set your engine renderer
     Set-PodeViewEngine -Type Pode
 

--- a/docs/Hosting/AzureFunctions.md
+++ b/docs/Hosting/AzureFunctions.md
@@ -54,7 +54,7 @@ Your Function's `function.json` will also need to contain at a minimum the Reque
 With the above being done, your Pode `server` can be created as follows:
 
 ```powershell
-Start-PodeServer -Request $TriggerMetadata -Type 'AzureFunctions' {
+Start-PodeServer -Request $TriggerMetadata -ServerlessType AzureFunctions {
     # logic
 }
 ```
@@ -69,7 +69,7 @@ The following `run.ps1` would be a simple example of using Pode to aid with rout
 param($Request, $TriggerMetadata)
 $endpoint = '/api/MyFunc'
 
-Start-PodeServer -Request $TriggerMetadata -Type 'AzureFunctions' {
+Start-PodeServer -Request $TriggerMetadata -ServerlessType AzureFunctions {
     # get route that can return data
     Add-PodeRoute -Method Get -Path $endpoint -ScriptBlock {
         Write-PodeJsonResponse -Value @{ 'Data' = 'some random data' }
@@ -97,7 +97,7 @@ All you need to do then is reference this directory as the root path for your se
 param($Request, $TriggerMetadata)
 $endpoint = '/api/MyFunc'
 
-Start-PodeServer -Request $TriggerMetadata -Type 'AzureFunctions' -RootPath '../www' {
+Start-PodeServer -Request $TriggerMetadata -ServerlessType AzureFunctions -RootPath '../www' {
     # set your engine renderer
     Set-PodeViewEngine -Type Pode
 

--- a/src/Private/Endpoints.ps1
+++ b/src/Private/Endpoints.ps1
@@ -55,7 +55,7 @@ function Get-PodeEndpoints
 {
     param(
         [Parameter(Mandatory=$true)]
-        [ValidateSet('Http', 'Ws')]
+        [ValidateSet('Http', 'Ws', 'Smtp', 'Tcp')]
         [string]
         $Type
     )
@@ -70,9 +70,31 @@ function Get-PodeEndpoints
         'ws' {
             $endpoints = @($PodeContext.Server.Endpoints.Values | Where-Object { @('ws', 'wss') -icontains $_.Protocol })
         }
+
+        'smtp' {
+            $endpoints = @($PodeContext.Server.Endpoints.Values | Where-Object { @('smtp') -icontains $_.Protocol })
+        }
+
+        'tcp' {
+            $endpoints = @($PodeContext.Server.Endpoints.Values | Where-Object { @('tcp') -icontains $_.Protocol })
+        }
     }
 
     return $endpoints
+}
+
+function Test-PodeEndpoints
+{
+    param(
+        [Parameter(Mandatory=$true)]
+        [ValidateSet('Http', 'Ws', 'Smtp', 'Tcp')]
+        [string]
+        $Type
+    )
+
+    $endpoints = (Get-PodeEndpoints -Type $Type)
+    return (($null -ne $endpoints) -and ($endpoints.Length -gt 0))
+
 }
 
 function Find-PodeEndpointName

--- a/src/Private/Gui.ps1
+++ b/src/Private/Gui.ps1
@@ -129,5 +129,5 @@ function Start-PodeGuiRunspace {
         }
     }
 
-    Add-PodeRunspace -Type 'Gui' -ScriptBlock $script
+    Add-PodeRunspace -Type Gui -ScriptBlock $script
 }

--- a/src/Private/Logging.ps1
+++ b/src/Private/Logging.ps1
@@ -338,7 +338,7 @@ function Start-PodeLoggingRunspace
         }
     }
 
-    Add-PodeRunspace -Type 'Main' -ScriptBlock $script
+    Add-PodeRunspace -Type Main -ScriptBlock $script
 }
 
 function Test-PodeLoggerBatches

--- a/src/Private/PodeServer.ps1
+++ b/src/Private/PodeServer.ps1
@@ -201,9 +201,8 @@ function Start-PodeWebServer
     }
 
     # start the runspace for listening on x-number of threads
-    1..$PodeContext.Threads.Web | ForEach-Object {
-        Add-PodeRunspace -Type 'Main' -ScriptBlock $listenScript `
-            -Parameters @{ 'Listener' = $listener; 'ThreadId' = $_ }
+    1..$PodeContext.Threads.General | ForEach-Object {
+        Add-PodeRunspace -Type Web -ScriptBlock $listenScript -Parameters @{ 'Listener' = $listener; 'ThreadId' = $_ }
     }
 
     # script to keep web server listening until cancelled
@@ -230,7 +229,7 @@ function Start-PodeWebServer
         }
     }
 
-    Add-PodeRunspace -Type 'Main' -ScriptBlock $waitScript -Parameters @{ 'Listener' = $listener }
+    Add-PodeRunspace -Type Web -ScriptBlock $waitScript -Parameters @{ 'Listener' = $listener }
 
     # browse to the first endpoint, if flagged
     if ($Browse) {

--- a/src/Private/Schedules.ps1
+++ b/src/Private/Schedules.ps1
@@ -56,7 +56,7 @@ function Start-PodeScheduleRunspace
         }
     }
 
-    Add-PodeRunspace -Type 'Main' -ScriptBlock $script
+    Add-PodeRunspace -Type Main -ScriptBlock $script
 }
 
 function Complete-PodeInternalSchedules

--- a/src/Private/Server.ps1
+++ b/src/Private/Server.ps1
@@ -38,8 +38,7 @@ function Start-PodeInternalServer
         # create timer/schedules for auto-restarting
         New-PodeAutoRestartServer
 
-        $_type = $PodeContext.Server.Type.ToUpperInvariant()
-        if (![string]::IsNullOrWhiteSpace($_type) -and !$PodeContext.Server.IsServerless)
+        if (!$PodeContext.Server.IsServerless -and ($PodeContext.Server.Types.Length -gt 0))
         {
             # start runspace for loggers
             Start-PodeLoggingRunspace
@@ -57,36 +56,49 @@ function Start-PodeInternalServer
         # start the appropriate server
         $endpoints = @()
 
-        switch ($_type)
-        {
-            'SMTP' {
-                $endpoints += (Start-PodeSmtpServer)
-            }
+        # - service
+        if ($PodeContext.Server.IsService) {
+            Start-PodeServiceServer
+        }
 
-            'TCP' {
-                $endpoints += (Start-PodeTcpServer)
-            }
+        # - serverless
+        elseif ($PodeContext.Server.IsServerless) {
+            switch ($PodeContext.Server.ServerlessType.ToUpperInvariant())
+            {
+                'AZUREFUNCTIONS' {
+                    Start-PodeAzFuncServer -Data $Request
+                }
 
-            { ($_ -ieq 'HTTP') -or ($_ -ieq 'HTTPS') } {
-                $endpoints += (Start-PodeWebServer -Browse:$Browse)
-            }
-
-            'SERVICE' {
-                Start-PodeServiceServer
-            }
-
-            'AZUREFUNCTIONS' {
-                Start-PodeAzFuncServer -Data $Request
-            }
-
-            'AWSLAMBDA' {
-                Start-PodeAwsLambdaServer -Data $Request
+                'AWSLAMBDA' {
+                    Start-PodeAwsLambdaServer -Data $Request
+                }
             }
         }
 
-        # start web sockets if enabled
-        if ($PodeContext.Server.WebSockets.Enabled) {
-            $endpoints += (Start-PodeSignalServer)
+        # - normal
+        else {
+            foreach ($_type in $PodeContext.Server.Types) {
+                switch ($_type.ToUpperInvariant())
+                {
+                    'SMTP' {
+                        $endpoints += (Start-PodeSmtpServer)
+                    }
+
+                    'TCP' {
+                        $endpoints += (Start-PodeTcpServer)
+                    }
+
+                    #{ ($_ -ieq 'HTTP') -or ($_ -ieq 'HTTPS') } {
+                    'HTTP' {
+                        $endpoints += (Start-PodeWebServer -Browse:$Browse)
+                    }
+
+                    #{ ($_ -ieq 'WS') -or ($_ -ieq 'WSS') } {
+                    'WS' {
+                        $endpoints += (Start-PodeSignalServer)
+                    }
+                }
+            }
         }
 
         # set the start time of the server (start and after restart)
@@ -94,7 +106,7 @@ function Start-PodeInternalServer
 
         # state what endpoints are being listened on
         if ($endpoints.Length -gt 0) {
-            Write-PodeHost "Listening on the following $($endpoints.Length) endpoint(s) [$($PodeContext.Threads.Web) thread(s)]:" -ForegroundColor Yellow
+            Write-PodeHost "Listening on the following $($endpoints.Length) endpoint(s) [$($PodeContext.Threads.General) thread(s)]:" -ForegroundColor Yellow
             $endpoints | ForEach-Object {
                 Write-PodeHost "`t- $($_)" -ForegroundColor Yellow
             }
@@ -176,9 +188,7 @@ function Restart-PodeInternalServer
         $PodeContext.Server.State.Clear()
 
         # reset type if smtp/tcp
-        if (@('smtp', 'tcp') -icontains $PodeContext.Server.Type) {
-            $PodeContext.Server.Type = [string]::Empty
-        }
+        $PodeContext.Server.Types = @()
 
         # recreate the session tokens
         Close-PodeDisposable -Disposable $PodeContext.Tokens.Cancellation

--- a/src/Private/Server.ps1
+++ b/src/Private/Server.ps1
@@ -88,12 +88,10 @@ function Start-PodeInternalServer
                         $endpoints += (Start-PodeTcpServer)
                     }
 
-                    #{ ($_ -ieq 'HTTP') -or ($_ -ieq 'HTTPS') } {
                     'HTTP' {
                         $endpoints += (Start-PodeWebServer -Browse:$Browse)
                     }
 
-                    #{ ($_ -ieq 'WS') -or ($_ -ieq 'WSS') } {
                     'WS' {
                         $endpoints += (Start-PodeSignalServer)
                     }

--- a/src/Private/ServiceServer.ps1
+++ b/src/Private/ServiceServer.ps1
@@ -44,5 +44,5 @@ function Start-PodeServiceServer
     }
 
     # start the runspace for the server
-    Add-PodeRunspace -Type 'Main' -ScriptBlock $serverScript
+    Add-PodeRunspace -Type Main -ScriptBlock $serverScript
 }

--- a/src/Private/SignalServer.ps1
+++ b/src/Private/SignalServer.ps1
@@ -108,7 +108,7 @@ function Start-PodeSignalServer
         }
     }
 
-    Add-PodeRunspace -Type 'Signals' -ScriptBlock $signalScript -Parameters @{ 'Listener' = $listener }
+    Add-PodeRunspace -Type Signals -ScriptBlock $signalScript -Parameters @{ 'Listener' = $listener }
 
     # script to queue messages from clients to send back to other clients from the server
     $clientScript = {
@@ -134,7 +134,7 @@ function Start-PodeSignalServer
         }
     }
 
-    Add-PodeRunspace -Type 'Signals' -ScriptBlock $clientScript -Parameters @{ 'Listener' = $listener }
+    Add-PodeRunspace -Type Signals -ScriptBlock $clientScript -Parameters @{ 'Listener' = $listener }
 
     # script to keep web server listening until cancelled
     $waitScript = {
@@ -160,6 +160,6 @@ function Start-PodeSignalServer
         }
     }
 
-    Add-PodeRunspace -Type 'Signals' -ScriptBlock $waitScript -Parameters @{ 'Listener' = $listener }
+    Add-PodeRunspace -Type Signals -ScriptBlock $waitScript -Parameters @{ 'Listener' = $listener }
     return @($endpoints.Url)
 }

--- a/src/Private/SmtpServer.ps1
+++ b/src/Private/SmtpServer.ps1
@@ -8,7 +8,7 @@ function Start-PodeSmtpServer
     }
 
     # the endpoint to listen on
-    $endpoint = @($PodeContext.Server.Endpoints.Values)[0]
+    $endpoint = @(Get-PodeEndpoints -Type Smtp)[0]
 
     # grab the relavant port
     $port = $endpoint.Port
@@ -123,9 +123,8 @@ function Start-PodeSmtpServer
     }
 
     # start the runspace for listening on x-number of threads
-    1..$PodeContext.Threads.Web | ForEach-Object {
-        Add-PodeRunspace -Type 'Main' -ScriptBlock $listenScript `
-            -Parameters @{ 'Listener' = $listener; 'ThreadId' = $_ }
+    1..$PodeContext.Threads.General | ForEach-Object {
+        Add-PodeRunspace -Type Smtp -ScriptBlock $listenScript -Parameters @{ 'Listener' = $listener; 'ThreadId' = $_ }
     }
 
     # script to keep smtp server listening until cancelled
@@ -152,7 +151,7 @@ function Start-PodeSmtpServer
         }
     }
 
-    Add-PodeRunspace -Type 'Main' -ScriptBlock $waitScript -Parameters @{ 'Listener' = $listener }
+    Add-PodeRunspace -Type Smtp -ScriptBlock $waitScript -Parameters @{ 'Listener' = $listener }
 
     # state where we're running
     return @("smtp://$($endpoint.FriendlyName):$($port)")

--- a/src/Private/TcpServer.ps1
+++ b/src/Private/TcpServer.ps1
@@ -6,7 +6,7 @@ function Start-PodeTcpServer
     }
 
     # the endpoint to listen on
-    $endpoint = @($PodeContext.Server.Endpoints.Values)[0]
+    $endpoint = @(Get-PodeEndpoints -Type Tcp)[0]
 
     # grab the relavant port
     $port = $endpoint.Port
@@ -90,9 +90,8 @@ function Start-PodeTcpServer
     }
 
     # start the runspace for listening on x-number of threads
-    1..$PodeContext.Threads.Web | ForEach-Object {
-        Add-PodeRunspace -Type 'Main' -ScriptBlock $listenScript `
-            -Parameters @{ 'Listener' = $listener; 'ThreadId' = $_ }
+    1..$PodeContext.Threads.General | ForEach-Object {
+        Add-PodeRunspace -Type Tcp -ScriptBlock $listenScript -Parameters @{ 'Listener' = $listener; 'ThreadId' = $_ }
     }
 
     # script to keep tcp server listening until cancelled
@@ -122,7 +121,7 @@ function Start-PodeTcpServer
         }
     }
 
-    Add-PodeRunspace -Type 'Main' -ScriptBlock $waitScript -Parameters @{ 'Listener' = $listener }
+    Add-PodeRunspace -Type Tcp -ScriptBlock $waitScript -Parameters @{ 'Listener' = $listener }
 
     # state where we're running
     return @("tcp://$($endpoint.FriendlyName):$($port)")

--- a/src/Private/Timers.ps1
+++ b/src/Private/Timers.ps1
@@ -49,7 +49,7 @@ function Start-PodeTimerRunspace
         }
     }
 
-    Add-PodeRunspace -Type 'Main' -ScriptBlock $script
+    Add-PodeRunspace -Type Main -ScriptBlock $script
 }
 
 function Invoke-PodeInternalTimer

--- a/src/Public/Core.ps1
+++ b/src/Public/Core.ps1
@@ -27,8 +27,8 @@ An override for the Server's root path.
 .PARAMETER Request
 Intended for Serverless environments, this is Requests details that Pode can parse and use.
 
-.PARAMETER Type
-The server type, to define how Pode should run and deal with incoming Requests.
+.PARAMETER ServerlessType
+Optional, this is the serverless type, to define how Pode should run and deal with incoming Requests.
 
 .PARAMETER StatusPageExceptions
 An optional value of Show/Hide to control where Stacktraces are shown in the Status Pages.
@@ -53,7 +53,7 @@ Start-PodeServer { /* logic */ }
 Start-PodeServer -Interval 10 { /* logic */ }
 
 .EXAMPLE
-Start-PodeServer -Request $LambdaInput -Type 'AwsLambda' { /* logic */ }
+Start-PodeServer -Request $LambdaInput -ServerlessType AwsLambda { /* logic */ }
 #>
 function Start-PodeServer
 {

--- a/src/Public/Core.ps1
+++ b/src/Public/Core.ps1
@@ -89,8 +89,7 @@ function Start-PodeServer
         [Parameter()]
         [ValidateSet('', 'AzureFunctions', 'AwsLambda')]
         [string]
-        #TODO: Rename this to ServerlessType ??
-        $Type = [string]::Empty,
+        $ServerlessType = [string]::Empty,
 
         [Parameter()]
         [ValidateSet('', 'Hide', 'Show')]
@@ -147,7 +146,7 @@ function Start-PodeServer
             -Threads $Threads `
             -Interval $Interval `
             -ServerRoot (Protect-PodeValue -Value $RootPath -Default $MyInvocation.PSScriptRoot) `
-            -ServerType $Type `
+            -ServerlessType $ServerlessType `
             -ListenerType $ListenerType `
             -StatusPageExceptions $StatusPageExceptions `
             -DisableTermination:$DisableTermination `
@@ -165,7 +164,7 @@ function Start-PodeServer
         Start-PodeInternalServer -Request $Request -Browse:$Browse
 
         # at this point, if it's just a one-one off script, return
-        if ([string]::IsNullOrWhiteSpace($PodeContext.Server.Type) -or $PodeContext.Server.IsServerless) {
+        if (($PodeContext.Server.Types.Length -eq 0) -or $PodeContext.Server.IsServerless) {
             return
         }
 
@@ -898,23 +897,16 @@ function Add-PodeEndpoint
 
     if (!$exists) {
         # has an endpoint already been defined for smtp/tcp?
-        if ((@('smtp', 'tcp') -icontains $Protocol) -and ($Protocol -ieq $PodeContext.Server.Type)) {
+        if ((@('smtp', 'tcp') -icontains $Protocol) -and ($PodeContext.Server.Types -icontains $Protocol)) {
             throw "An endpoint for $($Protocol.ToUpperInvariant()) has already been defined"
         }
 
-        # set server type, ensure we aren't trying to change the server's type
-        if (@('ws', 'wss') -icontains $Protocol) {
-            $PodeContext.Server.WebSockets.Enabled = $true
-        }
-        else {
-            $_type = (Resolve-PodeValue -Check ($Protocol -ieq 'https') -TrueValue 'http' -FalseValue $Protocol)
+        # set server type
+        $_type = (Resolve-PodeValue -Check ($Protocol -ieq 'https') -TrueValue 'http' -FalseValue $Protocol)
+        $_type = (Resolve-PodeValue -Check ($_type -ieq 'wss') -TrueValue 'ws' -FalseValue $_type)
 
-            if ([string]::IsNullOrWhiteSpace($PodeContext.Server.Type)) {
-                $PodeContext.Server.Type = $_type
-            }
-            elseif ($PodeContext.Server.Type -ine $_type) {
-                throw "Cannot add $($Protocol.ToUpperInvariant()) endpoint when already listening to $($PodeContext.Server.Type.ToUpperInvariant()) endpoints"
-            }
+        if ($PodeContext.Server.Types -inotcontains $_type) {
+            $PodeContext.Server.Types += $_type
         }
 
         # add the new endpoint

--- a/src/Public/Headers.ps1
+++ b/src/Public/Headers.ps1
@@ -40,14 +40,11 @@ function Add-PodeHeader
     }
 
     # add the header to the response
-    switch ($PodeContext.Server.Type) {
-        'http' {
-            $WebEvent.Response.Headers.Add($Name, $Value)
-        }
-
-        default {
-            $WebEvent.Response.Headers[$Name] = $Value
-        }
+    if ($PodeContext.Server.IsServerless) {
+        $WebEvent.Response.Headers[$Name] = $Value
+    }
+    else {
+        $WebEvent.Response.Headers.Add($Name, $Value)
     }
 }
 
@@ -161,14 +158,11 @@ function Set-PodeHeader
     }
 
     # set the header on the response
-    switch ($PodeContext.Server.Type) {
-        'http' {
-            $WebEvent.Response.Headers.Set($Name, $Value)
-        }
-
-        default {
-            $WebEvent.Response.Headers[$Name] = $Value
-        }
+    if ($PodeContext.Server.IsServerless) {
+        $WebEvent.Response.Headers[$Name] = $Value
+    }
+    else {
+        $WebEvent.Response.Headers.Set($Name, $Value)
     }
 }
 

--- a/tests/unit/Context.Tests.ps1
+++ b/tests/unit/Context.Tests.ps1
@@ -29,7 +29,7 @@ Describe 'Add-PodeEndpoint' {
             $PodeContext.Server = @{ Endpoints = @{}; EndpointsMap = @{}; 'Type' = $null }
             Add-PodeEndpoint -Address 'foo.com' -Protocol 'HTTP'
 
-            $PodeContext.Server.Type | Should Be 'HTTP'
+            $PodeContext.Server.Types | Should Be 'HTTP'
             $PodeContext.Server.Endpoints | Should Not Be $null
             $PodeContext.Server.Endpoints.Count | Should Be 1
 
@@ -46,7 +46,7 @@ Describe 'Add-PodeEndpoint' {
             $PodeContext.Server = @{ Endpoints = @{}; EndpointsMap = @{}; 'Type' = $null }
             Add-PodeEndpoint -Hostname 'foo.com' -Protocol 'HTTP'
 
-            $PodeContext.Server.Type | Should Be 'HTTP'
+            $PodeContext.Server.Types | Should Be 'HTTP'
             $PodeContext.Server.Endpoints | Should Not Be $null
             $PodeContext.Server.Endpoints.Count | Should Be 1
 
@@ -62,7 +62,7 @@ Describe 'Add-PodeEndpoint' {
             $PodeContext.Server = @{ Endpoints = @{}; EndpointsMap = @{}; 'Type' = $null }
             Add-PodeEndpoint -Address 'foo.com' -Protocol 'HTTP' -Name 'Example'
 
-            $PodeContext.Server.Type | Should Be 'HTTP'
+            $PodeContext.Server.Types | Should Be 'HTTP'
             $PodeContext.Server.Endpoints | Should Not Be $null
             $PodeContext.Server.Endpoints.Count | Should Be 1
 
@@ -77,7 +77,7 @@ Describe 'Add-PodeEndpoint' {
             $PodeContext.Server = @{ Endpoints = @{}; EndpointsMap = @{}; 'Type' = $null }
             Add-PodeEndpoint -Address 'foo.com' -Protocol 'HTTP'
 
-            $PodeContext.Server.Type | Should Be 'HTTP'
+            $PodeContext.Server.Types | Should Be 'HTTP'
             $PodeContext.Server.Endpoints | Should Not Be $null
             $PodeContext.Server.Endpoints.Count | Should Be 1
 
@@ -92,7 +92,7 @@ Describe 'Add-PodeEndpoint' {
             $PodeContext.Server = @{ Endpoints = @{}; EndpointsMap = @{}; 'Type' = $null }
             Add-PodeEndpoint -Address 'foo.com' -Port 80 -Protocol 'HTTP'
 
-            $PodeContext.Server.Type | Should Be 'HTTP'
+            $PodeContext.Server.Types | Should Be 'HTTP'
             $PodeContext.Server.Endpoints | Should Not Be $null
             $PodeContext.Server.Endpoints.Count | Should Be 1
 
@@ -106,7 +106,7 @@ Describe 'Add-PodeEndpoint' {
             $PodeContext.Server = @{ Endpoints = @{}; EndpointsMap = @{}; 'Type' = $null }
             Add-PodeEndpoint -Address '127.0.0.2' -Hostname 'foo.com' -Port 80 -Protocol 'HTTP'
 
-            $PodeContext.Server.Type | Should Be 'HTTP'
+            $PodeContext.Server.Types | Should Be 'HTTP'
             $PodeContext.Server.Endpoints | Should Not Be $null
             $PodeContext.Server.Endpoints.Count | Should Be 1
 
@@ -121,7 +121,7 @@ Describe 'Add-PodeEndpoint' {
             $PodeContext.Server = @{ Endpoints = @{}; EndpointsMap = @{}; 'Type' = $null }
             Add-PodeEndpoint -Address '127.0.0.1' -Protocol 'HTTP'
 
-            $PodeContext.Server.Type | Should Be 'HTTP'
+            $PodeContext.Server.Types | Should Be 'HTTP'
             $PodeContext.Server.Endpoints | Should Not Be $null
             $PodeContext.Server.Endpoints.Count | Should Be 1
 
@@ -135,7 +135,7 @@ Describe 'Add-PodeEndpoint' {
             $PodeContext.Server = @{ Endpoints = @{}; EndpointsMap = @{}; 'Type' = $null }
             Add-PodeEndpoint -Address 'all' -Protocol 'HTTP'
 
-            $PodeContext.Server.Type | Should Be 'HTTP'
+            $PodeContext.Server.Types | Should Be 'HTTP'
             $PodeContext.Server.Endpoints | Should Not Be $null
             $PodeContext.Server.Endpoints.Count | Should Be 1
 
@@ -150,7 +150,7 @@ Describe 'Add-PodeEndpoint' {
             $PodeContext.Server = @{ Endpoints = @{}; EndpointsMap = @{}; 'Type' = $null }
             Add-PodeEndpoint -Address '127.0.0.1' -Protocol 'HTTP'
 
-            $PodeContext.Server.Type | Should Be 'HTTP'
+            $PodeContext.Server.Types | Should Be 'HTTP'
             $PodeContext.Server.Endpoints | Should Not Be $null
             $PodeContext.Server.Endpoints.Count | Should Be 1
 
@@ -164,7 +164,7 @@ Describe 'Add-PodeEndpoint' {
             $PodeContext.Server = @{ Endpoints = @{}; EndpointsMap = @{}; 'Type' = $null }
             Add-PodeEndpoint -Port 80 -Protocol 'HTTP'
 
-            $PodeContext.Server.Type | Should Be 'HTTP'
+            $PodeContext.Server.Types | Should Be 'HTTP'
             $PodeContext.Server.Endpoints | Should Not Be $null
             $PodeContext.Server.Endpoints.Count | Should Be 1
 
@@ -178,7 +178,7 @@ Describe 'Add-PodeEndpoint' {
             $PodeContext.Server = @{ Endpoints = @{}; EndpointsMap = @{}; 'Type' = $null }
             Add-PodeEndpoint -Port 80 -Protocol 'HTTP'
 
-            $PodeContext.Server.Type | Should Be 'HTTP'
+            $PodeContext.Server.Types | Should Be 'HTTP'
             $PodeContext.Server.Endpoints | Should Not Be $null
             $PodeContext.Server.Endpoints.Count | Should Be 1
 
@@ -192,7 +192,7 @@ Describe 'Add-PodeEndpoint' {
             $PodeContext.Server = @{ Endpoints = @{}; EndpointsMap = @{}; 'Type' = $null }
             Add-PodeEndpoint -Address '127.0.0.1' -Port 80 -Protocol 'HTTP'
 
-            $PodeContext.Server.Type | Should Be 'HTTP'
+            $PodeContext.Server.Types | Should Be 'HTTP'
             $PodeContext.Server.Endpoints | Should Not Be $null
             $PodeContext.Server.Endpoints.Count | Should Be 1
 
@@ -206,7 +206,7 @@ Describe 'Add-PodeEndpoint' {
             $PodeContext.Server = @{ Endpoints = @{}; EndpointsMap = @{}; 'Type' = $null }
             Add-PodeEndpoint -Address '*' -Port 80 -Protocol 'HTTP'
 
-            $PodeContext.Server.Type | Should Be 'HTTP'
+            $PodeContext.Server.Types | Should Be 'HTTP'
             $PodeContext.Server.Endpoints | Should Not Be $null
             $PodeContext.Server.Endpoints.Count | Should Be 1
 
@@ -222,7 +222,7 @@ Describe 'Add-PodeEndpoint' {
             $PodeContext.Server = @{ Endpoints = @{}; EndpointsMap = @{}; 'Type' = $null }
             { Add-PodeEndpoint -Address '256.0.0.1' -Protocol 'HTTP' } | Should Throw 'Invalid IP Address'
 
-            $PodeContext.Server.Type | Should Be $null
+            $PodeContext.Server.Types | Should Be $null
             $PodeContext.Server.Endpoints.Count | Should Be 0
         }
 
@@ -230,7 +230,7 @@ Describe 'Add-PodeEndpoint' {
             $PodeContext.Server = @{ Endpoints = @{}; EndpointsMap = @{}; 'Type' = $null }
             { Add-PodeEndpoint -Address '256.0.0.1' -Port 80 -Protocol 'HTTP' } | Should Throw 'Invalid IP Address'
 
-            $PodeContext.Server.Type | Should Be $null
+            $PodeContext.Server.Types | Should Be $null
             $PodeContext.Server.Endpoints.Count | Should Be 0
         }
 
@@ -239,7 +239,7 @@ Describe 'Add-PodeEndpoint' {
             $ep1 = (Add-PodeEndpoint -Address '127.0.0.1' -Port 80 -Protocol 'HTTP' -PassThru)
             $ep2 = (Add-PodeEndpoint -Address 'pode.foo.com' -Port 80 -Protocol 'HTTP' -PassThru)
 
-            $PodeContext.Server.Type | Should Be 'HTTP'
+            $PodeContext.Server.Types | Should Be 'HTTP'
             $PodeContext.Server.Endpoints | Should Not Be $null
             $PodeContext.Server.Endpoints.Count | Should Be 2
 
@@ -259,7 +259,7 @@ Describe 'Add-PodeEndpoint' {
             Add-PodeEndpoint -Address '127.0.0.1' -Port 80 -Protocol 'HTTP' -Name 'Example1'
             Add-PodeEndpoint -Address 'pode.foo.com' -Port 80 -Protocol 'HTTP' -Name 'Example2'
 
-            $PodeContext.Server.Type | Should Be 'HTTP'
+            $PodeContext.Server.Types | Should Be 'HTTP'
             $PodeContext.Server.Endpoints | Should Not Be $null
             $PodeContext.Server.Endpoints.Count | Should Be 2
 
@@ -281,7 +281,7 @@ Describe 'Add-PodeEndpoint' {
             Add-PodeEndpoint -Address '127.0.0.1' -Port 80 -Protocol 'HTTP' -Name 'Http'
             Add-PodeEndpoint -Address 'pode.foo.com' -Port 80 -Protocol 'HTTPS' -Name 'Https'
 
-            $PodeContext.Server.Type | Should Be 'HTTP'
+            $PodeContext.Server.Types | Should Be 'HTTP'
             $PodeContext.Server.Endpoints | Should Not Be $null
             $PodeContext.Server.Endpoints.Count | Should Be 2
 
@@ -301,7 +301,7 @@ Describe 'Add-PodeEndpoint' {
             Add-PodeEndpoint -Address '127.0.0.1' -Port 80 -Protocol 'HTTP'
             Add-PodeEndpoint -Address '127.0.0.1' -Port 80 -Protocol 'HTTP'
 
-            $PodeContext.Server.Type | Should Be 'HTTP'
+            $PodeContext.Server.Types | Should Be 'HTTP'
             $PodeContext.Server.Endpoints | Should Not Be $null
             $PodeContext.Server.Endpoints.Count | Should Be 1
 
@@ -311,10 +311,11 @@ Describe 'Add-PodeEndpoint' {
             $endpoint.Address.ToString() | Should Be '127.0.0.1'
         }
 
-        It 'Throws error when adding two endpoints of different types' {
+        It 'Allows adding two endpoints of different types' {
             $PodeContext.Server = @{ Endpoints = @{}; EndpointsMap = @{}; 'Type' = $null }
             Add-PodeEndpoint -Address '127.0.0.1' -Port 80 -Protocol 'HTTP'
-            { Add-PodeEndpoint -Address 'pode.foo.com' -Port 80 -Protocol 'SMTP' } | Should Throw 'cannot add smtp endpoint'
+            Add-PodeEndpoint -Address 'pode.foo.com' -Port 80 -Protocol 'SMTP'
+            $PodeContext.Server.Endpoints.Count | Should Be 2
         }
 
         It 'Throws error when adding two endpoints with the same name' {

--- a/tests/unit/Headers.Tests.ps1
+++ b/tests/unit/Headers.Tests.ps1
@@ -156,7 +156,7 @@ Describe 'Set-PodeHeader' {
     }
 
     Context 'Serverless' {
-        $PodeContext = @{ 'Server' = @{ 'Type' = 'azurefunctions' } }
+        $PodeContext = @{ 'Server' = @{ ServerlessType = 'azurefunctions'; IsServerless = $true } }
 
         It 'Sets a header to response' {
             $script:WebEvent = @{ 'Response' = @{

--- a/tests/unit/Helpers.Tests.ps1
+++ b/tests/unit/Helpers.Tests.ps1
@@ -662,7 +662,7 @@ Describe 'ConvertFrom-PodeRequestContent' {
         }
 
         It 'Returns json data for azure-functions' {
-            $PodeContext = @{ 'Server' = @{ 'Type' = 'AzureFunctions'; 'BodyParsers' = @{} } }
+            $PodeContext = @{ 'Server' = @{ 'ServerlessType' = 'AzureFunctions'; 'BodyParsers' = @{}; 'IsServerless' = $true } }
 
             $result = ConvertFrom-PodeRequestContent -Request @{
                 'ContentEncoding' = [System.Text.Encoding]::UTF8;
@@ -674,7 +674,7 @@ Describe 'ConvertFrom-PodeRequestContent' {
         }
 
         It 'Returns json data for aws-lambda' {
-            $PodeContext = @{ 'Server' = @{ 'Type' = 'AwsLambda'; 'BodyParsers' = @{} } }
+            $PodeContext = @{ 'Server' = @{ 'ServerlessType' = 'AwsLambda'; 'BodyParsers' = @{}; 'IsServerless' = $true } }
 
             $result = ConvertFrom-PodeRequestContent -Request @{
                 'ContentEncoding' = [System.Text.Encoding]::UTF8;
@@ -1178,19 +1178,19 @@ Describe 'Close-PodeServerInternal' {
     Mock Write-Host { }
 
     It 'Closes out pode, but with no done flag' {
-        $PodeContext = @{ 'Server' = @{ 'Type' = 'Server' } }
+        $PodeContext = @{ 'Server' = @{ 'Types' = 'Server' } }
         Close-PodeServerInternal
         Assert-MockCalled Write-Host -Times 0 -Scope It
     }
 
     It 'Closes out pode, but with the done flag' {
-        $PodeContext = @{ 'Server' = @{ 'Type' = 'Server' } }
+        $PodeContext = @{ 'Server' = @{ 'Types' = 'Server' } }
         Close-PodeServerInternal -ShowDoneMessage
         Assert-MockCalled Write-Host -Times 1 -Scope It
     }
 
     It 'Closes out pode, but with no done flag if serverless' {
-        $PodeContext = @{ 'Server' = @{ 'Type' = 'Server'; 'IsServerless' = $true } }
+        $PodeContext = @{ 'Server' = @{ 'Types' = 'Server'; 'IsServerless' = $true } }
         Close-PodeServerInternal -ShowDoneMessage
         Assert-MockCalled Write-Host -Times 0 -Scope It
     }

--- a/tests/unit/Server.Tests.ps1
+++ b/tests/unit/Server.Tests.ps1
@@ -27,7 +27,7 @@ Describe 'Start-PodeInternalServer' {
     Mock Import-PodeFunctionsIntoRunspaceState { }
 
     It 'Calls one-off script logic' {
-        $PodeContext.Server = @{ Type = ([string]::Empty); Logic = {} }
+        $PodeContext.Server = @{ Types = ([string]::Empty); Logic = {} }
         Start-PodeInternalServer | Out-Null
 
         Assert-MockCalled Invoke-PodeScriptBlock -Times 1 -Scope It
@@ -41,7 +41,7 @@ Describe 'Start-PodeInternalServer' {
     }
 
     It 'Calls smtp server logic' {
-        $PodeContext.Server = @{ Type = 'SMTP'; Logic = {} }
+        $PodeContext.Server = @{ Types = 'SMTP'; Logic = {} }
         Start-PodeInternalServer | Out-Null
 
         Assert-MockCalled Invoke-PodeScriptBlock -Times 1 -Scope It
@@ -55,7 +55,7 @@ Describe 'Start-PodeInternalServer' {
     }
 
     It 'Calls tcp server logic' {
-        $PodeContext.Server = @{ Type = 'TCP'; Logic = {} }
+        $PodeContext.Server = @{ Types = 'TCP'; Logic = {} }
         Start-PodeInternalServer | Out-Null
 
         Assert-MockCalled Invoke-PodeScriptBlock -Times 1 -Scope It
@@ -69,21 +69,7 @@ Describe 'Start-PodeInternalServer' {
     }
 
     It 'Calls http web server logic' {
-        $PodeContext.Server = @{ Type = 'HTTP'; Logic = {} }
-        Start-PodeInternalServer | Out-Null
-
-        Assert-MockCalled Invoke-PodeScriptBlock -Times 1 -Scope It
-        Assert-MockCalled New-PodeRunspacePools -Times 1 -Scope It
-        Assert-MockCalled New-PodeRunspaceState -Times 1 -Scope It
-        Assert-MockCalled Start-PodeTimerRunspace -Times 1 -Scope It
-        Assert-MockCalled Start-PodeScheduleRunspace -Times 1 -Scope It
-        Assert-MockCalled Start-PodeSmtpServer -Times 0 -Scope It
-        Assert-MockCalled Start-PodeTcpServer -Times 0 -Scope It
-        Assert-MockCalled Start-PodeWebServer -Times 1 -Scope It
-    }
-
-    It 'Calls https web server logic' {
-        $PodeContext.Server = @{ Type = 'HTTPS'; Logic = {} }
+        $PodeContext.Server = @{ Types = 'HTTP'; Logic = {} }
         Start-PodeInternalServer | Out-Null
 
         Assert-MockCalled Invoke-PodeScriptBlock -Times 1 -Scope It


### PR DESCRIPTION
### Description of the Change
Endpoints can be either Http, Https, Ws, Wss, Smtp, or Tcp. However, right now a server can only run with endpoints of just Http/Ws, or of just Smtp, or just Tcp.

This change will make it so it's possible to have a server with any protocols.

The `-Type` parameter on `Start-PodeServer` has also been renamed to `-ServerlessType`, to it's more fitting as to its purpose.

### Related Issue
Resolves #622 

### Examples
```powershell
Start-PodeServer -Threads 2 {
    Add-PodeEndpoint -Address * -Port 8090 -Protocol Http
    Add-PodeEndpoint -Address * -Port 25 -Protocol Smtp

    Add-PodeRoute -Method Get -Path '/' -ScriptBlock {}
    Add-PodeHandler -Type Smtp -Name 'Main' -ScriptBlock {}
}
```
