### PR TITLE
Fix handling of AggregateExceptions

### DIFF
--- a/src/Listener/PodeHelpers.cs
+++ b/src/Listener/PodeHelpers.cs
@@ -31,8 +31,22 @@ namespace Pode
                 return;
             }
 
-            Console.WriteLine(ex.Message);
+            Console.WriteLine($"{ex.GetType().Name}: {ex.Message}");
             Console.WriteLine(ex.StackTrace);
+        }
+
+        public static void HandleAggregateException(AggregateException aex)
+        {
+            aex.Handle((ex) =>
+            {
+                if (ex is IOException || ex is OperationCanceledException)
+                {
+                    return true;
+                }
+
+                PodeHelpers.WriteException(ex);
+                return false;
+            });
         }
 
         public static string NewGuid(int length = 16)

--- a/src/Listener/PodeHelpers.cs
+++ b/src/Listener/PodeHelpers.cs
@@ -35,7 +35,7 @@ namespace Pode
             Console.WriteLine(ex.StackTrace);
         }
 
-        public static void HandleAggregateException(AggregateException aex)
+        public static void HandleAggregateException(AggregateException aex, PodeListener listener = default(PodeListener))
         {
             aex.Handle((ex) =>
             {
@@ -44,7 +44,7 @@ namespace Pode
                     return true;
                 }
 
-                PodeHelpers.WriteException(ex);
+                PodeHelpers.WriteException(ex, listener);
                 return false;
             });
         }

--- a/src/Listener/PodeResponse.cs
+++ b/src/Listener/PodeResponse.cs
@@ -111,6 +111,10 @@ namespace Pode
             }
             catch (OperationCanceledException) {}
             catch (IOException) {}
+            catch (AggregateException aex)
+            {
+                PodeHelpers.HandleAggregateException(aex);
+            }
             catch (Exception ex)
             {
                 PodeHelpers.WriteException(ex);
@@ -156,6 +160,10 @@ namespace Pode
             }
             catch (OperationCanceledException) {}
             catch (IOException) {}
+            catch (AggregateException aex)
+            {
+                PodeHelpers.HandleAggregateException(aex);
+            }
             catch (Exception ex)
             {
                 PodeHelpers.WriteException(ex);
@@ -238,6 +246,10 @@ namespace Pode
             }
             catch (OperationCanceledException) {}
             catch (IOException) {}
+            catch (AggregateException aex)
+            {
+                PodeHelpers.HandleAggregateException(aex);
+            }
             catch (Exception ex)
             {
                 PodeHelpers.WriteException(ex);

--- a/src/Listener/PodeSocket.cs
+++ b/src/Listener/PodeSocket.cs
@@ -216,7 +216,7 @@ namespace Pode
             catch (IOException) {}
             catch (AggregateException aex)
             {
-                PodeHelpers.HandleAggregateException(aex);
+                PodeHelpers.HandleAggregateException(aex, Listener);
             }
             catch (Exception ex)
             {

--- a/src/Listener/PodeSocket.cs
+++ b/src/Listener/PodeSocket.cs
@@ -7,6 +7,7 @@ using System.Net.Sockets;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
+using System.IO;
 
 namespace Pode
 {
@@ -212,6 +213,11 @@ namespace Pode
                 Task.Factory.StartNew(() => context.Receive(), context.ContextTimeoutToken.Token);
             }
             catch (OperationCanceledException) {}
+            catch (IOException) {}
+            catch (AggregateException aex)
+            {
+                PodeHelpers.HandleAggregateException(aex);
+            }
             catch (Exception ex)
             {
                 PodeHelpers.WriteException(ex, Listener);


### PR DESCRIPTION
### Description of the Change
Fix the handling of AggregateExceptions in PodeResponse.cs (and PodeSocket.cs), to prevent unneeded error messages.

### Related Issue
Resolves #776 