### PR TITLE
Adds new local windows user auth

### DIFF
--- a/docs/Tutorials/Authentication/Inbuilt/WindowsAD.md
+++ b/docs/Tutorials/Authentication/Inbuilt/WindowsAD.md
@@ -2,7 +2,7 @@
 
 Pode's inbuilt Windows AD authentication works cross-platform, using OpenLDAP to work in *nix environments.
 
-This authenticator can only be used with Basic and Form. Custom is also supported, but a username and password must be supplied.
+This authenticator can only be used with the Basic and Form schemes. Custom is also supported, but a username and password must be supplied.
 
 ## Usage
 
@@ -50,7 +50,7 @@ Start-PodeServer {
 
 ### Groups
 
-You can supply a list of group names to validate that user's are a member of them in AD. If you supply multiple group names, the user only needs to be a of one of the groups. You can supply the list of groups to the function's `-Groups` parameter as an array - the list is not case-sensitive:
+You can supply a list of group names to validate that users are a member of them in AD. If you supply multiple group names, the user only needs to be a member of one of the groups. You can supply the list of groups to the function's `-Groups` parameter as an array - the list is not case-sensitive:
 
 ```powershell
 Start-PodeServer {

--- a/docs/Tutorials/Authentication/Inbuilt/WindowsLocal.md
+++ b/docs/Tutorials/Authentication/Inbuilt/WindowsLocal.md
@@ -1,0 +1,61 @@
+# Windows Local Users
+
+Pode's inbuilt Windows local user authentication works only on Windows.
+
+This authenticator can only be used with the Basic and Form schemes. Custom is also supported, but a username and password must be supplied.
+
+## Usage
+
+To enable Windows local user authentication you can use the [`Add-PodeAuthWindowsLocal`](../../../../Functions/Authentication/Add-PodeAuthWindowsLocal) function. The following example will validate a user's credentials, supplied via a web-form, against the local users:
+
+```powershell
+Start-PodeServer {
+    New-PodeAuthScheme -Form | Add-PodeAuthWindowsLocal -Name 'Login'
+}
+```
+
+### User Object
+
+The User object returned, and accessible on Routes, and other functions via `$WebEvent.Auth.User`, will contain the following information:
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| UserType | string | Value is fixed to Local |
+| AuthenticationType | string | Value is fixed to WinNT |
+| Username | string | The user's username |
+| Name | string | The user's fullname |
+| FQDN | string | The Computer Name |
+| Domain | string | Value is fixed to localhost |
+| Groups | string[] | All groups of which the the user is a member |
+
+Such as:
+
+```powershell
+Add-PodeRoute -Method Get -Path '/info' -Authentication 'Login' -ScriptBlock {
+    Write-Host $WebEvent.Auth.User.Username
+}
+```
+
+### Groups
+
+You can supply a list of group names to validate that users are a member of them. If you supply multiple group names, the user only needs to be a member of one of the groups. You can supply the list of groups to the function's `-Groups` parameter as an array - the list is not case-sensitive:
+
+```powershell
+Start-PodeServer {
+    New-PodeAuthScheme -Form | Add-PodeAuthWindowsLocal -Name 'Login' -Groups @('admins', 'devops')
+}
+```
+
+If an user being authenticated is not in one of these groups, then a 401 is returned.
+
+### Users
+
+You can supply a list of authorised usernames to validate a user's access, after credentials are validated, and instead of of checking groups. You can supply the list of usernames to the function's `-Users` parameter as an array - the list is not case-sensitive:
+
+```powershell
+Start-PodeServer {
+    New-PodeAuthScheme -Form | Add-PodeAuthWindowsLocal -Name 'Login' -Users @('jsnow', 'rsanchez')
+}
+```
+
+If an user being authenticated is not one of the allowed users, then a 401 is returned.

--- a/examples/web-auth-form-local.ps1
+++ b/examples/web-auth-form-local.ps1
@@ -1,0 +1,65 @@
+$path = Split-Path -Parent -Path (Split-Path -Parent -Path $MyInvocation.MyCommand.Path)
+Import-Module "$($path)/src/Pode.psm1" -Force -ErrorAction Stop
+
+# or just:
+# Import-Module Pode
+
+<#
+This examples shows how to use session persistant authentication using Windows Local users.
+The example used here is Form authentication, sent from the <form> in HTML.
+
+Navigating to the 'http://localhost:8085' endpoint in your browser will auto-rediect you to the '/login'
+page. Here, you can type the details for a domain user. Clicking 'Login' will take you back to the home
+page with a greeting and a view counter. Clicking 'Logout' will purge the session and take you back to
+the login page.
+#>
+
+# create a server, and start listening on port 8085
+Start-PodeServer -Threads 2 {
+
+    # listen on localhost:8085
+    Add-PodeEndpoint -Address * -Port 8085 -Protocol Http
+    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+
+    # set the view engine
+    Set-PodeViewEngine -Type Pode
+
+    # setup session details
+    Enable-PodeSessionMiddleware -Secret 'schwifty' -Duration 120 -Extend
+
+    # setup form auth against windows local users (<form> in HTML)
+    New-PodeAuthScheme -Form | Add-PodeAuthWindowsLocal -Name 'Login' -Groups @() -Users @() -FailureUrl '/login' -SuccessUrl '/'
+
+
+    # home page:
+    # redirects to login page if not authenticated
+    Add-PodeRoute -Method Get -Path '/' -Authentication Login -ScriptBlock {
+        $WebEvent.Session.Data.Views++
+
+        Write-PodeViewResponse -Path 'auth-home' -Data @{
+            Username = $WebEvent.Auth.User.Name
+            Views = $WebEvent.Session.Data.Views
+        }
+    }
+
+
+    # login page:
+    # the login flag set below checks if there is already an authenticated session cookie. If there is, then
+    # the user is redirected to the home page. If there is no session then the login page will load without
+    # checking user authetication (to prevent a 401 status)
+    Add-PodeRoute -Method Get -Path '/login' -Authentication Login -Login -ScriptBlock {
+        Write-PodeViewResponse -Path 'auth-login' -FlashMessages
+    }
+
+
+    # login check:
+    # this is the endpoint the <form>'s action will invoke. If the user validates then they are set against
+    # the session as authenticated, and redirect to the home page. If they fail, then the login page reloads
+    Add-PodeRoute -Method Post -Path '/login' -Authentication Login -Login
+
+
+    # logout check:
+    # when the logout button is click, this endpoint is invoked. The logout flag set below informs this call
+    # to purge the currently authenticated session, and then redirect back to the login page
+    Add-PodeRoute -Method Post -Path '/logout' -Authentication Login -Logout
+}

--- a/src/Pode.psd1
+++ b/src/Pode.psd1
@@ -168,6 +168,7 @@
         'New-PodeAuthAzureADScheme',
         'Add-PodeAuth',
         'Add-PodeAuthWindowsAd',
+        'Add-PodeAuthWindowsLocal',
         'Remove-PodeAuth',
         'Add-PodeAuthMiddleware',
         'Add-PodeAuthIIS',

--- a/src/Private/Security.ps1
+++ b/src/Private/Security.ps1
@@ -820,8 +820,8 @@ function New-PodeSelfSignedCertificate
     $sanBuilder.AddIpAddress([ipaddress]::IPv6Loopback) | Out-Null
     $sanBuilder.AddDnsName('localhost') | Out-Null
 
-    if (![string]::IsNullOrWhiteSpace($env:COMPUTERNAME)) {
-        $sanBuilder.AddDnsName($env:COMPUTERNAME) | Out-Null
+    if (![string]::IsNullOrWhiteSpace($PodeContext.Server.ComputerName)) {
+        $sanBuilder.AddDnsName($PodeContext.Server.ComputerName) | Out-Null
     }
 
     $rsa = [RSA]::Create(2048)

--- a/src/Public/Logging.ps1
+++ b/src/Public/Logging.ps1
@@ -513,7 +513,7 @@ function Write-PodeErrorLog
     }
 
     # add general info
-    $item['Server'] = $env:COMPUTERNAME
+    $item['Server'] = $PodeContext.Server.ComputerName
     $item['Level'] = $Level
     $item['Date'] = [datetime]::Now
     $item['ThreadId'] = [int]$ThreadId


### PR DESCRIPTION
### Description of the Change
Adds a new `Add-PodeAuthWindowsLocal` function for local Windows user authentication. This works in a similar fashion to `Add-PodeAuthWindowsAd`, but using local users and groups.

### Related Issue
Resolves #625 

### Examples
```powershell
New-PodeAuthScheme -Form | Add-PodeAuthWindowsLocal -Name 'Login' -Groups @() -Users @() -FailureUrl '/login' -SuccessUrl '/'
```
