### PR TITLE
Add support for getting a list of current state names

### DIFF
--- a/src/Pode.psd1
+++ b/src/Pode.psd1
@@ -70,6 +70,7 @@
         'Save-PodeState',
         'Restore-PodeState',
         'Test-PodeState',
+        'Get-PodeStateNames',
 
         # response helpers
         'Set-PodeResponseAttachment',

--- a/src/Public/State.ps1
+++ b/src/Public/State.ps1
@@ -96,6 +96,68 @@ function Get-PodeState
 
 <#
 .SYNOPSIS
+Returns the current names of state variables.
+
+.DESCRIPTION
+Returns the current names of state variables that have been set. You can filter the result using Scope or a Pattern.
+
+.PARAMETER Pattern
+An optional regex Pattern to filter the state names.
+
+.PARAMETER Scope
+An optional Scope to filter the state names.
+
+.EXAMPLE
+$names = Get-PodeStateNames -Scope '<scope>'
+
+.EXAMPLE
+$names = Get-PodeStateNames -Pattern '^\w+[0-9]{0,2}$'
+#>
+function Get-PodeStateNames
+{
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [string]
+        $Pattern,
+
+        [Parameter()]
+        [string[]]
+        $Scope
+    )
+
+    if ($null -eq $PodeContext.Server.State) {
+        throw "Pode has not been initialised"
+    }
+
+    if ($null -eq $Scope) {
+        $Scope = @()
+    }
+
+    $tempState = $PodeContext.Server.State.Clone()
+    $keys = $tempState.Keys
+
+    if ($Scope.Length -gt 0) {
+        $keys = @(foreach($key in $keys) {
+            if ($tempState[$key].Scope -iin $Scope) {
+                $key
+            }
+        })
+    }
+
+    if (![string]::IsNullOrWhiteSpace($Pattern)) {
+        $keys = @(foreach($key in $keys) {
+            if ($key -imatch $Pattern) {
+                $key
+            }
+        })
+    }
+
+    return $keys
+}
+
+<#
+.SYNOPSIS
 Removes some state object from the shared state.
 
 .DESCRIPTION

--- a/src/Public/Utilities.ps1
+++ b/src/Public/Utilities.ps1
@@ -924,7 +924,7 @@ function New-PodeLockable
     )
 
     if (Test-PodeLockable -Name $Name) {
-        throw "Lockable object '$($Name)' already exists"
+        return
     }
 
     $PodeContext.Lockables.Custom[$Name] = [hashtable]::Synchronized(@{})


### PR DESCRIPTION
### Description of the Change
Adds a new `Get-PodeStateNames` function to return a list of state names currently being used, with the option of filtering the list by Scope or regex Pattern.

### Examples
```powershell
$names = Get-PodeStateNames -Scope '<scope>'
$names = Get-PodeStateNames -Pattern '^\w+[0-9]{0,2}$'
```
