### PR TITLE
Fix for a rare threading issue when hashing session data

### DIFF
--- a/src/Private/Sessions.ps1
+++ b/src/Private/Sessions.ps1
@@ -160,7 +160,7 @@ function Set-PodeSessionDataHash
         $Session.Data = @{}
     }
 
-    $Session.DataHash = (Invoke-PodeSHA256Hash -Value ($Session.Data | ConvertTo-Json -Depth 10 -Compress))
+    $Session.DataHash = (Invoke-PodeSHA256Hash -Value ($Session.Data.Clone() | ConvertTo-Json -Depth 10 -Compress))
 }
 
 function Test-PodeSessionDataHash


### PR DESCRIPTION
### Description of the Change
Fixes a rare threading issue when saving/hashing a session's data, where the data enumeration would "change" when converting to json for hashing.

### Related Issue
Resolves #768 
