### PR TITLE
Use Ubuntu 18, and PS7.1.1 in Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/powershell:7.0.1-ubuntu-16.04
+FROM mcr.microsoft.com/powershell:7.1.1-ubuntu-18.04
 LABEL maintainer="Matthew Kelly (Badgerati)"
 RUN mkdir -p /usr/local/share/powershell/Modules/Pode
 COPY ./pkg/ /usr/local/share/powershell/Modules/Pode

--- a/arm32.dockerfile
+++ b/arm32.dockerfile
@@ -1,4 +1,4 @@
-FROM badgerati/ps-core:7.0.1-arm32
+FROM badgerati/ps-core:7.1.1-arm32
 LABEL maintainer="Matthew Kelly (Badgerati)"
 RUN mkdir -p /usr/local/share/powershell/Modules/Pode
 COPY ./pkg/ /usr/local/share/powershell/Modules/Pode

--- a/docs/Getting-Started/Installation.md
+++ b/docs/Getting-Started/Installation.md
@@ -27,7 +27,7 @@ Install-Module -Name Pode
 [![Docker](https://img.shields.io/docker/stars/badgerati/pode.svg?label=Stars)](https://hub.docker.com/r/badgerati/pode/)
 [![Docker](https://img.shields.io/docker/pulls/badgerati/pode.svg?label=Pulls)](https://hub.docker.com/r/badgerati/pode/)
 
-Pode can run on *nix environments, therefore it only makes sense for there to be Docker images for you to use! The images use PowerShell Core on either an Ubuntu Xenial image (default), or an ARM32 image (for Raspberry Pis).
+Pode can run on *nix environments, therefore it only makes sense for there to be Docker images for you to use! The images use PowerShell v7.1.1 on either an Ubuntu Bionic image (default), or an ARM32 image (for Raspberry Pis).
 
 * To pull down the latest Pode image you can do:
 
@@ -36,7 +36,7 @@ Pode can run on *nix environments, therefore it only makes sense for there to be
 docker pull badgerati/pode:latest
 
 # or the following for a specific version:
-docker pull badgerati/pode:1.0.1
+docker pull badgerati/pode:2.1.0
 ```
 
 * To pull down the ARM32 Pode image you can do:
@@ -46,7 +46,7 @@ docker pull badgerati/pode:1.0.1
 docker pull badgerati/pode:latest-arm32
 
 # or the following for a specific version:
-docker pull badgerati/pode:1.0.1-arm32
+docker pull badgerati/pode:2.1.0-arm32
 ```
 
 Once pulled, you can [view here](../Docker) on how to use the image.
@@ -62,7 +62,7 @@ You can also get the Pode docker image from the GitHub Package Registry! The ima
 docker pull docker.pkg.github.com/badgerati/pode/pode:latest
 
 # or the following for a specific version:
-docker pull docker.pkg.github.com/badgerati/pode/pode:1.0.1
+docker pull docker.pkg.github.com/badgerati/pode/pode:2.1.0
 ```
 
 * To pull down the ARM32 Pode image you can do:
@@ -72,7 +72,7 @@ docker pull docker.pkg.github.com/badgerati/pode/pode:1.0.1
 docker pull docker.pkg.github.com/badgerati/pode/pode:latest-arm32
 
 # or the following for a specific version:
-docker pull docker.pkg.github.com/badgerati/pode/pode:1.0.1-arm32
+docker pull docker.pkg.github.com/badgerati/pode/pode:2.1.0-arm32
 ```
 
 Once pulled, you can [view here](../Docker) on how to use the image.

--- a/docs/Hosting/Docker.md
+++ b/docs/Hosting/Docker.md
@@ -2,7 +2,7 @@
 
 Pode has a Docker image that you can use to host your server, for instructions on pulling these images you can [look here](../../Installation).
 
-The images use PowerShell Core on either an Ubuntu Xenial (default) or ARM32 image.
+The images use PowerShell v7.1.1 on either an Ubuntu Bionic (default) or ARM32 image.
 
 ## Images
 
@@ -11,7 +11,7 @@ The images use PowerShell Core on either an Ubuntu Xenial (default) or ARM32 ima
 
 ### Default
 
-The default Pode image is an Ubuntu Xenial image with PowerShell Core and Pode installed. An example of using this image in your Dockerfile could be as follows:
+The default Pode image is an Ubuntu Bionic image with PowerShell v7.1.1 and Pode installed. An example of using this image in your Dockerfile could be as follows:
 
 ```dockerfile
 # pull down the pode image

--- a/packers/docker/arm32/Dockerfile
+++ b/packers/docker/arm32/Dockerfile
@@ -1,6 +1,6 @@
 FROM arm32v7/ubuntu:bionic
 
-ENV PS_VERSION=7.0.1
+ENV PS_VERSION=7.1.1
 ENV PS_PACKAGE=powershell-${PS_VERSION}-linux-arm32.tar.gz
 ENV PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/${PS_PACKAGE}
 


### PR DESCRIPTION
### Description of the Change
Bumps dockerfiles to use Ubuntu 18.04, and PS7.1.1

### Related Issue
Resolves #629 
Resolves #630 
