### PR TITLE
Add JWT support on Bearer and API key authentication

### DIFF
--- a/docs/Tutorials/Authentication/Methods/ApiKey.md
+++ b/docs/Tutorials/Authentication/Methods/ApiKey.md
@@ -66,6 +66,10 @@ Start-PodeServer {
 }
 ```
 
+## JWT
+
+You can supply a JWT using API key authentication, for more details [see here](../JWT).
+
 ## Full Example
 
 The following full example of API key authentication will setup and configure authentication, validate the key from the `X-API-KEY` header, and then validate on a specific Route:

--- a/docs/Tutorials/Authentication/Methods/Bearer.md
+++ b/docs/Tutorials/Authentication/Methods/Bearer.md
@@ -60,6 +60,10 @@ Start-PodeServer {
 }
 ```
 
+## JWT
+
+You can supply a JWT using Bearer authentication, for more details [see here](../JWT).
+
 ## Full Example
 
 The following full example of Bearer authentication will setup and configure authentication, validate the token, and then validate on a specific Route:

--- a/docs/Tutorials/Authentication/Methods/Custom.md
+++ b/docs/Tutorials/Authentication/Methods/Custom.md
@@ -56,7 +56,6 @@ For example, if you have a post validator script for the above Client Custom aut
 * ClientName
 * Username
 * Password
-* ClientName
 * Validation Result
 * Scheme ArgumentsList
 

--- a/docs/Tutorials/Authentication/Methods/JWT.md
+++ b/docs/Tutorials/Authentication/Methods/JWT.md
@@ -1,0 +1,92 @@
+# JWT
+
+Pode has inbuilt JWT parsing for either [Bearer](../Bearer) or [API Key](../ApiKey) authentications. Pode will attempt to validate and parse the token/key as a JWT, and if successful the JWT's payload will be passed as the parameter to [`Add-PodeAuth`](../../../../Functions/Authentication/Add-PodeAuth), instead of the token/key.
+
+For more information on JWTs, see the [official website](https://jwt.io).
+
+## Setup
+
+To start using JWT authentication, you can supply the `-AsJWT` switch with either the `-Bearer` or `-ApiKey` switch on [`New-PodeAuthScheme`](../../../../Functions/Authentication/New-PodeAuthScheme). You can also supply an optional `-Secret` that the JWT signature uses so Pode can validate the JWT:
+
+```powershell
+# jwt with no signature:
+New-PodeAuthScheme -Bearer -AsJWT | Add-PodeAuth -Name 'Example' -Sessionless -ScriptBlock {
+    param($payload)
+}
+
+# jwt with signature, signed with secret "abc":
+New-PodeAuthScheme -ApiKey -AsJWT -Secret 'abc' | Add-PodeAuth -Name 'Example' -Sessionless -ScriptBlock {
+    param($payload)
+}
+```
+
+The `$payload` will be a PSCustomObject of the converted JSON payload. For example, sending the following unsigned JWT in a request:
+
+```plain
+eyJhbGciOiJub25lIn0.eyJ1c2VybmFtZSI6Im1vcnR5Iiwic3ViIjoiMTIzIn0.
+```
+
+would produce a payload of:
+
+```plain
+sub:        123
+username:   morty
+```
+
+### Algorithms
+
+Pode supports the following algorithms for JWT signatures:
+
+* None
+* HS256
+* HS384
+* HS512
+
+For `none`, Pode expects there to be no signature with the JWT. For other algorithms, a `-Secret` is required, and a signature must be supplied with the JWT in requests.
+
+### Payload
+
+If the payload of the JWT contains a expiry (`exp`) or a not before (`nbf`) timestamp, Pode will validate it and return a 400 if the JWT is expired/not started.
+
+## Usage
+
+To send the JWT in a request, the JWT should be sent in place of where the usual bearer token/API key would have been. For example, for bearer it would be in the Authorization header:
+
+```plain
+Authorization: Bearer <jwt>
+```
+
+and for API keys, it would be in the location defined (header, cookie, or query string). For example, in the X-API-KEY header:
+
+```plain
+X-API-KEY: <jwt>
+```
+
+## Create JWT
+
+Pode has a simple [`ConvertTo-PodeJwt`](../../../../Functions/Authentication/ConvertTo-PodeJwt) that will build a JWT for you. It accepts a hashtable for `-Header` and `-Payload`, as well as an optional `-Secret`.
+
+The function will run some simple validation, and them build the JWT for you.
+
+For example:
+
+```powershell
+$header = @{
+    alg = 'hs256'
+    typ = 'JWT'
+}
+
+$payload = @{
+    sub = '123'
+    name = 'John Doe'
+    exp = ([System.DateTimeOffset]::Now.AddDays(1).ToUnixTimeSeconds())
+}
+
+ConvertTo-PodeJwt -Header $header -Payload $payload -Secret 'abc'
+```
+
+This return the following JWT:
+
+```plain
+eyJ0eXAiOiJKV1QiLCJhbGciOiJoczI1NiJ9.eyJleHAiOjE2MjI1NTMyMTQsIm5hbWUiOiJKb2huIERvZSIsInN1YiI6IjEyMyJ9.LP-O8OKwix91a-SZwVK35gEClLZQmsORbW0un2Z4RkY
+```

--- a/docs/Tutorials/Authentication/Overview.md
+++ b/docs/Tutorials/Authentication/Overview.md
@@ -22,6 +22,7 @@ The following schemes are supported:
 * [Client Certificate](../Methods/ClientCertificate)
 * [Digest](../Methods/Digest)
 * [Form](../Methods/Form)
+* [JWT](../Methods/JWT) (Done using [Bearer](../Methods/Bearer) or [API Key](../Methods/ApiKey))
 * [OAuth2](../Methods/OAuth2)
 
 Or you can define a custom scheme:

--- a/examples/web-auth-apikey-jwt.ps1
+++ b/examples/web-auth-apikey-jwt.ps1
@@ -1,0 +1,69 @@
+param(
+    [Parameter()]
+    [ValidateSet('Header', 'Query', 'Cookie')]
+    [string]
+    $Location = 'Header'
+)
+
+$path = Split-Path -Parent -Path (Split-Path -Parent -Path $MyInvocation.MyCommand.Path)
+Import-Module "$($path)/src/Pode.psm1" -Force -ErrorAction Stop
+
+# or just:
+# Import-Module Pode
+
+# -------------
+# None Signed
+# Req: Invoke-RestMethod -Uri 'http://localhost:8085/users' -Headers @{ 'X-API-KEY' = 'eyJhbGciOiJub25lIn0.eyJ1c2VybmFtZSI6Im1vcnR5Iiwic3ViIjoiMTIzIn0.' }
+# -------------
+
+# -------------
+# Signed
+# Req: Invoke-RestMethod -Uri 'http://localhost:8085/users' -Headers @{ 'X-API-KEY' = 'eyJhbGciOiJoczI1NiJ9.eyJ1c2VybmFtZSI6Im1vcnR5Iiwic3ViIjoiMTIzIn0.WIOvdwk4mNrNC9EtTcQccmLHJc02gAuonXClHMFOjKM' }
+#
+# (add -Secret 'secret' to New-PodeAuthScheme below)
+# -------------
+
+# create a server, and start listening on port 8085
+Start-PodeServer -Threads 2 {
+
+    # listen on localhost:8085
+    Add-PodeEndpoint -Address * -Port 8085 -Protocol Http
+
+    New-PodeLoggingMethod -File -Name 'requests' | Enable-PodeRequestLogging
+    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+
+    # setup bearer auth
+    New-PodeAuthScheme -ApiKey -Location $Location -AsJWT | Add-PodeAuth -Name 'Validate' -Sessionless -ScriptBlock {
+        param($jwt)
+
+        # here you'd check a real user storage, this is just for example
+        if ($jwt.username -ieq 'morty') {
+            return @{
+                User = @{
+                    ID ='M0R7Y302'
+                    Name = 'Morty'
+                    Type = 'Human'
+                }
+            }
+        }
+
+        return $null
+    }
+
+    # GET request to get list of users (since there's no session, authentication will always happen)
+    Add-PodeRoute -Method Get -Path '/users' -Authentication 'Validate' -ScriptBlock {
+        Write-PodeJsonResponse -Value @{
+            Users = @(
+                @{
+                    Name = 'Deep Thought'
+                    Age = 42
+                },
+                @{
+                    Name = 'Leeroy Jenkins'
+                    Age = 1337
+                }
+            )
+        }
+    }
+
+}

--- a/examples/web-auth-apikey.ps1
+++ b/examples/web-auth-apikey.ps1
@@ -18,6 +18,7 @@ Start-PodeServer -Threads 2 {
     Add-PodeEndpoint -Address * -Port 8085 -Protocol Http
 
     New-PodeLoggingMethod -File -Name 'requests' | Enable-PodeRequestLogging
+    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
 
     # setup bearer auth
     New-PodeAuthScheme -ApiKey -Location $Location | Add-PodeAuth -Name 'Validate' -Sessionless -ScriptBlock {

--- a/src/Pode.psd1
+++ b/src/Pode.psd1
@@ -182,6 +182,7 @@
         'Add-PodeAuthMiddleware',
         'Add-PodeAuthIIS',
         'Add-PodeAuthUserFile',
+        'ConvertTo-PodeJwt',
 
         # logging
         'New-PodeLoggingMethod',

--- a/src/Private/Authentication.ps1
+++ b/src/Private/Authentication.ps1
@@ -266,7 +266,7 @@ function Get-PodeAuthApiKeyType
         if ([string]::IsNullOrWhiteSpace($apiKey)) {
             return @{
                 Message = "No $($options.LocationName) $($options.Location) found"
-                Code = 401
+                Code = 400
             }
         }
 
@@ -278,6 +278,7 @@ function Get-PodeAuthApiKeyType
         if ($options.AsJWT) {
             try {
                 $payload = ConvertFrom-PodeJwt -Token $apiKey -Secret $options.Secret
+                Test-PodeJwt -Payload $payload
             }
             catch {
                 if ($_.Exception.Message -ilike '*jwt*') {
@@ -336,7 +337,7 @@ function Get-PodeAuthBearerType
         if ([string]::IsNullOrWhiteSpace($token)) {
             return @{
                 Message = "No Bearer token found"
-                Code = 401
+                Code = 400
             }
         }
 
@@ -348,6 +349,7 @@ function Get-PodeAuthBearerType
         if ($options.AsJWT) {
             try {
                 $payload = ConvertFrom-PodeJwt -Token $token -Secret $options.Secret
+                Test-PodeJwt -Payload $payload
             }
             catch {
                 if ($_.Exception.Message -ilike '*jwt*') {

--- a/src/Private/Authentication.ps1
+++ b/src/Private/Authentication.ps1
@@ -263,7 +263,6 @@ function Get-PodeAuthApiKeyType
         }
 
         # 401 if no key
-        $apiKey = $apiKey.Trim()
         if ([string]::IsNullOrWhiteSpace($apiKey)) {
             return @{
                 Message = "No $($options.LocationName) $($options.Location) found"
@@ -272,11 +271,25 @@ function Get-PodeAuthApiKeyType
         }
 
         # build the result
+        $apiKey = $apiKey.Trim()
         $result = @($apiKey)
 
         # convert as jwt?
         if ($options.AsJWT) {
-            $payload = ConvertFrom-PodeJwt -Token $apiKey -Secret $options.Secret
+            try {
+                $payload = ConvertFrom-PodeJwt -Token $apiKey -Secret $options.Secret
+            }
+            catch {
+                if ($_.Exception.Message -ilike '*jwt*') {
+                    return @{
+                        Message = $_.Exception.Message
+                        Code = 400
+                    }
+                }
+
+                throw
+            }
+
             $result = @($payload)
         }
 
@@ -319,7 +332,7 @@ function Get-PodeAuthBearerType
         }
 
         # 401 if no token
-        $token = $atoms[1].Trim()
+        $token = $atoms[1]
         if ([string]::IsNullOrWhiteSpace($token)) {
             return @{
                 Message = "No Bearer token found"
@@ -328,11 +341,25 @@ function Get-PodeAuthBearerType
         }
 
         # build the result
+        $token = $token.Trim()
         $result = @($token)
 
         # convert as jwt?
         if ($options.AsJWT) {
-            $payload = ConvertFrom-PodeJwt -Token $token -Secret $options.Secret
+            try {
+                $payload = ConvertFrom-PodeJwt -Token $token -Secret $options.Secret
+            }
+            catch {
+                if ($_.Exception.Message -ilike '*jwt*') {
+                    return @{
+                        Message = $_.Exception.Message
+                        Code = 400
+                    }
+                }
+
+                throw
+            }
+
             $result = @($payload)
         }
 

--- a/src/Private/Authentication.ps1
+++ b/src/Private/Authentication.ps1
@@ -263,6 +263,7 @@ function Get-PodeAuthApiKeyType
         }
 
         # 401 if no key
+        $apiKey = $apiKey.Trim()
         if ([string]::IsNullOrWhiteSpace($apiKey)) {
             return @{
                 Message = "No $($options.LocationName) $($options.Location) found"
@@ -270,8 +271,17 @@ function Get-PodeAuthApiKeyType
             }
         }
 
-        # return the key
-        return @($apiKey.Trim())
+        # build the result
+        $result = @($apiKey)
+
+        # convert as jwt?
+        if ($options.AsJWT) {
+            $payload = ConvertFrom-PodeJwt -Token $apiKey -Secret $options.Secret
+            $result = @($payload)
+        }
+
+        # return the result
+        return $result
     }
 }
 
@@ -308,8 +318,26 @@ function Get-PodeAuthBearerType
             }
         }
 
-        # return token for calling validator
-        return @($atoms[1].Trim())
+        # 401 if no token
+        $token = $atoms[1].Trim()
+        if ([string]::IsNullOrWhiteSpace($token)) {
+            return @{
+                Message = "No Bearer token found"
+                Code = 401
+            }
+        }
+
+        # build the result
+        $result = @($token)
+
+        # convert as jwt?
+        if ($options.AsJWT) {
+            $payload = ConvertFrom-PodeJwt -Token $token -Secret $options.Secret
+            $result = @($payload)
+        }
+
+        # return the result
+        return $result
     }
 }
 

--- a/src/Private/Cryptography.ps1
+++ b/src/Private/Cryptography.ps1
@@ -421,12 +421,7 @@ function ConvertFrom-PodeJwtBase64Value
 
     # return json
     try {
-        if (Test-PodeIsPSCore) {
-            return ($Value | ConvertFrom-Json -AsHashtable)
-        }
-        else {
-            return ($Value | ConvertFrom-Json)
-        }
+        return ($Value | ConvertFrom-Json)
     }
     catch {
         throw "Invalid JSON value found in JWT"

--- a/src/Private/Cryptography.ps1
+++ b/src/Private/Cryptography.ps1
@@ -1,18 +1,75 @@
 function Invoke-PodeHMACSHA256Hash
 {
-    param (
+    [CmdletBinding(DefaultParameterSetName='String')]
+    param(
         [Parameter(Mandatory=$true)]
-        [ValidateNotNullOrEmpty()]
         [string]
         $Value,
 
-        [Parameter(Mandatory=$true)]
-        [ValidateNotNullOrEmpty()]
+        [Parameter(Mandatory=$true, ParameterSetName='String')]
         [string]
-        $Secret
+        $Secret,
+
+        [Parameter(Mandatory=$true, ParameterSetName='Bytes')]
+        [byte[]]
+        $SecretBytes
     )
 
-    $crypto = [System.Security.Cryptography.HMACSHA256]::new([System.Text.Encoding]::UTF8.GetBytes($Secret))
+    if (![string]::IsNullOrWhiteSpace($Secret)) {
+        $SecretBytes = [System.Text.Encoding]::UTF8.GetBytes($Secret)
+    }
+
+    $crypto = [System.Security.Cryptography.HMACSHA256]::new($SecretBytes)
+    return [System.Convert]::ToBase64String($crypto.ComputeHash([System.Text.Encoding]::UTF8.GetBytes($Value)))
+}
+
+function Invoke-PodeHMACSHA384Hash
+{
+    [CmdletBinding(DefaultParameterSetName='String')]
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Value,
+
+        [Parameter(Mandatory=$true, ParameterSetName='String')]
+        [string]
+        $Secret,
+
+        [Parameter(Mandatory=$true, ParameterSetName='Bytes')]
+        [byte[]]
+        $SecretBytes
+    )
+
+    if (![string]::IsNullOrWhiteSpace($Secret)) {
+        $SecretBytes = [System.Text.Encoding]::UTF8.GetBytes($Secret)
+    }
+
+    $crypto = [System.Security.Cryptography.HMACSHA384]::new($SecretBytes)
+    return [System.Convert]::ToBase64String($crypto.ComputeHash([System.Text.Encoding]::UTF8.GetBytes($Value)))
+}
+
+function Invoke-PodeHMACSHA512Hash
+{
+    [CmdletBinding(DefaultParameterSetName='String')]
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Value,
+
+        [Parameter(Mandatory=$true, ParameterSetName='String')]
+        [string]
+        $Secret,
+
+        [Parameter(Mandatory=$true, ParameterSetName='Bytes')]
+        [byte[]]
+        $SecretBytes
+    )
+
+    if (![string]::IsNullOrWhiteSpace($Secret)) {
+        $SecretBytes = [System.Text.Encoding]::UTF8.GetBytes($Secret)
+    }
+
+    $crypto = [System.Security.Cryptography.HMACSHA512]::new($SecretBytes)
     return [System.Convert]::ToBase64String($crypto.ComputeHash([System.Text.Encoding]::UTF8.GetBytes($Value)))
 }
 
@@ -182,4 +239,130 @@ function Invoke-PodeValueUnsign
     }
 
     return $raw
+}
+
+function ConvertFrom-PodeJwt
+{
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Token,
+
+        [Parameter()]
+        [byte[]]
+        $Secret
+    )
+
+    # get the parts
+    $parts = ($Token -isplit '\.')
+
+    # check number of parts (should be 2 or 3)
+    if (($parts.Length -le 1) -or ($parts.Length -gt 3)) {
+        throw "Invalid JWT supplied"
+    }
+
+    # convert to header
+    $header = ConvertFrom-PodeJwtBase64Value -Value $parts[0]
+    if ([string]::IsNullOrWhiteSpace($header.alg)) {
+        throw "Invalid JWT header algorithm supplied"
+    }
+
+    # convert to payload
+    $payload = ConvertFrom-PodeJwtBase64Value -Value $parts[1]
+
+    # check "none" signature, and return payload if no signature
+    $isNoneAlg = ($header.alg -ieq 'none')
+
+    if (($parts.Length -eq 2) -and !$isNoneAlg) {
+        throw "No JWT signature supplied for $($header.alg)"
+    }
+
+    if (($parts.Length -eq 3) -and $isNoneAlg) {
+        throw "Expected no JWT signature to be supplied"
+    }
+
+    if ($isNoneAlg) {
+        return $payload
+    }
+
+    # otherwise, we have an alg for the signature, so we need to validate it
+    $sig = "$($parts[0]).$($parts[1])"
+
+    if (($null -eq $Secret) -or ($Secret.Length -eq 0)) {
+        throw "No JWT secret supplied for validating signature"
+    }
+
+    switch ($header.alg.ToUpperInvariant()) {
+        'HS256' {
+            $sig = Invoke-PodeHMACSHA256Hash -Value $sig -SecretBytes $Secret
+            $sig = ConvertTo-PodeJwtBase64Value -Value $sig
+        }
+
+        'HS384' {
+            $sig = Invoke-PodeHMACSHA384Hash -Value $sig -SecretBytes $Secret
+            $sig = ConvertTo-PodeJwtBase64Value -Value $sig
+        }
+
+        'HS512' {
+            $sig = Invoke-PodeHMACSHA512Hash -Value $sig -SecretBytes $Secret
+            $sig = ConvertTo-PodeJwtBase64Value -Value $sig
+        }
+
+        default {
+            throw "The JWT algorithm is not currently supported: $($header.alg)"
+        }
+    }
+
+    if ($sig -ne $parts[2]) {
+        throw "Invalid JWT signature supplied"
+    }
+
+    # it's valid return the payload!
+    return $payload
+}
+
+function ConvertTo-PodeJwtBase64Value
+{
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Value
+    )
+
+    $Value = ($Value -ireplace '\+', '-')
+    $Value = ($Value -ireplace '/', '_')
+    $Value = ($Value -ireplace '=', '')
+
+    return $Value
+}
+
+function ConvertFrom-PodeJwtBase64Value
+{
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Value
+    )
+
+    # map chars
+    $Value = ($Value -ireplace '-', '+')
+    $Value = ($Value -ireplace '_', '/')
+
+    # add padding
+    switch ($Value.Length % 4) {
+        1 { $Value = $Value.Substring(0, $Value.Length - 1) }
+        2 { $Value += '==' }
+        3 { $Value += '=' }
+    }
+
+    # convert base64 to string
+    $Value = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($Value))
+
+    # return json
+    if (Test-PodeIsPSCore) {
+        return ($Value | ConvertFrom-Json -AsHashtable)
+    }
+    else {
+        return ($Value | ConvertFrom-Json)
+    }
 }

--- a/src/Private/Cryptography.ps1
+++ b/src/Private/Cryptography.ps1
@@ -316,6 +316,32 @@ function ConvertFrom-PodeJwt
     return $payload
 }
 
+function Test-PodeJwt
+{
+    param(
+        [Parameter(Mandatory=$true)]
+        [pscustomobject]
+        $Payload
+    )
+
+    $now = [datetime]::Now
+    $unixStart = [datetime]::new(1970, 1, 1)
+
+    # validate expiry
+    if (![string]::IsNullOrWhiteSpace($Payload.exp)) {
+        if ($now -gt $unixStart.AddSeconds($Payload.exp)) {
+            throw "The JWT has expired"
+        }
+    }
+
+    # validate not-before
+    if (![string]::IsNullOrWhiteSpace($Payload.nbf)) {
+        if ($now -lt $unixStart.AddSeconds($Payload.nbf)) {
+            throw "The JWT is not yet valid for use"
+        }
+    }
+}
+
 function New-PodeJwtSignature
 {
     param(

--- a/src/Private/Mappers.ps1
+++ b/src/Private/Mappers.ps1
@@ -238,6 +238,7 @@ function Get-PodeContentType
         '.json' { return 'application/json' }
         '.jsx' { return 'text/jscript' }
         '.jsxbin' { return 'text/plain' }
+        '.jwt' { return 'application/jwt' }
         '.latex' { return 'application/x-latex' }
         '.library-ms' { return 'application/windows-library+xml' }
         '.lit' { return 'application/x-ms-reader' }

--- a/src/Public/Authentication.ps1
+++ b/src/Public/Authentication.ps1
@@ -1418,7 +1418,10 @@ A Hashtable containing the Payload information for the JWT.
 An Optional Secret for signing the JWT. This is mandatory if the Header algorithm isn't "none".
 
 .EXAMPLE
-An example
+ConvertTo-PodeJwt -Header @{ alg = 'none' } -Payload @{ sub = '123'; name = 'John' }
+
+.EXAMPLE
+ConvertTo-PodeJwt -Header @{ alg = 'hs256' } -Payload @{ sub = '123'; name = 'John' } -Secret 'abc'
 #>
 function ConvertTo-PodeJwt
 {

--- a/src/Public/Authentication.ps1
+++ b/src/Public/Authentication.ps1
@@ -233,7 +233,17 @@ function New-PodeAuthScheme
         [Parameter(ParameterSetName='Basic')]
         [Parameter(ParameterSetName='Form')]
         [switch]
-        $AsCredential
+        $AsCredential,
+
+        [Parameter(ParameterSetName='Bearer')]
+        [Parameter(ParameterSetName='ApiKey')]
+        [switch]
+        $AsJWT,
+
+        [Parameter(ParameterSetName='Bearer')]
+        [Parameter(ParameterSetName='ApiKey')]
+        [string]
+        $Secret
     )
 
     # default realm
@@ -296,6 +306,11 @@ function New-PodeAuthScheme
         }
 
         'bearer' {
+            $secretBytes = $null
+            if (![string]::IsNullOrWhiteSpace($Secret)) {
+                $secretBytes = [System.Text.Encoding]::UTF8.GetBytes($Secret)
+            }
+
             return @{
                 Name = 'Bearer'
                 Realm = (Protect-PodeValue -Value $Realm -Default $_realm)
@@ -312,6 +327,8 @@ function New-PodeAuthScheme
                 Arguments = @{
                     HeaderTag = (Protect-PodeValue -Value $HeaderTag -Default 'Bearer')
                     Scopes = $Scope
+                    AsJWT = $AsJWT
+                    Secret = $secretBytes
                 }
             }
         }
@@ -382,6 +399,11 @@ function New-PodeAuthScheme
                 })[$Location]
             }
 
+            $secretBytes = $null
+            if (![string]::IsNullOrWhiteSpace($Secret)) {
+                $secretBytes = [System.Text.Encoding]::UTF8.GetBytes($Secret)
+            }
+
             return @{
                 Name = 'ApiKey'
                 Realm = (Protect-PodeValue -Value $Realm -Default $_realm)
@@ -395,6 +417,8 @@ function New-PodeAuthScheme
                 Arguments = @{
                     Location = $Location
                     LocationName = $LocationName
+                    AsJWT = $AsJWT
+                    Secret = $secretBytes
                 }
             }
         }

--- a/tests/integration/Authentication.Tests.ps1
+++ b/tests/integration/Authentication.Tests.ps1
@@ -1,3 +1,7 @@
+$path = $MyInvocation.MyCommand.Path
+$src = (Split-Path -Parent -Path $path) -ireplace '[\\/]tests[\\/]integration', '/src/'
+Get-ChildItem "$($src)/*.ps1" -Recurse | Resolve-Path | ForEach-Object { . $_ }
+
 Describe 'Authentication Requests' {
 
     BeforeAll {
@@ -55,7 +59,6 @@ Describe 'Authentication Requests' {
                     if ($key -ieq 'test-key') {
                         return @{
                             User = @{ ID ='M0R7Y302' }
-                            Scope = 'write'
                         }
                     }
 
@@ -63,6 +66,40 @@ Describe 'Authentication Requests' {
                 }
 
                 Add-PodeRoute -Method Get -Path '/auth/apikey' -Authentication 'ApiKeyAuth' -ScriptBlock {
+                    Write-PodeJsonResponse -Value @{ Result = 'OK' }
+                }
+
+                # API KEY - JWT (not signed)
+                New-PodeAuthScheme -ApiKey -AsJWT | Add-PodeAuth -Name 'ApiKeyNotSignedJwtAuth' -Sessionless -ScriptBlock {
+                    param($jwt)
+
+                    if ($jwt.username -ieq 'morty') {
+                        return @{
+                            User = @{ ID ='M0R7Y302' }
+                        }
+                    }
+
+                    return $null
+                }
+
+                Add-PodeRoute -Method Get -Path '/auth/apikey/jwt/notsigned' -Authentication 'ApiKeyNotSignedJwtAuth' -ScriptBlock {
+                    Write-PodeJsonResponse -Value @{ Result = 'OK' }
+                }
+
+                # API KEY - JWT (signed)
+                New-PodeAuthScheme -ApiKey -AsJWT -Secret 'secret' | Add-PodeAuth -Name 'ApiKeySignedJwtAuth' -Sessionless -ScriptBlock {
+                    param($jwt)
+
+                    if ($jwt.username -ieq 'morty') {
+                        return @{
+                            User = @{ ID ='M0R7Y302' }
+                        }
+                    }
+
+                    return $null
+                }
+
+                Add-PodeRoute -Method Get -Path '/auth/apikey/jwt/signed' -Authentication 'ApiKeySignedJwtAuth' -ScriptBlock {
                     Write-PodeJsonResponse -Value @{ Result = 'OK' }
                 }
 
@@ -111,16 +148,94 @@ Describe 'Authentication Requests' {
 
 
     # API KEY
-    It 'apikey - returns ok for valid token' {
+    It 'apikey - returns ok for valid key' {
         $result = Invoke-RestMethod -Uri "$($Endpoint)/auth/apikey" -Method Get -Headers @{ 'X-API-KEY' = 'test-key' }
         $result.Result | Should Be 'OK'
     }
 
-    It 'apikey - returns 401 for invalid token' {
+    It 'apikey - returns 401 for invalid key' {
         { Invoke-RestMethod -Uri "$($Endpoint)/auth/apikey" -Method Get -Headers @{ 'X-API-KEY' = 'fake-key' } -ErrorAction Stop } | Should Throw '401'
     }
 
-    It 'apikey - returns 400 for no token' {
+    It 'apikey - returns 401 for no key' {
         { Invoke-RestMethod -Uri "$($Endpoint)/auth/apikey" -Method Get -ErrorAction Stop } | Should Throw '401'
+    }
+
+
+    # API KEY - JWT (not signed)
+    It 'apikey - jwt not signed - returns ok for valid key' {
+        $header = @{ alg = 'none' }
+        $payload = @{ sub = '123'; username = 'morty' }
+        $jwt = ConvertTo-PodeJwt -Header $header -Payload $payload
+
+        $result = Invoke-RestMethod -Uri "$($Endpoint)/auth/apikey/jwt/notsigned" -Method Get -Headers @{ 'X-API-KEY' = $jwt }
+        $result.Result | Should Be 'OK'
+    }
+
+    It 'apikey -jwt not signed - returns 400 for invalid key - invalid base64' {
+        $header = @{ alg = 'none' }
+        $payload = @{ sub = '123'; username = 'morty' }
+        $jwt = ConvertTo-PodeJwt -Header $header -Payload $payload
+
+        { Invoke-RestMethod -Uri "$($Endpoint)/auth/apikey/jwt/notsigned" -Method Get -Headers @{ 'X-API-KEY' = "hh$($jwt)" } -ErrorAction Stop } | Should Throw '400'
+    }
+
+    It 'apikey -jwt not signed - returns 401 for invalid key - invalid username' {
+        $header = @{ alg = 'none' }
+        $payload = @{ sub = '123'; username = 'rick' }
+        $jwt = ConvertTo-PodeJwt -Header $header -Payload $payload
+
+        { Invoke-RestMethod -Uri "$($Endpoint)/auth/apikey/jwt/notsigned" -Method Get -Headers @{ 'X-API-KEY' = $jwt } -ErrorAction Stop } | Should Throw '401'
+    }
+
+
+    # API KEY - JWT (signed)
+    It 'apikey - jwt signed - returns ok for valid key' {
+        $header = @{ alg = 'hs256' }
+        $payload = @{ sub = '123'; username = 'morty' }
+        $jwt = ConvertTo-PodeJwt -Header $header -Payload $payload -Secret 'secret'
+
+        $result = Invoke-RestMethod -Uri "$($Endpoint)/auth/apikey/jwt/signed" -Method Get -Headers @{ 'X-API-KEY' = $jwt }
+        $result.Result | Should Be 'OK'
+    }
+
+    It 'apikey - jwt signed - returns 400 for invalid key - invalid base64' {
+        $header = @{ alg = 'hs256' }
+        $payload = @{ sub = '123'; username = 'morty' }
+        $jwt = ConvertTo-PodeJwt -Header $header -Payload $payload -Secret 'secret'
+
+        { Invoke-RestMethod -Uri "$($Endpoint)/auth/apikey/jwt/signed" -Method Get -Headers @{ 'X-API-KEY' = "hh$($jwt)" } -ErrorAction Stop } | Should Throw '400'
+    }
+
+    It 'apikey - jwt signed - returns 400 for invalid key - invalid signature' {
+        $header = @{ alg = 'hs256' }
+        $payload = @{ sub = '123'; username = 'morty' }
+        $jwt = ConvertTo-PodeJwt -Header $header -Payload $payload -Secret 'secret'
+
+        { Invoke-RestMethod -Uri "$($Endpoint)/auth/apikey/jwt/signed" -Method Get -Headers @{ 'X-API-KEY' = "$($jwt)hh" } -ErrorAction Stop } | Should Throw '400'
+    }
+
+    It 'apikey - jwt signed - returns 400 for invalid key - invalid secret' {
+        $header = @{ alg = 'hs256' }
+        $payload = @{ sub = '123'; username = 'morty' }
+        $jwt = ConvertTo-PodeJwt -Header $header -Payload $payload -Secret 'fake'
+
+        { Invoke-RestMethod -Uri "$($Endpoint)/auth/apikey/jwt/signed" -Method Get -Headers @{ 'X-API-KEY' = $jwt } -ErrorAction Stop } | Should Throw '400'
+    }
+
+    It 'apikey - jwt signed - returns 400 for invalid key - none algorithm' {
+        $header = @{ alg = 'none' }
+        $payload = @{ sub = '123'; username = 'morty' }
+        $jwt = ConvertTo-PodeJwt -Header $header -Payload $payload
+
+        { Invoke-RestMethod -Uri "$($Endpoint)/auth/apikey/jwt/signed" -Method Get -Headers @{ 'X-API-KEY' = $jwt } -ErrorAction Stop } | Should Throw '400'
+    }
+
+    It 'apikey - jwt signed - returns 401 for invalid key - invalid username' {
+        $header = @{ alg = 'hs256' }
+        $payload = @{ sub = '123'; username = 'rick' }
+        $jwt = ConvertTo-PodeJwt -Header $header -Payload $payload -Secret 'secret'
+
+        { Invoke-RestMethod -Uri "$($Endpoint)/auth/apikey/jwt/signed" -Method Get -Headers @{ 'X-API-KEY' = $jwt } -ErrorAction Stop } | Should Throw '401'
     }
 }

--- a/tests/unit/Cryptography.Tests.ps1
+++ b/tests/unit/Cryptography.Tests.ps1
@@ -3,24 +3,6 @@ $src = (Split-Path -Parent -Path $path) -ireplace '[\\/]tests[\\/]unit', '/src/'
 Get-ChildItem "$($src)/*.ps1" -Recurse | Resolve-Path | ForEach-Object { . $_ }
 
 Describe 'Invoke-PodeHMACSHA256Hash' {
-    Context 'Invalid parameters supplied' {
-        It 'Throws null value error' {
-            { Invoke-PodeHMACSHA256Hash -Value $null -Secret 'key' } | Should Throw 'argument is null or empty'
-        }
-
-        It 'Throws empty value error' {
-            { Invoke-PodeHMACSHA256Hash -Value '' -Secret 'key' } | Should Throw 'argument is null or empty'
-        }
-
-        It 'Throws null secret error' {
-            { Invoke-PodeHMACSHA256Hash -Value 'value' -Secret $null } | Should Throw 'argument is null or empty'
-        }
-
-        It 'Throws empty secret error' {
-            { Invoke-PodeHMACSHA256Hash -Value 'value' -Secret '' } | Should Throw 'argument is null or empty'
-        }
-    }
-
     Context 'Valid parameters' {
         It 'Returns encrypted data' {
             Invoke-PodeHMACSHA256Hash -Value 'value' -Secret 'key' | Should Be 'kPv88V50o2uJ29sqch2a7P/f3dxcg+J/dZJZT3GTJIE='


### PR DESCRIPTION
### Description of the Change
Add JWT support onto Bearer and API key authentication. This will parse and validate a JWT, returning and supplying the JWT's payload to `Add-PodeAuth` instead of the token/key.

Supports signed and non-signed JWTs. Signed tokens can use HS256, 384, or 512.

If a token has an `exp` or `nbf`, it is also validated.

### Related Issue
Resolves #752 

### Examples

```powershell
# jwt with no signature:
New-PodeAuthScheme -Bearer -AsJWT | Add-PodeAuth -Name 'Example' -Sessionless -ScriptBlock {
    param($payload)
}

# jwt with signature, signed with secret "abc":
New-PodeAuthScheme -ApiKey -AsJWT -Secret 'abc' | Add-PodeAuth -Name 'Example' -Sessionless -ScriptBlock {
    param($payload)
}
```
