### PR TITLE
Allow overriding Bearer/Digest Authorization tags

### DIFF
--- a/docs/Tutorials/Authentication/Methods/Basic.md
+++ b/docs/Tutorials/Authentication/Methods/Basic.md
@@ -18,7 +18,7 @@ Start-PodeServer {
 }
 ```
 
-By default, Pode will check if the Request's header contains an `Authorization` key, and whether the value of that key starts with `Basic`. The `New-PodeAuthScheme -Basic` function can be supplied parameters to customise this name, as well as the encoding.
+By default, Pode will check if the Request's header contains an `Authorization` key, and whether the value of that key starts with `Basic` tag. The `New-PodeAuthScheme -Basic` function can be supplied parameters to customise the tag using `-HeaderTag`, as well as the `-Encoding`.
 
 For example, to use `ASCII` encoding rather than the default `ISO-8859-1` you could do:
 

--- a/docs/Tutorials/Authentication/Methods/Bearer.md
+++ b/docs/Tutorials/Authentication/Methods/Bearer.md
@@ -18,7 +18,7 @@ Start-PodeServer {
 }
 ```
 
-By default, Pode will check if the Request's header contains an `Authorization` key, and whether the value of that key starts with `Bearer`.
+By default, Pode will check if the Request's header contains an `Authorization` key, and whether the value of that key starts with `Bearer` tag. The `New-PodeAuthScheme -Bearer` function can be supplied parameters to customise the tag using `-HeaderTag`.
 
 You can also optionally return a `Scope` property alongside the `User`. If you specify any scopes with [`New-PodeAuthScheme`](../../../../Functions/Authentication/New-PodeAuthScheme) then it will be validated in the Bearer's post validator - a 403 will be returned if the scope is invalid.
 

--- a/docs/Tutorials/Authentication/Methods/Digest.md
+++ b/docs/Tutorials/Authentication/Methods/Digest.md
@@ -20,9 +20,9 @@ Start-PodeServer {
 
 Unlike other forms of authentication where you only need return the User on success. Digest requires you to also return the Password of the user as a separate property. This password is what is used as the secret key to generate the client's response hash, and allows the server to re-generate the hash for validation. (Not returning the password will result in an HTTP 401 challenge response).
 
-By default, Pode will check if the Request's header contains an `Authorization` key, and whether the value of that key starts with `Digest`. Pode will also gather the rest of the parameters in the header such as the Nonce, NonceCount, etc. An HTTP 401 challenge will be sent back if the Authorization header is invalid.
+By default, Pode will check if the Request's header contains an `Authorization` key, and whether the value of that key starts with `Digest` tag. The `New-PodeAuthScheme -Digest` function can be supplied parameters to customise the tag using `-HeaderTag`. Pode will also gather the rest of the parameters in the header such as the Nonce, NonceCount, etc. An HTTP 401 challenge will be sent back if the Authorization header is invalid.
 
-The HashTable of parameters sent to the [`Add-PodeAuth`](../../../../Functions/Authentication/Add-PodeAuth) functions's ScriptBlock are the following:
+The HashTable of parameters sent to the [`Add-PodeAuth`](../../../../Functions/Authentication/Add-PodeAuth) function's ScriptBlock are the following:
 
 | Parameter | Description |
 | --------- | ----------- |

--- a/src/Private/Authentication.ps1
+++ b/src/Private/Authentication.ps1
@@ -255,9 +255,9 @@ function Get-PodeAuthBearerType
             }
         }
 
-        if ($atoms[0] -ine 'Bearer') {
+        if ($atoms[0] -ine $options.HeaderTag) {
             return @{
-                Message = 'Authorization header is not Bearer'
+                Message = "Authorization header is not $($options.HeaderTag)"
                 Challenge = (New-PodeAuthBearerChallenge -Scopes $options.Scopes -ErrorType invalid_request)
                 Code = 400
             }
@@ -375,9 +375,9 @@ function Get-PodeAuthDigestType
             }
         }
 
-        if ($atoms[0] -ine 'Digest') {
+        if ($atoms[0] -ine $options.HeaderTag) {
             return @{
-                Message = 'Authorization header is not Digest'
+                Message = "Authorization header is not $($options.HeaderTag)"
                 Challenge = (New-PodeAuthDigestChallenge)
                 Code = 401
             }

--- a/src/Public/Authentication.ps1
+++ b/src/Public/Authentication.ps1
@@ -12,7 +12,7 @@ If supplied, will use the inbuilt Basic Authentication credentials retriever.
 The Encoding to use when decoding the Basic Authorization header.
 
 .PARAMETER HeaderTag
-The name of the type of Basic Authentication.
+The Tag name used in the Authorization header, ie: Basic, Bearer, Digest.
 
 .PARAMETER Form
 If supplied, will use the inbuilt Form Authentication credentials retriever.
@@ -103,8 +103,10 @@ function New-PodeAuthScheme
         $Encoding = 'ISO-8859-1',
 
         [Parameter(ParameterSetName='Basic')]
+        [Parameter(ParameterSetName='Bearer')]
+        [Parameter(ParameterSetName='Digest')]
         [string]
-        $HeaderTag = 'Basic',
+        $HeaderTag,
 
         [Parameter(ParameterSetName='Form')]
         [switch]
@@ -256,7 +258,9 @@ function New-PodeAuthScheme
                 }
                 InnerScheme = $InnerScheme
                 Scheme = 'http'
-                Arguments = @{}
+                Arguments = @{
+                    HeaderTag = (Protect-PodeValue -Value $HeaderTag -Default 'Digest')
+                }
             }
         }
 
@@ -275,6 +279,7 @@ function New-PodeAuthScheme
                 Scheme = 'http'
                 InnerScheme = $InnerScheme
                 Arguments = @{
+                    HeaderTag = (Protect-PodeValue -Value $HeaderTag -Default 'Bearer')
                     Scopes = $Scope
                 }
             }


### PR DESCRIPTION
### Description of the Change
Allows for the changing of the Bearer and Digest header tags.

### Related Issue
Resolves #732 

### Examples
```powershell
New-PodeAuthScheme -Bearer -HeaderTag 'api-key'
```
