### PR TITLE
Update the Socket Listener to handle larger request payloads, and fix receiving SSL requests

### DIFF
--- a/examples/web-pages-simple.ps1
+++ b/examples/web-pages-simple.ps1
@@ -1,0 +1,30 @@
+param (
+    [int]
+    $Port = 8085
+)
+
+$path = Split-Path -Parent -Path (Split-Path -Parent -Path $MyInvocation.MyCommand.Path)
+Import-Module "$($path)/src/Pode.psm1" -Force -ErrorAction Stop
+
+# or just:
+# Import-Module Pode
+
+# create a server, and start listening on port 8085
+Start-PodeServer -Threads 2 {
+
+    # listen on localhost:8085
+    Add-PodeEndpoint -Address * -Port 8090 -Protocol Http -Name '8090Address'
+    Add-PodeEndpoint -Address * -Port $Port -Protocol Http -Name '8085Address' -RedirectTo '8090Address'
+
+    # log errors to the terminal
+    # New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+
+    # set view engine to pode renderer
+    Set-PodeViewEngine -Type Pode
+
+    # GET request for web page on "localhost:8085/"
+    Add-PodeRoute -Method Get -Path '/' -ScriptBlock {
+        Write-PodeViewResponse -Path 'simple' -Data @{ 'numbers' = @(1, 2, 3); }
+    }
+
+}

--- a/src/Listener/PodeContext.cs
+++ b/src/Listener/PodeContext.cs
@@ -22,7 +22,7 @@ namespace Pode
 
         public bool CloseImmediately
         {
-            get => (State == PodeContextState.Error || Request.CloseImmediately);
+            get => (State == PodeContextState.Error || State == PodeContextState.Closing || Request.CloseImmediately);
         }
 
         public bool IsWebSocket
@@ -173,13 +173,18 @@ namespace Pode
             {
                 State = PodeContextState.Receiving;
                 Request.Receive();
-                State = PodeContextState.Received;
                 SetContextType();
             }
             catch
             {
                 State = PodeContextState.Error;
             }
+        }
+
+        public void EndReceive(bool close)
+        {
+            PodeSocket.HandleContext(this);
+            State = close ? PodeContextState.Closing : PodeContextState.Received;
         }
 
         public void StartReceive()

--- a/src/Listener/PodeContext.cs
+++ b/src/Listener/PodeContext.cs
@@ -167,13 +167,14 @@ namespace Pode
             }
         }
 
-        public void Receive()
+        public async void Receive()
         {
             try
             {
                 State = PodeContextState.Receiving;
-                Request.Receive();
+                var close = await Request.Receive();
                 SetContextType();
+                EndReceive(close);
             }
             catch
             {

--- a/src/Listener/PodeContext.cs
+++ b/src/Listener/PodeContext.cs
@@ -184,8 +184,8 @@ namespace Pode
 
         public void EndReceive(bool close)
         {
-            PodeSocket.HandleContext(this);
             State = close ? PodeContextState.Closing : PodeContextState.Received;
+            PodeSocket.HandleContext(this);
         }
 
         public void StartReceive()

--- a/src/Listener/PodeContextState.cs
+++ b/src/Listener/PodeContextState.cs
@@ -6,6 +6,7 @@ namespace Pode
         Open,
         Receiving,
         Received,
+        Closing,
         Closed,
         Error,
         SslError

--- a/src/Listener/PodeHelpers.cs
+++ b/src/Listener/PodeHelpers.cs
@@ -10,6 +10,7 @@ namespace Pode
         public const string WEB_SOCKET_MAGIC_KEY = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
         public const string NEW_LINE = "\r\n";
         public const string NEW_LINE_UNIX = "\n";
+        public const int BYTE_SIZE = sizeof(byte);
 
         public static void WriteException(Exception ex, PodeListener listener = default(PodeListener))
         {
@@ -35,6 +36,36 @@ namespace Pode
                 rnd.GetBytes(bytes);
                 return (new Guid(bytes)).ToString();
             }
+        }
+
+        public static byte[] Slice(byte[] array, int startIndex, int count = 0)
+        {
+            if (count <= 0 || startIndex + count > array.Length)
+            {
+                count = array.Length - startIndex;
+            }
+
+            var newArray = new byte[count];
+            Buffer.BlockCopy(array, startIndex * BYTE_SIZE, newArray, 0, count * BYTE_SIZE);
+            return newArray;
+        }
+
+        public static byte[] Concat(byte[] array1, byte[] array2)
+        {
+            if (array1.Length == 0)
+            {
+                return array2;
+            }
+
+            if (array2.Length == 0)
+            {
+                return array1;
+            }
+
+            var newArray = new byte[array1.Length + array2.Length];
+            Buffer.BlockCopy(array1, 0, newArray, 0, array1.Length * BYTE_SIZE);
+            Buffer.BlockCopy(array2, 0, newArray, array1.Length * BYTE_SIZE, array2.Length * BYTE_SIZE);
+            return newArray;
         }
     }
 }

--- a/src/Listener/PodeHttpRequest.cs
+++ b/src/Listener/PodeHttpRequest.cs
@@ -57,17 +57,13 @@ namespace Pode
                 return;
             }
 
-            if (IsSsl)
-            {
-                bytes = bytes.Take(bytes.Length - 29).ToArray();
-            }
-
             // get the raw string for headers
             var content = Encoding.GetString(bytes, 0, bytes.Length);
 
             // new line char, and req lines
             var newline = (content.Contains(PodeHelpers.NEW_LINE) ? PodeHelpers.NEW_LINE : PodeHelpers.NEW_LINE_UNIX);
             var reqLines = content.Split(new string[] { newline }, StringSplitOptions.None);
+            content = string.Empty;
 
             // parse the headers, unless we're waiting for the body
             var bodyIndex = 0;
@@ -79,6 +75,13 @@ namespace Pode
             // parse the body
             ParseBody(bytes, reqLines, newline, bodyIndex);
             AwaitingBody = (ContentLength > 0 && RawBody.Length < ContentLength);
+
+            // cleanup
+            reqLines = default(string[]);
+
+            // Console.WriteLine($"ContentLength: {ContentLength}");
+            // Console.WriteLine($"RawBody: {RawBody.Length}");
+            // Console.WriteLine($"Awaiting: {AwaitingBody}");
         }
 
         private int ParseHeaders(string[] reqLines, string newline)
@@ -272,6 +275,13 @@ namespace Pode
 
             // set the body
             Body = Encoding.GetString(RawBody);
+        }
+
+        public override void Dispose()
+        {
+            RawBody = default(byte[]);
+            Body = string.Empty;
+            base.Dispose();
         }
     }
 }

--- a/src/Listener/PodeHttpRequest.cs
+++ b/src/Listener/PodeHttpRequest.cs
@@ -30,6 +30,8 @@ namespace Pode
         public string Host { get; private set; }
         public bool AwaitingBody { get; private set; }
 
+        private bool IsRequestLineValid { get; set; }
+
         private bool _isWebSocket = false;
         public bool IsWebSocket
         {
@@ -50,11 +52,13 @@ namespace Pode
 
         protected override bool ValidateInput(byte[] bytes)
         {
+            // we need more bytes!
             if (bytes.Length == 0)
             {
                 return false;
             }
 
+            // wait until we have the rest of the payload
             if (AwaitingBody)
             {
                 return (bytes.Length >= (ContentLength - RawBody.Length));
@@ -64,13 +68,26 @@ namespace Pode
             var previousIndex = -1;
             var index = Array.IndexOf(bytes, lf);
 
-            // req line
+            // do we have a request line yet?
             if (index == -1)
             {
                 return false;
             }
 
-            // headers
+            // is the request line valid?
+            if (!IsRequestLineValid)
+            {
+                var reqLine = Encoding.GetString(bytes, 0, index).Trim();
+                var reqMeta = Regex.Split(reqLine, "\\s+");
+                if (reqMeta.Length != 3)
+                {
+                    throw new HttpRequestException($"Invalid request line: {reqLine} [{reqMeta.Length}]");
+                }
+
+                IsRequestLineValid = true;
+            }
+
+            // check if we have all the headers
             while (true)
             {
                 previousIndex = index;
@@ -100,6 +117,8 @@ namespace Pode
                 }
             }
 
+            // we're valid!
+            IsRequestLineValid = false;
             return true;
         }
 
@@ -133,11 +152,6 @@ namespace Pode
 
             // cleanup
             reqLines = default(string[]);
-
-            // Console.WriteLine($"ContentLength: {ContentLength}");
-            // Console.WriteLine($"RawBody: {RawBody.Length}");
-            // Console.WriteLine($"Awaiting: {AwaitingBody}");
-
             return (!AwaitingBody);
         }
 
@@ -286,7 +300,7 @@ namespace Pode
                 {
                     // get index of newline char, read start>index bytes as HEX for length
                     c_index = Array.IndexOf(bytes, (byte)newline[0], start);
-                    c_hexBytes = bytes.Skip(start).Take(c_index - start);
+                    c_hexBytes = PodeHelpers.Slice(bytes, start, c_index - start);
 
                     c_hex = string.Empty;
                     foreach (var b in c_hexBytes)
@@ -303,14 +317,14 @@ namespace Pode
 
                     // read those X hex bytes from (newline index + newline length)
                     start = c_index + newline.Length;
-                    c_rawBytes.AddRange(bytes.Skip(start).Take(c_length));
+                    c_rawBytes.AddRange(PodeHelpers.Slice(bytes, start, c_length));
 
                     // skip bytes for ending newline, and set new start
                     start = (start + c_length - 1) + newline.Length + 1;
                 }
 
                 RawBody = hasBody
-                    ? RawBody.Concat(c_rawBytes).ToArray()
+                    ? PodeHelpers.Concat(RawBody, c_rawBytes.ToArray())
                     : c_rawBytes.ToArray();
             }
 
@@ -318,16 +332,16 @@ namespace Pode
             else if (ContentLength > 0)
             {
                 RawBody = hasBody
-                    ? RawBody.Concat(bytes.Skip(start).Take(ContentLength)).ToArray()
-                    : bytes.Skip(start).Take(ContentLength).ToArray();
+                    ? PodeHelpers.Concat(RawBody, PodeHelpers.Slice(bytes, start, ContentLength))
+                    : PodeHelpers.Slice(bytes, start, ContentLength);
             }
 
             // else just read all
             else
             {
                 RawBody = hasBody
-                    ? RawBody.Concat(bytes.Skip(start)).ToArray()
-                    : bytes.Skip(start).ToArray();
+                    ? PodeHelpers.Concat(RawBody, PodeHelpers.Slice(bytes, start))
+                    : PodeHelpers.Slice(bytes, start);
             }
 
             // set the body

--- a/src/Listener/PodeHttpRequest.cs
+++ b/src/Listener/PodeHttpRequest.cs
@@ -50,18 +50,13 @@ namespace Pode
 
         protected override bool ValidateInput(byte[] bytes)
         {
-            Console.WriteLine($"hmm1");
             if (bytes.Length == 0)
             {
-                Console.WriteLine("nop1");
                 return false;
             }
-            Console.WriteLine($"TMP BYTES: {bytes.Length}");
-            Console.WriteLine($"FIRST: {bytes[0]}");
 
             if (AwaitingBody)
             {
-                Console.WriteLine($"CONTENT: {ContentLength - RawBody.Length}");
                 return (bytes.Length >= (ContentLength - RawBody.Length));
             }
 
@@ -70,21 +65,17 @@ namespace Pode
             var index = Array.IndexOf(bytes, lf);
 
             // req line
-            Console.WriteLine($"hmm2 -- {index}");
             if (index == -1)
             {
-                Console.WriteLine("nop2");
                 return false;
             }
 
             // headers
-            Console.WriteLine($"hmm3");
             while (true)
             {
                 previousIndex = index;
                 index = Array.IndexOf(bytes, lf, index + 1);
 
-                // Console.WriteLine($"hmm2 -- {index} -- {bytes.Length}");
                 if (index - previousIndex <= 2)
                 {
                     if (index - previousIndex == 1)
@@ -105,12 +96,10 @@ namespace Pode
 
                 if (index == -1)
                 {
-                    Console.WriteLine("nop3");
                     return false;
                 }
             }
 
-            Console.WriteLine("yup1");
             return true;
         }
 
@@ -145,9 +134,9 @@ namespace Pode
             // cleanup
             reqLines = default(string[]);
 
-            Console.WriteLine($"ContentLength: {ContentLength}");
-            Console.WriteLine($"RawBody: {RawBody.Length}");
-            Console.WriteLine($"Awaiting: {AwaitingBody}");
+            // Console.WriteLine($"ContentLength: {ContentLength}");
+            // Console.WriteLine($"RawBody: {RawBody.Length}");
+            // Console.WriteLine($"Awaiting: {AwaitingBody}");
 
             return (!AwaitingBody);
         }

--- a/src/Listener/PodeRequest.cs
+++ b/src/Listener/PodeRequest.cs
@@ -78,7 +78,7 @@ namespace Pode
 
         private byte[] _buffer;
         private MemoryStream _bufferStream;
-        private const int _bufferSize = 16384; //8192;
+        private const int _bufferSize = 16384;
         protected AsyncCallback AsyncReadCallback;
 
         private void ReadCallback(IAsyncResult ares)
@@ -86,10 +86,6 @@ namespace Pode
             var req = (PodeRequest)ares.AsyncState;
 
             var read = InputStream.EndRead(ares);
-            if (read < _bufferSize - 29) {
-                Console.WriteLine($"READ: {read} -- {_bufferStream.ToArray().Length} -- {_bufferStream.ToArray().LastOrDefault()}");
-            }
-            
             if (read == 0)
             {
                 _bufferStream.Dispose();
@@ -102,27 +98,18 @@ namespace Pode
                 _bufferStream.Write(_buffer, 0, read);
             }
 
-            // System.Threading.Thread.Sleep(10);
-            // System.Threading.Thread.Sleep(10);
-            // System.Threading.Thread.Sleep(10);
-            // System.Threading.Thread.Sleep(10);
-            // if (read == _bufferSize || Socket.Available > 0)
             if (Socket.Available > 0 || !ValidateInput(_bufferStream.ToArray()))
             {
-                // InputStream.BeginRead(_buffer, 0, _bufferSize, AsyncReadCallback, this);
-                Console.WriteLine($"BR1 -- {Socket.Available}");
                 BeginRead();
             }
             else
             {
                 var bytes = _bufferStream.ToArray();
-                Console.WriteLine($"BYTES: {bytes.Length}");
                 if (!Parse(bytes))
                 {
                     bytes = default(byte[]);
                     _bufferStream.Dispose();
                     _bufferStream = new MemoryStream();
-                    Console.WriteLine("BR2");
                     BeginRead();
                 }
                 else
@@ -150,52 +137,9 @@ namespace Pode
             {
                 Error = default(HttpRequestException);
 
-
                 _buffer = new byte[_bufferSize];
                 _bufferStream = new MemoryStream();
-                Console.WriteLine("RECEIVING!");
-                // AsyncReadCallback = new AsyncCallback(ReadCallback);
-                // InputStream.BeginRead(_buffer, 0, _bufferSize, AsyncReadCallback, this);
                 BeginRead();
-
-
-
-
-                // var allBytes = default(byte[]);
-                // var task = default(Task<int>);
-                // var bytes = default(byte[]);
-                // var count = 0;
-
-                // using (var buffer = new MemoryStream())
-                // {
-                    // while ((count = Socket.Available) > 0)
-                    // {
-                        // if (count > 8192)
-                        // {
-                        //     count = 8192;
-                        // }
-
-                        // bytes = new byte[count];
-                        // task = InputStream.ReadAsync(bytes, 0, count);
-                        // task.Wait(Context.Listener.CancellationToken);
-
-                        // Console.WriteLine($"COUNT: {count}");
-                        // Console.WriteLine($"READ: {task.Result}");
-
-                    //     buffer.WriteAsync(bytes, 0, task.Result).Wait(Context.Listener.CancellationToken);
-                    // }
-
-                    // allBytes = buffer.GetBuffer();
-
-                    // if (allBytes[allBytes.Length - 1] == (byte)0)
-                    // {
-                    //     var index = Array.IndexOf(allBytes, (byte)0);
-                    //     allBytes = allBytes.Take(index).ToArray();
-                    // }
-                // }
-
-                // Parse(allBytes);
-                // allBytes = default(byte[]);
             }
             catch (HttpRequestException httpex)
             {

--- a/src/Listener/PodeRequest.cs
+++ b/src/Listener/PodeRequest.cs
@@ -177,6 +177,7 @@ namespace Pode
 
             if (InputStream != default(Stream))
             {
+                Console.WriteLine("Input Disposed");
                 InputStream.Dispose();
             }
         }

--- a/src/Listener/PodeRequest.cs
+++ b/src/Listener/PodeRequest.cs
@@ -99,7 +99,6 @@ namespace Pode
 
                 while ((read = await BeginRead()) > 0)
                 {
-
                     BufferStream.Write(Buffer, 0, read);
 
                     if (Socket.Available > 0 || !ValidateInput(BufferStream.ToArray()))

--- a/src/Listener/PodeRequest.cs
+++ b/src/Listener/PodeRequest.cs
@@ -174,6 +174,11 @@ namespace Pode
             {
                 PodeSocket.CloseSocket(Socket);
             }
+
+            if (InputStream != default(Stream))
+            {
+                InputStream.Dispose();
+            }
         }
     }
 }

--- a/src/Listener/PodeRequest.cs
+++ b/src/Listener/PodeRequest.cs
@@ -131,7 +131,6 @@ namespace Pode
             }
             catch (Exception ex)
             {
-                PodeHelpers.WriteException(ex);
                 Error = new HttpRequestException(ex.Message, ex);
                 Error.Data.Add("PodeStatusCode", 400);
             }

--- a/src/Listener/PodeResponse.cs
+++ b/src/Listener/PodeResponse.cs
@@ -76,7 +76,8 @@ namespace Pode
                     OutputStream.WriteTo(Request.InputStream);
                 }
             }
-            catch (IOException) { }
+            catch (OperationCanceledException) {}
+            catch (IOException) {}
             catch (Exception ex)
             {
                 PodeHelpers.WriteException(ex);
@@ -157,7 +158,8 @@ namespace Pode
                     Request.InputStream.Flush();
                 }
             }
-            catch (IOException) { }
+            catch (OperationCanceledException) {}
+            catch (IOException) {}
             catch (Exception ex)
             {
                 PodeHelpers.WriteException(ex);

--- a/src/Listener/PodeResponse.cs
+++ b/src/Listener/PodeResponse.cs
@@ -240,7 +240,6 @@ namespace Pode
         {
             if (OutputStream != default(MemoryStream))
             {
-                Console.WriteLine("Output Disposed");
                 OutputStream.Dispose();
             }
         }

--- a/src/Listener/PodeResponse.cs
+++ b/src/Listener/PodeResponse.cs
@@ -75,6 +75,9 @@ namespace Pode
                 {
                     OutputStream.WriteTo(Request.InputStream);
                 }
+
+                message = string.Empty;
+                buffer = default(byte[]);
             }
             catch (OperationCanceledException) {}
             catch (IOException) {}

--- a/src/Listener/PodeResponse.cs
+++ b/src/Listener/PodeResponse.cs
@@ -240,6 +240,7 @@ namespace Pode
         {
             if (OutputStream != default(MemoryStream))
             {
+                Console.WriteLine("Output Disposed");
                 OutputStream.Dispose();
             }
         }

--- a/src/Listener/PodeSmtpRequest.cs
+++ b/src/Listener/PodeSmtpRequest.cs
@@ -55,13 +55,13 @@ namespace Pode
             Context.Response.WriteLine($"220 {Context.PodeSocket.Hostnames[0]} -- Pode Proxy Server", true);
         }
 
-        protected override void Parse(byte[] bytes)
+        protected override bool Parse(byte[] bytes)
         {
             // if there are no bytes, return (0 bytes read means we can close the socket)
             if (bytes.Length == 0)
             {
                 Command = string.Empty;
-                return;
+                return true;
             }
 
             // get the raw string for headers
@@ -72,14 +72,14 @@ namespace Pode
             {
                 Command = string.Empty;
                 Context.Response.WriteLine("501 Invalid command received", true);
-                return;
+                return true;
             }
 
             // quit
             if (IsCommand(content, "QUIT"))
             {
                 Command = "QUIT";
-                return;
+                return true;
             }
 
             // helo
@@ -87,7 +87,7 @@ namespace Pode
             {
                 Command = "EHLO";
                 Context.Response.WriteLine("250 OK", true);
-                return;
+                return true;
             }
 
             // to
@@ -96,7 +96,7 @@ namespace Pode
                 Command = "RCPT TO";
                 Context.Response.WriteLine("250 OK", true);
                 To.Add(ParseEmail(content));
-                return;
+                return true;
             }
 
             // from
@@ -105,7 +105,7 @@ namespace Pode
                 Command = "MAIL FROM";
                 Context.Response.WriteLine("250 OK", true);
                 From = ParseEmail(content);
-                return;
+                return true;
             }
 
             // data
@@ -113,7 +113,7 @@ namespace Pode
             {
                 Command = "DATA";
                 Context.Response.WriteLine("354 Start mail input; end with <CR><LF>.<CR><LF>", true);
-                return;
+                return true;
             }
 
             // check prior command
@@ -136,7 +136,7 @@ namespace Pode
                     {
                         Command = string.Empty;
                         Context.Response.WriteLine("501 Invalid DATA received", true);
-                        return;
+                        return true;
                     }
 
                     CanProcess = true;
@@ -145,6 +145,8 @@ namespace Pode
                 default:
                     throw new HttpRequestException();
             }
+
+            return true;
         }
 
         public void Reset()

--- a/src/Listener/PodeSocket.cs
+++ b/src/Listener/PodeSocket.cs
@@ -208,10 +208,77 @@ namespace Pode
             try
             {
                 // add context to be processed?
-                var process = true;
+                // var process = true;
 
                 // deal with context
                 context.Receive();
+
+                // if we need to exit now, dispose and exit
+                // if (context.CloseImmediately)
+                // {
+                //     PodeHelpers.WriteException(context.Request.Error, Listener);
+                //     context.Dispose(true);
+                //     process = false;
+                // }
+
+                // if it's a websocket, upgrade it, then add context back for re-receiving
+                // else if (context.IsWebSocket && !context.IsWebSocketUpgraded)
+                // {
+                //     context.UpgradeWebSocket();
+                //     process = false;
+                //     context.Dispose();
+                // }
+
+                // if it's an email, re-receive unless processable
+                // else if (context.IsSmtp)
+                // {
+                //     if (!context.SmtpRequest.CanProcess)
+                //     {
+                //         process = false;
+                //         context.Dispose();
+                //     }
+                // }
+
+                // if it's http and awaiting the body
+                // else if (context.IsHttp)
+                // {
+                //     if (context.HttpRequest.AwaitingBody)
+                //     {
+                //         process = false;
+                //         context.Dispose();
+                //     }
+                // }
+
+                // add the context for processing
+                // if (process)
+                // {
+                //     if (context.IsWebSocket)
+                //     {
+                //         Listener.AddClientSignal(context.WsRequest.NewClientSignal());
+                //         context.Dispose();
+                //     }
+                //     else
+                //     {
+                //         Listener.AddContext(context);
+                //     }
+                // }
+            }
+            catch (Exception ex)
+            {
+                PodeHelpers.WriteException(ex, Listener);
+            }
+
+            // add args back to connections
+            ClearSocketAsyncEvent(args);
+            ReceiveConnections.Enqueue(args);
+        }
+
+        public void HandleContext(PodeContext context)
+        {
+            try
+            {
+                // add context to be processed?
+                var process = true;
 
                 // if we need to exit now, dispose and exit
                 if (context.CloseImmediately)
@@ -267,10 +334,6 @@ namespace Pode
             {
                 PodeHelpers.WriteException(ex, Listener);
             }
-
-            // add args back to connections
-            ClearSocketAsyncEvent(args);
-            ReceiveConnections.Enqueue(args);
         }
 
         private SocketAsyncEventArgs NewAcceptConnection()

--- a/src/Listener/PodeSocket.cs
+++ b/src/Listener/PodeSocket.cs
@@ -55,6 +55,7 @@ namespace Pode
 
             Socket = new Socket(Endpoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
             Socket.ReceiveTimeout = 100;
+            Socket.NoDelay = true;
         }
 
         public void BindListener(PodeListener listener)

--- a/src/Listener/PodeSocket.cs
+++ b/src/Listener/PodeSocket.cs
@@ -207,61 +207,7 @@ namespace Pode
 
             try
             {
-                // add context to be processed?
-                // var process = true;
-
-                // deal with context
                 context.Receive();
-
-                // if we need to exit now, dispose and exit
-                // if (context.CloseImmediately)
-                // {
-                //     PodeHelpers.WriteException(context.Request.Error, Listener);
-                //     context.Dispose(true);
-                //     process = false;
-                // }
-
-                // if it's a websocket, upgrade it, then add context back for re-receiving
-                // else if (context.IsWebSocket && !context.IsWebSocketUpgraded)
-                // {
-                //     context.UpgradeWebSocket();
-                //     process = false;
-                //     context.Dispose();
-                // }
-
-                // if it's an email, re-receive unless processable
-                // else if (context.IsSmtp)
-                // {
-                //     if (!context.SmtpRequest.CanProcess)
-                //     {
-                //         process = false;
-                //         context.Dispose();
-                //     }
-                // }
-
-                // if it's http and awaiting the body
-                // else if (context.IsHttp)
-                // {
-                //     if (context.HttpRequest.AwaitingBody)
-                //     {
-                //         process = false;
-                //         context.Dispose();
-                //     }
-                // }
-
-                // add the context for processing
-                // if (process)
-                // {
-                //     if (context.IsWebSocket)
-                //     {
-                //         Listener.AddClientSignal(context.WsRequest.NewClientSignal());
-                //         context.Dispose();
-                //     }
-                //     else
-                //     {
-                //         Listener.AddContext(context);
-                //     }
-                // }
             }
             catch (Exception ex)
             {

--- a/src/Listener/PodeSocket.cs
+++ b/src/Listener/PodeSocket.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Net.Sockets;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
 
 namespace Pode
 {
@@ -207,7 +208,7 @@ namespace Pode
 
             try
             {
-                context.Receive();
+                Task.Factory.StartNew(() => context.Receive());
             }
             catch (Exception ex)
             {

--- a/src/Listener/PodeWsRequest.cs
+++ b/src/Listener/PodeWsRequest.cs
@@ -38,7 +38,7 @@ namespace Pode
             return new PodeClientSignal(WebSocket, Body);
         }
 
-        protected override void Parse(byte[] bytes)
+        protected override bool Parse(byte[] bytes)
         {
             // get the length and op-code
             var dataLength = bytes[1] - 128;
@@ -104,6 +104,8 @@ namespace Pode
             {
                 Context.Response.WriteFrame(string.Empty, PodeWsOpCode.Pong);
             }
+
+            return true;
         }
 
         public override void Dispose()

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -1203,6 +1203,7 @@ function ConvertFrom-PodeRequestContent
             }
 
             $Result.Data = (Invoke-PodeScriptBlock -ScriptBlock $parser.ScriptBlock -Arguments $_args -Return)
+            $Content = $null
             return $Result
         }
     }
@@ -1298,6 +1299,7 @@ function ConvertFrom-PodeRequestContent
         }
     }
 
+    $Content = $null
     return $Result
 }
 

--- a/src/Private/PodeServer.ps1
+++ b/src/Private/PodeServer.ps1
@@ -192,6 +192,7 @@ function Start-PodeWebServer
                     Invoke-PodeEndware -WebEvent $WebEvent -Endware $_endware
                 }
                 finally {
+                    $WebEvent = $null
                     Close-PodeDisposable -Disposable $context
                 }
             }

--- a/src/Private/Streams.ps1
+++ b/src/Private/Streams.ps1
@@ -52,9 +52,9 @@ function Read-PodeByteLineFromByteArray
 
     # grab the portion of the bytes array - which is our line
     return @{
-        'Bytes' = $Bytes[$StartIndex..$fIndex];
-        'StartIndex' = $StartIndex;
-        'EndIndex' = $index;
+        Bytes       = $Bytes[$StartIndex..$fIndex];
+        StartIndex  = $StartIndex;
+        EndIndex    = $index;
     }
 }
 
@@ -144,7 +144,7 @@ function ConvertFrom-PodeBytesToString
         $RemoveNewLine
     )
 
-    if (Test-PodeIsEmpty $Bytes) {
+    if (($null -eq $Bytes) -or ($Bytes.Length -eq 0)) {
         return $Bytes
     }
 
@@ -164,8 +164,8 @@ function Get-PodeNewLineBytes
     )
 
     return @{
-        'NewLine' = @($Encoding.GetBytes("`n"))[0];
-        'Return' = @($Encoding.GetBytes("`r"))[0];
+        NewLine = @($Encoding.GetBytes("`n"))[0];
+        Return  = @($Encoding.GetBytes("`r"))[0];
     }
 }
 


### PR DESCRIPTION
### Description of the Change
This work aims to resolve issues when receiving requests with large payloads (like >50MB), and when receiving requests with payloads over SSL.

In both cases, the full payload was either corrupted, or never present.

The logic for receiving a request's content from the stream is now done via the async/await pattern on streams, and it now uses Buffer.BlockCopy for some extra speed 🐎 

### Related Issue
Resolves #655 
