### PR TITLE
Use GUID when no secret supplied for sessions, unless custom storage is being used

### DIFF
--- a/docs/Tutorials/Middleware/Types/Sessions.md
+++ b/docs/Tutorials/Middleware/Types/Sessions.md
@@ -1,8 +1,8 @@
 # Sessions
 
-Session Middleware is supported on web requests and responses in the form of signed-cookies/headers and server-side data storage. When configured, the middleware will check for a session-cookie/header on the request; if a cookie/header is not found on the request, or the session is not in the store, then a new session is created and attached to the response. If there is a session, then the appropriate data is loaded from the store.
+Session Middleware is supported on web requests and responses in the form of signed-cookies/headers and server-side data storage. When configured, the middleware will check for a session-cookie/header on the request; if a cookie/header is not found on the request, or the session is not in storage, then a new session is created and attached to the response. If there is a session, then the appropriate data for that session is loaded from storage.
 
-The duration of the session-cookie/header can be specified, as well as whether to extend the duration each time on each request. A secret-key to sign sessions can be supplied, as well as the ability to specify custom data stores - the default is in-mem, custom could be anything like Redis/MongoDB.
+The duration of the session-cookie/header can be specified, as well as whether to extend the duration each time on each request. A secret-key to sign sessions can be supplied (default is a random GUID), as well as the ability to specify custom data stores - the default is in-memory, but custom storage could be anything like Redis/MongoDB/etc.
 
 !!! note
     Using sessions via headers is best used with REST APIs and the CLI. It's not advised to use them for normal websites, as browsers don't send back response headers in new requests - unlike cookies.
@@ -11,13 +11,15 @@ The duration of the session-cookie/header can be specified, as well as whether t
 
 To initialise sessions in Pode you use the [`Enable-PodeSessionMiddleware`](../../../../Functions/Middleware/Enable-PodeSessionMiddleware) function. This function will configure and automatically create Middleware to enable sessions. By default sessions are set using cookies, but support is also available for headers.
 
+Sessions are automatically signed using a random GUID. For Pode running on a single server using the default in-memory storage this is OK. However if you're running Pode on multiple servers, or if you're defining a custom storage then a `-Secret` is required - this is so that sessions from different servers, or after a server restart, don't become corrupt and unusable.
+
 ### Cookies
 
 The following is an example of how to setup session middleware using cookies:
 
 ```powershell
 Start-PodeServer {
-    Enable-PodeSessionMiddleware -Secret 'schwifty' -Duration 120 -Extend
+    Enable-PodeSessionMiddleware -Duration 120 -Extend
 }
 ```
 
@@ -29,7 +31,7 @@ Sessions are also supported using headers - useful for CLI requests. The followi
 
 ```powershell
 Start-PodeServer {
-    Enable-PodeSessionMiddleware -Secret 'schwifty' -Duration 120 -Extend -UseHeaders
+    Enable-PodeSessionMiddleware -Duration 120 -Extend -UseHeaders
 }
 ```
 
@@ -47,13 +49,13 @@ Within a route, or middleware, you can get the current authenticated sessionId u
 
 You can flag sessions as being strict using the `-Strict` switch. Strict sessions will extend the signing process by also using the client's UserAgent and RemoteIPAddress, to help prevent session sharing on different browsers/consoles.
 
-You can supply the secret value as normal, Pode will automatically extend it for you.
+Pode will automatically extend the Secret for signing for you, whether you're using the default GUID, or supplying a specific `-Secret` value.
 
 ## Storage
 
-The inbuilt storage for sessions is a simple In-Memory store - with auto-cleanup for expired sessions.
+The inbuilt storage for sessions is a simple in-memory store - with auto-cleanup for expired sessions.
 
-If supplied, the `-Storage` parameter is a `psobject` with the following required `NoteProperty` scriptblock members:
+You can define a custom storage by supplying a `psobject` to the `-Storage` parameter, and also note that a `-Secret` will be required. The `psobject` supplied should have the following `NoteProperty` scriptblock members:
 
 ```powershell
 [hashtable] Get([string] $sessionId)
@@ -64,22 +66,29 @@ If supplied, the `-Storage` parameter is a `psobject` with the following require
 For example, the following is a mock up of a Storage for Redis (note that the functions are fake):
 
 ```powershell
+# create the object
 $store = New-Object -TypeName psobject
 
+# add a Get property for retreiving a session's data by SessionId
 $store | Add-Member -MemberType NoteProperty -Name Get -Value {
     param($sessionId)
     return (Get-RedisKey -Key $sessionId)
 }
 
+# add a Set property to save a session's data
 $store | Add-Member -MemberType NoteProperty -Name Set -Value {
     param($sessionId, $data, $expiry)
     Set-RedisKey -Key $sessionId -Value $data -TimeToLive $expiry
 }
 
+# add a Delete property to delete a session's data by SessionId
 $store | Add-Member -MemberType NoteProperty -Name Delete -Value {
     param($sessionId)
     Remove-RedisKey -Key $sessionId
 }
+
+# enable session middleware - a secret is required
+Enable-PodeSessionMiddleware -Duration 120 -Storage $store -Secret 'schwifty'
 ```
 
 ## Session Data
@@ -92,7 +101,7 @@ An example of using sessions in a Route to increment a views counter could be do
 
 ```powershell
 Start-PodeServer {
-    Enable-PodeSessionMiddleware -Secret 'schwifty' -Duration 120
+    Enable-PodeSessionMiddleware -Duration 120
 
     Add-PodeRoute -Method Get -Path '/' -ScriptBlock {
         $WebEvent.Session.Data.Views++

--- a/docs/Tutorials/Routes/Examples/LoginPage.md
+++ b/docs/Tutorials/Routes/Examples/LoginPage.md
@@ -1,6 +1,6 @@
 # Creating a Login Page
 
-This is an example of having a website with a login and home page - with a logout button. The pages will all be done using `.pode` files, and authentication will be done using Form authentication with Sessions.
+This is an example of having a website with a login and home page - with a logout button. The pages will all be done using `.pode` files, and authentication will be done using [Form authentication](../../../Authentication/Methods/Form) with [Sessions]((../../../Middleware/Types/Sessions)).
 
 !!! info
     The full example can be seen on GitHub in [`examples/web-auth-form.ps1`](https://github.com/Badgerati/Pode/blob/develop/examples/web-auth-form.ps1).
@@ -38,7 +38,7 @@ Set-PodeViewEngine -Type Pode
 To use sessions for our authentication (so we can stay logged in), we need to setup Session Middleware using the [`Enable-PodeSessionMiddleware`](../../../../Functions/Middleware/Enable-PodeSessionMiddleware) function. Here our sessions will last for 2 minutes, and will be extended on each request:
 
 ```powershell
-Enable-PodeSessionMiddleware -Secret 'schwifty' -Duration 120 -Extend
+Enable-PodeSessionMiddleware -Duration 120 -Extend
 ```
 
 Once we have the Session Middleware initialised, we need to setup Form authentication - the username/password here are hard-coded, but normally you would validate against some database. We also specify a `-FailureUrl`, which is the URL to redirect a user to if they try to access a page un-authenticated. The `-SuccessUrl` is the URL to redirect to on successful authentication.
@@ -110,7 +110,7 @@ Start-PodeServer -Thread 2 {
     Set-PodeViewEngine -Type Pode
 
     # setup session middleware
-    Enable-PodeSessionMiddleware -Secret 'schwifty' -Duration 120 -Extend
+    Enable-PodeSessionMiddleware -Duration 120 -Extend
 
     # setup form authentication
     New-PodeAuthScheme -Form | Add-PodeAuth -Name 'Login' -FailureUrl '/login' -SuccessUrl '/' -ScriptBlock {

--- a/docs/Tutorials/Routes/Examples/RestApiSessions.md
+++ b/docs/Tutorials/Routes/Examples/RestApiSessions.md
@@ -1,6 +1,6 @@
 # REST APIs and Sessions
 
-Sessions in Pode are normally done using cookies, but you can also use them via headers as well. This way you can have two endpoints for authentication login/logout, and the rest of your routes depend on a valid SessionId.
+[Sessions](../../../Middleware/Types/Sessions) in Pode are normally done using cookies, but you can also use them via headers as well. This way you can have two endpoints for authentication login/logout, and the rest of your routes depend on a valid SessionId.
 
 !!! info
     The full example can be seen on GitHub in `examples/web-auth-basic-header.ps1`.
@@ -26,7 +26,7 @@ Add-PodeEndpoint -Address * -Port 8080 -Protocol Http
 To use sessions with headers for our authentication, we need to setup Session Middleware using the [`Enable-PodeSessionMiddleware`](../../../../Functions/Middleware/Enable-PodeSessionMiddleware) function. Here our sessions will last for 2 minutes, and will be extended on each request:
 
 ```powershell
-Enable-PodeSessionMiddleware -Secret 'schwifty' -Duration 120 -Extend -UseHeaders
+Enable-PodeSessionMiddleware -Duration 120 -Extend -UseHeaders
 ```
 
 ## Authentication

--- a/examples/web-auth-basic-header.ps1
+++ b/examples/web-auth-basic-header.ps1
@@ -28,7 +28,7 @@ Start-PodeServer -Threads 2 {
     New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
 
     # setup session details
-    Enable-PodeSessionMiddleware -Secret 'schwifty' -Duration 120 -Extend -UseHeaders -Strict
+    Enable-PodeSessionMiddleware -Duration 120 -Extend -UseHeaders -Strict
 
     # setup basic auth (base64> username:password in header)
     New-PodeAuthScheme -Basic | Add-PodeAuth -Name 'Login' -ScriptBlock {

--- a/examples/web-auth-form-ad.ps1
+++ b/examples/web-auth-form-ad.ps1
@@ -25,7 +25,7 @@ Start-PodeServer -Threads 2 {
     Set-PodeViewEngine -Type Pode
 
     # setup session details
-    Enable-PodeSessionMiddleware -Secret 'schwifty' -Duration 120 -Extend
+    Enable-PodeSessionMiddleware -Duration 120 -Extend
 
     # setup form auth against windows AD (<form> in HTML)
     New-PodeAuthScheme -Form | Add-PodeAuthWindowsAd -Name 'Login' -Groups @() -Users @() -FailureUrl '/login' -SuccessUrl '/'

--- a/examples/web-auth-form-creds.ps1
+++ b/examples/web-auth-form-creds.ps1
@@ -28,7 +28,7 @@ Start-PodeServer -Threads 2 {
     New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
 
     # setup session details
-    Enable-PodeSessionMiddleware -Secret 'schwifty' -Duration 120 -Extend
+    Enable-PodeSessionMiddleware -Duration 120 -Extend
 
     # setup form auth (<form> in HTML)
     New-PodeAuthScheme -Form -AsCredential | Add-PodeAuth -Name 'Login' -FailureUrl '/login' -SuccessUrl '/' -ScriptBlock {

--- a/examples/web-auth-form-file.ps1
+++ b/examples/web-auth-form-file.ps1
@@ -28,7 +28,7 @@ Start-PodeServer -Threads 2 {
     Set-PodeViewEngine -Type Pode
 
     # setup session details
-    Enable-PodeSessionMiddleware -Secret 'schwifty' -Duration 120 -Extend
+    Enable-PodeSessionMiddleware -Duration 120 -Extend
 
     # setup form auth against user file (<form> in HTML)
     New-PodeAuthScheme -Form | Add-PodeAuthUserFile -Name 'Login' -FilePath './users/users.json' -FailureUrl '/login' -SuccessUrl '/'

--- a/examples/web-auth-form-local.ps1
+++ b/examples/web-auth-form-local.ps1
@@ -25,7 +25,7 @@ Start-PodeServer -Threads 2 {
     Set-PodeViewEngine -Type Pode
 
     # setup session details
-    Enable-PodeSessionMiddleware -Secret 'schwifty' -Duration 120 -Extend
+    Enable-PodeSessionMiddleware -Duration 120 -Extend
 
     # setup form auth against windows local users (<form> in HTML)
     New-PodeAuthScheme -Form | Add-PodeAuthWindowsLocal -Name 'Login' -Groups @() -Users @() -FailureUrl '/login' -SuccessUrl '/'

--- a/examples/web-auth-form.ps1
+++ b/examples/web-auth-form.ps1
@@ -27,7 +27,7 @@ Start-PodeServer -Threads 2 {
     New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
 
     # setup session details
-    Enable-PodeSessionMiddleware -Secret 'schwifty' -Duration 120 -Extend
+    Enable-PodeSessionMiddleware -Duration 120 -Extend
 
     # setup form auth (<form> in HTML)
     New-PodeAuthScheme -Form | Add-PodeAuth -Name 'Login' -FailureUrl '/login' -SuccessUrl '/' -ScriptBlock {

--- a/examples/web-auth-oauth2-form.ps1
+++ b/examples/web-auth-oauth2-form.ps1
@@ -25,7 +25,7 @@ Start-PodeServer -Threads 2 {
     Set-PodeViewEngine -Type Pode
 
     # setup session details
-    Enable-PodeSessionMiddleware -Secret 'schwifty' -Duration 120 -Extend
+    Enable-PodeSessionMiddleware -Duration 120 -Extend
 
     # setup form auth against Azure AD (the following are from registering an app in the portal)
     $clientId = '<client-id-from-portal>'

--- a/examples/web-auth-oauth2.ps1
+++ b/examples/web-auth-oauth2.ps1
@@ -25,7 +25,7 @@ Start-PodeServer -Threads 2 {
     Set-PodeViewEngine -Type Pode
 
     # setup session details
-    Enable-PodeSessionMiddleware -Secret 'schwifty' -Duration 120 -Extend
+    Enable-PodeSessionMiddleware -Duration 120 -Extend
 
     # setup form auth against Azure AD (the following are from registering an app in the portal)
     $clientId = '<client-id-from-portal>'

--- a/examples/web-csrf.ps1
+++ b/examples/web-csrf.ps1
@@ -28,7 +28,7 @@ Start-PodeServer -Threads 2 {
         }
 
         'session' {
-            Enable-PodeSessionMiddleware -Secret 'schwifty' -Duration 120
+            Enable-PodeSessionMiddleware -Duration 120
             Enable-PodeCsrfMiddleware
         }
     }

--- a/examples/web-sessions.ps1
+++ b/examples/web-sessions.ps1
@@ -14,7 +14,7 @@ Start-PodeServer {
     Set-PodeViewEngine -Type Pode
 
     # setup session details
-    Enable-PodeSessionMiddleware -Secret 'schwifty' -Duration 120 -Extend -Generator {
+    Enable-PodeSessionMiddleware -Duration 120 -Extend -Generator {
         return [System.IO.Path]::GetRandomFileName()
     }
 


### PR DESCRIPTION
### Description of the Change
On `Enable-PodeSessionMiddleware` when no `-Secret` is supplied use a random GUID as default. If you're using custom `-Storage` then a secret is required.

### Related Issue
Resolves #765 
