### PR TITLE
Fixes when an endpoint's hostname is localhost and bound to a route

### DIFF
--- a/src/Private/Endpoints.ps1
+++ b/src/Private/Endpoints.ps1
@@ -124,7 +124,7 @@ function Find-PodeEndpointName
 
     # change localhost to ip address
     if (($Address -ilike 'localhost:*') -or ($Address -ilike "$($PodeContext.Server.ComputerName):*")) {
-        $Address = ($Address -ireplace 'localhost\:', "(127\.0\.0\.1|0\.0\.0\.0|localhost|$([regex]::Escape($PodeContext.Server.ComputerName))):")
+        $Address = ($Address -ireplace "(localhost|$([regex]::Escape($PodeContext.Server.ComputerName)))\:", "(127\.0\.0\.1|0\.0\.0\.0|localhost|$([regex]::Escape($PodeContext.Server.ComputerName))):")
     }
     else {
         $Address = [regex]::Escape($Address)

--- a/src/Private/Endpoints.ps1
+++ b/src/Private/Endpoints.ps1
@@ -124,7 +124,7 @@ function Find-PodeEndpointName
 
     # change localhost to ip address
     if (($Address -ilike 'localhost:*') -or ($Address -ilike "$($PodeContext.Server.ComputerName):*")) {
-        $Address = ($Address -ireplace 'localhost\:', '(127\.0\.0\.1|0\.0\.0\.0):')
+        $Address = ($Address -ireplace 'localhost\:', "(127\.0\.0\.1|0\.0\.0\.0|localhost|$([regex]::Escape($PodeContext.Server.ComputerName))):")
     }
     else {
         $Address = [regex]::Escape($Address)


### PR DESCRIPTION
### Description of the Change
Fixes when an endpoint it created with a hostname of `localhost` or of `$env:COMPUTERNAME`, and using `-EndpointName` on routes.

### Related Issue
Resolves #663 
