### PR TITLE
Fix rate limiting preventing requests when no endpoint name

### DIFF
--- a/examples/web-pages.ps1
+++ b/examples/web-pages.ps1
@@ -24,6 +24,9 @@ Start-PodeServer -Threads 2 {
     Add-PodeAccessRule -Access Deny -Type IP -Values '10.10.0.0/24'
     Add-PodeAccessRule -Access Deny -Type IP -Values all
 
+    # limit
+    Add-PodeLimitRule -Type IP -Values all -Limit 100 -Seconds 5
+
     # log requests to the terminal
     New-PodeLoggingMethod -Terminal -Batch 10 -BatchTimeout 10 | Enable-PodeRequestLogging
     New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging

--- a/src/Private/Security.ps1
+++ b/src/Private/Security.ps1
@@ -185,13 +185,16 @@ function Test-PodeRouteLimit
 function Test-PodeEndpointLimit
 {
     param (
-        [Parameter(Mandatory=$true)]
-        [ValidateNotNull()]
+        [Parameter()]
         [string]
         $EndpointName
     )
 
     $type = 'Endpoint'
+
+    if ([string]::IsNullOrWhiteSpace($EndpointName)) {
+        return $true
+    }
 
     # get the limit rules and active list
     $rules = $PodeContext.Server.Limits.Rules[$type]
@@ -491,6 +494,9 @@ function Add-PodeEndpointLimit
     if ($Seconds -le 0) {
         throw "Seconds value cannot be 0 or less for $($IP)"
     }
+    
+    # we need to check endpoints on requests
+    $PodeContext.Server.FindRouteEndpoint = $true
 
     # get current rules
     $rules = $PodeContext.Server.Limits.Rules[$type]


### PR DESCRIPTION
### Description of the Change
Fixes a bug with rate limiting and named endpoints, where rate limiting would fail with a null reference exception.

### Related Issue
Resolves #689 
