### PR TITLE
Add -AsCredential to New-PodeAuthScheme

### DIFF
--- a/docs/Tutorials/Authentication/Methods/Basic.md
+++ b/docs/Tutorials/Authentication/Methods/Basic.md
@@ -1,10 +1,14 @@
 # Basic
 
-Basic Authentication is when you pass an encoded `username:password` value on the header of your requests: `@{ 'Authorization' = 'Basic <base64 encoded username:password>' }`.
+Basic Authentication is when you pass an encoded `username:password` value in the Authorization header of your requests:
+
+```plain
+Authorization: Basic <base64 encoded username:password>
+```
 
 ## Setup
 
-To setup and start using Basic Authentication in Pode you use the `New-PodeAuthScheme -Basic` function, and then pipe this into the [`Add-PodeAuth`](../../../../Functions/Authentication/Add-PodeAuth) function. The [`Add-PodeAuth`](../../../../Functions/Authentication/Add-PodeAuth) function's ScriptBlock is supplied the username and password:
+To start using Basic Authentication in Pode you can use `New-PodeAuthScheme -Basic`, and then pipe the object returned into [`Add-PodeAuth`](../../../../Functions/Authentication/Add-PodeAuth). The [`Add-PodeAuth`](../../../../Functions/Authentication/Add-PodeAuth) function's ScriptBlock is supplied the username and password parsed from the Authorization header:
 
 ```powershell
 Start-PodeServer {
@@ -18,7 +22,7 @@ Start-PodeServer {
 }
 ```
 
-By default, Pode will check if the Request's header contains an `Authorization` key, and whether the value of that key starts with `Basic` tag. The `New-PodeAuthScheme -Basic` function can be supplied parameters to customise the tag using `-HeaderTag`, as well as the `-Encoding`.
+By default, Pode will check if the request's headers contains an `Authorization` key, and whether the value of that key starts with `Basic` tag. The `New-PodeAuthScheme -Basic` function can be supplied parameters to customise the tag using `-HeaderTag`, as well as the `-Encoding`.
 
 For example, to use `ASCII` encoding rather than the default `ISO-8859-1` you could do:
 
@@ -28,9 +32,23 @@ Start-PodeServer {
 }
 ```
 
+The credentials supplied to [`Add-PodeAuth`](../../../../Functions/Authentication/Add-PodeAuth)'s scriptblock are, by default, the username and password. This can be changed to a pscredential object instead by suppling `-AsCredential` on [`New-PodeAuthScheme`]:
+
+```powershell
+Start-PodeServer {
+    New-PodeAuthScheme -Basic -AsCredential | Add-PodeAuth -Name 'Login' -Sessionless -ScriptBlock {
+        param($creds)
+
+        # check if the user is valid
+
+        return @{ User = $user }
+    }
+}
+```
+
 ## Middleware
 
-Once configured you can start using Basic Authentication to validate incoming Requests. You can either configure the validation to happen on every Route as global Middleware, or as custom Route Middleware.
+Once configured you can start using Basic Authentication to validate incoming requests. You can either configure the validation to happen on every Route as global Middleware, or as custom Route Middleware.
 
 The following will use Basic Authentication to validate every request on every Route:
 

--- a/docs/Tutorials/Authentication/Methods/Basic.md
+++ b/docs/Tutorials/Authentication/Methods/Basic.md
@@ -32,7 +32,7 @@ Start-PodeServer {
 }
 ```
 
-The credentials supplied to [`Add-PodeAuth`](../../../../Functions/Authentication/Add-PodeAuth)'s scriptblock are, by default, the username and password. This can be changed to a pscredential object instead by suppling `-AsCredential` on [`New-PodeAuthScheme`]:
+The credentials supplied to [`Add-PodeAuth`](../../../../Functions/Authentication/Add-PodeAuth)'s scriptblock are, by default, the username and password. This can be changed to a pscredential object instead by suppling `-AsCredential` on [`New-PodeAuthScheme`](../../../../Functions/Authentication/New-PodeAuthScheme):
 
 ```powershell
 Start-PodeServer {

--- a/docs/Tutorials/Authentication/Methods/Form.md
+++ b/docs/Tutorials/Authentication/Methods/Form.md
@@ -1,10 +1,10 @@
 # Form
 
-Form Authentication is for when you're using a `<form>` in HTML, and you submit the form. This Authentication method expects a `username` and `password` to be passed from the form's input fields.
+Form Authentication is for when you're using a `<form>` on your webpage, and it gets submitted. This Authentication method expects a `username` and `password` to be passed from the form's input fields, via POST request.
 
 ## Setup
 
-To setup and start using Form Authentication in Pode you use the `New-PodeAuthScheme -Form` function, and then pipe this into the [`Add-PodeAuth`](../../../../Functions/Authentication/Add-PodeAuth) function:
+To start using Form Authentication in Pode you can use `New-PodeAuthScheme -Form`, and then pipe the object returned into [`Add-PodeAuth`](../../../../Functions/Authentication/Add-PodeAuth). The [`Add-PodeAuth`](../../../../Functions/Authentication/Add-PodeAuth) function's ScriptBlock is supplied the username and password parsed from the request's payload:
 
 ```powershell
 Start-PodeServer {
@@ -18,7 +18,7 @@ Start-PodeServer {
 }
 ```
 
-By default, Pode will check if the Request's payload contains a `username` and `password` fields. The `New-PodeAuthScheme -Form` function can be supplied parameters to allow for custom names of these fields.
+By default, Pode will check if the request's payload contains a `username` and `password` fields. The `New-PodeAuthScheme -Form` function can be supplied parameters to allow for custom names of these fields.
 
 For example, to look for the field `email` rather than the default `username` you could do:
 
@@ -28,9 +28,23 @@ Start-PodeServer {
 }
 ```
 
+The credentials supplied to [`Add-PodeAuth`](../../../../Functions/Authentication/Add-PodeAuth)'s scriptblock are, by default, the username and password. This can be changed to a pscredential object instead by suppling `-AsCredential` on [`New-PodeAuthScheme`]:
+
+```powershell
+Start-PodeServer {
+    New-PodeAuthScheme -Form -AsCredential | Add-PodeAuth -Name 'Login' -ScriptBlock {
+        param($creds)
+
+        # check if the user is valid
+
+        return @{ User = $user }
+    }
+}
+```
+
 ## Middleware
 
-Once configured you can start using Form Authentication to validate incoming Requests. You can either configure the validation to happen on every Route as global Middleware, or as custom Route Middleware.
+Once configured you can start using Form Authentication to validate incoming requests. You can either configure the validation to happen on every Route as global Middleware, or as custom Route Middleware.
 
 The following will use Form Authentication to validate every request on every Route:
 

--- a/docs/Tutorials/Authentication/Methods/Form.md
+++ b/docs/Tutorials/Authentication/Methods/Form.md
@@ -28,7 +28,7 @@ Start-PodeServer {
 }
 ```
 
-The credentials supplied to [`Add-PodeAuth`](../../../../Functions/Authentication/Add-PodeAuth)'s scriptblock are, by default, the username and password. This can be changed to a pscredential object instead by suppling `-AsCredential` on [`New-PodeAuthScheme`]:
+The credentials supplied to [`Add-PodeAuth`](../../../../Functions/Authentication/Add-PodeAuth)'s scriptblock are, by default, the username and password. This can be changed to a pscredential object instead by suppling `-AsCredential` on [`New-PodeAuthScheme`](../../../../Functions/Authentication/New-PodeAuthScheme):
 
 ```powershell
 Start-PodeServer {

--- a/examples/web-auth-form-creds.ps1
+++ b/examples/web-auth-form-creds.ps1
@@ -1,0 +1,86 @@
+$path = Split-Path -Parent -Path (Split-Path -Parent -Path $MyInvocation.MyCommand.Path)
+Import-Module "$($path)/src/Pode.psm1" -Force -ErrorAction Stop
+
+# or just:
+# Import-Module Pode
+
+<#
+This examples shows how to use session persistant authentication, for things like logins on websites.
+The example used here is Form authentication, sent from the <form> in HTML, and converts the
+credentials into a pscredential object
+
+Navigating to the 'http://localhost:8085' endpoint in your browser will auto-rediect you to the '/login'
+page. Here, you can type the username (morty) and the password (pickle); clicking 'Login' will take you
+back to the home page with a greeting and a view counter. Clicking 'Logout' will purge the session and
+take you back to the login page.
+#>
+
+# create a server, and start listening on port 8085
+Start-PodeServer -Threads 2 {
+
+    # listen on localhost:8085
+    Add-PodeEndpoint -Address * -Port 8085 -Protocol Http
+
+    # set the view engine
+    Set-PodeViewEngine -Type Pode
+
+    # enable error logging
+    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+
+    # setup session details
+    Enable-PodeSessionMiddleware -Secret 'schwifty' -Duration 120 -Extend
+
+    # setup form auth (<form> in HTML)
+    New-PodeAuthScheme -Form -AsCredential | Add-PodeAuth -Name 'Login' -FailureUrl '/login' -SuccessUrl '/' -ScriptBlock {
+        param($creds)
+
+        # here you'd check a real user storage, this is just for example
+        $username = $creds.GetNetworkCredential().username
+        $password = $creds.GetNetworkCredential().password
+
+        if ($username -eq 'morty' -and $password -eq 'pickle') {
+            return @{
+                User = @{
+                    ID ='M0R7Y302'
+                    Name = 'Morty'
+                    Type = 'Human'
+                }
+            }
+        }
+
+        return @{ Message = 'Invalid details supplied' }
+    }
+
+
+    # home page:
+    # redirects to login page if not authenticated
+    Add-PodeRoute -Method Get -Path '/' -Authentication Login -ScriptBlock {
+        $WebEvent.Session.Data.Views++
+
+        Write-PodeViewResponse -Path 'auth-home' -Data @{
+            Username = $WebEvent.Auth.User.Name
+            Views = $WebEvent.Session.Data.Views
+        }
+    }
+
+
+    # login page:
+    # the login flag set below checks if there is already an authenticated session cookie. If there is, then
+    # the user is redirected to the home page. If there is no session then the login page will load without
+    # checking user authetication (to prevent a 401 status)
+    Add-PodeRoute -Method Get -Path '/login' -Authentication Login -Login -ScriptBlock {
+        Write-PodeViewResponse -Path 'auth-login' -FlashMessages
+    }
+
+
+    # login check:
+    # this is the endpoint the <form>'s action will invoke. If the user validates then they are set against
+    # the session as authenticated, and redirect to the home page. If they fail, then the login page reloads
+    Add-PodeRoute -Method Post -Path '/login' -Authentication Login -Login
+
+
+    # logout check:
+    # when the logout button is click, this endpoint is invoked. The logout flag set below informs this call
+    # to purge the currently authenticated session, and then redirect back to the login page
+    Add-PodeRoute -Method Post -Path '/logout' -Authentication Login -Logout
+}

--- a/src/Private/Authentication.ps1
+++ b/src/Private/Authentication.ps1
@@ -54,8 +54,18 @@ function Get-PodeAuthBasicType
         $username = $decoded.Substring(0, $index)
         $password = $decoded.Substring($index + 1)
 
+        # build the result
+        $result = @($username, $password)
+
+        # convert to credential?
+        if ($options.AsCredential) {
+            $passSecure = ConvertTo-SecureString -String $password -AsPlainText -Force
+            $creds = [pscredential]::new($username, $passSecure)
+            $result = @($creds)
+        }
+
         # return data for calling validator
-        return @($username, $password)
+        return $result
     }
 }
 
@@ -503,8 +513,18 @@ function Get-PodeAuthFormType
             }
         }
 
+        # build the result
+        $result = @($username, $password)
+
+        # convert to credential?
+        if ($options.AsCredential) {
+            $passSecure = ConvertTo-SecureString -String $password -AsPlainText -Force
+            $creds = [pscredential]::new($username, $passSecure)
+            $result = @($creds)
+        }
+
         # return data for calling validator
-        return @($username, $password)
+        return $result
     }
 }
 

--- a/src/Public/Authentication.ps1
+++ b/src/Public/Authentication.ps1
@@ -80,6 +80,9 @@ An optional array of Scopes for Bearer/OAuth2 Authentication. (These are case-se
 .PARAMETER InnerScheme
 An optional authentication Scheme (from New-PodeAuthScheme) that will be called prior to this Scheme.
 
+.PARAMETER AsCredential
+If supplied, username/password credentials for Basic/Form authentication will instead be supplied as a pscredential object.
+
 .EXAMPLE
 $basic_auth = New-PodeAuthScheme -Basic
 
@@ -203,7 +206,12 @@ function New-PodeAuthScheme
 
         [Parameter(ValueFromPipeline=$true)]
         [hashtable]
-        $InnerScheme
+        $InnerScheme,
+
+        [Parameter(ParameterSetName='Basic')]
+        [Parameter(ParameterSetName='Form')]
+        [switch]
+        $AsCredential
     )
 
     # default realm
@@ -225,6 +233,7 @@ function New-PodeAuthScheme
                 Arguments = @{
                     HeaderTag = (Protect-PodeValue -Value $HeaderTag -Default 'Basic')
                     Encoding = (Protect-PodeValue -Value $Encoding -Default 'ISO-8859-1')
+                    AsCredential = $AsCredential
                 }
             }
         }
@@ -301,6 +310,7 @@ function New-PodeAuthScheme
                         Username = (Protect-PodeValue -Value $UsernameField -Default 'username')
                         Password = (Protect-PodeValue -Value $PasswordField -Default 'password')
                     }
+                    AsCredential = $AsCredential
                 }
             }
         }


### PR DESCRIPTION
### Description of the Change
Adds an `-AsCredential` switch to `New-PodeAuthScheme`, so username/password parameters passed to `Add-PodeAuth`  will be passed as a pscredential object instead. Only supported for `-Basic` and `-Form` authentication.

### Related Issue
Resolves #743 

### Examples
```powershell
New-PodeAuthScheme -Basic -AsCredential | Add-PodeAuth -Name 'Login' -Sessionless -ScriptBlock {
    param($creds)

    # check if the user is valid

    return @{ User = $user }
}
```
