### PR TITLE
Only map the AccessToken from WinIdentity

### DIFF
--- a/src/Private/Authentication.ps1
+++ b/src/Private/Authentication.ps1
@@ -723,7 +723,9 @@ function Get-PodeAuthWindowsADIISMethod
             # create base user object
             $user = @{
                 UserType = 'Domain'
-                Identity = $winIdentity
+                Identity = @{
+                    AccessToken = $winIdentity.AccessToken
+                }
                 AuthenticationType = $winIdentity.AuthenticationType
                 DistinguishedName = [string]::Empty
                 Username = $username


### PR DESCRIPTION
### Description of the Change
A fix for IIS authentication where the WinIdentity object could be huge at times, and if the server was using sessions it would cause massive memory build up and high CPU.

The fix is to only map the AccessToken of the WinIdentity, instead of the whole object.

### Related Issue
Resolves #690
