### PR TITLE
Adds new Alpine docker image, and bumps images to 7.1.3

### DIFF
--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -1,4 +1,4 @@
-FROM badgerati/ps-core:7.1.3-arm32
+FROM mcr.microsoft.com/powershell:7.1.3-alpine-3.12-20210316
 LABEL maintainer="Matthew Kelly (Badgerati)"
 RUN mkdir -p /usr/local/share/powershell/Modules/Pode
 COPY ./pkg/ /usr/local/share/powershell/Modules/Pode

--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/powershell:7.1.3-ubuntu-18.04
+FROM badgerati/ps-core:7.1.3-arm32
 LABEL maintainer="Matthew Kelly (Badgerati)"
 RUN mkdir -p /usr/local/share/powershell/Modules/Pode
 COPY ./pkg/ /usr/local/share/powershell/Modules/Pode

--- a/arm32.dockerfile
+++ b/arm32.dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/powershell:7.1.3-alpine-3.12-20210316
+FROM mcr.microsoft.com/powershell:7.1.3-arm32v7-ubuntu-18.04-20210316
 LABEL maintainer="Matthew Kelly (Badgerati)"
 RUN mkdir -p /usr/local/share/powershell/Modules/Pode
 COPY ./pkg/ /usr/local/share/powershell/Modules/Pode

--- a/arm32.dockerfile
+++ b/arm32.dockerfile
@@ -1,4 +1,4 @@
-FROM badgerati/ps-core:7.1.1-arm32
+FROM mcr.microsoft.com/powershell:7.1.3-alpine-3.12-20210316
 LABEL maintainer="Matthew Kelly (Badgerati)"
 RUN mkdir -p /usr/local/share/powershell/Modules/Pode
 COPY ./pkg/ /usr/local/share/powershell/Modules/Pode

--- a/docs/Getting-Started/Installation.md
+++ b/docs/Getting-Started/Installation.md
@@ -41,7 +41,7 @@ Install-Module -Name Pode
 [![Docker](https://img.shields.io/docker/stars/badgerati/pode.svg?label=Stars)](https://hub.docker.com/r/badgerati/pode/)
 [![Docker](https://img.shields.io/docker/pulls/badgerati/pode.svg?label=Pulls)](https://hub.docker.com/r/badgerati/pode/)
 
-Pode can run on *nix environments, therefore it only makes sense for there to be Docker images for you to use! The images use PowerShell v7.1.1 on either an Ubuntu Bionic image (default), or an ARM32 image (for Raspberry Pis).
+Pode can run on *nix environments, therefore it only makes sense for there to be Docker images for you to use! The images use PowerShell v7.1.3 on either an Ubuntu Bionic image (default), an Alpine image, or an ARM32 image (for Raspberry Pis).
 
 * To pull down the latest Pode image you can do:
 
@@ -50,7 +50,17 @@ Pode can run on *nix environments, therefore it only makes sense for there to be
 docker pull badgerati/pode:latest
 
 # or the following for a specific version:
-docker pull badgerati/pode:2.1.0
+docker pull badgerati/pode:2.2.2
+```
+
+* To pull down the Alpine Pode image you can do:
+
+```powershell
+# for latest
+docker pull badgerati/pode:latest-alpine
+
+# or the following for a specific version:
+docker pull badgerati/pode:2.2.2-alpine
 ```
 
 * To pull down the ARM32 Pode image you can do:
@@ -60,7 +70,7 @@ docker pull badgerati/pode:2.1.0
 docker pull badgerati/pode:latest-arm32
 
 # or the following for a specific version:
-docker pull badgerati/pode:2.1.0-arm32
+docker pull badgerati/pode:2.2.2-arm32
 ```
 
 Once pulled, you can [view here](../Docker) on how to use the image.
@@ -76,7 +86,17 @@ You can also get the Pode docker image from the GitHub Package Registry! The ima
 docker pull docker.pkg.github.com/badgerati/pode/pode:latest
 
 # or the following for a specific version:
-docker pull docker.pkg.github.com/badgerati/pode/pode:2.1.0
+docker pull docker.pkg.github.com/badgerati/pode/pode:2.2.2
+```
+
+* To pull down the Alpine Pode image you can do:
+
+```powershell
+# for latest
+docker pull docker.pkg.github.com/badgerati/pode/pode:latest-apline
+
+# or the following for a specific version:
+docker pull docker.pkg.github.com/badgerati/pode/pode:2.2.2-alpine
 ```
 
 * To pull down the ARM32 Pode image you can do:
@@ -86,7 +106,7 @@ docker pull docker.pkg.github.com/badgerati/pode/pode:2.1.0
 docker pull docker.pkg.github.com/badgerati/pode/pode:latest-arm32
 
 # or the following for a specific version:
-docker pull docker.pkg.github.com/badgerati/pode/pode:2.1.0-arm32
+docker pull docker.pkg.github.com/badgerati/pode/pode:2.2.2-arm32
 ```
 
 Once pulled, you can [view here](../Docker) on how to use the image.

--- a/docs/Hosting/Docker.md
+++ b/docs/Hosting/Docker.md
@@ -2,7 +2,7 @@
 
 Pode has a Docker image that you can use to host your server, for instructions on pulling these images you can [look here](../../Installation).
 
-The images use PowerShell v7.1.1 on either an Ubuntu Bionic (default) or ARM32 image.
+The images use PowerShell v7.1.3 on either an Ubuntu Bionic (default), Alpine, or ARM32 image.
 
 ## Images
 
@@ -11,7 +11,7 @@ The images use PowerShell v7.1.1 on either an Ubuntu Bionic (default) or ARM32 i
 
 ### Default
 
-The default Pode image is an Ubuntu Bionic image with PowerShell v7.1.1 and Pode installed. An example of using this image in your Dockerfile could be as follows:
+The default Pode image is an Ubuntu Bionic image with PowerShell v7.1.3 and Pode installed. An example of using this image in your Dockerfile could be as follows:
 
 ```dockerfile
 # pull down the pode image

--- a/docs/Hosting/Docker.md
+++ b/docs/Hosting/Docker.md
@@ -30,6 +30,27 @@ EXPOSE 8085
 CMD [ "pwsh", "-c", "cd /usr/src/app; ./web-pages-docker.ps1" ]
 ```
 
+### Alpine
+
+Pode also has an image for Alpine, an example of using this image in your Dockerfile could be as follows:
+
+```dockerfile
+# pull down the pode image
+FROM badgerati/pode:latest-alpine
+
+# or use the following for GitHub
+# FROM docker.pkg.github.com/badgerati/pode/pode:latest-alpine
+
+# copy over the local files to the container
+COPY . /usr/src/app/
+
+# expose the port
+EXPOSE 8085
+
+# run the server
+CMD [ "pwsh", "-c", "cd /usr/src/app; ./web-pages-docker.ps1" ]
+```
+
 ### ARM32
 
 Pode also has an image for ARM32, meaning you can run Pode on Raspberry Pis. An example of using this image in your Dockerfile could be as follows:

--- a/packers/docker/arm32/Dockerfile
+++ b/packers/docker/arm32/Dockerfile
@@ -1,6 +1,6 @@
 FROM arm32v7/ubuntu:bionic
 
-ENV PS_VERSION=7.1.1
+ENV PS_VERSION=7.1.3
 ENV PS_PACKAGE=powershell-${PS_VERSION}-linux-arm32.tar.gz
 ENV PS_PACKAGE_URL=https://github.com/PowerShell/PowerShell/releases/download/v${PS_VERSION}/${PS_PACKAGE}
 


### PR DESCRIPTION
### Description of the Change
Bumps the docker images to use PowerShell 7.1.3, and changes the ARM32 image to use the now new official image from Microsoft.

Also, adds a new Alpine image.

### Related Issue
Resolves #726 
