### PR TITLE
Add Support and Documentation for Kerberos Constrained Delegation

### DIFF
--- a/docs/Hosting/IIS.md
+++ b/docs/Hosting/IIS.md
@@ -131,6 +131,11 @@ If the required header is missing, then Pode responds with a 401. The retrieved 
 ### Kerberos Constrained Delegation
 
 Pode can impersonate the user that requests the webpage using Kerberos Constrained Delegation (KCD).
+
+Requirements
+- The use of KCD requires additional configuration in the Active Directory (read up on PrincipalsAllowedToDelegateToAccount)
+- No Session Middleware configured
+
 This can be done using the following example:
 
 ```powershell
@@ -140,7 +145,6 @@ This can be done using the following example:
 })
 ```
 
-!!! note The use of KCD requires additional configuration the Active Directory 
 
 ### Additional Validation
 

--- a/docs/Hosting/IIS.md
+++ b/docs/Hosting/IIS.md
@@ -115,6 +115,7 @@ If the required header is missing, then Pode responds with a 401. The retrieved 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
 | UserType | string | Specifies if the user is a Domain or Local user |
+| Identity | System.Security.Principal.WindowsIdentity | Returns the WindowsIdentity which can be used for Impersonation |
 | AuthenticationType | string | Value is fixed to LDAP |
 | DistinguishedName | string | The distinguished name of the user |
 | Username | string | The user's username (without domain) |
@@ -126,6 +127,20 @@ If the required header is missing, then Pode responds with a 401. The retrieved 
 
 !!! note
     If the authenticated user is a Local User, then the following properties will be empty: FQDN, Email, and DistinguishedName
+
+### Kerberos Constrained Delegation
+
+Pode can impersonate the user that requests the webpage using Kerberos Constrained Delegation (KCD).
+This can be done using the following example:
+
+```powershell
+[System.Security.Principal.WindowsIdentity]::RunImpersonated($WebEvent.Auth.User.Identity.AccessToken,{
+    $newIdentity = [Security.Principal.WindowsIdentity]::GetCurrent() | Select-Object -ExpandProperty 'Name'    
+    Write-PodeTextResponse -Value "You are running this command as the server user $newIdentity"
+})
+```
+
+!!! note The use of KCD requires additional configuration the Active Directory 
 
 ### Additional Validation
 

--- a/src/Private/Authentication.ps1
+++ b/src/Private/Authentication.ps1
@@ -723,6 +723,7 @@ function Get-PodeAuthWindowsADIISMethod
             # create base user object
             $user = @{
                 UserType = 'Domain'
+                Identity = $winIdentity
                 AuthenticationType = $winIdentity.AuthenticationType
                 DistinguishedName = [string]::Empty
                 Username = $username


### PR DESCRIPTION
### Description of the Change
Adds Support and Documentation for Kerberos Constrained Delegation to use the current user session against a backend application like a SQL Database

### Related Issue
Closes #667 

### Examples
Pode can impersonate the user that requests the webpage using Kerberos Constrained Delegation (KCD).
This can be done using the following example:

```powershell
[System.Security.Principal.WindowsIdentity]::RunImpersonated($WebEvent.Auth.User.Identity.AccessToken,{
    $newIdentity = [Security.Principal.WindowsIdentity]::GetCurrent() | Select-Object -ExpandProperty 'Name'    
    Write-PodeTextResponse -Value "You are running this command as the server user $newIdentity"
})
```

