### PR TITLE
Further fixes for endpoint+route use-case validation when using -EndpointName

### DIFF
--- a/src/Listener/PodeRequest.cs
+++ b/src/Listener/PodeRequest.cs
@@ -14,6 +14,7 @@ namespace Pode
     public class PodeRequest : IDisposable
     {
         public EndPoint RemoteEndPoint { get; private set; }
+        public EndPoint LocalEndPoint { get; private set; }
         public bool IsSsl { get; private set; }
         public bool IsKeepAlive { get; protected set; }
         public virtual bool CloseImmediately { get => false; }
@@ -31,6 +32,7 @@ namespace Pode
         {
             Socket = socket;
             RemoteEndPoint = socket.RemoteEndPoint;
+            LocalEndPoint = socket.LocalEndPoint;
         }
 
         public PodeRequest(PodeRequest request)
@@ -40,6 +42,7 @@ namespace Pode
             IsKeepAlive = request.IsKeepAlive;
             Socket = request.Socket;
             RemoteEndPoint = Socket.RemoteEndPoint;
+            LocalEndPoint = Socket.LocalEndPoint;
             Error = request.Error;
             Context = request.Context;
         }

--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -184,6 +184,7 @@ function New-PodeContext
     # set the IP address details
     $ctx.Server.Endpoints = @{}
     $ctx.Server.EndpointsMap = @{}
+    $ctx.Server.FindRouteEndpoint = $false
 
     # general encoding for the server
     $ctx.Server.Encoding = New-Object System.Text.UTF8Encoding

--- a/src/Private/Endpoints.ps1
+++ b/src/Private/Endpoints.ps1
@@ -108,21 +108,38 @@ function Find-PodeEndpointName
         [string]
         $Address,
 
+        [Parameter()]
+        [System.Net.EndPoint]
+        $LocalAddress,
+
+        [switch]
+        $Force,
+
         [switch]
         $ThrowError
     )
 
-    if ([string]::IsNullOrWhiteSpace($Protocol) -or [string]::IsNullOrWhiteSpace($Address)) {
+    if (!$PodeContext.Server.FindRouteEndpoint -and !$Force) {
         return $null
     }
 
-    # add a default port if missing
+    if ([string]::IsNullOrWhiteSpace($Protocol) -or
+        [string]::IsNullOrWhiteSpace($Address) -or
+        [string]::IsNullOrWhiteSpace($LocalAddress)) {
+        return $null
+    }
+
+    <#
+       using Host header
+    #>
+
+    # add a default port to the address if missing
     if (!$Address.Contains(':')) {
         $port = Get-PodeDefaultPort -Protocol $Protocol -Real
         $Address = "$($Address):$($port)"
     }
 
-    # change localhost to ip address
+    # change localhost/computer name to ip address
     if (($Address -ilike 'localhost:*') -or ($Address -ilike "$($PodeContext.Server.ComputerName):*")) {
         $Address = ($Address -ireplace "(localhost|$([regex]::Escape($PodeContext.Server.ComputerName)))\:", "(127\.0\.0\.1|0\.0\.0\.0|localhost|$([regex]::Escape($PodeContext.Server.ComputerName))):")
     }
@@ -130,10 +147,53 @@ function Find-PodeEndpointName
         $Address = [regex]::Escape($Address)
     }
 
-    # create the endpoint key
+    # create the endpoint key for address
     $key = "$($Protocol)\|$($Address)"
 
-    # try and find endpoint
+    # try and find endpoint for address
+    $key = @(foreach ($k in $PodeContext.Server.EndpointsMap.Keys) {
+        if ($k -imatch $key) {
+            $k
+            break
+        }
+    })[0]
+
+    if (![string]::IsNullOrWhiteSpace($key) -and $PodeContext.Server.EndpointsMap.ContainsKey($key)) {
+        return $PodeContext.Server.EndpointsMap[$key]
+    }
+
+    <#
+       using local endpoint from socket
+    #>
+
+    # setup the local address as a string
+    $_localAddress = "$($LocalAddress.Address.IPAddressToString):$($LocalAddress.Port)"
+    $_localAddress = [regex]::Escape($_localAddress)
+
+    # create the endpoint key for local address
+    $key = "$($Protocol)\|$($_localAddress)"
+
+    # try and find endpoint for local address
+    $key = @(foreach ($k in $PodeContext.Server.EndpointsMap.Keys) {
+        if ($k -imatch $key) {
+            $k
+            break
+        }
+    })[0]
+
+    if (![string]::IsNullOrWhiteSpace($key) -and $PodeContext.Server.EndpointsMap.ContainsKey($key)) {
+        return $PodeContext.Server.EndpointsMap[$key]
+    }
+
+    <#
+       check for * address
+    #>
+
+    # set * address as string
+    $_anyAddress = "0\.0\.0\.0:$($LocalAddress.Port)"
+    $key = "$($Protocol)\|$($_anyAddress)"
+
+    # try and find endpoint for any address
     $key = @(foreach ($k in $PodeContext.Server.EndpointsMap.Keys) {
         if ($k -imatch $key) {
             $k
@@ -147,7 +207,7 @@ function Find-PodeEndpointName
 
     # error?
     if ($ThrowError) {
-        throw "Endpoint with protocol '$($Protocol)' and address '$($Address)' does not exist"
+        throw "Endpoint with protocol '$($Protocol)' and address '$($Address)' or local address '$($_localAddress)' does not exist"
     }
 
     return $null

--- a/src/Private/PodeServer.ps1
+++ b/src/Private/PodeServer.ps1
@@ -129,7 +129,7 @@ function Start-PodeWebServer
                         $WebEvent.AcceptEncoding = (Get-PodeAcceptEncoding -AcceptEncoding (Get-PodeHeader -Name 'Accept-Encoding') -ThrowError)
 
                         # endpoint name
-                        $WebEvent.Endpoint.Name = (Find-PodeEndpointName -Protocol $WebEvent.Endpoint.Protocol -Address $WebEvent.Endpoint.Address)
+                        $WebEvent.Endpoint.Name = (Find-PodeEndpointName -Protocol $WebEvent.Endpoint.Protocol -Address $WebEvent.Endpoint.Address -LocalAddress $WebEvent.Request.LocalEndPoint)
 
                         # add logging endware for post-request
                         Add-PodeRequestLogEndware -WebEvent $WebEvent

--- a/src/Private/Server.ps1
+++ b/src/Private/Server.ps1
@@ -160,6 +160,7 @@ function Restart-PodeInternalServer
         # clear endpoints
         $PodeContext.Server.Endpoints.Clear()
         $PodeContext.Server.EndpointsMap.Clear()
+        $PodeContext.Server.FindRouteEndpoint = $false
 
         # clear openapi
         $PodeContext.Server.OpenAPI = Get-PodeOABaseObject

--- a/src/Public/Routes.ps1
+++ b/src/Public/Routes.ps1
@@ -138,6 +138,10 @@ function Add-PodeRoute
     $Path = Update-PodeRoutePlaceholders -Path $Path
 
     # get endpoints from name
+    if (!$PodeContext.Server.FindRouteEndpoint) {
+        $PodeContext.Server.FindRouteEndpoint = !(Test-PodeIsEmpty $EndpointName)
+    }
+
     $endpoints = Find-PodeEndpoints -EndpointName $EndpointName
 
     # ensure the route doesn't already exist for each endpoint
@@ -346,6 +350,10 @@ function Add-PodeStaticRoute
     $Path = Update-PodeRoutePlaceholders -Path $Path
 
     # get endpoints from name
+    if (!$PodeContext.Server.FindRouteEndpoint) {
+        $PodeContext.Server.FindRouteEndpoint = !(Test-PodeIsEmpty $EndpointName)
+    }
+
     $endpoints = Find-PodeEndpoints -EndpointName $EndpointName
 
     # ensure the route doesn't already exist for each endpoint


### PR DESCRIPTION
### Description of the Change
This applies further fixes, on top of #663, to resolve issues when ensuring a route is bound to an endpoint. Certain cases like using an IP address, but a user has host filed a hostname instead, then we can used the LocalEndPoint from the Socket for this. Or a drop-all, where if there is a generic 0.0.0.0 endpoint, use this.

### Related Issue
Resolves #669 
