### PR TITLE
Add support for logging to the Event Viewer

### DIFF
--- a/docs/Tutorials/Logging/Methods/EventViewer.md
+++ b/docs/Tutorials/Logging/Methods/EventViewer.md
@@ -1,0 +1,43 @@
+# Event Viewer
+
+You can log items to the Windows Event Viewer, using Pode's unbuilt Event Viewer logging logic. You can log anything, but it's best to use this in conjunction with [`Enable-PodeErrorLogging`](../../../../Functions/Logging/Enable-PodeErrorLogging) and [`Write-PodeErrorLog`](../../../../Functions/Logging/Write-PodeErrorLog).
+
+Errors will be logged using an appropriate error level, but other log items will be logged as Informational by default.
+
+By default, Pode will log to the Application log with a source of Pode, and an Event ID of 0.
+
+## Usage
+
+When using this log method, Pode will first check if the source exists, and will then attempt to create it. To do this, you will need to be running Pode as an administrator.
+
+If however you're running Pode locally, or in a situation where you can't run Pode as a full admin - like in IIS - then you will first have to create the source yourself manually. Assuming a source of `Pode` and in the `Application` log, you can use the following:
+
+```powershell
+[System.Diagnostics.EventLog]::CreateEventSource('Pode', 'Application')
+```
+
+Once the source is created, Pode can log to the Event Viewer without being an admin!
+
+To enable and log errors to the Event Viewer, the following will work:
+
+```powershell
+New-PodeLoggingMethod -EventViewer | Enable-PodeErrorLogging
+```
+
+This will log to the `Application` log using `Pode` as the source.
+
+## Event Log
+
+To log to a different event log, other than Application, you can specify the log via `-EventLogName`:
+
+```powershell
+New-PodeLoggingMethod -EventViewer -EventLogName SomeLogName | Enable-PodeErrorLogging
+```
+
+## Event Source
+
+To log using a different source, other than Pode, you can specify the source via `-Source`:
+
+```powershell
+New-PodeLoggingMethod -EventViewer -Source WebsiteName | Enable-PodeErrorLogging
+```

--- a/docs/Tutorials/Logging/Overview.md
+++ b/docs/Tutorials/Logging/Overview.md
@@ -2,12 +2,12 @@
 
 There are two aspects to logging in Pode: Methods and Types.
 
-* Methods define how log items should be recorded, such as to a file or terminal.
+* Methods define how log items should be recorded, such as to a file, terminal, or event viewer.
 * Types define how items to log are transformed, and what should be supplied to the Method.
 
 For example when you supply an Exception to [`Write-PodeErrorLog`](../../../Functions/Logging/Write-PodeErrorLog), this Exception is first supplied to Pode's inbuilt Error logging type. This type transforms any Exception (or Error Record) into a string which can then be supplied to the File logging method.
 
-In Pode you can use File, Terminal or a Custom method. As well as Request, Error, or a Custom type.
+In Pode you can use File, Terminal, Event Viewer, or a Custom method. As well as Request, Error, or a Custom type.
 
 This means you could write a logging method to output to an S3 bucket, Splunk, or any other logging platform.
 


### PR DESCRIPTION
### Description of the Change
Adds support for logging to Windows Event Viewer. This works in PS5.1, 6 and 7, and requires the server to be running as an admin if a new source has to be created. For scenarios where admin isn't possible, a source should be created manually first and Pode can log freely to the Event Viewer.

When using Event Viewer with Error logging, the entries will have an appropriate log level; other entries are defaulted to Informational.

The Log, Source and EventID can be customised, but they are defaulted to Application, Pode, and 0 respectively.

### Related Issue
Resolves #723 

### Examples
```powershell
New-PodeLoggingMethod -EventViewer | Enable-PodeErrorLogging
```
