### PR TITLE
#655: Fix for request bodies that are huuge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ pode_modules/
 ps_modules/
 docs/[Ff]unctions/
 examples/state.json
+examples/issue-*
 pkg/
 
 

--- a/src/Listener/PodeContext.cs
+++ b/src/Listener/PodeContext.cs
@@ -265,7 +265,8 @@ namespace Pode
                     SmtpRequest.Reset();
                 }
 
-                if (!IsKeepAlive || force)
+                // dispose of request if not KeepAlive, and not waiting for body
+                if (((IsHttp && !HttpRequest.AwaitingBody) || !IsHttp) && (!IsKeepAlive || force))
                 {
                     State = PodeContextState.Closed;
                     Request.Dispose();
@@ -275,8 +276,8 @@ namespace Pode
             }
             catch {}
 
-            // if keep-alive, setup for re-receive
-            if (IsKeepAlive && !force)
+            // if keep-alive, or awaiting body, setup for re-receive
+            if (((IsHttp && HttpRequest.AwaitingBody) || IsKeepAlive) && !force)
             {
                 StartReceive();
             }


### PR DESCRIPTION
### Description of the Change
If a large enough payload was supplied, Pode wouldn't read all of the content - causing a 400 error. This fixes the issue by making Pode wait for the rest of the payload to be received - similar to how we fixed proxies and KeepAlive.

### Related Issue
Resolves #655 
