### PR TITLE
Fixes from start the Pode.Web module

### DIFF
--- a/src/Pode.psd1
+++ b/src/Pode.psd1
@@ -88,6 +88,7 @@
         'Set-PodeViewEngine',
         'Use-PodePartialView',
         'Send-PodeSignal',
+        'Add-PodeViewFolder',
 
         # utility helpers
         'Wait-PodeTask',
@@ -167,6 +168,8 @@
         'New-PodeAuthScheme',
         'New-PodeAuthAzureADScheme',
         'Add-PodeAuth',
+        'Get-PodeAuth',
+        'Clear-PodeAuth',
         'Add-PodeAuthWindowsAd',
         'Add-PodeAuthWindowsLocal',
         'Remove-PodeAuth',

--- a/src/Private/Authentication.ps1
+++ b/src/Private/Authentication.ps1
@@ -830,7 +830,11 @@ function Get-PodeAuthMiddlewareScript
             # run auth scheme script to parse request for data
             $_args = @($auth.Scheme.Arguments)
             if ($null -ne $auth.Scheme.ScriptBlock.UsingVariables) {
-                $_args = @($auth.Scheme.ScriptBlock.UsingVariables.Value) + $_args
+                $_vars = @()
+                foreach ($_var in $auth.Scheme.ScriptBlock.UsingVariables) {
+                    $_vars += ,$_var.Value
+                }
+                $_args = $_vars + $_args
             }
 
             # call inner schemes first
@@ -846,7 +850,11 @@ function Get-PodeAuthMiddlewareScript
                 for ($i = $_inner.Length - 1; $i -ge 0; $i--) {
                     $_tmp_args = @($_inner[$i].Arguments)
                     if ($null -ne $_inner[$i].ScriptBlock.UsingVariables) {
-                        $_tmp_args = @($_inner[$i].ScriptBlock.UsingVariables.Value) + $_tmp_args
+                        $_vars = @()
+                        foreach ($_var in $_inner[$i].ScriptBlock.UsingVariables) {
+                            $_vars += ,$_var.Value
+                        }
+                        $_tmp_args = $_vars + $_tmp_args
                     }
 
                     $_tmp_args += ,$schemes
@@ -872,7 +880,11 @@ function Get-PodeAuthMiddlewareScript
 
                 $_args = @($result) + @($auth.Arguments)
                 if ($null -ne $auth.UsingVariables) {
-                    $_args = @($auth.UsingVariables.Value) + $_args
+                    $_vars = @()
+                    foreach ($_var in $auth.UsingVariables) {
+                        $_vars += ,$_var.Value
+                    }
+                    $_args = $_vars + $_args
                 }
 
                 $result = (Invoke-PodeScriptBlock -ScriptBlock $auth.ScriptBlock -Arguments $_args -Return -Splat)
@@ -881,7 +893,11 @@ function Get-PodeAuthMiddlewareScript
                 if ([string]::IsNullOrWhiteSpace($result.Code) -and !(Test-PodeIsEmpty $auth.Scheme.PostValidator.Script)) {
                     $_args = @($original) + @($result) + @($auth.Scheme.Arguments)
                     if ($null -ne $auth.Scheme.PostValidator.UsingVariables) {
-                        $_args = @($auth.Scheme.PostValidator.UsingVariables.Value) + $_args
+                        $_vars = @()
+                        foreach ($_var in $auth.Scheme.PostValidator.UsingVariables) {
+                            $_vars += ,$_var.Value
+                        }
+                        $_args = $_vars + $_args
                     }
 
                     $result = (Invoke-PodeScriptBlock -ScriptBlock $auth.Scheme.PostValidator.Script -Arguments $_args -Return -Splat)

--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -222,6 +222,9 @@ function New-PodeContext
         '*' = @{};
     }
 
+    # custom view paths
+    $ctx.Server.Views = @{}
+
     # handlers for tcp
     $ctx.Server.Handlers = @{
         'tcp' = @{};

--- a/src/Private/Endware.ps1
+++ b/src/Private/Endware.ps1
@@ -24,7 +24,11 @@ function Invoke-PodeEndware
         try {
             $_args = @($eware.Arguments)
             if ($null -ne $eware.UsingVariables) {
-                $_args = @($eware.UsingVariables.Value) + $_args
+                $_vars = @()
+                foreach ($_var in $eware.UsingVariables) {
+                    $_vars += ,$_var.Value
+                }
+                $_args = $_vars + $_args
             }
 
             Invoke-PodeScriptBlock -ScriptBlock $eware.Logic -Arguments $_args -Scoped -Splat | Out-Null

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -84,7 +84,11 @@ function Get-PodeFileContentUsingViewEngine
                 }
 
                 if ($null -ne $PodeContext.Server.ViewEngine.UsingVariables) {
-                    $_args = @($PodeContext.Server.ViewEngine.UsingVariables.Value) + $_args
+                    $_vars = @()
+                    foreach ($_var in $PodeContext.Server.ViewEngine.UsingVariables) {
+                        $_vars += ,$_var.Value
+                    }
+                    $_args = $_vars + $_args
                 }
 
                 $content = (Invoke-PodeScriptBlock -ScriptBlock $PodeContext.Server.ViewEngine.ScriptBlock -Arguments $_args -Return -Splat)
@@ -1191,7 +1195,11 @@ function ConvertFrom-PodeRequestContent
 
             $_args = @($Content)
             if ($null -ne $parser.UsingVariables) {
-                $_args = @($parser.UsingVariables.Value) + $_args
+                $_vars = @()
+                foreach ($_var in $parser.UsingVariables) {
+                    $_vars += ,$_var.Value
+                }
+                $_args = $_vars + $_args
             }
 
             $Result.Data = (Invoke-PodeScriptBlock -ScriptBlock $parser.ScriptBlock -Arguments $_args -Return)

--- a/src/Private/Logging.ps1
+++ b/src/Private/Logging.ps1
@@ -299,7 +299,11 @@ function Start-PodeLoggingRunspace
             # convert to log item into a writable format
             $_args = @($log.Item) + @($logger.Arguments)
             if ($null -ne $logger.UsingVariables) {
-                $_args = @($logger.UsingVariables.Value) + $_args
+                $_vars = @()
+                foreach ($_var in $logger.UsingVariables) {
+                    $_vars += ,$_var.Value
+                }
+                $_args = $_vars + $_args
             }
 
             $result = @(Invoke-PodeScriptBlock -ScriptBlock $logger.ScriptBlock -Arguments $_args -Return -Splat)
@@ -327,7 +331,11 @@ function Start-PodeLoggingRunspace
             if ($null -ne $result) {
                 $_args = @(,$result) + @($logger.Method.Arguments)
                 if ($null -ne $logger.Method.UsingVariables) {
-                    $_args = @($logger.Method.UsingVariables.Value) + $_args
+                    $_vars = @()
+                    foreach ($_var in $logger.Method.UsingVariables) {
+                        $_vars += ,$_var.Value
+                    }
+                    $_args = $_vars + $_args
                 }
 
                 Invoke-PodeScriptBlock -ScriptBlock $logger.Method.ScriptBlock -Arguments $_args -Splat
@@ -357,7 +365,11 @@ function Test-PodeLoggerBatches
 
             $_args = @(,$result) + @($logger.Method.Arguments)
             if ($null -ne $logger.Method.UsingVariables) {
-                $_args = @($logger.Method.UsingVariables.Value) + $_args
+                $_vars = @()
+                foreach ($_var in $logger.Method.UsingVariables) {
+                    $_vars += ,$_var.Value
+                }
+                $_args = $_vars + $_args
             }
 
             Invoke-PodeScriptBlock -ScriptBlock $logger.Method.ScriptBlock -Arguments $_args -Splat

--- a/src/Private/Middleware.ps1
+++ b/src/Private/Middleware.ps1
@@ -45,7 +45,11 @@ function Invoke-PodeMiddleware
         try {
             $_args = @($midware.Arguments)
             if ($null -ne $midware.UsingVariables) {
-                $_args = @($midware.UsingVariables.Value) + $_args
+                $_vars = @()
+                foreach ($_var in $midware.UsingVariables) {
+                    $_vars += ,$_var.Value
+                }
+                $_args = $_vars + $_args
             }
 
             $continue = Invoke-PodeScriptBlock -ScriptBlock $midware.Logic -Arguments $_args -Return -Scoped -Splat

--- a/src/Private/PodeServer.ps1
+++ b/src/Private/PodeServer.ps1
@@ -157,7 +157,11 @@ function Start-PodeWebServer
                                 elseif ($null -ne $WebEvent.Route.Logic) {
                                     $_args = @($WebEvent.Route.Arguments)
                                     if ($null -ne $WebEvent.Route.UsingVariables) {
-                                        $_args = @($WebEvent.Route.UsingVariables.Value) + $_args
+                                        $_vars = @()
+                                        foreach ($_var in $WebEvent.Route.UsingVariables) {
+                                            $_vars += ,$_var.Value
+                                        }
+                                        $_args = $_vars + $_args
                                     }
 
                                     Invoke-PodeScriptBlock -ScriptBlock $WebEvent.Route.Logic -Arguments $_args -Scoped -Splat

--- a/src/Private/Server.ps1
+++ b/src/Private/Server.ps1
@@ -140,6 +140,7 @@ function Restart-PodeInternalServer
             $PodeContext.Server.Handlers[$_].Clear()
         }
 
+        $PodeContext.Views.Clear()
         $PodeContext.Timers.Clear()
         $PodeContext.Schedules.Clear()
         $PodeContext.Server.Logging.Types.Clear()

--- a/src/Private/Serverless.ps1
+++ b/src/Private/Serverless.ps1
@@ -95,7 +95,11 @@ function Start-PodeAzFuncServer
                     else {
                         $_args = @($WebEvent.Route.Arguments)
                         if ($null -ne $WebEvent.Route.UsingVariables) {
-                            $_args = @($WebEvent.Route.UsingVariables.Value) + $_args
+                            $_vars = @()
+                            foreach ($_var in $WebEvent.Route.UsingVariables) {
+                                $_vars += ,$_var.Value
+                            }
+                            $_args = $_vars + $_args
                         }
 
                         Invoke-PodeScriptBlock -ScriptBlock $WebEvent.Route.Logic -Arguments $_args -Scoped -Splat
@@ -210,7 +214,11 @@ function Start-PodeAwsLambdaServer
                     else {
                         $_args = @($WebEvent.Route.Arguments)
                         if ($null -ne $WebEvent.Route.UsingVariables) {
-                            $_args = @($WebEvent.Route.UsingVariables.Value) + $_args
+                            $_vars = @()
+                            foreach ($_var in $WebEvent.Route.UsingVariables) {
+                                $_vars += ,$_var.Value
+                            }
+                            $_args = $_vars + $_args
                         }
 
                         Invoke-PodeScriptBlock -ScriptBlock $WebEvent.Route.Logic -Arguments $_args -Scoped -Splat

--- a/src/Private/ServiceServer.ps1
+++ b/src/Private/ServiceServer.ps1
@@ -26,7 +26,11 @@ function Start-PodeServiceServer
 
                     $_args = @($handler.Arguments)
                     if ($null -ne $handler.UsingVariables) {
-                        $_args = @($handler.UsingVariables.Value) + $_args
+                        $_vars = @()
+                        foreach ($_var in $handler.UsingVariables) {
+                            $_vars += ,$_var.Value
+                        }
+                        $_args = $_vars + $_args
                     }
 
                     Invoke-PodeScriptBlock -ScriptBlock $handler.Logic -Arguments $_args -Scoped -Splat

--- a/src/Private/SmtpServer.ps1
+++ b/src/Private/SmtpServer.ps1
@@ -103,7 +103,11 @@ function Start-PodeSmtpServer
 
                             $_args = @($handler.Arguments)
                             if ($null -ne $handler.UsingVariables) {
-                                $_args = @($handler.UsingVariables.Value) + $_args
+                                $_vars = @()
+                                foreach ($_var in $handler.UsingVariables) {
+                                    $_vars += ,$_var.Value
+                                }
+                                $_args = $_vars + $_args
                             }
 
                             Invoke-PodeScriptBlock -ScriptBlock $handler.Logic -Arguments $_args -Scoped -Splat

--- a/src/Private/TcpServer.ps1
+++ b/src/Private/TcpServer.ps1
@@ -71,7 +71,11 @@ function Start-PodeTcpServer
 
                         $_args = @($handler.Arguments)
                         if ($null -ne $handler.UsingVariables) {
-                            $_args = @($handler.UsingVariables.Value) + $_args
+                            $_vars = @()
+                            foreach ($_var in $handler.UsingVariables) {
+                                $_vars += ,$_var.Value
+                            }
+                            $_args = $_vars + $_args
                         }
 
                         Invoke-PodeScriptBlock -ScriptBlock $handler.Logic -Arguments $_args -Scoped -Splat

--- a/src/Private/Timers.ps1
+++ b/src/Private/Timers.ps1
@@ -64,7 +64,11 @@ function Invoke-PodeInternalTimer
 
         $_args = @($Timer.Arguments)
         if ($null -ne $Timer.UsingVariables) {
-            $_args = @($Timer.UsingVariables.Value) + $_args
+            $_vars = @()
+            foreach ($_var in $Timer.UsingVariables) {
+                $_vars += ,$_var.Value
+            }
+            $_args = $_vars + $_args
         }
 
         Invoke-PodeScriptBlock -ScriptBlock $Timer.Script -Arguments $_args -Scoped -Splat

--- a/src/Public/Authentication.ps1
+++ b/src/Public/Authentication.ps1
@@ -545,6 +545,37 @@ function Add-PodeAuth
 
 <#
 .SYNOPSIS
+Gets an Authentication method.
+
+.DESCRIPTION
+Gets an Authentication method.
+
+.PARAMETER Name
+The Name of an Authentication method.
+
+.EXAMPLE
+Get-PodeAuth -Name 'Main'
+#>
+function Get-PodeAuth
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Name
+    )
+
+    # ensure the name exists
+    if (!(Test-PodeAuth -Name $Name)) {
+        throw "Authentication method not defined: $($Name)"
+    }
+
+    # get auth method
+    return $PodeContext.Server.Authentications[$Name]
+}
+
+<#
+.SYNOPSIS
 Adds the inbuilt Windows AD Authentication method for verifying users.
 
 .DESCRIPTION

--- a/src/Public/Responses.ps1
+++ b/src/Public/Responses.ps1
@@ -1374,7 +1374,7 @@ Add a custom path that contains additional views.
 .DESCRIPTION
 Add a custom path that contains additional views.
 
-.PARAMETER Path
+.PARAMETER Name
 The Name of the views folder.
 
 .PARAMETER Source

--- a/tests/unit/Server.Tests.ps1
+++ b/tests/unit/Server.Tests.ps1
@@ -152,6 +152,7 @@ Describe 'Restart-PodeInternalServer' {
             }
             Timers = @{ 'key' = 'value' }
             Schedules = @{ 'key' = 'value' };
+            Views = @{ 'key' = 'value' };
         }
 
         Restart-PodeInternalServer | Out-Null


### PR DESCRIPTION
These are some quick and general fixes/improvements I found from starting the Pode.Web module.

* New `Add-PodeViewFolder` to enable support for custom view folders (like within a module)
* Fixes a bug with `$using:` where array elements were not splatted properly
* New `Get-PodeAuth`, so we can get and auth back

On the custom view folders:
```powershell
Add-PodeViewFolder -Name Custom -Source 'c:/path/to/folder'
Write-PodeViewResponse -Path 'index' -Folder Custom
```