### PR TITLE
Allow OpenApi OperationId to be specified

### DIFF
--- a/src/Private/OpenApi.ps1
+++ b/src/Private/OpenApi.ps1
@@ -299,6 +299,7 @@ function Get-PodeOpenApiDefinitionInternal
             $def.paths[$_route.OpenApi.Path][$method] = @{
                 summary = $_route.OpenApi.Summary
                 description = $_route.OpenApi.Description
+                operationId = $_route.OpenApi.OperationId
                 tags = @($_route.OpenApi.Tags)
                 deprecated = $_route.OpenApi.Deprecated
                 responses = $_route.OpenApi.Responses

--- a/src/Public/OpenApi.ps1
+++ b/src/Public/OpenApi.ps1
@@ -1314,6 +1314,9 @@ A quick Summary of the route.
 .PARAMETER Description
 A longer Description of the route.
 
+.PARAMETER OperationId
+Sets the OperationId of the route.
+
 .PARAMETER Tags
 An array of Tags for the route, mostly for grouping.
 

--- a/src/Public/OpenApi.ps1
+++ b/src/Public/OpenApi.ps1
@@ -1344,6 +1344,10 @@ function Set-PodeOARouteInfo
         $Description,
 
         [Parameter()]
+        [string]
+        $OperationId,
+
+        [Parameter()]
         [string[]]
         $Tags,
 
@@ -1357,6 +1361,7 @@ function Set-PodeOARouteInfo
     foreach ($r in @($Route)) {
         $r.OpenApi.Summary = $Summary
         $r.OpenApi.Description = $Description
+        $r.OpenApi.OperationId = $OperationId
         $r.OpenApi.Tags = $Tags
         $r.OpenApi.Deprecated = $Deprecated.IsPresent
     }


### PR DESCRIPTION
### Description of the Change
I added a parameter to Set-PodeOARouteInfo to be able to specify an operationId for the route.

### Additional Context
This is relevant, if you use client-gens like nswag to create meaningful names for operations independent of the routes.
