### PR TITLE
Parse username during AD authentication

### DIFF
--- a/src/Private/Authentication.ps1
+++ b/src/Private/Authentication.ps1
@@ -537,6 +537,9 @@ function Get-PodeAuthWindowsADMethod
     return {
         param($username, $password, $options)
 
+        # parse username to remove domains
+        $username = (($username -split '@')[0] -split '\\')[-1]
+
         # validate and retrieve the AD user
         $noGroups = $options.NoGroups
         $openLdap = $options.OpenLDAP


### PR DESCRIPTION
### Description of the Change
Parse the username supplied AD authentication, so a user can supply their name as:
* `<username>`
* `<domain>\<username>`
* `<username>@<domain>`

### Related Issue
Resolves #631
