### PR TITLE
Fix logic for auto-importing modules

### DIFF
--- a/docs/Getting-Started/KnownIssues.md
+++ b/docs/Getting-Started/KnownIssues.md
@@ -89,3 +89,15 @@ For HTTPS there are a few issues you may run into, and to resolve them you can u
 ```
 
 * On *nix platforms, for self-signed certificates, you may need to use `-SkipCertificateCheck` on `Invoke-WebRequest` and `Invoke-RestMethod`.
+
+## ActiveDirectory Module
+
+If you're using commands from the ActiveDirectory module - such as `Get-ADUser` - and they're not working as expected, you'll need to import the module first so it's loaded into the runspaces appropriately:
+
+```powershell
+Import-Module ActiveDirectory
+
+Start-PodeServer {
+    # ...
+}
+```

--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -404,7 +404,10 @@ function Import-PodeModulesIntoRunspaceState
     }
 
     # load modules into runspaces, if allowed
-    $modules = (Get-Module | Where-Object { ($_.ModuleType -ieq 'script') -and ($_.Name -ine 'pode') }).Name | Sort-Object -Unique
+    $modules = (Get-Module |
+        Where-Object {
+            ($_.Name -ine 'pode') -and ($_.Name -inotlike 'microsoft.powershell.*')
+        }).Name | Sort-Object -Unique
 
     foreach ($module in $modules) {
         # only exported modules? is the module exported?


### PR DESCRIPTION
### Description of the Change
Fixes the logic for auto-importing modules, so it imports modules like ActiveDirectory correctly.

### Related Issue
Resolves #702 

### Examples
This now works:

```powershell
Import-Module ActiveDirectory

Start-PodeServer {
    Add-PodeEndpoint -Address localhost -Port 8080 -Protocol Http

    Add-PodeRoute -Method Get -Path '/user' -ScriptBlock {
        $user = Get-ADUser -Identity $username -Properties EmployeeID, Title, Department
    }
}
```
