### PR TITLE
Add helper function Use-PodeRoutes to auto-load files containing routes

### DIFF
--- a/docs/Tutorials/Routes/Overview.md
+++ b/docs/Tutorials/Routes/Overview.md
@@ -34,6 +34,8 @@ Here, anyone who calls `http://localhost:8080/ping` will receive the following r
 
 The scriptblock for the route will have access to the `$WebEvent` variable which contains information about the current [web event](../../WebEvent). This argument will contain the `Request` and `Response` objects, `Data` (from POST), and the `Query` (from the query string of the URL), as well as any `Parameters` from the route itself (eg: `/:accountId`).
 
+You can add your routes straight into the [`Start-PodeServer`](../../../Functions/Core/Start-PodeServer) scriptblock, or separate them into different files. These files can then be dot-sourced, or you can use [`Use-PodeRoutes`](../../../Functions/Routes/Use-PodeRoutes) to automatically load all ps1 files within a `/routes` directory at the root of your server.
+
 ## Payloads
 
 The following is an example of using data from a request's payload - ie, the data in the body of POST request. To retrieve values from the payload you can use the `.Data` property on the `$WebEvent` variable to a route's logic.

--- a/examples/routes/route.ps1
+++ b/examples/routes/route.ps1
@@ -1,0 +1,3 @@
+Add-PodeRoute -Method Get -Path '/route-file' -ScriptBlock {
+    Write-PodeJsonResponse -Value @{ Message = "I'm from a route file!" }
+}

--- a/examples/web-pages.ps1
+++ b/examples/web-pages.ps1
@@ -47,6 +47,8 @@ Start-PodeServer -Threads 2 {
         }
     }
 
+    Use-PodeRoutes -Path './routes'
+
     # GET request for web page on "localhost:8085/"
     Add-PodeRoute -Method Get -Path '/' -ScriptBlock {
         # $WebEvent.Request | Write-PodeLog -Name 'custom'

--- a/src/Pode.psd1
+++ b/src/Pode.psd1
@@ -130,6 +130,7 @@
         'Get-PodeRoute',
         'Get-PodeStaticRoute',
         'Get-PodeSignalRoute',
+        'Use-PodeRoutes',
 
         # handlers
         'Add-PodeHandler',

--- a/src/Public/Routes.ps1
+++ b/src/Public/Routes.ps1
@@ -1358,3 +1358,47 @@ function Get-PodeSignalRoute
     # return
     return $routes
 }
+
+<#
+.SYNOPSIS
+Automatically loads route ps1 files
+
+.DESCRIPTION
+Automatically loads route ps1 files from either a /routes folder, or a custom folder. Saves space dot-sourcing them all one-by-one.
+
+.PARAMETER Path
+Optional Path to a folder containing ps1 files, can be relative or literal.
+
+.EXAMPLE
+Use-PodeRoutes
+
+.EXAMPLE
+Use-PodeRoutes -Path './my-routes'
+#>
+function Use-PodeRoutes
+{
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [string]
+        $Path
+    )
+
+    # use default ./routes, or custom path
+    if ([string]::IsNullOrWhiteSpace($Path)) {
+        $Path = Join-PodeServerRoot -Folder 'routes'
+    }
+    else {
+        $Path = Get-PodeRelativePath -Path $Path -JoinRoot
+    }
+
+    # fail if path not found
+    if (!(Test-PodePath -Path $Path -NoStatus)) {
+        throw "Path to load routes not found: $($Path)"
+    }
+
+    # get .ps1 files and load them
+    Get-ChildItem -Path $Path -Filter *.ps1 -Force -Recurse | ForEach-Object {
+        Use-PodeScript -Path $_.FullName
+    }
+}


### PR DESCRIPTION
### Description of the Change
Adds a new helper function, `Use-PodeRoutes`, to auto-load route ps1 files - to save dot-sourcing lots of them.

By default, this loads from a `/routes` folder, but a `-Path` can be supplied.

### Related Issue
Resolves #731 

### Examples
```powershell
Use-PodeRoutes

# or

Use-PodeRoutes -Path '/my-routes'
```