### PR TITLE
Adds support for changing certificate store on Add-PodeEndpoint

### DIFF
--- a/docs/Tutorials/Certificates.md
+++ b/docs/Tutorials/Certificates.md
@@ -11,6 +11,8 @@ There are 6 ways to setup HTTPS on [`Add-PodeEndpoint`](../../Functions/Core/Add
 5. Supplying `-X509Certificate` of type `X509Certificate`.
 6. Supplying the `-SelfSigned` switch, to generate a quick self-signed `X509Certificate`.
 
+Note: for 3. and 4. you can change the certificate store used by supplying `-CertificateStoreName` and/or `-CertificateStoreLocation`.
+
 ## Usage
 
 ### File
@@ -33,6 +35,8 @@ Start-PodeServer {
 }
 ```
 
+Note: You can change the certificate store used by supplying `-CertificateStoreName` and/or `-CertificateStoreLocation`.
+
 ### Name
 
 On Windows only, you can use a certificate that is installed at `Cert:\CurrentUser\My` using its subject name:
@@ -42,6 +46,8 @@ Start-PodeServer {
     Add-PodeEndpoint -Address * -Port 8090 -Protocol Https -CertificateName '*.example.com'
 }
 ```
+
+Note: You can change the certificate store used by supplying `-CertificateStoreName` and/or `-CertificateStoreLocation`.
 
 ### X509
 

--- a/docs/Tutorials/Endpoints/Basics.md
+++ b/docs/Tutorials/Endpoints/Basics.md
@@ -53,8 +53,10 @@ If you add an HTTPS or WSS endpoint, then you'll be required to also supply cert
 | ---- | ----------- |
 | Certificate | The path to a `.pfx` or `.cer` certificate |
 | CertificatePassword | The password for the above `.pfx` certificate |
-| CertificateThumbprint | The thumbprint of a certificate in `CurrentUser\My` (Windows only) |
-| CertificateName | The subject name of a certificate in `CurrentUser\My` (Windows only) |
+| CertificateThumbprint | The thumbprint of a certificate to find (Windows only) |
+| CertificateName | The subject name of a certificate to find (Windows only) |
+| CertificateStoreName | The name of the certificate store (Default: My) (Windows only) |
+| CertificateStoreLocation | The location of the certificate store (Default: CurrentUser) (Windows only) |
 | X509Certificate | A raw X509Certificate object |
 | SelfSigned | If supplied, Pode will automatically generate a self-signed certificate as an X509Certificate object |
 

--- a/src/Private/Security.ps1
+++ b/src/Private/Security.ps1
@@ -763,7 +763,15 @@ function Find-PodeCertificateInCertStore
 
         [Parameter(Mandatory=$true)]
         [string]
-        $Query
+        $Query,
+
+        [Parameter(Mandatory=$true)]
+        [X509Certificates.StoreName]
+        $StoreName,
+
+        [Parameter(Mandatory=$true)]
+        [X509Certificates.StoreLocation]
+        $StoreLocation
     )
 
     # fail if not windows
@@ -772,10 +780,7 @@ function Find-PodeCertificateInCertStore
     }
 
     # open the currentuser\my store
-    $x509store = [X509Certificates.X509Store]::new(
-        [X509Certificates.StoreName]::My,
-        [X509Certificates.StoreLocation]::CurrentUser
-    )
+    $x509store = [X509Certificates.X509Store]::new($StoreName, $StoreLocation)
 
     try {
         # attempt to find the cert
@@ -791,7 +796,7 @@ function Find-PodeCertificateInCertStore
 
     # fail if no cert found for query
     if (($null -eq $x509certs) -or ($x509certs.Count -eq 0)) {
-        throw "No certificate could be found in CurrentUser\My for '$($Thumbprint)'"
+        throw "No certificate could be found in $($StoreLocation)\$($StoreName) for '$($Query)'"
     }
 
     return ([X509Certificates.X509Certificate2]($x509certs[0]))
@@ -802,10 +807,22 @@ function Get-PodeCertificateByThumbprint
     param(
         [Parameter(Mandatory=$true)]
         [string]
-        $Thumbprint
+        $Thumbprint,
+
+        [Parameter(Mandatory=$true)]
+        [X509Certificates.StoreName]
+        $StoreName,
+
+        [Parameter(Mandatory=$true)]
+        [X509Certificates.StoreLocation]
+        $StoreLocation
     )
 
-    return (Find-PodeCertificateInCertStore -FindType ([X509Certificates.X509FindType]::FindByThumbprint) -Query $Thumbprint)
+    return (Find-PodeCertificateInCertStore `
+        -FindType ([X509Certificates.X509FindType]::FindByThumbprint) `
+        -Query $Thumbprint `
+        -StoreName $StoreName `
+        -StoreLocation $StoreLocation)
 }
 
 function Get-PodeCertificateByName
@@ -813,10 +830,22 @@ function Get-PodeCertificateByName
     param(
         [Parameter(Mandatory=$true)]
         [string]
-        $Name
+        $Name,
+
+        [Parameter(Mandatory=$true)]
+        [X509Certificates.StoreName]
+        $StoreName,
+
+        [Parameter(Mandatory=$true)]
+        [X509Certificates.StoreLocation]
+        $StoreLocation
     )
 
-    return (Find-PodeCertificateInCertStore -FindType ([X509Certificates.X509FindType]::FindBySubjectName) -Query $Name)
+    return (Find-PodeCertificateInCertStore `
+        -FindType ([X509Certificates.X509FindType]::FindBySubjectName) `
+        -Query $Name `
+        -StoreName $StoreName `
+        -StoreLocation $StoreLocation)
 }
 
 function New-PodeSelfSignedCertificate

--- a/src/Public/Core.ps1
+++ b/src/Public/Core.ps1
@@ -719,6 +719,16 @@ function Add-PodeEndpoint
         [string]
         $CertificateName,
 
+        [Parameter(ParameterSetName='CertName')]
+        [Parameter(ParameterSetName='CertThumb')]
+        [System.Security.Cryptography.X509Certificates.StoreName]
+        $CertificateStoreName = 'My',
+
+        [Parameter(ParameterSetName='CertName')]
+        [Parameter(ParameterSetName='CertThumb')]
+        [System.Security.Cryptography.X509Certificates.StoreLocation]
+        $CertificateStoreLocation = 'CurrentUser',
+
         [Parameter(Mandatory=$true, ParameterSetName='CertRaw')]
         [Parameter()]
         [X509Certificate]
@@ -884,11 +894,11 @@ function Add-PodeEndpoint
             }
 
             'certthumb' {
-                $obj.Certificate.Raw = Get-PodeCertificateByThumbprint -Thumbprint $CertificateThumbprint
+                $obj.Certificate.Raw = Get-PodeCertificateByThumbprint -Thumbprint $CertificateThumbprint -StoreName $CertificateStoreName -StoreLocation $CertificateStoreLocation
             }
 
             'certname' {
-                $obj.Certificate.Raw = Get-PodeCertificateByName -Name $CertificateName
+                $obj.Certificate.Raw = Get-PodeCertificateByName -Name $CertificateName -StoreName $CertificateStoreName -StoreLocation $CertificateStoreLocation
             }
 
             'certself' {

--- a/src/Public/Core.ps1
+++ b/src/Public/Core.ps1
@@ -637,6 +637,12 @@ A certificate thumbprint to bind onto HTTPS endpoints (Windows).
 .PARAMETER CertificateName
 A certificate subject name to bind onto HTTPS endpoints (Windows).
 
+.PARAMETER CertificateStoreName
+The name of a certifcate store where a certificate can be found (Default: My) (Windows).
+
+.PARAMETER CertificateStoreLocation
+The location of a certifcate store where a certificate can be found (Default: CurrentUser) (Windows).
+
 .PARAMETER X509Certificate
 The raw X509 certificate that can be use to enable HTTPS
 


### PR DESCRIPTION
### Description of the Change
Adds support for `-CertificateStoreName` and `-CertificateStoreLocation` on `Add-PodeEndpoint` to allow changing the certificate store.

### Related Issue
Resolves #698 

### Examples
```powershell
Add-PodeEndpoint -Address * -Port 8443 -Protocol Https -CertificateName '*.example.com' -CertificateStoreLocation LocalMachine
```
