### PR TITLE
Bump mkdocs-material version

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,13 +5,16 @@ theme:
   logo: images/icon.png
   favicon: images/favicon.ico
   features:
-    - tabs
+    - navigation.tabs
+    - navigation.tabs.sticky
   palette:
+    scheme: preference
     primary: cyan
     accent: cyan
 
 markdown_extensions:
-  - codehilite
+  - pymdownx.highlight
+  - pymdownx.superfences
   - admonition
   - meta
 

--- a/pode.build.ps1
+++ b/pode.build.ps1
@@ -14,7 +14,7 @@ $Versions = @{
     SevenZip = '18.5.0.20180730'
     DotNetCore = '3.1.5'
     Checksum = '0.2.0'
-    MkDocsTheme = '5.2.1'
+    MkDocsTheme = '6.2.8'
     PlatyPS = '0.14.0'
 }
 


### PR DESCRIPTION
### Description of the Change
Bump version of mkdocs-material theme for docs to v6.2.8.

### Related Issue
Resolves #683 
