### PR TITLE
Don't set Console:TreatControlC when in PS ISE

### DIFF
--- a/src/Public/Core.ps1
+++ b/src/Public/Core.ps1
@@ -153,7 +153,7 @@ function Start-PodeServer
             -Quiet:$Quiet
 
         # set it so ctrl-c can terminate, unless serverless/iis, or disabled
-        if (!$PodeContext.Server.DisableTermination) {
+        if (!$PodeContext.Server.DisableTermination -and ($null -eq $psISE)) {
             [Console]::TreatControlCAsInput = $true
         }
 


### PR DESCRIPTION
### Description of the Change
When running in the PS ISE, skip setting `[Console]::TreatControlCAsInput` otherwise it'll throw an error. From testing, Ctrl+C still works.

### Related Issue
Resolves #720 
