### PR TITLE
Adds support for custom lockable objects

### DIFF
--- a/docs/Tutorials/SharedState.md
+++ b/docs/Tutorials/SharedState.md
@@ -25,7 +25,7 @@ An example of setting a hashtable variable in the state is as follows:
 ```powershell
 Start-PodeServer {
     Add-PodeTimer -Name 'do-something' -Interval 5 -ScriptBlock {
-        Lock-PodeObject -Object $TimerEvent.Lockable {
+        Lock-PodeObject -Object $TimerEvent.Lockable -ScriptBlock {
             Set-PodeState -Name 'data' -Value @{ 'Name' = 'Rick Sanchez' } | Out-Null
         }
     }
@@ -43,7 +43,7 @@ Start-PodeServer {
     Add-PodeTimer -Name 'do-something' -Interval 5 -ScriptBlock {
         $value = $null
 
-        Lock-PodeObject -Object $TimerEvent.Lockable {
+        Lock-PodeObject -Object $TimerEvent.Lockable -ScriptBlock {
             $value = (Get-PodeState -Name 'data')
         }
 
@@ -61,7 +61,7 @@ An example of removing a variable from the state is as follows:
 ```powershell
 Start-PodeServer {
     Add-PodeTimer -Name 'do-something' -Interval 5 -ScriptBlock {
-        Lock-PodeObject -Object $TimerEvent.Lockable {
+        Lock-PodeObject -Object $TimerEvent.Lockable -ScriptBlock {
             Remove-PodeState -Name 'data' | Out-Null
         }
     }
@@ -77,7 +77,7 @@ An example of saving the current state every hour is as follows:
 ```powershell
 Start-PodeServer {
     Add-PodeSchedule -Name 'save-state' -Cron '@hourly' -ScriptBlock {
-        Lock-PodeObject -Object $lockable {
+        Lock-PodeObject -Object $lockable -ScriptBlock {
             Save-PodeState -Path './state.json'
         }
     }
@@ -117,7 +117,7 @@ Start-PodeServer {
     # timer to add a random number to the shared state
     Add-PodeTimer -Name 'forever' -Interval 2 -ScriptBlock {
         # ensure we're thread safe
-        Lock-PodeObject -Object $TimerEvent.Lockable {
+        Lock-PodeObject -Object $TimerEvent.Lockable -ScriptBlock {
 
             # attempt to get the hashtable from the state
             $hash = (Get-PodeState -Name 'hash')
@@ -133,7 +133,7 @@ Start-PodeServer {
     # route to return the value of the hashtable from shared state
     Add-PodeRoute -Method Get -Path '/' -ScriptBlock {
         # again, ensure we're thread safe
-        Lock-PodeObject -Object $WebEvent.Lockable {
+        Lock-PodeObject -Object $WebEvent.Lockable -ScriptBlock {
 
             # get the hashtable from the state and return it
             $hash = (Get-PodeState -Name 'hash')
@@ -144,7 +144,7 @@ Start-PodeServer {
     # route to remove the hashtable from shared state
     Add-PodeRoute -Method Delete -Path '/' -ScriptBlock {
         # ensure we're thread safe
-        Lock-PodeObject -Object $WebEvent.Lockable {
+        Lock-PodeObject -Object $WebEvent.Lockable -ScriptBlock {
 
             # remove the hashtable from the state
             Remove-PodeState -Name 'hash' | Out-Null

--- a/docs/Tutorials/Threading.md
+++ b/docs/Tutorials/Threading.md
@@ -1,6 +1,6 @@
 # Threading
 
-By default Pode deals with incoming requests synchronously in a single thread. You can increase the number of threads/runspaces that Pode uses to handle requests by using the `-Threads` parameter on the [`Start-PodeServer`](../../Functions/Core/Start-PodeServer) function:
+By default Pode deals with incoming requests synchronously in a single thread. You can increase the number of threads/runspaces that Pode uses to handle requests by using the `-Threads` parameter on [`Start-PodeServer`](../../Functions/Core/Start-PodeServer):
 
 ```powershell
 Start-PodeServer -Threads 2 {
@@ -9,3 +9,62 @@ Start-PodeServer -Threads 2 {
 ```
 
 The number of threads supplied only applies to Web, SMTP, and TCP servers. If `-Threads` is not supplied, or is <=0 then the number of threads is forced to the default of 1.
+
+## Locking
+
+When using multi-threading in Pode at times you'll want to ensure certain functions run thread-safe. To do this you can use [`Lock-PodeObject`](../../Functions/Utilities/Lock-PodeObject) which will lock an object cross-thread.
+
+### Global
+
+In event objects, like `$WebEvent`, there is a global `Lockable` object that you can use - this object is synchronized across every thread, so locking it on one will lock it on all:
+
+```powershell
+Add-PodeRoute -Method Get -Path '/save' -ScriptBlock {
+    Lock-PodeObject -Object $WebEvent.Lockable -ScriptBlock {
+        Save-PodeState -Path './state.json'
+    }
+}
+```
+
+### Custom
+
+The global lockable is good, but at times you will have separate processes where they can use different lockables objects - rather than sharing a global one and locking each other out needlessly.
+
+To create a custom lockable object you can use [`New-PodeLockable`](../../Functions/Utilities/New-PodeLockable), and this will create a synchronized object across all threads that you can use. You cna then use this object via [`Get-PodeLockable`](../../Functions/Utilities/Get-PodeLockable) and pipe it into [`Lock-PodeObject`](../../Functions/Utilities/Lock-PodeObject):
+
+```powershell
+New-PodeLockable -Name 'Lock1'
+
+Add-PodeRoute -Method Get -Path '/save' -ScriptBlock {
+    Get-PodeLockable -Name 'Lock1' | Lock-PodeObject -ScriptBlock {
+        Save-PodeState -Path './state.json'
+    }
+}
+```
+
+On [`Lock-PodeObject`](../../Functions/Utilities/Lock-PodeObject) there's also a `-CheckGlobal` switch. This switch will check if the global lockable is locked, and wait for it to free up before locking the specified object and running the script. This is useful if you have a number of custom lockables, and then when saving the current state you lock the global. Every other process could lock their custom lockables, but then also check the global lockable and block until saving state is finished.
+
+For example, the following has two routes. The first route locks the global lockable and sleeps for 10 seconds, whereas the second route locks the custom object but checks the global for locking. Calling the first route then the second straight after, they will both return after 10 seconds:
+
+```powershell
+Start-PodeServer -Threads 2 {
+    Add-PodeEndpoint -Address * -Port 8090 -Protocol Http
+
+    New-PodeLockable -Name 'TestLock'
+
+    # lock global, sleep for 10secs
+    Add-PodeRoute -Method Get -Path '/route1' -ScriptBlock {
+        Lock-PodeObject -Object $WebEvent.Lockable -ScriptBlock {
+            Start-Sleep -Seconds 10
+        }
+
+        Write-PodeJsonResponse -Value @{ Route = 1; Thread = $ThreadId }
+    }
+
+    # lock custom, but check global
+    Add-PodeRoute -Method Get -Path '/route2' -ScriptBlock {
+        Get-PodeLockable -Name 'TestLock' | Lock-PodeObject -CheckGlobal -ScriptBlock {}
+        Write-PodeJsonResponse -Value @{ Route = 2; Thread = $ThreadId }
+    }
+}
+```

--- a/examples/lockables.ps1
+++ b/examples/lockables.ps1
@@ -1,0 +1,41 @@
+$path = Split-Path -Parent -Path (Split-Path -Parent -Path $MyInvocation.MyCommand.Path)
+Import-Module "$($path)/src/Pode.psm1" -Force -ErrorAction Stop
+
+# or just:
+# Import-Module Pode
+
+# create a basic server
+Start-PodeServer -Threads 2 {
+
+    Add-PodeEndpoint -Address * -Port 8090 -Protocol Http
+    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+
+    New-PodeLockable -Name 'TestLock'
+
+    Add-PodeRoute -Method Get -Path '/custom-route1' -ScriptBlock {
+        Get-PodeLockable -Name 'TestLock' | Lock-PodeObject -ScriptBlock {
+            Start-Sleep -Seconds 10
+        }
+
+        Write-PodeJsonResponse -Value @{ Route = 1; Thread = $ThreadId }
+    }
+
+    Add-PodeRoute -Method Get -Path '/custom-route2' -ScriptBlock {
+        Get-PodeLockable -Name 'TestLock' | Lock-PodeObject -ScriptBlock {}
+        Write-PodeJsonResponse -Value @{ Route = 2; Thread = $ThreadId }
+    }
+
+    Add-PodeRoute -Method Get -Path '/global-route1' -ScriptBlock {
+        Lock-PodeObject -Object $WebEvent.Lockable -ScriptBlock {
+            Start-Sleep -Seconds 10
+        }
+
+        Write-PodeJsonResponse -Value @{ Route = 1; Thread = $ThreadId }
+    }
+
+    Add-PodeRoute -Method Get -Path '/global-route2' -ScriptBlock {
+        Get-PodeLockable -Name 'TestLock' | Lock-PodeObject -CheckGlobal -ScriptBlock {}
+        Write-PodeJsonResponse -Value @{ Route = 2; Thread = $ThreadId }
+    }
+
+}

--- a/examples/looping-service.ps1
+++ b/examples/looping-service.ps1
@@ -9,7 +9,7 @@ Start-PodeServer -Interval 3 {
 
     Add-PodeHandler -Type Service -Name 'Hello' -ScriptBlock {
         Write-Host 'hello, world!'
-        Lock-PodeObject -Object $ServiceEvent.Lockable {
+        Lock-PodeObject -Object $ServiceEvent.Lockable -ScriptBlock {
             "Look I'm locked!" | Out-PodeHost
         }
     }

--- a/examples/shared-state.ps1
+++ b/examples/shared-state.ps1
@@ -29,7 +29,7 @@ Start-PodeServer {
     Add-PodeTimer -Name 'forever' -Interval 2 -ScriptBlock {
         $hash = $null
 
-        Lock-PodeObject -Object $WebEvent.Lockable {
+        Lock-PodeObject -Object $TimerEvent.Lockable -ScriptBlock {
             $hash = (Get-PodeState -Name 'hash1')
             $hash.values += (Get-Random -Minimum 0 -Maximum 10)
             Save-PodeState -Path './state.json' -Scope Scope1 #-Exclude 'hash1'
@@ -38,7 +38,7 @@ Start-PodeServer {
 
     # route to retrieve and return the value of the hashtable from global state
     Add-PodeRoute -Method Get -Path '/array' -ScriptBlock {
-        Lock-PodeObject -Object $WebEvent.Lockable {
+        Lock-PodeObject -Object $WebEvent.Lockable -ScriptBlock {
             $hash = (Get-PodeState 'hash1')
             Write-PodeJsonResponse -Value $hash
         }
@@ -46,8 +46,8 @@ Start-PodeServer {
 
     # route to remove the hashtable from global state
     Add-PodeRoute -Method Delete -Path '/array' -ScriptBlock {
-        Lock-PodeObject -Object $WebEvent.Lockable {
-            $hash = (Set-PodeState -Name 'hash' -Value @{})
+        Lock-PodeObject -Object $WebEvent.Lockable -ScriptBlock {
+            $hash = (Set-PodeState -Name 'hash1' -Value @{})
             $hash.values = @()
         }
     }

--- a/examples/timers.ps1
+++ b/examples/timers.ps1
@@ -14,7 +14,7 @@ Start-PodeServer {
     Add-PodeTimer -Name 'forever' -Interval 5 -ScriptBlock {
         '- - -' | Out-PodeHost
         $using:message | Out-PodeHost
-        Lock-PodeObject -Object $TimerEvent.Lockable {
+        Lock-PodeObject -Object $TimerEvent.Lockable -ScriptBlock {
             "Look I'm locked!" | Out-PodeHost
         }
         '- - -' | Out-PodeHost

--- a/src/Pode.psd1
+++ b/src/Pode.psd1
@@ -114,6 +114,10 @@
         'Write-PodeHost',
         'Test-PodeIsIIS',
         'Test-PodeIsHeroku',
+        'New-PodeLockable',
+        'Remove-PodeLockable',
+        'Get-PodeLockable',
+        'Test-PodeLockable',
 
         # routes
         'Add-PodeRoute',

--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -68,7 +68,7 @@ function New-PodeContext
         Add-Member -MemberType NoteProperty -Name RunspaceState -Value $null -PassThru |
         Add-Member -MemberType NoteProperty -Name Tokens -Value @{} -PassThru |
         Add-Member -MemberType NoteProperty -Name LogsToProcess -Value $null -PassThru |
-        Add-Member -MemberType NoteProperty -Name Lockable -Value $null -PassThru |
+        Add-Member -MemberType NoteProperty -Name Lockables -Value $null -PassThru |
         Add-Member -MemberType NoteProperty -Name Server -Value @{} -PassThru |
         Add-Member -MemberType NoteProperty -Name Metrics -Value @{} -PassThru |
         Add-Member -MemberType NoteProperty -Name Listeners -Value @() -PassThru
@@ -323,7 +323,10 @@ function New-PodeContext
     }
 
     # session state
-    $ctx.Lockable = [hashtable]::Synchronized(@{})
+    $ctx.Lockables = @{
+        Global = [hashtable]::Synchronized(@{})
+        Custom = @{}
+    }
 
     # setup runspaces
     $ctx.Runspaces = @()
@@ -545,7 +548,7 @@ function New-PodeStateContext
         Add-Member -MemberType NoteProperty -Name Tokens -Value $Context.Tokens -PassThru |
         Add-Member -MemberType NoteProperty -Name Metrics -Value $Context.Metrics -PassThru |
         Add-Member -MemberType NoteProperty -Name LogsToProcess -Value $Context.LogsToProcess -PassThru |
-        Add-Member -MemberType NoteProperty -Name Lockable -Value $Context.Lockable -PassThru |
+        Add-Member -MemberType NoteProperty -Name Lockables -Value $Context.Lockables -PassThru |
         Add-Member -MemberType NoteProperty -Name Server -Value $Context.Server -PassThru)
 }
 

--- a/src/Private/PodeServer.ps1
+++ b/src/Private/PodeServer.ps1
@@ -102,7 +102,7 @@ function Start-PodeWebServer
                             Auth = @{}
                             Response = $Response
                             Request = $Request
-                            Lockable = $PodeContext.Lockable
+                            Lockable = $PodeContext.Lockables.Global
                             Path = [System.Web.HttpUtility]::UrlDecode($Request.Url.AbsolutePath)
                             Method = $Request.HttpMethod.ToLowerInvariant()
                             Query = $null

--- a/src/Private/Schedules.ps1
+++ b/src/Private/Schedules.ps1
@@ -122,7 +122,7 @@ function Invoke-PodeInternalScheduleLogic
         # setup event param
         $parameters = @{
             Event = @{
-                Lockable = $PodeContext.Lockable
+                Lockable = $PodeContext.Lockables.Global
             }
         }
 

--- a/src/Private/Serverless.ps1
+++ b/src/Private/Serverless.ps1
@@ -33,7 +33,7 @@ function Start-PodeAzFuncServer
                 Auth = @{}
                 Response = $response
                 Request = $request
-                Lockable = $PodeContext.Lockable
+                Lockable = $PodeContext.Lockables.Global
                 Path = [string]::Empty
                 Method = $request.Method.ToLowerInvariant()
                 Query = $request.Query
@@ -167,7 +167,7 @@ function Start-PodeAwsLambdaServer
                 Auth = @{}
                 Response = $response
                 Request = $request
-                Lockable = $PodeContext.Lockable
+                Lockable = $PodeContext.Lockables.Global
                 Path = [System.Web.HttpUtility]::UrlDecode($request.path)
                 Method = $request.httpMethod.ToLowerInvariant()
                 Query = $request.queryStringParameters

--- a/src/Private/ServiceServer.ps1
+++ b/src/Private/ServiceServer.ps1
@@ -16,7 +16,7 @@ function Start-PodeServiceServer
             {
                 # the event object
                 $ServiceEvent = @{
-                    Lockable = $PodeContext.Lockable
+                    Lockable = $PodeContext.Lockables.Global
                 }
 
                 # invoke the service handlers

--- a/src/Private/SignalServer.ps1
+++ b/src/Private/SignalServer.ps1
@@ -141,7 +141,7 @@ function Start-PodeSignalServer
                     $SignalEvent = @{
                         Response = $Response
                         Request = $Request
-                        Lockable = $PodeContext.Lockable
+                        Lockable = $PodeContext.Lockables.Global
                         Path = [System.Web.HttpUtility]::UrlDecode($Request.Url.AbsolutePath)
                         Data = @{
                             Path = [System.Web.HttpUtility]::UrlDecode($payload.path)

--- a/src/Private/SmtpServer.ps1
+++ b/src/Private/SmtpServer.ps1
@@ -70,7 +70,7 @@ function Start-PodeSmtpServer
                         $SmtpEvent = @{
                             Response = $Response
                             Request = $Request
-                            Lockable = $PodeContext.Lockable
+                            Lockable = $PodeContext.Lockables.Global
                             Email = @{
                                 From = $Request.From
                                 To = $Request.To

--- a/src/Private/TcpServer.ps1
+++ b/src/Private/TcpServer.ps1
@@ -61,7 +61,7 @@ function Start-PodeTcpServer
                 if ((Test-PodeIPAccess -IP $ip) -and (Test-PodeIPLimit -IP $ip)) {
                     $TcpEvent = @{
                         Client = $client
-                        Lockable = $PodeContext.Lockable
+                        Lockable = $PodeContext.Lockables.Global
                     }
 
                     # invoke the tcp handlers

--- a/src/Private/Timers.ps1
+++ b/src/Private/Timers.ps1
@@ -60,7 +60,7 @@ function Invoke-PodeInternalTimer
     )
 
     try {
-        $global:TimerEvent = @{ Lockable = $PodeContext.Lockable }
+        $global:TimerEvent = @{ Lockable = $PodeContext.Lockables.Global }
 
         $_args = @($Timer.Arguments)
         if ($null -ne $Timer.UsingVariables) {

--- a/src/Public/Utilities.ps1
+++ b/src/Public/Utilities.ps1
@@ -153,7 +153,10 @@ function Lock-PodeObject
         $ScriptBlock,
 
         [switch]
-        $Return
+        $Return,
+
+        [switch]
+        $CheckGlobal
     )
 
     if ($null -eq $Object) {
@@ -167,6 +170,10 @@ function Lock-PodeObject
     $locked = $false
 
     try {
+        if ($CheckGlobal) {
+            Lock-PodeObject -Object $PodeContext.Lockables.Global -ScriptBlock {}
+        }
+
         [System.Threading.Monitor]::Enter($Object.SyncRoot)
         $locked = $true
 
@@ -889,4 +896,110 @@ function Test-PodeIsHeroku
     param()
 
     return $PodeContext.Server.IsHeroku
+}
+
+<#
+.SYNOPSIS
+Creates a new custom lockable object for use with Lock-PodeObject.
+
+.DESCRIPTION
+Creates a new custom lockable object for use with Lock-PodeObject.
+
+.PARAMETER Name
+The Name of the lockable object.
+
+.EXAMPLE
+New-PodeLockable -Name 'Lock1'
+#>
+function New-PodeLockable
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Name
+    )
+
+    if (Test-PodeLockable -Name $Name) {
+        throw "Lockable object '$($Name)' already exists"
+    }
+
+    $PodeContext.Lockables.Custom[$Name] = [hashtable]::Synchronized(@{})
+}
+
+<#
+.SYNOPSIS
+Removes a custom lockable object.
+
+.DESCRIPTION
+Removes a custom lockable object.
+
+.PARAMETER Name
+The Name of the lockable object to remove.
+
+.EXAMPLE
+Remove-PodeLockable -Name 'Lock1'
+#>
+function Remove-PodeLockable
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Name
+    )
+
+    if (Test-PodeLockable -Name $Name) {
+        $PodeContext.Lockables.Custom.Remove($Name)
+    }
+}
+
+<#
+.SYNOPSIS
+Get a custom lockable object for use with Lock-PodeObject.
+
+.DESCRIPTION
+Get a custom lockable object for use with Lock-PodeObject.
+
+.PARAMETER Name
+The Name of the lockable object.
+
+.EXAMPLE
+Get-PodeLockable -Name 'Lock1' | Lock-PodeObject -ScriptBlock {}
+#>
+function Get-PodeLockable
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Name
+    )
+
+    return $PodeContext.Lockables.Custom[$Name]
+}
+
+<#
+.SYNOPSIS
+Test if a custom lockable object exists.
+
+.DESCRIPTION
+Test if a custom lockable object exists.
+
+.PARAMETER Name
+The Name of the lockable object.
+
+.EXAMPLE
+Test-PodeLockable -Name 'Lock1'
+#>
+function Test-PodeLockable
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Name
+    )
+
+    return $PodeContext.Lockables.Custom.ContainsKey($Name)
 }

--- a/src/Public/Utilities.ps1
+++ b/src/Public/Utilities.ps1
@@ -133,6 +133,9 @@ The ScriptBlock to invoke.
 .PARAMETER Return
 If supplied, any values from the ScriptBlock will be returned.
 
+.PARAMETER CheckGlobal
+If supplied, will check the global Lockable object and wait until it's freed-up before locking the passed object.
+
 .EXAMPLE
 Lock-PodeObject -Object $SomeArray -ScriptBlock { /* logic */ }
 


### PR DESCRIPTION
### Description of the Change
Adds support for custom lockable objects, so you can use different lockables for processes that don't need to share one global object.

Adds:
* `New-PodeLockable`
* `Remove-PodeLockable`
* `Get-PodeLockable`
* `Test-PodeLockable`

### Related Issue
Resolves #769 

### Examples
The following has two routes. The first route locks the global lockable and sleeps for 10 seconds, whereas the second route locks the custom object but checks the global for locking. Calling the first route then the second straight after, they will both return after 10 seconds:

```powershell
Start-PodeServer -Threads 2 {
    Add-PodeEndpoint -Address * -Port 8090 -Protocol Http

    New-PodeLockable -Name 'TestLock'

    # lock global, sleep for 10secs
    Add-PodeRoute -Method Get -Path '/route1' -ScriptBlock {
        Lock-PodeObject -Object $WebEvent.Lockable -ScriptBlock {
            Start-Sleep -Seconds 10
        }

        Write-PodeJsonResponse -Value @{ Route = 1; Thread = $ThreadId }
    }

    # lock custom, but check global
    Add-PodeRoute -Method Get -Path '/route2' -ScriptBlock {
        Get-PodeLockable -Name 'TestLock' | Lock-PodeObject -CheckGlobal -ScriptBlock {}
        Write-PodeJsonResponse -Value @{ Route = 2; Thread = $ThreadId }
    }
}
```
