### PR TITLE
Adds support on SMTPs for Attachments

### DIFF
--- a/examples/mail-server.ps1
+++ b/examples/mail-server.ps1
@@ -28,9 +28,15 @@ Start-PodeServer -Threads 2 {
         Write-Host '|'
         Write-Host $SmtpEvent.Email.Body
         Write-Host '|'
-        Write-Host $SmtpEvent.Email.Data
+        # Write-Host $SmtpEvent.Email.Data
+        # Write-Host '|'
+        $SmtpEvent.Email.Attachments | Out-Default
+        if ($SmtpEvent.Email.Attachments.Length -gt 0) {
+            #$SmtpEvent.Email.Attachments[0].Save('C:\temp')
+        }
         Write-Host '|'
         $SmtpEvent.Email | Out-Default
+        $SmtpEvent.Request | out-default
         Write-Host '- - - - - - - - - - - - - - - - - -'
     }
 

--- a/src/Listener/PodeForm.cs
+++ b/src/Listener/PodeForm.cs
@@ -48,6 +48,11 @@ namespace Pode
                 }
             }
 
+            return ParseHttp(form, lines, boundaryLineIndexes, contentEncoding);
+        }
+
+        private static PodeForm ParseHttp(PodeForm form, List<byte[]> lines, List<int> boundaryLineIndexes, Encoding contentEncoding)
+        {
             var boundaryLineIndex = 0;
             var disposition = string.Empty;
             var fields = new Dictionary<string, string>();
@@ -128,6 +133,16 @@ namespace Pode
             }
 
             return (contentEncoding.GetString(bytes).StartsWith(boundary));
+        }
+
+        public static bool IsLineBoundary(string line, string boundary)
+        {
+            if (string.IsNullOrEmpty(line))
+            {
+                return false;
+            }
+
+            return line.StartsWith(boundary);
         }
     }
 }

--- a/src/Listener/PodeHelpers.cs
+++ b/src/Listener/PodeHelpers.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Security.Cryptography;
 
 namespace Pode
@@ -97,6 +98,19 @@ namespace Pode
             }
 
             return lines;
+        }
+
+        public static T[] Subset<T>(T[] array, int startIndex, int endIndex)
+        {
+            var count = endIndex - startIndex;
+            var newArray = new T[count];
+            Array.Copy(array, startIndex, newArray, 0, count);
+            return newArray;
+        }
+
+        public static List<T> Subset<T>(List<T> list, int startIndex, int endIndex)
+        {
+            return Subset(list.ToArray(), startIndex, endIndex).ToList<T>();
         }
     }
 }

--- a/src/Listener/PodeSmtpAttachment.cs
+++ b/src/Listener/PodeSmtpAttachment.cs
@@ -1,0 +1,41 @@
+using System;
+using System.IO;
+
+namespace Pode
+{
+    public class PodeSmtpAttachment : IDisposable
+    {
+        public string Name { get; private set; }
+        public string ContentType { get; private set; }
+        public string ContentEncoding { get; private set; }
+        public byte[] Bytes => _stream.ToArray();
+
+        private MemoryStream _stream;
+
+        public PodeSmtpAttachment(string name, MemoryStream stream, string contentType, string contentEncoding)
+        {
+            Name = name;
+            ContentType = contentType;
+            ContentEncoding = contentEncoding;
+            _stream = stream;
+        }
+
+        public void Save(string path, bool addNameToPath = true)
+        {
+            if (addNameToPath)
+            {
+                path = Path.Combine(path, Name);
+            }
+
+            using (var file = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None))
+            {
+                _stream.WriteTo(file);
+            }
+        }
+
+        public void Dispose()
+        {
+            _stream.Dispose();
+        }
+    }
+}

--- a/src/Listener/PodeSmtpRequest.cs
+++ b/src/Listener/PodeSmtpRequest.cs
@@ -7,6 +7,7 @@ using System.Text.RegularExpressions;
 using System.Linq;
 using System.Globalization;
 using _Encoding = System.Text.Encoding;
+using System.IO;
 
 namespace Pode
 {
@@ -14,9 +15,11 @@ namespace Pode
     {
         public string ContentType { get; private set; }
         public string ContentEncoding { get; private set; }
+        public string Boundary { get; private set; }
         public Hashtable Headers { get; private set; }
+        public List<PodeSmtpAttachment> Attachments { get; private set; }
         public string Body { get; private set; }
-        public string RawBody { get; private set; }
+        public byte[] RawBody { get; private set; }
         public string Subject { get; private set; }
         public bool IsUrgent { get; private set; }
         public string From { get; private set; }
@@ -39,12 +42,41 @@ namespace Pode
 
         private bool IsCommand(string content, string command)
         {
+            if (string.IsNullOrWhiteSpace(content))
+            {
+                return false;
+            }
+
             return content.StartsWith(command, true, CultureInfo.InvariantCulture);
         }
 
         public void SendAck()
         {
             Context.Response.WriteLine($"220 {Context.PodeSocket.Hostnames[0]} -- Pode Proxy Server", true);
+        }
+
+        protected override bool ValidateInput(byte[] bytes)
+        {
+            // we need more bytes!
+            if (bytes.Length == 0)
+            {
+                return false;
+            }
+
+            // for data, we need to wait till it ends with a '.<CR><LF>'
+            if (IsCommand(Command, "DATA"))
+            {
+                if (bytes.Length < 3)
+                {
+                    return false;
+                }
+
+                return (bytes[bytes.Length - 3] == (byte)46
+                    && bytes[bytes.Length - 2] == (byte)13
+                    && bytes[bytes.Length - 1] == (byte)10);
+            }
+
+            return true;
         }
 
         protected override bool Parse(byte[] bytes)
@@ -112,17 +144,35 @@ namespace Pode
             switch (Command.ToUpperInvariant())
             {
                 case "DATA":
+                    CanProcess = true;
                     Context.Response.WriteLine("250 OK", true);
-                    RawBody = content;
-                    ParseHeaders(content);
+                    RawBody = bytes;
+                    Attachments = new List<PodeSmtpAttachment>();
+
+                    // parse the headers
+                    Headers = ParseHeaders(content);
                     Subject = $"{Headers["Subject"]}";
                     IsUrgent = ($"{Headers["Priority"]}".Equals("urgent", StringComparison.InvariantCultureIgnoreCase) || $"{Headers["Importance"]}".Equals("high", StringComparison.InvariantCultureIgnoreCase));
-                    ContentType = $"{Headers["Content-Type"]}";
                     ContentEncoding = $"{Headers["Content-Transfer-Encoding"]}";
 
+                    ContentType = $"{Headers["Content-Type"]}";
+                    if (!string.IsNullOrEmpty(Boundary) && !ContentType.Contains("boundary="))
+                    {
+                        ContentType = ContentType.TrimEnd(';');
+                        ContentType += $"; boundary={Boundary}";
+                    }
+
+                    // check if body is valid and parse, else error
                     if (IsBodyValid(content))
                     {
-                        ParseBody(content);
+                        // parse the body
+                        Body = ConvertBodyType(ConvertBodyEncoding(ParseBody(content), ContentEncoding), ContentType);
+
+                        // if we have a boundary, get attachments/body
+                        if (!string.IsNullOrWhiteSpace(Boundary))
+                        {
+                            ParseBoundary();
+                        }
                     }
                     else
                     {
@@ -130,8 +180,6 @@ namespace Pode
                         Context.Response.WriteLine("501 Invalid DATA received", true);
                         return true;
                     }
-
-                    CanProcess = true;
                     break;
 
                 default:
@@ -148,12 +196,22 @@ namespace Pode
             From = string.Empty;
             To = new List<string>();
             Body = string.Empty;
-            RawBody = string.Empty;
+            RawBody = default(byte[]);
             Command = string.Empty;
             ContentType = string.Empty;
             ContentEncoding = string.Empty;
             Subject = string.Empty;
             IsUrgent = false;
+
+            if (Attachments != default(List<PodeSmtpAttachment>))
+            {
+                foreach (var attachment in Attachments)
+                {
+                    attachment.Dispose();
+                }
+            }
+
+            Attachments = new List<PodeSmtpAttachment>();
         }
 
         private string ParseEmail(string value)
@@ -167,9 +225,9 @@ namespace Pode
             return string.Empty;
         }
 
-        private void ParseHeaders(string value)
+        private Hashtable ParseHeaders(string value)
         {
-            Headers = new Hashtable(StringComparer.InvariantCultureIgnoreCase);
+            var headers = new Hashtable(StringComparer.InvariantCultureIgnoreCase);
 
             var lines = value.Split(new string[] { PodeHelpers.NEW_LINE }, StringSplitOptions.None);
             var match = default(Match);
@@ -181,12 +239,22 @@ namespace Pode
                     break;
                 }
 
+                // header
                 match = Regex.Match(line, "^(?<name>.*?)\\:\\s+(?<value>.*?)$");
                 if (match.Success)
                 {
-                    Headers.Add(match.Groups["name"].Value, match.Groups["value"].Value);
+                    headers.Add(match.Groups["name"].Value, match.Groups["value"].Value);
+                }
+
+                // boundary line
+                match = Regex.Match(line, "^\\s*boundary=(?<boundary>.+?)$");
+                if (match.Success)
+                {
+                    Boundary = match.Groups["boundary"].Value;
                 }
             }
+
+            return headers;
         }
 
         private bool IsBodyValid(string value)
@@ -195,36 +263,97 @@ namespace Pode
             return (Array.LastIndexOf(lines, ".") > -1);
         }
 
-        private void ParseBody(string value)
+        private void ParseBoundary()
         {
-            Body = string.Empty;
+            var lines = Body.Split(new string[] { PodeHelpers.NEW_LINE }, StringSplitOptions.None);
+            var boundaryStart = $"--{Boundary}";
+            var boundaryEnd = $"{boundaryStart}--";
 
+            var boundaryLineIndexes = new List<int>();
+            for (var i = 0; i < lines.Length; i++)
+            {
+                if (PodeForm.IsLineBoundary(lines[i], boundaryStart) || PodeForm.IsLineBoundary(lines[i], boundaryEnd))
+                {
+                    boundaryLineIndexes.Add(i);
+                }
+            }
+
+            var boundaryIndex = 0;
+            var nextBoundaryIndex = 0;
+
+            for (var i = 0; i < (boundaryLineIndexes.Count - 1); i++)
+            {
+                boundaryIndex = boundaryLineIndexes[i];
+                nextBoundaryIndex = boundaryLineIndexes[i + 1];
+
+                // get the boundary headers
+                var boundaryBody = string.Join(PodeHelpers.NEW_LINE, PodeHelpers.Subset(lines, boundaryIndex + 1, nextBoundaryIndex + 1));
+                var headers = ParseHeaders(boundaryBody);
+
+                var contentType = $"{headers["Content-Type"]}";
+                var contentEncoding = $"{headers["Content-Transfer-Encoding"]}";
+
+                // get the boundary 
+                var body = ParseBody(boundaryBody, Boundary);
+                var bodyBytes = ConvertBodyEncoding(body, contentEncoding);
+
+                // file or main body?
+                var contentDisposition = $"{headers["Content-Disposition"]}";
+                if (!string.IsNullOrEmpty(contentDisposition) && contentDisposition.Equals("attachment", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    var match = Regex.Match(contentType, "name=(?<name>.+)");
+                    var name = match.Groups["name"].Value;
+
+                    var stream = new MemoryStream();
+                    stream.Write(bodyBytes, 0, bodyBytes.Length);
+                    var attachment = new PodeSmtpAttachment(name, stream, contentType, contentEncoding);
+                    Attachments.Add(attachment);
+                }
+                else
+                {
+                    Body = ConvertBodyType(bodyBytes, contentType);
+                }
+            }
+        }
+
+        private string ParseBody(string value, string boundary = null)
+        {
             // split the message up
             var lines = value.Split(new string[] { PodeHelpers.NEW_LINE }, StringSplitOptions.None);
 
+            // what's the end char?
+            var useBoundary = !string.IsNullOrEmpty(boundary);
+            var endChar = useBoundary ? $"--{boundary}" : ".";
+            var trimCount = useBoundary ? 1 : 2;
+
             // get the index of the first blank line, and last dot
             var indexOfBlankLine = Array.IndexOf(lines, string.Empty);
-            var indexOfLastDot = Array.LastIndexOf(lines, ".");
+
+            var indexOfLastDot = Array.LastIndexOf(lines, endChar);
+            if (indexOfLastDot == -1 && useBoundary)
+            {
+                indexOfLastDot = Array.LastIndexOf(lines, $"{endChar}--");
+            }
 
             // get the body
-            var bodyLines = lines.Skip(indexOfBlankLine + 1).Take(indexOfLastDot - indexOfBlankLine - 2);
+            var bodyLines = lines.Skip(indexOfBlankLine + 1).Take(indexOfLastDot - indexOfBlankLine - trimCount);
             var body = string.Join(PodeHelpers.NEW_LINE, bodyLines);
 
             // if there's no body, return
             if (indexOfLastDot == -1 || string.IsNullOrWhiteSpace(body))
             {
-                Body = body;
-                return;
+                return string.Empty;
             }
 
-            // decode body based on encoding
-            var bodyBytes = default(byte[]);
+            return body;
+        }
 
-            switch (ContentEncoding.ToLowerInvariant())
+        private byte[] ConvertBodyEncoding(string body, string contentEncoding)
+        {
+            switch (contentEncoding.ToLowerInvariant())
             {
                 case "base64":
-                    bodyBytes = Convert.FromBase64String(body);
-                    break;
+                    return Convert.FromBase64String(body);
 
                 case "quoted-printable":
                     var match = default(Match);
@@ -232,47 +361,68 @@ namespace Pode
                     {
                         body = (body.Replace(match.Groups["code"].Value, $"{(char)Convert.ToInt32(match.Groups["hex"].Value, 16)}"));
                     }
-                    break;
-            }
 
-            // if body bytes set, convert to string based on type
-            if (bodyBytes != default(byte[]))
+                    return _Encoding.UTF8.GetBytes(body);
+
+                default:
+                    return _Encoding.UTF8.GetBytes(body);
+            }
+        }
+
+        private string ConvertBodyType(byte[] bytes, string contentType)
+        {
+            if (bytes == default(byte[]) || bytes.Length == 0)
             {
-                var type = ContentType.ToLowerInvariant();
+                return string.Empty;
+            }
 
-                // utf-7
-                if (type.Contains("utf-7"))
-                {
-                    body = _Encoding.UTF7.GetString(bodyBytes);
-                }
+            contentType = contentType.ToLowerInvariant();
 
-                // utf-8
-                else if (type.Contains("utf-8"))
-                {
-                    body = _Encoding.UTF8.GetString(bodyBytes);
-                }
+            // utf-7
+            if (contentType.Contains("utf-7"))
+            {
+                return _Encoding.UTF7.GetString(bytes);
+            }
 
-                // utf-16
-                else if (type.Contains("utf-16"))
-                {
-                    body = _Encoding.Unicode.GetString(bodyBytes);
-                }
+            // utf-8
+            else if (contentType.Contains("utf-8"))
+            {
+                return _Encoding.UTF8.GetString(bytes);
+            }
 
-                // utf-32
-                else if (type.Contains("utf32"))
-                {
-                    body = _Encoding.UTF32.GetString(bodyBytes);
-                }
+            // utf-16
+            else if (contentType.Contains("utf-16"))
+            {
+                return _Encoding.Unicode.GetString(bytes);
+            }
 
-                // default (ascii)
-                else
+            // utf-32
+            else if (contentType.Contains("utf32"))
+            {
+                return _Encoding.UTF32.GetString(bytes);
+            }
+
+            // default (ascii)
+            else
+            {
+                return _Encoding.ASCII.GetString(bytes);
+            }
+        }
+
+        public override void Dispose()
+        {
+            RawBody = default(byte[]);
+            Body = string.Empty;
+
+            if (Attachments != default(List<PodeSmtpAttachment>))
+            {
+                foreach (var attachment in Attachments)
                 {
-                    body = _Encoding.ASCII.GetString(bodyBytes);
+                    attachment.Dispose();
                 }
             }
 
-            // set body
-            Body = body;
+            base.Dispose();
         }
     }
 }

--- a/src/Listener/PodeSmtpRequest.cs
+++ b/src/Listener/PodeSmtpRequest.cs
@@ -37,6 +37,7 @@ namespace Pode
         {
             CanProcess = false;
             IsKeepAlive = true;
+            Command = string.Empty;
             To = new List<string>();
         }
 
@@ -183,7 +184,7 @@ namespace Pode
                     break;
 
                 default:
-                    throw new HttpRequestException();
+                    throw new HttpRequestException("Invalid SMTP command");
             }
 
             return true;

--- a/src/Private/SmtpServer.ps1
+++ b/src/Private/SmtpServer.ps1
@@ -62,56 +62,70 @@ function Start-PodeSmtpServer
 
                 try
                 {
-                    $Request = $context.Request
-                    $Response = $context.Response
+                    try
+                    {
+                        $Request = $context.Request
+                        $Response = $context.Response
 
-                    $SmtpEvent = @{
-                        Response = $Response
-                        Request = $Request
-                        Lockable = $PodeContext.Lockable
-                        Email = @{
-                            From = $Request.From
-                            To = $Request.To
-                            Data = $Request.RawBody
-                            Headers = $Request.Headers
-                            Subject = $Request.Subject
-                            IsUrgent = $Request.IsUrgent
-                            ContentType = $Request.ContentType
-                            ContentEncoding = $Request.ContentEncoding
-                            Body = $Request.Body
-                        }
-                    }
-
-                    # convert the ip
-                    $ip = (ConvertTo-PodeIPAddress -Address $Request.RemoteEndPoint)
-
-                    # ensure the request ip is allowed
-                    if (!(Test-PodeIPAccess -IP $ip)) {
-                        $Response.WriteLine('554 Your IP address was rejected', $true)
-                    }
-
-                    # has the ip hit the rate limit?
-                    elseif (!(Test-PodeIPLimit -IP $ip)) {
-                        $Response.WriteLine('554 Your IP address has hit the rate limit', $true)
-                    }
-
-                    # deal with smtp call
-                    else {
-                        $handlers = Get-PodeHandler -Type Smtp
-                        foreach ($name in $handlers.Keys) {
-                            $handler = $handlers[$name]
-
-                            $_args = @($handler.Arguments)
-                            if ($null -ne $handler.UsingVariables) {
-                                $_vars = @()
-                                foreach ($_var in $handler.UsingVariables) {
-                                    $_vars += ,$_var.Value
-                                }
-                                $_args = $_vars + $_args
+                        $SmtpEvent = @{
+                            Response = $Response
+                            Request = $Request
+                            Lockable = $PodeContext.Lockable
+                            Email = @{
+                                From = $Request.From
+                                To = $Request.To
+                                Data = $Request.RawBody
+                                Headers = $Request.Headers
+                                Subject = $Request.Subject
+                                IsUrgent = $Request.IsUrgent
+                                ContentType = $Request.ContentType
+                                ContentEncoding = $Request.ContentEncoding
+                                Attachments = $Request.Attachments
+                                Body = $Request.Body
                             }
-
-                            Invoke-PodeScriptBlock -ScriptBlock $handler.Logic -Arguments $_args -Scoped -Splat
                         }
+
+                        # stop now if the request has an error
+                        if ($Request.IsAborted) {
+                            throw $Request.Error
+                        }
+
+                        # convert the ip
+                        $ip = (ConvertTo-PodeIPAddress -Address $Request.RemoteEndPoint)
+
+                        # ensure the request ip is allowed
+                        if (!(Test-PodeIPAccess -IP $ip)) {
+                            $Response.WriteLine('554 Your IP address was rejected', $true)
+                        }
+
+                        # has the ip hit the rate limit?
+                        elseif (!(Test-PodeIPLimit -IP $ip)) {
+                            $Response.WriteLine('554 Your IP address has hit the rate limit', $true)
+                        }
+
+                        # deal with smtp call
+                        else {
+                            $handlers = Get-PodeHandler -Type Smtp
+                            foreach ($name in $handlers.Keys) {
+                                $handler = $handlers[$name]
+
+                                $_args = @($handler.Arguments)
+                                if ($null -ne $handler.UsingVariables) {
+                                    $_vars = @()
+                                    foreach ($_var in $handler.UsingVariables) {
+                                        $_vars += ,$_var.Value
+                                    }
+                                    $_args = $_vars + $_args
+                                }
+
+                                Invoke-PodeScriptBlock -ScriptBlock $handler.Logic -Arguments $_args -Scoped -Splat
+                            }
+                        }
+                    }
+                    catch [System.OperationCanceledException] {}
+                    catch {
+                        $_ | Write-PodeErrorLog
+                        $_.Exception | Write-PodeErrorLog -CheckInnerException
                     }
                 }
                 finally {


### PR DESCRIPTION
### Description of the Change
Adds support on SMTPs for Attachments, and also stabilises receiving content for the DATA command.

Attachment Name/Bytes will be available in `$SmtpEvent.Email.Attachments`. There's also a `.Save(<path>)` method for saving attachments.

### Related Issue
Resolves #763

### Examples
```powershell
Add-PodeHandler -Type Smtp -Name 'Main' -ScriptBlock {
    $SmtpEvent.Email.Attachments[0].Save('C:\temp')
}
```
