### PR TITLE
Add missing -EndpointName to Set-PodeResponseAttachment

### DIFF
--- a/examples/assets/file.txt
+++ b/examples/assets/file.txt
@@ -1,0 +1,1 @@
+Hello there.

--- a/src/Private/PodeServer.ps1
+++ b/src/Private/PodeServer.ps1
@@ -147,7 +147,7 @@ function Start-PodeWebServer
                                 # invoke the route
                                 if ($null -ne $WebEvent.StaticContent) {
                                     if ($WebEvent.StaticContent.IsDownload) {
-                                        Set-PodeResponseAttachment -Path $WebEvent.Path
+                                        Set-PodeResponseAttachment -Path $WebEvent.Path -EndpointName $WebEvent.Endpoint.Name
                                     }
                                     else {
                                         $cachable = $WebEvent.StaticContent.IsCachable

--- a/src/Private/Serverless.ps1
+++ b/src/Private/Serverless.ps1
@@ -85,7 +85,7 @@ function Start-PodeAzFuncServer
                     # invoke the route
                     if ($null -ne $WebEvent.StaticContent) {
                         if ($WebEvent.StaticContent.IsDownload) {
-                            Set-PodeResponseAttachment -Path $WebEvent.Path
+                            Set-PodeResponseAttachment -Path $WebEvent.Path -EndpointName $WebEvent.Endpoint.Name
                         }
                         else {
                             $cachable = $WebEvent.StaticContent.IsCachable
@@ -204,7 +204,7 @@ function Start-PodeAwsLambdaServer
                     # invoke the route
                     if ($null -ne $WebEvent.StaticContent) {
                         if ($WebEvent.StaticContent.IsDownload) {
-                            Set-PodeResponseAttachment -Path $WebEvent.Path
+                            Set-PodeResponseAttachment -Path $WebEvent.Path -EndpointName $WebEvent.Endpoint.Name
                         }
                         else {
                             $cachable = $WebEvent.StaticContent.IsCachable

--- a/src/Public/Responses.ps1
+++ b/src/Public/Responses.ps1
@@ -15,6 +15,9 @@ Failing this, if the file path exists as a literal/relative file, then this file
 Manually specify the content type of the response rather than infering it from the attachment's file extension.
 The supplied value must match the valid ContentType format, e.g. application/json
 
+.PARAMETER EndpointName
+Optional EndpointName that the static route was creating under.
+
 .EXAMPLE
 Set-PodeResponseAttachment -Path 'downloads/installer.exe'
 
@@ -26,6 +29,9 @@ Set-PodeResponseAttachment -Path 'c:/content/accounts.xlsx'
 
 .EXAMPLE
 Set-PodeResponseAttachment -Path './data.txt' -ContentType 'application/json'
+
+.EXAMPLE
+Set-PodeResponseAttachment -Path '/assets/data.txt' -EndpointName 'Example'
 #>
 function Set-PodeResponseAttachment
 {
@@ -37,11 +43,15 @@ function Set-PodeResponseAttachment
 
         [ValidatePattern('^\w+\/[\w\.\+-]+$')]
         [string]
-        $ContentType
+        $ContentType,
+
+        [Parameter()]
+        [string]
+        $EndpointName
     )
 
     # only attach files from public/static-route directories when path is relative
-    $_path = (Find-PodeStaticRoute -Path $Path -CheckPublic).Content.Source
+    $_path = (Find-PodeStaticRoute -Path $Path -CheckPublic -EndpointName $EndpointName).Content.Source
 
     # if there's no path, check the original path (in case it's literal/relative)
     if (!(Test-PodePath $_path -NoStatus)) {


### PR DESCRIPTION
### Description of the Change
Adds EndpointName support to `Set-PodeResponseAttachment`, to resolve an issue getting/downloading files from static routes bound to endpoints.

### Related Issue
Resolves #686 

### Examples
```powershell
Add-PodeEndpoint -Address localhost -Protocol Http -Name 'Main'
Add-PodeStaticRoute -Path '/assets' -Source './assets' -DownloadOnly

Add-PodeRoute -Method Get -Path '/download' -EndpointName 'Main' -ScriptBlock {
    Set-PodeResponseAttachment -Path '/assets/file.txt' -EndpointName 'Main'
}
```
