### PR TITLE
Add docs for IIS recycling, and support for graceful shutdown from IIS

### DIFF
--- a/docs/Hosting/IIS.md
+++ b/docs/Hosting/IIS.md
@@ -167,7 +167,7 @@ You can setup a binding in IIS for HTTPS with a Certificate, and IIS will deal w
 
 ## Recycling
 
-By default, IIS has certain setting that will recycle/shutdown your Application Pools. This will cause some requests to "spin-up" the site for the first time, and go slow.
+By default, IIS has certain settings that will recycle/shutdown your Application Pools. This will cause some requests to "spin-up" the site for the first time, and go slow.
 
 To help prevent this, below are some of the common setting that can be altered to stop IIS recycling/shutting down your site:
 
@@ -179,7 +179,7 @@ To help prevent this, below are some of the common setting that can be altered t
     1. Set the "Regular Time Interval" to 0
     2. Remove all times from "Specific Times"
 
-This isn't bulletproof, and IIS can sometimes to restart your site if it feels like it. Also make sure that there are no periodic processes anywhere that might recycle Application Pools, or run `iisreset`.
+This isn't bulletproof, and IIS can sometimes restart your site if it feels like it. Also make sure that there are no periodic processes anywhere that might recycle Application Pools, or run `iisreset`.
 
 When IIS does restart your site, the log file should show the usual Pode "Terminating" message, but preceded with "(IIS Shutdown)".
 

--- a/docs/Hosting/IIS.md
+++ b/docs/Hosting/IIS.md
@@ -165,6 +165,45 @@ You can setup a binding in IIS for HTTPS with a Certificate, and IIS will deal w
 8. Select the required certificate from the dropdown
 9. Select OK to create the Binding
 
+## Recycling
+
+By default, IIS has certain setting that will recycle/shutdown your Application Pools. This will cause some requests to "spin-up" the site for the first time, and go slow.
+
+To help prevent this, below are some of the common setting that can be altered to stop IIS recycling/shutting down your site:
+
+1. Open IIS, and select the Application Pools folder
+2. Right click your Application Pool, and select "Advanced Settings..."
+3. Under "Process Model", to stop IIS shutting down your site
+    1. Set the "Idle Time-out" to 0
+4. Under "Recycling", to stop IIS recycling your site
+    1. Set the "Regular Time Interval" to 0
+    2. Remove all times from "Specific Times"
+
+This isn't bulletproof, and IIS can sometimes to restart your site if it feels like it. Also make sure that there are no periodic processes anywhere that might recycle Application Pools, or run `iisreset`.
+
+When IIS does restart your site, the log file should show the usual Pode "Terminating" message, but preceded with "(IIS Shutdown)".
+
+### Debug Line
+
+Whenever IIS recycles/shuts down your site, you may see a debug line in your logs if the initial HTTP shutdown request fails, such as:
+
+```plain
+Entering debug mode. Use h or ? for help.
+
+At C:\Program Files\PowerShell\Modules\Pode\2.0.3\Public\Core.ps1:176 char:13
++ $key = Get-PodeConsoleKey
++ ~~~~~~~~~~~~~~~~~~~~~~~~~
+[DBG]: PS D:\wwwroot\sitename>>
+```
+
+This is nothing to worry about, and is purely just IIS terminating the PowerShell runspace to shutdown the Application Pool.
+
+## ASP.NET Token
+
+When hosted via IIS, Pode inspects every request to make sure the mandatory `MS-ASPNETCORE-TOKEN` header is present. This is a token supplied by IIS, and if it's missing Pode will reject the request with a 400 response.
+
+There's nothing you need to do, IIS informs Pode about the token for you, and IIS will add the header to the requests automatically for you as well.
+
 ## IIS Authentication
 
 If you decide to use IIS for Windows Authentication, then you can retrieve the authenticated user in Pode. This is done using the [`Add-PodeAuthIIS`](../../Functions/Authentication/Add-PodeAuthIIS) function, and it will check for the `MS-ASPNETCORE-WINAUTHTOKEN` header from IIS. The function creates a custom Authentication Type and Method, and can be used on Routes like other Authentications in Pode:

--- a/examples/iis-example.ps1
+++ b/examples/iis-example.ps1
@@ -1,0 +1,20 @@
+$path = Split-Path -Parent -Path (Split-Path -Parent -Path $MyInvocation.MyCommand.Path)
+Import-Module "$($path)/src/Pode.psm1" -Force -ErrorAction Stop
+
+# or just:
+# Import-Module Pode
+
+# create a server, and start listening on port 8085
+Start-PodeServer {
+
+    # listen on localhost:8085
+    Add-PodeEndpoint -Address * -Port 8085 -Protocol Http
+    New-PodeLoggingMethod -Terminal | Enable-PodeRequestLogging
+    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+
+    Add-PodeRoute -Method Get -Path '/' -ScriptBlock {
+        Write-PodeJsonResponse -Value @{ Message = 'Hello' }
+        $WebEvent.Request.Headers | Out-Default
+    }
+
+}

--- a/examples/web.config
+++ b/examples/web.config
@@ -1,0 +1,27 @@
+<configuration>
+  <location path="." inheritInChildApplications="false">
+    <system.webServer>
+      <handlers>
+        <remove name="WebDAV" />
+        <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModuleV2" resourceType="Unspecified" />
+        <remove name="ExtensionlessUrlHandler-Integrated-4.0" />
+        <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" />
+        <remove name="ExtensionlessUrl-Integrated-4.0" />
+        <add name="ExtensionlessUrl-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" />
+      </handlers>
+
+      <modules>
+        <remove name="WebDAVModule" />
+      </modules>
+
+      <aspNetCore processPath="pwsh.exe" arguments=".\iis-example.ps1" stdoutLogEnabled="true" stdoutLogFile=".\logs\stdout" hostingModel="OutOfProcess"/>
+
+      <security>
+        <authorization>
+          <remove users="*" roles="" verbs="" />
+          <add accessType="Allow" users="*" verbs="GET,HEAD,POST,PUT,DELETE,DEBUG,OPTIONS" />
+        </authorization>
+      </security>
+    </system.webServer>
+  </location>
+</configuration>

--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -177,6 +177,13 @@ function New-PodeContext
         if (!(Test-PodeIsEmpty $env:WEBSITE_IIS_SITE_NAME)) {
             $ctx.Server.Quiet = $true
         }
+
+        # set iis token/settings
+        $ctx.Server.IIS = @{
+            Token = $env:ASPNETCORE_TOKEN
+            Port = $env:ASPNETCORE_PORT
+            Shutdown = $false
+        }
     }
 
     # is the server running under Heroku?

--- a/src/Private/Middleware.ps1
+++ b/src/Private/Middleware.ps1
@@ -374,7 +374,6 @@ function Initialize-PodeIISMiddleware
 
     # add route to gracefully shutdown server for iis
     Add-PodeRoute -Method Post -Path '/iisintegration' -ScriptBlock {
-        $WebEvent.Request.Headers | Out-Default
         $eventType = Get-PodeHeader -Name 'MS-ASPNETCORE-EVENT'
 
         # no x-forward

--- a/src/Private/Server.ps1
+++ b/src/Private/Server.ps1
@@ -16,6 +16,9 @@ function Start-PodeInternalServer
         # create the shared runspace state
         New-PodeRunspaceState
 
+        # if iis, setup global middleware to validate token
+        Initialize-PodeIISMiddleware
+
         # get the server's script and invoke it - to set up routes, timers, middleware, etc
         $_script = $PodeContext.Server.Logic
         if (Test-PodePath -Path $PodeContext.Server.LogicPath -NoStatus) {

--- a/src/Public/Core.ps1
+++ b/src/Public/Core.ps1
@@ -186,6 +186,10 @@ function Start-PodeServer
             }
         }
 
+        if ($PodeContext.Server.IsIIS -and $PodeContext.Server.IIS.Shutdown) {
+            Write-PodeHost '(IIS Shutdown) ' -NoNewline -ForegroundColor Yellow
+        }
+
         Write-PodeHost 'Terminating...' -NoNewline -ForegroundColor Yellow
         $PodeContext.Tokens.Cancellation.Cancel()
     }


### PR DESCRIPTION
### Description of the Change
* Add documentation about IIS recycling and the debug line in the logs
* Add support for IIS shutdown endpoint, to gracefully shutdown and prevent the debug lines
  * This also adds support for IIS middleware to check each request for an IIS token
  * The shutdown endpoint has further validation to ensure the request is local and comes from IIS only

### Related Issue
Resolves #741
