### PR TITLE
Allow referencing component schemas in component schemas

### DIFF
--- a/src/Pode.psd1
+++ b/src/Pode.psd1
@@ -220,6 +220,7 @@
         'New-PodeOAStringProperty',
         'New-PodeOABoolProperty',
         'New-PodeOAObjectProperty',
+        'New-PodeOASchemaProperty',
         'ConvertTo-PodeOAParameter',
         'Set-PodeOARouteInfo',
         'Enable-PodeOpenApiViewer',

--- a/src/Private/OpenApi.ps1
+++ b/src/Private/OpenApi.ps1
@@ -124,18 +124,17 @@ function ConvertTo-PodeOASchemaProperty
         $Property
     )
 
-    # schema refs
-    if($Property['$ref']) {
-        $schema = @{ 
-            '$ref' = $Property['$ref']
-        };
-        return $schema;
-    }
-
     # base schema type
     $schema = @{
         type = $Property.type
         format = $Property.format
+    }
+
+    # schema refs
+    if($Property.type -ieq 'schema') {
+        $schema = @{ 
+            '$ref' = "#components/schemas/$($Property['schema'])"
+        }
     }
 
     # are we using an array?

--- a/src/Private/OpenApi.ps1
+++ b/src/Private/OpenApi.ps1
@@ -124,6 +124,14 @@ function ConvertTo-PodeOASchemaProperty
         $Property
     )
 
+    # schema refs
+    if($Property['$ref']) {
+        $schema = @{ 
+            '$ref' = $Property['$ref']
+        };
+        return $schema;
+    }
+
     # base schema type
     $schema = @{
         type = $Property.type

--- a/src/Public/OpenApi.ps1
+++ b/src/Public/OpenApi.ps1
@@ -1221,7 +1221,7 @@ function New-PodeOAObjectProperty
 
 <#
 .SYNOPSIS
-Creates a OpenAPI reference property.
+Creates a OpenAPI schema reference property.
 
 .DESCRIPTION
 Creates a new OpenAPI schema reference from another OpenAPI schema.
@@ -1261,6 +1261,7 @@ function New-PodeOASchemaProperty
 
     $param = @{
         name = $Name
+        description = $Description
         '$ref' = "#/components/schemas/$ComponentSchema"
     }
 

--- a/src/Public/OpenApi.ps1
+++ b/src/Public/OpenApi.ps1
@@ -1255,14 +1255,15 @@ function New-PodeOASchemaProperty
         $Description
     )
 
-    if(!(Test-PodeOAComponentSchema -Name $ComponentSchema)) {
+    if(!(Test-PodeOAComponentSchema -Name $Reference)) {
         throw "The OpenApi component schema doesn't exist: $($Reference)"
     }
 
     $param = @{
+        type = 'schema'
         name = $Name
         description = $Description
-        '$ref' = "#/components/schemas/$ComponentSchema"
+        schema = $Reference
     }
 
     return $param

--- a/src/Public/OpenApi.ps1
+++ b/src/Public/OpenApi.ps1
@@ -1229,7 +1229,7 @@ Creates a new OpenAPI schema reference from another OpenAPI schema.
 .PARAMETER Name
 The Name of the property.
 
-.PARAMETER ComponentSchema
+.PARAMETER Reference
 An component schema name.
 
 .PARAMETER Description
@@ -1246,17 +1246,17 @@ function New-PodeOASchemaProperty
         [string]
         $Name,
 
-        [Parameter(Mandatory=$true, ParameterSetName = 'ComponentSchema')]
+        [Parameter(Mandatory=$true)]
         [string]
-        $ComponentSchema,
+        $Reference,
 
         [Parameter()]
         [string]
         $Description
     )
 
-    if(-not (Test-PodeOAComponentSchema -Name $ComponentSchema)) {
-        throw "Could not find component schema $ComponentSchema";
+    if(!(Test-PodeOAComponentSchema -Name $ComponentSchema)) {
+        throw "The OpenApi component schema doesn't exist: $($Reference)"
     }
 
     $param = @{

--- a/src/Public/OpenApi.ps1
+++ b/src/Public/OpenApi.ps1
@@ -1235,6 +1235,9 @@ An component schema name.
 .PARAMETER Description
 A Description of the property.
 
+.PARAMETER Array
+If supplied, the schema reference will be treated as an array.
+
 .EXAMPLE
 New-PodeOASchemaProperty -Name 'Config' -ComponentSchema "MyConfigSchema"
 #>
@@ -1252,7 +1255,10 @@ function New-PodeOASchemaProperty
 
         [Parameter()]
         [string]
-        $Description
+        $Description,
+
+        [switch]
+        $Array
     )
 
     if(!(Test-PodeOAComponentSchema -Name $Reference)) {
@@ -1260,10 +1266,11 @@ function New-PodeOASchemaProperty
     }
 
     $param = @{
-        type = 'schema'
         name = $Name
-        description = $Description
+        type = 'schema'
         schema = $Reference
+        array = $Array.IsPresent
+        description = $Description
     }
 
     return $param

--- a/src/Public/OpenApi.ps1
+++ b/src/Public/OpenApi.ps1
@@ -1221,6 +1221,54 @@ function New-PodeOAObjectProperty
 
 <#
 .SYNOPSIS
+Creates a OpenAPI reference property.
+
+.DESCRIPTION
+Creates a new OpenAPI schema reference from another OpenAPI schema.
+
+.PARAMETER Name
+The Name of the property.
+
+.PARAMETER ComponentSchema
+An component schema name.
+
+.PARAMETER Description
+A Description of the property.
+
+.EXAMPLE
+New-PodeOASchemaProperty -Name 'Config' -ComponentSchema "MyConfigSchema"
+#>
+function New-PodeOASchemaProperty
+{
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [string]
+        $Name,
+
+        [Parameter(Mandatory=$true, ParameterSetName = 'ComponentSchema')]
+        [string]
+        $ComponentSchema,
+
+        [Parameter()]
+        [string]
+        $Description
+    )
+
+    if(-not (Test-PodeOAComponentSchema -Name $ComponentSchema)) {
+        throw "Could not find component schema $ComponentSchema";
+    }
+
+    $param = @{
+        name = $Name
+        '$ref' = "#/components/schemas/$ComponentSchema"
+    }
+
+    return $param
+}
+
+<#
+.SYNOPSIS
 Converts an OpenAPI property into a Request Parameter.
 
 .DESCRIPTION


### PR DESCRIPTION
### Description of the Change
I added a cmdlet `New-PodeOASchemaProperty` which allows to create $refs to component schemas.

### Related Issue
No related issue, I'm doing unsolicited PRs again - sorry.

### Examples
Can be used like this:

```
Add-PodeOAComponentSchema -Name "ManagedOrganizationUnitConfiguration" -Schema (
    New-PodeOAObjectProperty -Properties @(
        (New-PodeOABoolProperty -Name "AllowBatchCreation"),
        (New-PodeOABoolProperty -Name "CheckForDuplicates"),
    ));

Add-PodeOAComponentSchema -Name "ManagedOrganizationalUnitsResponse" -Schema (
    New-PodeOAObjectProperty -Properties @(
        (New-PodeOAStringProperty -Name "Uuid" -Required),
        (New-PodeOAStringProperty -Name "Name" -Required),
        (New-PodeOASchemaProperty -Name "Config" -Reference "ManagedOrganizationUnitConfiguration")
    ));
```

### Additional Context
I'm not completely sure about my changes in /private/OpenApi.ps1, but my swagger file looked correct (just a small excerpt):
```
"ManagedOrganizationalUnitsResponse": {
  "properties": {
    "Uuid": {
      "type": "string",
      "format": ""
    },
    "Name": {
      "type": "string",
      "format": ""
    },
    "Config": {
      "$ref": "#/components/schemas/ManagedOrganizationUnitConfiguration"
    },
}
```
