### PR TITLE
Add support for custom signal routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Then navigate to `http://127.0.0.1:8000` in your browser.
 * OpenAPI, Swagger, and ReDoc support
 * Listen on a single or multiple IP address/hostnames
 * Cross-platform support for HTTP, HTTPS, TCP and SMTP
-* Cross-platform support for server-to-client WebSockets, including secure WebSockets
+* Cross-platform support for WebSockets, including secure WebSockets
 * Host REST APIs, Web Pages, and Static Content (with caching)
 * Support for custom error pages
 * Request and Response compression using GZip/Deflate

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,7 +19,7 @@ Pode is a Cross-Platform framework to create web servers that host REST APIs, We
 * OpenAPI, Swagger, and ReDoc support
 * Listen on a single or multiple IP address/hostnames
 * Cross-platform support for HTTP, HTTPS, TCP and SMTP
-* Cross-platform support for server-to-client WebSockets, including secure WebSockets
+* Cross-platform support for WebSockets, including secure WebSockets
 * Host REST APIs, Web Pages, and Static Content (with caching)
 * Support for custom error pages
 * Request and Response compression using GZip/Deflate

--- a/examples/web-signal.ps1
+++ b/examples/web-signal.ps1
@@ -23,4 +23,15 @@ Start-PodeServer -Threads 5 {
     Add-PodeRoute -Method Get -Path '/' -ScriptBlock {
         Write-PodeViewResponse -Path 'websockets'
     }
+
+    # SIGNAL route, to return current date
+    Add-PodeSignalRoute -Path '/' -ScriptBlock {
+        $msg = $SignalEvent.Data.Message
+
+        if ($msg -ieq '[date]') {
+            $msg = [datetime]::Now.ToString()
+        }
+
+        Send-PodeSignal -Value $msg -Path $SignalEvent.Data.Path -ClientId $SignalEvent.Data.ClientId
+    }
 }

--- a/packers/choco/pode.nuspec
+++ b/packers/choco/pode.nuspec
@@ -19,7 +19,7 @@ Pode is a Cross-Platform framework for creating web servers to host REST APIs an
 * OpenAPI, Swagger, and ReDoc support
 * Listen on a single or multiple IP address/hostnames
 * Cross-platform support for HTTP, HTTPS, TCP and SMTP
-* Cross-platform support for server-to-client WebSockets, including secure WebSockets
+* Cross-platform support for WebSockets, including secure WebSockets
 * Host REST APIs, Web Pages, and Static Content (with caching)
 * Support for custom error pages
 * Request and Response compression using GZip/Deflate

--- a/src/Listener/PodeContext.cs
+++ b/src/Listener/PodeContext.cs
@@ -295,8 +295,7 @@ namespace Pode
             // add open web socket to listener
             var webSocket = new PodeWebSocket(this, HttpRequest.Url.AbsolutePath, clientId);
 
-            var wsRequest = new PodeWsRequest(HttpRequest);
-            wsRequest.WebSocket = webSocket;
+            var wsRequest = new PodeWsRequest(HttpRequest, webSocket);
             Request = wsRequest;
 
             Listener.AddWebSocket(WsRequest.WebSocket);

--- a/src/Listener/PodeWsRequest.cs
+++ b/src/Listener/PodeWsRequest.cs
@@ -8,7 +8,10 @@ namespace Pode
         public PodeWsOpCode OpCode { get; private set; }
         public string Body { get; private set; }
         public byte[] RawBody { get; private set; }
-        public PodeWebSocket WebSocket { get; set; }
+        public PodeWebSocket WebSocket { get; private set; }
+        public Uri Url { get; private set; }
+        public string Host { get; private set; }
+        public int ContentLength { get; private set; }
 
         private WebSocketCloseStatus _closeStatus = WebSocketCloseStatus.Empty;
         public WebSocketCloseStatus CloseStatus
@@ -27,10 +30,15 @@ namespace Pode
             get => (OpCode == PodeWsOpCode.Close);
         }
 
-        public PodeWsRequest(PodeRequest request)
+        public PodeWsRequest(PodeHttpRequest request, PodeWebSocket webSocket)
             : base(request)
         {
+            WebSocket = webSocket;
             IsKeepAlive = true;
+
+            var _proto = (IsSsl ? "wss" : "ws");
+            Host = request.Host;
+            Url = new Uri($"{_proto}://{request.Url.Authority}{request.Url.PathAndQuery}");
         }
 
         public PodeClientSignal NewClientSignal()
@@ -74,6 +82,7 @@ namespace Pode
 
             // set the raw/body
             RawBody = bytes;
+            ContentLength = RawBody.Length;
             Body = Encoding.GetString(decoded);
 
             // get the close status and description

--- a/src/Pode.psd1
+++ b/src/Pode.psd1
@@ -118,14 +118,18 @@
         # routes
         'Add-PodeRoute',
         'Add-PodeStaticRoute',
+        'Add-PodeSignalRoute',
         'Remove-PodeRoute',
         'Remove-PodeStaticRoute',
+        'Remove-PodeSignalRoute',
         'Clear-PodeRoutes',
         'Clear-PodeStaticRoutes',
+        'Clear-PodeSignalRoutes',
         'ConvertTo-PodeRoute',
         'Add-PodePage',
         'Get-PodeRoute',
         'Get-PodeStaticRoute',
+        'Get-PodeSignalRoute',
 
         # handlers
         'Add-PodeHandler',
@@ -224,6 +228,7 @@
         'Get-PodeServerUptime',
         'Get-PodeServerRestartCount',
         'Get-PodeServerRequestMetric',
+        'Get-PodeServerSignalMetric',
 
         # AutoImport
         'Export-PodeModule',

--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -216,17 +216,18 @@ function New-PodeContext
 
     # routes for pages and api
     $ctx.Server.Routes = @{
-        'delete' = @{};
-        'get' = @{};
-        'head' = @{};
-        'merge' = @{};
-        'options' = @{};
-        'patch' = @{};
-        'post' = @{};
-        'put' = @{};
-        'trace' = @{};
-        'static' = @{};
-        '*' = @{};
+        'delete'    = @{}
+        'get'       = @{}
+        'head'      = @{}
+        'merge'     = @{}
+        'options'   = @{}
+        'patch'     = @{}
+        'post'      = @{}
+        'put'       = @{}
+        'trace'     = @{}
+        'static'    = @{}
+        'signal'    = @{}
+        '*'         = @{}
     }
 
     # custom view paths
@@ -273,6 +274,9 @@ function New-PodeContext
         Requests = @{
             Total = 0
             StatusCodes = @{}
+        }
+        Signals = @{
+            Total = 0
         }
     }
 

--- a/src/Private/Metrics.ps1
+++ b/src/Private/Metrics.ps1
@@ -32,3 +32,29 @@ function Update-PodeServerRequestMetrics
         }
     }
 }
+
+function Update-PodeServerSignalMetrics
+{
+    param(
+        [Parameter()]
+        [hashtable]
+        $SignalEvent
+    )
+
+    if ($null -eq $SignalEvent) {
+        return
+    }
+
+    # metrics to update
+    $metrics = @($PodeContext.Metrics.Signals)
+    if ($null -ne $SignalEvent.Route) {
+        $metrics += $SignalEvent.Route.Metrics.Requests
+    }
+
+    # increment the request metrics
+    foreach ($metric in $metrics) {
+        Lock-PodeObject -Object $metric -ScriptBlock {
+            $metric.Total++
+        }
+    }
+}

--- a/src/Private/Routes.ps1
+++ b/src/Private/Routes.ps1
@@ -2,7 +2,7 @@ function Test-PodeRoute
 {
     param (
         [Parameter(Mandatory=$true)]
-        [ValidateSet('DELETE', 'GET', 'HEAD', 'MERGE', 'OPTIONS', 'PATCH', 'POST', 'PUT', 'TRACE', 'STATIC', '*')]
+        [ValidateSet('DELETE', 'GET', 'HEAD', 'MERGE', 'OPTIONS', 'PATCH', 'POST', 'PUT', 'TRACE', 'STATIC', 'SIGNAL', '*')]
         [string]
         $Method,
 
@@ -27,7 +27,7 @@ function Find-PodeRoute
 {
     param (
         [Parameter(Mandatory=$true)]
-        [ValidateSet('DELETE', 'GET', 'HEAD', 'MERGE', 'OPTIONS', 'PATCH', 'POST', 'PUT', 'TRACE', 'STATIC', '*')]
+        [ValidateSet('DELETE', 'GET', 'HEAD', 'MERGE', 'OPTIONS', 'PATCH', 'POST', 'PUT', 'TRACE', 'STATIC', 'SIGNAL', '*')]
         [string]
         $Method,
 
@@ -187,6 +187,22 @@ function Find-PodeStaticRoute
         }
         Route = $found
     }
+}
+
+function Find-PodeSignalRoute
+{
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Path,
+
+        [Parameter()]
+        [string]
+        $EndpointName
+    )
+
+    # attempt to get a signal route for the path
+    return (Find-PodeRoute -Method 'signal' -Path $Path -EndpointName $EndpointName)
 }
 
 function Test-PodeRouteValidForCaching

--- a/src/Private/SignalServer.ps1
+++ b/src/Private/SignalServer.ps1
@@ -177,7 +177,7 @@ function Start-PodeSignalServer
                         Invoke-PodeScriptBlock -ScriptBlock $SignalEvent.Route.Logic -Arguments $_args -Scoped -Splat
                     }
                     else {
-                        Send-PodeSignal -Value $SignalEvent.Message -Path $SignalEvent.Path -ClientId $SignalEvent.ClientId
+                        Send-PodeSignal -Value $SignalEvent.Data.Message -Path $SignalEvent.Data.Path -ClientId $SignalEvent.Data.ClientId
                     }
                 }
                 catch [System.OperationCanceledException] {}

--- a/src/Public/Metrics.ps1
+++ b/src/Public/Metrics.ps1
@@ -98,3 +98,21 @@ function Get-PodeServerRequestMetric
 
     return $PodeContext.Metrics.Requests.StatusCodes[$strCode]
 }
+
+<#
+.SYNOPSIS
+Returns the total number of Signal requests the Server has receieved.
+
+.DESCRIPTION
+Returns the total number of Signal requests the Server has receieved.
+
+.EXAMPLE
+$totalReqs = Get-PodeServerSignalMetric
+#>
+function Get-PodeServerSignalMetric
+{
+    [CmdletBinding()]
+    param()
+
+    return $PodeContext.Metrics.Signals.Total
+}


### PR DESCRIPTION
### Description of the Change
Adds support for custom signal routes on client messages - so they can be parsed/customised and then `Send-PodeSignal` to re-broadcast messages to back to other clients.

### Related Issue
Resolves #711 

### Examples
If relevant, include any examples of using what you have changed.
```powershell
Add-PodeSignalRoute -Path '/' -ScriptBlock {
    $msg = $SignalEvent.Data.Message

    if ($msg -ieq '[date]') {
        $msg = [datetime]::Now.ToString()
    }

    Send-PodeSignal -Value $msg -Path $SignalEvent.Data.Path -ClientId $SignalEvent.Data.ClientId
}
```