### PR TITLE
Fix to make headers in request/response case-insensitive

### DIFF
--- a/src/Listener/PodeContext.cs
+++ b/src/Listener/PodeContext.cs
@@ -78,7 +78,7 @@ namespace Pode
             PodeSocket = podeSocket;
             Listener = listener;
             Timestamp = DateTime.UtcNow;
-            Data = new Hashtable();
+            Data = new Hashtable(StringComparer.InvariantCultureIgnoreCase);
 
             Type = PodeContextType.Unknown;
             State = PodeContextState.New;

--- a/src/Listener/PodeHttpRequest.cs
+++ b/src/Listener/PodeHttpRequest.cs
@@ -122,7 +122,7 @@ namespace Pode
             ProtocolVersion = Regex.Split(Protocol, "/")[1];
 
             // headers
-            Headers = new Hashtable();
+            Headers = new Hashtable(StringComparer.InvariantCultureIgnoreCase);
             var bodyIndex = 0;
             var h_index = 0;
             var h_line = string.Empty;

--- a/src/Listener/PodeResponseHeaders.cs
+++ b/src/Listener/PodeResponseHeaders.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace Pode
@@ -17,7 +18,7 @@ namespace Pode
 
         public PodeResponseHeaders()
         {
-            Headers = new Dictionary<string, IList<object>>();
+            Headers = new Dictionary<string, IList<object>>(StringComparer.InvariantCultureIgnoreCase);
         }
 
         public bool ContainsKey(string name)

--- a/src/Listener/PodeSmtpRequest.cs
+++ b/src/Listener/PodeSmtpRequest.cs
@@ -150,7 +150,7 @@ namespace Pode
         public void Reset()
         {
             CanProcess = false;
-            Headers = new Hashtable();
+            Headers = new Hashtable(StringComparer.InvariantCultureIgnoreCase);
             From = string.Empty;
             To = new List<string>();
             Body = string.Empty;
@@ -175,7 +175,7 @@ namespace Pode
 
         private void ParseHeaders(string value)
         {
-            Headers = new Hashtable();
+            Headers = new Hashtable(StringComparer.InvariantCultureIgnoreCase);
 
             var lines = value.Split(new string[] { PodeHelpers.NEW_LINE }, StringSplitOptions.None);
             var match = default(Match);


### PR DESCRIPTION
### Description of the Change
Fixes an issue where Request and Response headers, in the .NET listener, weren't being treated as case-insensitive.

### Related Issue
Resolves #672
