### PR TITLE
Adds support for registering scripts to be invoked when certain events occur

### DIFF
--- a/docs/Tutorials/Events.md
+++ b/docs/Tutorials/Events.md
@@ -1,0 +1,46 @@
+# Events
+
+Pode lets you register scripts to be run when certain server events are triggered. The following types of events can have scripts registered:
+
+* Start
+* Terminate
+* Restart
+* Browser
+
+## Overview
+
+You can use [`Register-PodeEvent`](../../Functions/Events/Register-PodeEvent) to register a script that can be run when an event within Pode is triggered. Each event can have multiple scripts registered, and you can unregister a script at any point using [`Unregister-PodeEvent`](../../Functions/Events/Unregister-PodeEvent):
+
+```powershell
+# register:
+Register-PodeEvent -Type Start -Name '<name>' -ScriptBlock {
+    # inform a portal, write a log, etc
+}
+
+# unregister:
+Unregister-PodeEvent -Type Start -Name '<name>'
+```
+
+You can also retrieve a registered script using [`Get-PodeEvent`](../../Functions/Events/Get-PodeEvent).
+
+## Types
+
+### Start
+
+Scripts registered to the `Start` event will all be invoked just after the server's main scriptblock has been invoked - ie: the `-ScriptBlock` supplied to [`Start-PodeServer`](../../Functions/Core/Start-PodeServer).
+
+These scripts will also be re-invoked after a server restart has occurred.
+
+### Terminate
+
+Scripts registered to the `Terminate` event will all be invoked just before the server terminates. Ie, when the `Terminating...` message usually appears in the terminal, the script will run just after this and just before the `Done` message.
+
+These script *will not* run when a Restart is triggered.
+
+### Restart
+
+Scripts registered to the `Restart` event will all be invoked whenever an internal server restart occurs. This could be due to file monitoring, auto-restarting, `Ctrl+R`, or [`Restart-PodeServer`](../../Functions/Core/Restart-PodeServer). They will be invoked just after the `Restarting...` message appears in the terminal, and just before the `Done` message.
+
+### Browser
+
+Scripts registered to the `Browser` event will all be invoked whenever the server is told to open a browser, ie: when `Ctrl+B` is pressed.

--- a/docs/Tutorials/Events.md
+++ b/docs/Tutorials/Events.md
@@ -21,7 +21,11 @@ Register-PodeEvent -Type Start -Name '<name>' -ScriptBlock {
 Unregister-PodeEvent -Type Start -Name '<name>'
 ```
 
-You can also retrieve a registered script using [`Get-PodeEvent`](../../Functions/Events/Get-PodeEvent).
+The scriptblock supplied to `Register-PodeEvent` also supports `$using:` variables. You can retrieve a registered script using [`Get-PodeEvent`](../../Functions/Events/Get-PodeEvent):
+
+```powershell
+$evt = Get-PodeEvent -Type Start -Name '<name>'
+```
 
 ## Types
 

--- a/src/Pode.psd1
+++ b/src/Pode.psd1
@@ -248,7 +248,7 @@
         'Unregister-PodeEvent',
         'Test-PodeEvent',
         'Get-PodeEvent',
-        'Clear-PodeEvents'
+        'Clear-PodeEvent'
     )
 
     # Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.

--- a/src/Pode.psd1
+++ b/src/Pode.psd1
@@ -241,7 +241,14 @@
         # AutoImport
         'Export-PodeModule',
         'Export-PodeSnapin',
-        'Export-PodeFunction'
+        'Export-PodeFunction',
+
+        # Events
+        'Register-PodeEvent',
+        'Unregister-PodeEvent',
+        'Test-PodeEvent',
+        'Get-PodeEvent',
+        'Clear-PodeEvents'
     )
 
     # Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.

--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -331,6 +331,14 @@ function New-PodeContext
     # setup runspaces
     $ctx.Runspaces = @()
 
+    # setup events
+    $ctx.Server.Events = @{
+        Start = [ordered]@{}
+        Terminate = [ordered]@{}
+        Restart = [ordered]@{}
+        Browser = [ordered]@{}
+    }
+
     # return the new context
     return $ctx
 }

--- a/src/Private/Server.ps1
+++ b/src/Private/Server.ps1
@@ -38,6 +38,9 @@ function Start-PodeInternalServer
         New-PodeRunspacePools
         Open-PodeRunspacePools
 
+        # run start event hooks
+        Invoke-PodeEvent -Type Start
+
         # create timer/schedules for auto-restarting
         New-PodeAutoRestartServer
 
@@ -125,6 +128,9 @@ function Restart-PodeInternalServer
         # inform restart
         Write-PodeHost 'Restarting server...' -NoNewline -ForegroundColor Cyan
 
+        # run restart event hooks
+        Invoke-PodeEvent -Type Restart
+
         # cancel the session token
         $PodeContext.Tokens.Cancellation.Cancel()
 
@@ -141,6 +147,10 @@ function Restart-PodeInternalServer
 
         $PodeContext.Server.Handlers.Keys.Clone() | ForEach-Object {
             $PodeContext.Server.Handlers[$_].Clear()
+        }
+
+        $PodeContext.Server.Events.Keys.Clone() | ForEach-Object {
+            $PodeContext.Server.Events[$_].Clear()
         }
 
         $PodeContext.Server.Views.Clear()

--- a/src/Public/Core.ps1
+++ b/src/Public/Core.ps1
@@ -182,6 +182,7 @@ function Start-PodeServer
 
             # check for open browser
             if (Test-PodeOpenBrowserPressed -Key $key) {
+                Invoke-PodeEvent -Type Browser
                 Start-Process (Get-PodeEndpointUrl)
             }
         }
@@ -191,6 +192,7 @@ function Start-PodeServer
         }
 
         Write-PodeHost 'Terminating...' -NoNewline -ForegroundColor Yellow
+        Invoke-PodeEvent -Type Terminate
         $PodeContext.Tokens.Cancellation.Cancel()
     }
     catch {

--- a/src/Public/Events.ps1
+++ b/src/Public/Events.ps1
@@ -1,0 +1,108 @@
+function Register-PodeEvent
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [ValidateSet('Start', 'Terminate', 'Restart', 'Browser')]
+        [string]
+        $Type,
+
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Name,
+
+        [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
+        [scriptblock]
+        $ScriptBlock,
+
+        [Parameter()]
+        [object[]]
+        $ArgumentList
+    )
+
+    # error if already registered
+    if (Test-PodeEvent -Type $Type -Name $Name) {
+        throw "$($Type) event already registered: $($Name)"
+    }
+
+    # check if the scriptblock has any using vars
+    $ScriptBlock, $usingVars = Invoke-PodeUsingScriptConversion -ScriptBlock $ScriptBlock -PSSession $PSCmdlet.SessionState
+
+    # add event
+    $PodeContext.Server.Events[$Type][$Name] = @{
+        Name = $Name
+        ScriptBlock = $ScriptBlock
+        UsingVariables = $usingVars
+        Arguments = $ArgumentList
+    }
+}
+
+function Unregister-PodeEvent
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [ValidateSet('Start', 'Terminate', 'Restart', 'Browser')]
+        [string]
+        $Type,
+
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Name
+    )
+
+    # error if not registered
+    if (!(Test-PodeEvent -Type $Type -Name $Name)) {
+        throw "No $($Type) event registered: $($Name)"
+    }
+
+    # remove event
+    $PodeContext.Server.Events[$Type].Remove($Name) | Out-Null
+}
+
+function Test-PodeEvent
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [ValidateSet('Start', 'Terminate', 'Restart', 'Browser')]
+        [string]
+        $Type,
+
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Name
+    )
+
+    return $PodeContext.Server.Events[$Type].Contains($Name)
+}
+
+function Get-PodeEvent
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [ValidateSet('Start', 'Terminate', 'Restart', 'Browser')]
+        [string]
+        $Type,
+
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Name
+    )
+
+    return $PodeContext.Server.Events[$Type][$Name]
+}
+
+function Clear-PodeEvents
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [ValidateSet('Start', 'Terminate', 'Restart', 'Browser')]
+        [string]
+        $Type
+    )
+
+    $PodeContext.Server.Events[$Type].Clear() | Out-Null
+}

--- a/src/Public/Events.ps1
+++ b/src/Public/Events.ps1
@@ -1,3 +1,25 @@
+<#
+.SYNOPSIS
+Registers a script to be run when a certain server event occurs within Pode
+
+.DESCRIPTION
+Registers a script to be run when a certain server event occurs within Pode, such as Start, Terminate, and Restart.
+
+.PARAMETER Type
+The Type of event to be registered.
+
+.PARAMETER Name
+A unique Name for the registered event.
+
+.PARAMETER ScriptBlock
+A ScriptBlock to invoke when the event is triggered.
+
+.PARAMETER ArgumentList
+An array of arguments to supply to the ScriptBlock.
+
+.EXAMPLE
+Register-PodeEvent -Type Start -Name 'Event1' -ScriptBlock { }
+#>
 function Register-PodeEvent
 {
     [CmdletBinding()]
@@ -37,6 +59,22 @@ function Register-PodeEvent
     }
 }
 
+<#
+.SYNOPSIS
+Unregisters an event that has been registered with the specified Name.
+
+.DESCRIPTION
+Unregisters an event that has been registered with the specified Name.
+
+.PARAMETER Type
+The Type of the event to unregister.
+
+.PARAMETER Name
+The Name of the event to unregister.
+
+.EXAMPLE
+Unregister-PodeEvent -Type Start -Name 'Event1'
+#>
 function Unregister-PodeEvent
 {
     [CmdletBinding()]
@@ -60,6 +98,22 @@ function Unregister-PodeEvent
     $PodeContext.Server.Events[$Type].Remove($Name) | Out-Null
 }
 
+<#
+.SYNOPSIS
+Tests if an event has been registered with the specified Name.
+
+.DESCRIPTION
+Tests if an event has been registered with the specified Name.
+
+.PARAMETER Type
+The Type of the event to test.
+
+.PARAMETER Name
+The Name of the event to test.
+
+.EXAMPLE
+Test-PodeEvent -Type Start -Name 'Event1'
+#>
 function Test-PodeEvent
 {
     [CmdletBinding()]
@@ -77,6 +131,22 @@ function Test-PodeEvent
     return $PodeContext.Server.Events[$Type].Contains($Name)
 }
 
+<#
+.SYNOPSIS
+Retrieves an event.
+
+.DESCRIPTION
+Retrieves an event.
+
+.PARAMETER Type
+The Type of event to retrieve.
+
+.PARAMETER Name
+The Name of the event to retrieve.
+
+.EXAMPLE
+Get-PodeEvent -Type Start -Name 'Event1'
+#>
 function Get-PodeEvent
 {
     [CmdletBinding()]
@@ -94,7 +164,20 @@ function Get-PodeEvent
     return $PodeContext.Server.Events[$Type][$Name]
 }
 
-function Clear-PodeEvents
+<#
+.SYNOPSIS
+Clears an event of all registered scripts.
+
+.DESCRIPTION
+Clears an event of all registered scripts.
+
+.PARAMETER Type
+The Type of event to clear.
+
+.EXAMPLE
+Clear-PodeEvent -Type Start
+#>
+function Clear-PodeEvent
 {
     [CmdletBinding()]
     param(

--- a/tests/unit/Server.Tests.ps1
+++ b/tests/unit/Server.Tests.ps1
@@ -25,6 +25,7 @@ Describe 'Start-PodeInternalServer' {
     Mock Import-PodeModulesIntoRunspaceState { }
     Mock Import-PodeSnapinsIntoRunspaceState { }
     Mock Import-PodeFunctionsIntoRunspaceState { }
+    Mock Invoke-PodeEvent { }
 
     It 'Calls one-off script logic' {
         $PodeContext.Server = @{ Types = ([string]::Empty); Logic = {} }
@@ -91,6 +92,7 @@ Describe 'Restart-PodeInternalServer' {
     Mock Start-PodeInternalServer { }
     Mock Write-PodeErrorLog { }
     Mock Close-PodeDisposable { }
+    Mock Invoke-PodeEvent { }
 
     It 'Resetting the server values' {
         $PodeContext = @{
@@ -99,7 +101,7 @@ Describe 'Restart-PodeInternalServer' {
                 Restart = New-Object System.Threading.CancellationTokenSource;
             };
             Server = @{
-                Routes =@{
+                Routes = @{
                     GET = @{ 'key' = 'value' };
                     POST = @{ 'key' = 'value' };
                 };
@@ -145,6 +147,9 @@ Describe 'Restart-PodeInternalServer' {
                     Functions = @{ Exported = @() }
                 }
                 Views = @{ 'key' = 'value' };
+                Events = @{
+                    Start = @{}
+                }
             };
             Metrics = @{
                 Server = @{


### PR DESCRIPTION
### Description of the Change
Adds support for registering scripts to be invoked when certain events within Pode occur. The following events can have scripts registered:

* Start
* Terminate
* Restart
* Browser

Each type of event can have multiple scripts registered via `Register-PodeEvent`, and can be unregistered using `Unregister-PodeEvent`.

### Related Issue
Resolves #766 

### Examples
```powershell
# register:
Register-PodeEvent -Type Start -Name '<name>' -ScriptBlock {
    # inform a portal, write a log, etc
}

# unregister:
Unregister-PodeEvent -Type Start -Name '<name>'
```
