### PR TITLE
Add support for redirecting to origin on login

### DIFF
--- a/docs/Tutorials/Cookies.md
+++ b/docs/Tutorials/Cookies.md
@@ -22,13 +22,15 @@ Add-PodeRoute -Method Get -Path '/' -ScriptBlock {
 
 ## Getting Cookies
 
-To retrieve the value of a cookie on the request, you can use [`Get-PodeCookie`](../../Functions/Cookies/Get-PodeCookie):
+To retrieve a cookie on the request, you can use [`Get-PodeCookie`](../../Functions/Cookies/Get-PodeCookie):
 
 ```powershell
 Add-PodeRoute -Method Get -Path '/' -ScriptBlock {
     Get-PodeCookie -Name 'CookieName'
 }
 ```
+
+This will return a cookie object with value, duration, etc. To retrieve just the value of a cookie use [`Get-PodeCookieValue`](../../Functions/Cookies/Get-PodeCookieValue)
 
 ## Removing Cookies
 

--- a/src/Pode.psd1
+++ b/src/Pode.psd1
@@ -46,6 +46,7 @@
         'Test-PodeCookie',
         'Test-PodeCookieSigned',
         'Update-PodeCookieExpiry',
+        'Get-PodeCookieValue',
 
         # flash
         'Add-PodeFlashMessage',

--- a/src/Private/Authentication.ps1
+++ b/src/Private/Authentication.ps1
@@ -1137,6 +1137,10 @@ function Set-PodeAuthStatus
 
         # check if we have a failure url redirect
         if (![string]::IsNullOrWhiteSpace($Failure.Url)) {
+            if ($Success.UseOrigin) {
+                Set-PodeCookie -Name 'pode.redirecturl' -Value $WebEvent.Request.Url.PathAndQuery
+            }
+
             Move-PodeResponseUrl -Url $Failure.Url
         }
         else {
@@ -1148,7 +1152,17 @@ function Set-PodeAuthStatus
 
     # if no statuscode, success, so check if we have a success url redirect (but only for auto-login routes)
     if ((!$NoSuccessRedirect -or $LoginRoute) -and ![string]::IsNullOrWhiteSpace($Success.Url)) {
-        Move-PodeResponseUrl -Url $Success.Url
+        $url = $Success.Url
+        if ($Success.UseOrigin) {
+            $tmpUrl = Get-PodeCookieValue -Name 'pode.redirecturl'
+            Remove-PodeCookie -Name 'pode.redirecturl'
+
+            if (![string]::IsNullOrWhiteSpace($tmpUrl)) {
+                $url = $tmpUrl
+            }
+        }
+
+        Move-PodeResponseUrl -Url $url
         return $false
     }
 

--- a/src/Public/Authentication.ps1
+++ b/src/Public/Authentication.ps1
@@ -454,6 +454,9 @@ The URL to redirect to when authentication succeeds when logging in.
 .PARAMETER Sessionless
 If supplied, authenticated users will not be stored in sessions, and sessions will not be used.
 
+.PARAMETER SuccessUseOrigin
+If supplied, successful authentication from a login page will redirect back to the originating page instead of the FailureUrl.
+
 .EXAMPLE
 New-PodeAuthScheme -Form | Add-PodeAuth -Name 'Main' -ScriptBlock { /* logic */ }
 #>
@@ -497,7 +500,10 @@ function Add-PodeAuth
         $SuccessUrl,
 
         [switch]
-        $Sessionless
+        $Sessionless,
+
+        [switch]
+        $SuccessUseOrigin
     )
 
     # ensure the name doesn't already exist
@@ -531,6 +537,7 @@ function Add-PodeAuth
         }
         Success = @{
             Url = $SuccessUrl
+            UseOrigin = $SuccessUseOrigin
         }
     }
 
@@ -619,6 +626,9 @@ If supplied, groups will not be retrieved for the user in AD.
 .PARAMETER OpenLDAP
 If supplied, and on Windows, OpenLDAP will be used instead.
 
+.PARAMETER SuccessUseOrigin
+If supplied, successful authentication from a login page will redirect back to the originating page instead of the FailureUrl.
+
 .EXAMPLE
 New-PodeAuthScheme -Form | Add-PodeAuthWindowsAd -Name 'WinAuth'
 
@@ -684,7 +694,10 @@ function Add-PodeAuthWindowsAd
         $NoGroups,
 
         [switch]
-        $OpenLDAP
+        $OpenLDAP,
+
+        [switch]
+        $SuccessUseOrigin
     )
 
     # ensure the name doesn't already exist
@@ -744,6 +757,7 @@ function Add-PodeAuthWindowsAd
         }
         Success = @{
             Url = $SuccessUrl
+            UseOrigin = $SuccessUseOrigin
         }
     }
 }
@@ -879,6 +893,9 @@ If supplied, groups will not be retrieved for the user in AD.
 .PARAMETER NoLocalCheck
 If supplied, Pode will not at attempt to retrieve local User/Group information for the authenticated user.
 
+.PARAMETER SuccessUseOrigin
+If supplied, successful authentication from a login page will redirect back to the originating page instead of the FailureUrl.
+
 .EXAMPLE
 Add-PodeAuthIIS -Name 'IISAuth'
 
@@ -928,7 +945,10 @@ function Add-PodeAuthIIS
         $NoGroups,
 
         [switch]
-        $NoLocalCheck
+        $NoLocalCheck,
+
+        [switch]
+        $SuccessUseOrigin
     )
 
     # ensure we're on Windows!
@@ -975,6 +995,7 @@ function Add-PodeAuthIIS
         -FailureMessage $FailureMessage `
         -SuccessUrl $SuccessUrl `
         -Sessionless:$Sessionless `
+        -SuccessUseOrigin:$SuccessUseOrigin `
         -ArgumentList @{
             Users = $Users
             Groups = $Groups
@@ -1027,6 +1048,9 @@ Optional ScriptBlock that is passed the found user object for further validation
 .PARAMETER Sessionless
 If supplied, authenticated users will not be stored in sessions, and sessions will not be used.
 
+.PARAMETER SuccessUseOrigin
+If supplied, successful authentication from a login page will redirect back to the originating page instead of the FailureUrl.
+
 .EXAMPLE
 New-PodeAuthScheme -Form | Add-PodeAuthUserFile -Name 'Login'
 
@@ -1078,7 +1102,10 @@ function Add-PodeAuthUserFile
         $ScriptBlock,
 
         [switch]
-        $Sessionless
+        $Sessionless,
+
+        [switch]
+        $SuccessUseOrigin
     )
 
     # ensure the name doesn't already exist
@@ -1135,6 +1162,7 @@ function Add-PodeAuthUserFile
         }
         Success = @{
             Url = $SuccessUrl
+            UseOrigin = $SuccessUseOrigin
         }
     }
 }
@@ -1175,6 +1203,9 @@ If supplied, authenticated users will not be stored in sessions, and sessions wi
 
 .PARAMETER NoGroups
 If supplied, groups will not be retrieved for the user.
+
+.PARAMETER SuccessUseOrigin
+If supplied, successful authentication from a login page will redirect back to the originating page instead of the FailureUrl.
 
 .EXAMPLE
 New-PodeAuthScheme -Form | Add-PodeAuthWindowsLocal -Name 'WinAuth'
@@ -1226,7 +1257,10 @@ function Add-PodeAuthWindowsLocal
 
         [Parameter(ParameterSetName='NoGroups')]
         [switch]
-        $NoGroups
+        $NoGroups,
+
+        [switch]
+        $SuccessUseOrigin
     )
 
     # ensure we're on Windows!
@@ -1274,6 +1308,7 @@ function Add-PodeAuthWindowsLocal
         }
         Success = @{
             Url = $SuccessUrl
+            UseOrigin = $SuccessUseOrigin
         }
     }
 }

--- a/src/Public/Cookies.ps1
+++ b/src/Public/Cookies.ps1
@@ -160,6 +160,46 @@ function Get-PodeCookie
 
 <#
 .SYNOPSIS
+Retrieves the value of a cookie from the Request.
+
+.DESCRIPTION
+Retrieves the value of a cookie from the Request, with the option to supply a secret to unsign the cookie's value.
+
+.PARAMETER Name
+The name of the cookie to retrieve.
+
+.PARAMETER Secret
+The secret used to unsign the cookie's value.
+
+.EXAMPLE
+Get-PodeCookieValue -Name 'Views'
+
+.EXAMPLE
+Get-PodeCookieValue -Name 'Views' -Secret 'hunter2'
+#>
+function Get-PodeCookieValue
+{
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Name,
+
+        [Parameter()]
+        [string]
+        $Secret
+    )
+
+    $cookie = Get-PodeCookie -Name $Name -Secret $Secret
+    if ($null -eq $cookie) {
+        return $null
+    }
+
+    return $cookie.Value
+}
+
+<#
+.SYNOPSIS
 Tests if a cookie exists on the Request.
 
 .DESCRIPTION


### PR DESCRIPTION
### Description of the Change
Adds support for login pages to redirect back to the originating page, rather than the FailureUrl path. This can be enabled by passing `-SuccessUseOrigin` to `Add-PodeAuth`.

For example:
* `-FailureUrl` is `/`
* User navigates to `/about`, which redirects to `/login`
* User logs in, and is redirected back to `/about` instead of `/`

### Related Issue
Resolves #684 

### Examples
```powershell
New-PodeAuthScheme -Form | Add-PodeAuth -Name Example -SuccessUseOrigin -ScriptBlock {
    # ...
}
```
