### PR TITLE
Reset the body to empty on new requests

### DIFF
--- a/src/Listener/PodeHttpRequest.cs
+++ b/src/Listener/PodeHttpRequest.cs
@@ -45,7 +45,7 @@ namespace Pode
         {
             get
             {
-                if (RawBody.Length > 0)
+                if (RawBody != default(byte[]) && RawBody.Length > 0)
                 {
                     _body = Encoding.GetString(RawBody);
                 }
@@ -187,6 +187,7 @@ namespace Pode
         {
             // reset raw body
             RawBody = default(byte[]);
+            _body = string.Empty;
 
             // first line is method/url
             var reqMeta = Regex.Split(reqLines[0].Trim(), "\\s+");


### PR DESCRIPTION
### Description of the Change
Fixes an issue with KeepAlive requests not resetting body content.

### Related Issue
Resolves #738 
