### PR TITLE
Fix certificate X509FindType enum

### DIFF
--- a/src/Private/Security.ps1
+++ b/src/Private/Security.ps1
@@ -799,7 +799,7 @@ function Get-PodeCertificateByThumbprint
         $Thumbprint
     )
 
-    return (Find-PodeCertificateInCertStore -FindType [X509FindType]::FindByThumbprint -Query $Thumbprint)
+    return (Find-PodeCertificateInCertStore -FindType ([X509Certificates.X509FindType]::FindByThumbprint) -Query $Thumbprint)
 }
 
 function Get-PodeCertificateByName
@@ -810,7 +810,7 @@ function Get-PodeCertificateByName
         $Name
     )
 
-    return (Find-PodeCertificateInCertStore -FindType [X509FindType]::FindBySubjectName -Query $Name)
+    return (Find-PodeCertificateInCertStore -FindType ([X509Certificates.X509FindType]::FindBySubjectName) -Query $Name)
 }
 
 function New-PodeSelfSignedCertificate


### PR DESCRIPTION
### Description of the Change
Fixes an issue supplying the `[X509FindType]` enum when querying for certificates.

### Related Issue
Resolves #642
