### PR TITLE
Remove extra NewLine from form files

### DIFF
--- a/src/Private/Streams.ps1
+++ b/src/Private/Streams.ps1
@@ -209,7 +209,7 @@ function Remove-PodeNewLineBytesFromArray
     )
 
     $nlBytes = Get-PodeNewLineBytes -Encoding $Encoding
-    $length = $Bytes.Length
+    $length = $Bytes.Length - 1
 
     if ($Bytes[$length] -eq $nlBytes.NewLine) {
         $length--


### PR DESCRIPTION
### Description of the Change
When trying the example code from the issue if you compare the source file to the file downloaded they are identical except the downloaded file have "0D 0A" HEX which is ASCII CRLF added to the end of it.
I found that in the code there was a case to remove it but the length to index was missing the -1 adjustment

### Related Issue
https://github.com/Badgerati/Pode.Web/issues/15
