### PR TITLE
Text wrapping fix for ldapsearch

### DIFF
--- a/src/Private/Authentication.ps1
+++ b/src/Private/Authentication.ps1
@@ -1332,7 +1332,7 @@ function Get-PodeAuthADResult
         [switch]
         $OpenLDAP
     )
-    $samaccountname = ($Username -split '\\')[-1]
+
     try
     {
         # validate the user's AD creds
@@ -1430,7 +1430,7 @@ function Open-PodeAuthADConnection
     }
     else {
         $dcName = "DC=$(($Server -split '\.') -join ',DC=')"
-        $query = (Get-PodeAuthADQuery -Username $samaccountname)
+        $query = (Get-PodeAuthADQuery -Username $Username)
         $hostname = "$($Protocol)://$($Server)"
 
         $user = $Username
@@ -1483,7 +1483,7 @@ function Get-PodeAuthADUser
         $OpenLDAP
     )
 
-    $query = (Get-PodeAuthADQuery -Username $samaccountname)
+    $query = (Get-PodeAuthADQuery -Username $Username)
 
     # generate query to find user
     if ((Test-PodeIsWindows) -and !$OpenLDAP) {


### PR DESCRIPTION
### Description of the Change

`function Add-PodeAuthWindowsAd` leveraging `ldapsearch` (Linux/MacOS) fails to check groups properly.

1. The ldapsearch command is not using the `-o ldif-wrap=no` option to prevent wrapping which causes
`DistinguishedName = (Get-PodeOpenLdapValue -Lines $result -Property 'dn')` in `Get-PodeAuthADQuery` to only grab part of the dn value. This partial DN value is passed to `$groups = (Get-PodeAuthADGroups -Connection $connection -DistinguishedName $user.DistinguishedName -OpenLDAP:$OpenLDAP)` in `function Get-PodeAuthADResult` which fails to return any groups as a result. This would only cause problems if the returned DN was sufficiently long enough to wrap.

**Solution:** Adding `-o ldif-wrap=no`, wrapping is not used eliminating the issue.
