### PR TITLE
Add new Restart-PodeServer to allow restarting server manually

### DIFF
--- a/docs/Tutorials/Restarting/Overview.md
+++ b/docs/Tutorials/Restarting/Overview.md
@@ -1,10 +1,11 @@
 # Overview
 
-There are 3 ways to restart a running Pode server:
+There are 4 ways to restart a running Pode server:
 
 1. **Ctrl+R**: If you press `Ctrl+R` on a running server, it will trigger a restart to take place.
     1a. On Unix you can use `Shift+R`.
 2. [**File Monitoring**](../Types/FileMonitoring): This will watch for file changes, and if enabled will trigger the server to restart.
 3. [**Auto-Restarting**](../Types/AutoRestarting): Defined within the `server.psd1` configuration file, you can set schedules for the server to automatically restart.
+4. [`Restart-PodeServer`](../../../Functions/Core/Restart-PodeServer): This function lets you manually restart Pode from within the server.
 
 When the server restarts, it will re-invoke the `-ScriptBlock` supplied to the [`Start-PodeServer`](../../../Functions/Core/Start-PodeServer) function. This means the best approach to reload new modules/scripts it to dot-source/[`Use-PodeScript`](../../../Functions/Utilities/Use-PodeScript) your scripts into your server, as any changes to the main `scriptblock` will **not** take place.

--- a/src/Pode.psd1
+++ b/src/Pode.psd1
@@ -200,6 +200,7 @@
         # core
         'Start-PodeServer',
         'Close-PodeServer',
+        'Restart-PodeServer',
         'Start-PodeStaticServer',
         'Show-PodeGui',
         'Add-PodeEndpoint',

--- a/src/Public/Core.ps1
+++ b/src/Public/Core.ps1
@@ -226,6 +226,24 @@ function Close-PodeServer
 
 <#
 .SYNOPSIS
+Restarts the Pode server.
+
+.DESCRIPTION
+Restarts the Pode server.
+
+.EXAMPLE
+Restart-PodeServer
+#>
+function Restart-PodeServer
+{
+    [CmdletBinding()]
+    param()
+
+    $PodeContext.Tokens.Restart.Cancel()
+}
+
+<#
+.SYNOPSIS
 Helper wrapper function to start a Pode web server for a static website at the current directory.
 
 .DESCRIPTION


### PR DESCRIPTION
### Description of the Change
Adds a new `Restart-PodeServer` function to allow restarting the server internally manually.

### Related Issue
Resolves #767 

### Examples
```powershell
Add-PodeTimer -Name 'Example' -Interval 20 -ScriptBlock {
    Restart-PodeServer
}
```
