### PR TITLE
Adds a new ScriptBlock parameter to inbuilt Authentication methods

### DIFF
--- a/docs/Hosting/IIS.md
+++ b/docs/Hosting/IIS.md
@@ -127,6 +127,33 @@ If the required header is missing, then Pode responds with a 401. The retrieved 
 !!! note
     If the authenticated user is a Local User, then the following properties will be empty: FQDN, Email, and DistinguishedName
 
+### Additional Validation
+
+Similar to the normal [`Add-PodeAuth`](../../Functions/Authentication/Add-PodeAuth), [`Add-PodeAuthIIS`](../../Functions/Authentication/Add-PodeAuthIIS) can be supplied can an optional ScriptBlock parameter. This ScriptBlock is supplied the found User object as a parameter, structured as details above. You can then use this to further check the user, or load additional user information from another storage.
+
+The ScriptBlock has the same return rules as [`Add-PodeAuth`](../../Functions/Authentication/Add-PodeAuth), as can be seen in the [Overview](../../Tutorials/Authentication/Overview).
+
+For example, to return the user back:
+
+```powershell
+Add-PodeAuthIIS -Name 'IISAuth' -Sessionless -ScriptBlock {
+    param($user)
+
+    # check or load extra data
+
+    return @{ User = $user }
+}
+```
+
+Or to fail authentication with an error message:
+
+```powershell
+Add-PodeAuthIIS -Name 'IISAuth' -Sessionless -ScriptBlock {
+    param($user)
+    return @{ Message = 'Authorisation failed' }
+}
+```
+
 ## Azure Web Apps
 
 To host your Pode server under IIS using Azure Web Apps, ensure the OS type is Windows and the framework is .NET Core 2.1/3.0.

--- a/docs/Tutorials/Authentication/Inbuilt/UserFile.md
+++ b/docs/Tutorials/Authentication/Inbuilt/UserFile.md
@@ -97,8 +97,35 @@ You can supply a list of authorised usernames to validate a user's access, after
 
 ```powershell
 Start-PodeServer {
-    New-PodeAuthScheme -Form | Add-PodeAuthWindowsAd -Name 'Login' -Users @('jsnow', 'rsanchez')
+    New-PodeAuthScheme -Form | Add-PodeAuthUserFile -Name 'Login' -Users @('jsnow', 'rsanchez')
 }
 ```
 
 If an user being authenticated is not one of the allowed users, then a 401 is returned.
+
+### Additional Validation
+
+Similar to the normal [`Add-PodeAuth`](../../../../Functions/Authentication/Add-PodeAuth), [`Add-PodeAuthUserFile`](../../../../Functions/Authentication/Add-PodeAuthUserFile) can be supplied can an optional ScriptBlock parameter. This ScriptBlock is supplied the found User object as a parameter, structured as details above. You can then use this to further check the user, or load additional user information from another storage.
+
+The ScriptBlock has the same return rules as [`Add-PodeAuth`](../../../../Functions/Authentication/Add-PodeAuth), as can be seen in the [Overview](../../Overview).
+
+For example, to return the user back:
+
+```powershell
+New-PodeAuthScheme -Form | Add-PodeAuthUserFile -Name 'Login' -ScriptBlock {
+    param($user)
+
+    # check or load extra data
+
+    return @{ User = $user }
+}
+```
+
+Or to fail authentication with an error message:
+
+```powershell
+New-PodeAuthScheme -Form | Add-PodeAuthUserFile -Name 'Login' -ScriptBlock {
+    param($user)
+    return @{ Message = 'Authorisation failed' }
+}
+```

--- a/docs/Tutorials/Authentication/Inbuilt/WindowsAD.md
+++ b/docs/Tutorials/Authentication/Inbuilt/WindowsAD.md
@@ -71,3 +71,30 @@ Start-PodeServer {
 ```
 
 If an user being authenticated is not one of the allowed users, then a 401 is returned.
+
+### Additional Validation
+
+Similar to the normal [`Add-PodeAuth`](../../../../Functions/Authentication/Add-PodeAuth), [`Add-PodeAuthWindowsAd`](../../../../Functions/Authentication/Add-PodeAuthWindowsAd) can be supplied can an optional ScriptBlock parameter. This ScriptBlock is supplied the found User object as a parameter, structured as details above. You can then use this to further check the user, or load additional user information from another storage.
+
+The ScriptBlock has the same return rules as [`Add-PodeAuth`](../../../../Functions/Authentication/Add-PodeAuth), as can be seen in the [Overview](../../Overview).
+
+For example, to return the user back:
+
+```powershell
+New-PodeAuthScheme -Form | Add-PodeAuthWindowsAd -Name 'Login' -ScriptBlock {
+    param($user)
+
+    # check or load extra data
+
+    return @{ User = $user }
+}
+```
+
+Or to fail authentication with an error message:
+
+```powershell
+New-PodeAuthScheme -Form | Add-PodeAuthWindowsAd -Name 'Login' -ScriptBlock {
+    param($user)
+    return @{ Message = 'Authorisation failed' }
+}
+```

--- a/docs/Tutorials/Authentication/Inbuilt/WindowsLocal.md
+++ b/docs/Tutorials/Authentication/Inbuilt/WindowsLocal.md
@@ -59,3 +59,30 @@ Start-PodeServer {
 ```
 
 If an user being authenticated is not one of the allowed users, then a 401 is returned.
+
+### Additional Validation
+
+Similar to the normal [`Add-PodeAuth`](../../../../Functions/Authentication/Add-PodeAuth), [`Add-PodeAuthWindowsLocal`](../../../../Functions/Authentication/Add-PodeAuthWindowsLocal) can be supplied can an optional ScriptBlock parameter. This ScriptBlock is supplied the found User object as a parameter, structured as details above. You can then use this to further check the user, or load additional user information from another storage.
+
+The ScriptBlock has the same return rules as [`Add-PodeAuth`](../../../../Functions/Authentication/Add-PodeAuth), as can be seen in the [Overview](../../Overview).
+
+For example, to return the user back:
+
+```powershell
+New-PodeAuthScheme -Form | Add-PodeAuthWindowsLocal -Name 'Login' -ScriptBlock {
+    param($user)
+
+    # check or load extra data
+
+    return @{ User = $user }
+}
+```
+
+Or to fail authentication with an error message:
+
+```powershell
+New-PodeAuthScheme -Form | Add-PodeAuthWindowsLocal -Name 'Login' -ScriptBlock {
+    param($user)
+    return @{ Message = 'Authorisation failed' }
+}
+```

--- a/src/Private/Authentication.ps1
+++ b/src/Private/Authentication.ps1
@@ -555,10 +555,15 @@ function Get-PodeAuthUserFileMethod
             return @{ Message = 'You are not authorised to access this website' }
         }
 
-        # return user
-        return @{
-            User = $user
+        $result = @{ User = $user }
+
+        # call additional scriptblock if supplied
+        if ($null -ne $options.ScriptBlock.Script) {
+            $result = Invoke-PodeAuthInbuiltScriptBlock -User $result.User -ScriptBlock $options.ScriptBlock.Script -UsingVariables $options.ScriptBlock.UsingVariables
         }
+
+        # return final result, this could contain a user obj, or an error message from custom scriptblock
+        return $result
     }
 }
 
@@ -592,14 +597,49 @@ function Get-PodeAuthWindowsADMethod
             return @{ Message = 'An unexpected error occured' }
         }
 
-        # is the user valid for any users/groups?
-        if (Test-PodeAuthUserGroups -User $result.User -Users $options.Users -Groups $options.Groups) {
-            return $result
+        # is the user valid for any users/groups - if not, error!
+        if (!(Test-PodeAuthUserGroups -User $result.User -Users $options.Users -Groups $options.Groups)) {
+            return @{ Message = 'You are not authorised to access this website' }
         }
 
-        # else, they shall not pass!
-        return @{ Message = 'You are not authorised to access this website' }
+        # call additional scriptblock if supplied
+        if ($null -ne $options.ScriptBlock.Script) {
+            $result = Invoke-PodeAuthInbuiltScriptBlock -User $result.User -ScriptBlock $options.ScriptBlock.Script -UsingVariables $options.ScriptBlock.UsingVariables
+        }
+
+        # return final result, this could contain a user obj, or an error message from custom scriptblock
+        return $result
     }
+}
+
+function Invoke-PodeAuthInbuiltScriptBlock
+{
+    param(
+        [Parameter(Mandatory=$true)]
+        [hashtable]
+        $User,
+
+        [Parameter(Mandatory=$true)]
+        [scriptblock]
+        $ScriptBlock,
+
+        [Parameter()]
+        $UsingVariables
+    )
+
+    $_tmp_args = @($User)
+
+    if ($null -ne $UsingVariables) {
+        $_vars = @()
+
+        foreach ($_var in $UsingVariables) {
+            $_vars += ,$_var.Value
+        }
+
+        $_tmp_args = $_vars + $_tmp_args
+    }
+
+    return (Invoke-PodeScriptBlock -ScriptBlock $ScriptBlock -Arguments $_tmp_args -Return -Splat)
 }
 
 function Get-PodeAuthWindowsLocalMethod
@@ -643,13 +683,20 @@ function Get-PodeAuthWindowsLocalMethod
             Close-PodeDisposable -Disposable $ad -Close
         }
 
-        # is the user valid for any users/groups?
-        if (Test-PodeAuthUserGroups -User $user -Users $options.Users -Groups $options.Groups) {
-            return @{ User = $user }
+        # is the user valid for any users/groups - if not, error!
+        if (!(Test-PodeAuthUserGroups -User $user -Users $options.Users -Groups $options.Groups)) {
+            return @{ Message = 'You are not authorised to access this website' }
         }
 
-        # else, they shall not pass!
-        return @{ Message = 'You are not authorised to access this website' }
+        $result = @{ User = $user }
+
+        # call additional scriptblock if supplied
+        if ($null -ne $options.ScriptBlock.Script) {
+            $result = Invoke-PodeAuthInbuiltScriptBlock -User $result.User -ScriptBlock $options.ScriptBlock.Script -UsingVariables $options.ScriptBlock.UsingVariables
+        }
+
+        # return final result, this could contain a user obj, or an error message from custom scriptblock
+        return $result
     }
 }
 
@@ -764,13 +811,20 @@ function Get-PodeAuthWindowsADIISMethod
             $win32Handler::CloseHandle($winAuthToken)
         }
 
-        # is the user valid for any users/groups?
-        if (Test-PodeAuthUserGroups -User $user -Users $options.Users -Groups $options.Groups) {
-            return @{ User = $user }
+        # is the user valid for any users/groups - if not, error!
+        if (!(Test-PodeAuthUserGroups -User $user -Users $options.Users -Groups $options.Groups)) {
+            return @{ Message = 'You are not authorised to access this website' }
         }
 
-        # else, they shall not pass!
-        return @{ Message = 'You are not authorised to access this website' }
+        $result = @{ User = $user }
+
+        # call additional scriptblock if supplied
+        if ($null -ne $options.ScriptBlock.Script) {
+            $result = Invoke-PodeAuthInbuiltScriptBlock -User $result.User -ScriptBlock $options.ScriptBlock.Script -UsingVariables $options.ScriptBlock.UsingVariables
+        }
+
+        # return final result, this could contain a user obj, or an error message from custom scriptblock
+        return $result
     }
 }
 

--- a/src/Public/Authentication.ps1
+++ b/src/Public/Authentication.ps1
@@ -669,6 +669,10 @@ function Add-PodeAuthWindowsAd
         [string]
         $SuccessUrl,
 
+        [Parameter()]
+        [scriptblock]
+        $ScriptBlock,
+
         [switch]
         $Sessionless,
 
@@ -709,6 +713,11 @@ function Add-PodeAuthWindowsAd
         $Domain = ($Fqdn -split '\.')[0]
     }
 
+    # if we have a scriptblock, deal with using vars
+    if ($null -ne $ScriptBlock) {
+        $ScriptBlock, $usingVars = Invoke-PodeUsingScriptConversion -ScriptBlock $ScriptBlock -PSSession $PSCmdlet.SessionState
+    }
+
     # add Windows AD auth method to server
     $PodeContext.Server.Authentications[$Name] = @{
         Scheme = $Scheme
@@ -720,6 +729,10 @@ function Add-PodeAuthWindowsAd
             Groups = $Groups
             NoGroups = $NoGroups
             OpenLDAP = $OpenLDAP
+            ScriptBlock = @{
+                Script = $ScriptBlock
+                UsingVariables = $usingVars
+            }
         }
         Sessionless = $Sessionless
         Failure = @{
@@ -897,6 +910,10 @@ function Add-PodeAuthIIS
         [string]
         $SuccessUrl,
 
+        [Parameter()]
+        [scriptblock]
+        $ScriptBlock,
+
         [switch]
         $Sessionless,
 
@@ -916,6 +933,11 @@ function Add-PodeAuthIIS
     # ensure the name doesn't already exist
     if (Test-PodeAuth -Name $Name) {
         throw "IIS Authentication method already defined: $($Name)"
+    }
+
+    # if we have a scriptblock, deal with using vars
+    if ($null -ne $ScriptBlock) {
+        $ScriptBlock, $usingVars = Invoke-PodeUsingScriptConversion -ScriptBlock $ScriptBlock -PSSession $PSCmdlet.SessionState
     }
 
     # create the auth scheme for getting the token header
@@ -952,6 +974,10 @@ function Add-PodeAuthIIS
             Groups = $Groups
             NoGroups = $NoGroups
             NoLocalCheck = $NoLocalCheck
+            ScriptBlock = @{
+                Script = $ScriptBlock
+                UsingVariables = $usingVars
+            }
         }
 }
 
@@ -1038,6 +1064,10 @@ function Add-PodeAuthUserFile
         [string]
         $SuccessUrl,
 
+        [Parameter()]
+        [scriptblock]
+        $ScriptBlock,
+
         [switch]
         $Sessionless
     )
@@ -1070,6 +1100,11 @@ function Add-PodeAuthUserFile
         throw "The user file does not exist: $($FilePath)"
     }
 
+    # if we have a scriptblock, deal with using vars
+    if ($null -ne $ScriptBlock) {
+        $ScriptBlock, $usingVars = Invoke-PodeUsingScriptConversion -ScriptBlock $ScriptBlock -PSSession $PSCmdlet.SessionState
+    }
+
     # add Windows AD auth method to server
     $PodeContext.Server.Authentications[$Name] = @{
         Scheme = $Scheme
@@ -1079,6 +1114,10 @@ function Add-PodeAuthUserFile
             Users = $Users
             Groups = $Groups
             HmacSecret = $HmacSecret
+            ScriptBlock = @{
+                Script = $ScriptBlock
+                UsingVariables = $usingVars
+            }
         }
         Sessionless = $Sessionless
         Failure = @{
@@ -1166,6 +1205,10 @@ function Add-PodeAuthWindowsLocal
         [string]
         $SuccessUrl,
 
+        [Parameter()]
+        [scriptblock]
+        $ScriptBlock,
+
         [switch]
         $Sessionless,
 
@@ -1194,6 +1237,11 @@ function Add-PodeAuthWindowsLocal
         throw 'Sessions are required to use session persistent authentication'
     }
 
+    # if we have a scriptblock, deal with using vars
+    if ($null -ne $ScriptBlock) {
+        $ScriptBlock, $usingVars = Invoke-PodeUsingScriptConversion -ScriptBlock $ScriptBlock -PSSession $PSCmdlet.SessionState
+    }
+
     # add Windows Local auth method to server
     $PodeContext.Server.Authentications[$Name] = @{
         Scheme = $Scheme
@@ -1202,6 +1250,10 @@ function Add-PodeAuthWindowsLocal
             Users = $Users
             Groups = $Groups
             NoGroups = $NoGroups
+            ScriptBlock = @{
+                Script = $ScriptBlock
+                UsingVariables = $usingVars
+            }
         }
         Sessionless = $Sessionless
         Failure = @{


### PR DESCRIPTION
### Description of the Change
Adds a new optional `-ScriptBlock` parameter to the following functions:

* `Add-PodeAuthWindowsAd`
* `Add-PodeAuthWindowsLocal`
* `Add-PodeAuthUserFile`
* `Add-PodeAuthIIS`

If supplied, the scriptblock will be passed the found `$user` object, and you can perform further validation on the user or retrieve extra information.

### Related Issue
Resolves #657 

### Examples
```powershell
New-PodeAuthScheme -Form | Add-PodeAuthWindowsAd -Name 'Login' -FailureUrl '/login' -SuccessUrl '/' -ScriptBlock {
    param($user)

    # check user, retrieve further data from another storage, ie:
    $theme = Get-UserDataFromSql -Email $user.email
    $user.theme = $theme

    return @{ User = $user }
}
```
