### PR TITLE
Update Windows AD OpenLDAP domain docs, and add SearchBase parameter

### DIFF
--- a/docs/Tutorials/Authentication/Inbuilt/WindowsAD.md
+++ b/docs/Tutorials/Authentication/Inbuilt/WindowsAD.md
@@ -48,6 +48,30 @@ Start-PodeServer {
 }
 ```
 
+### Domain
+
+For OpenLDAP Pode will automatically retrieve the NetBIOS to be prepended on the username, ie: `<domain>\<username>`. This is automatically generate by used the first part of the DNS server's FQDN, for example if your server's FQDN was `test.example.com` then Pode would set the NetBIOS as `test`.
+
+You can use a custom domain NetBIOS by suppliying the `-Domain` parameter:
+
+```powershell
+Start-PodeServer {
+    New-PodeAuthScheme -Form | Add-PodeAuthWindowsAd -Name 'Login' -Fqdn 'test.example.com' -Domain 'testdomain'
+}
+```
+
+### SearchBase
+
+When authentication users via OpenLDAP, the base distinguished name search from is the server root, ie: `DC=test,DC=example,DC=com`. You can further refine this by suppliying a `-SearchBase` that will be prepended onto the base internally:
+
+For example, the below will search in `OU=CustomUsers,DC=test,DC=example,DC=com`:
+
+```powershell
+Start-PodeServer {
+    New-PodeAuthScheme -Form | Add-PodeAuthWindowsAd -Name 'Login' -Fqdn 'test.example.com' -SearchBase 'OU=CustomUsers'
+}
+```
+
 ### Groups
 
 You can supply a list of group names to validate that users are a member of them in AD. If you supply multiple group names, the user only needs to be a member of one of the groups. You can supply the list of groups to the function's `-Groups` parameter as an array - the list is not case-sensitive:

--- a/docs/Tutorials/Authentication/Inbuilt/WindowsAD.md
+++ b/docs/Tutorials/Authentication/Inbuilt/WindowsAD.md
@@ -62,13 +62,13 @@ Start-PodeServer {
 
 ### SearchBase
 
-When authentication users via OpenLDAP, the base distinguished name search from is the server root, ie: `DC=test,DC=example,DC=com`. You can further refine this by suppliying a `-SearchBase` that will be prepended onto the base internally:
+When authenticating users via OpenLDAP, the default base distinguished name searched from will be the server root, ie: `DC=test,DC=example,DC=com`. You can refine this by supplying an optional `-SearchBase`, that should be the full distinguished name:
 
 For example, the below will search in `OU=CustomUsers,DC=test,DC=example,DC=com`:
 
 ```powershell
 Start-PodeServer {
-    New-PodeAuthScheme -Form | Add-PodeAuthWindowsAd -Name 'Login' -Fqdn 'test.example.com' -SearchBase 'OU=CustomUsers'
+    New-PodeAuthScheme -Form | Add-PodeAuthWindowsAd -Name 'Login' -SearchBase 'OU=CustomUsers,DC=test,DC=example,DC=com'
 }
 ```
 

--- a/src/Private/Authentication.ps1
+++ b/src/Private/Authentication.ps1
@@ -1438,9 +1438,11 @@ function Open-PodeAuthADConnection
         }
     }
     else {
-        $baseDn = "DC=$(($Server -split '\.') -join ',DC=')"
         if (![string]::IsNullOrWhiteSpace($SearchBase)) {
-            $baseDn = "$($SearchBase),$($baseDn)"
+            $baseDn = $SearchBase
+        }
+        else {
+            $baseDn = "DC=$(($Server -split '\.') -join ',DC=')"
         }
 
         $query = (Get-PodeAuthADQuery -Username $Username)

--- a/src/Public/Authentication.ps1
+++ b/src/Public/Authentication.ps1
@@ -691,7 +691,10 @@ The Scheme to use for retrieving credentials (From New-PodeAuthScheme).
 A custom FQDN for the DNS of the AD you wish to authenticate against. (Alias: Server)
 
 .PARAMETER Domain
-(Unix Only) A custom domain name that is prepended onto usernames that are missing it (<Domain>\<Username>).
+(Unix Only) A custom NetBIOS domain name that is prepended onto usernames that are missing it (<Domain>\<Username>).
+
+.PARAMETER SearchBase
+(Unix Only) An optional searchbase to refine the LDAP query. This will be appended onto the DC=Server generated internally.
 
 .PARAMETER Groups
 An array of Group names to only allow access.
@@ -755,6 +758,10 @@ function Add-PodeAuthWindowsAd
         [Parameter()]
         [string]
         $Domain,
+
+        [Parameter()]
+        [string]
+        $SearchBase,
 
         [Parameter(ParameterSetName='Groups')]
         [string[]]
@@ -835,6 +842,7 @@ function Add-PodeAuthWindowsAd
         Arguments = @{
             Server = $Fqdn
             Domain = $Domain
+            SearchBase = $SearchBase
             Users = $Users
             Groups = $Groups
             NoGroups = $NoGroups

--- a/src/Public/Authentication.ps1
+++ b/src/Public/Authentication.ps1
@@ -694,7 +694,7 @@ A custom FQDN for the DNS of the AD you wish to authenticate against. (Alias: Se
 (Unix Only) A custom NetBIOS domain name that is prepended onto usernames that are missing it (<Domain>\<Username>).
 
 .PARAMETER SearchBase
-(Unix Only) An optional searchbase to refine the LDAP query. This will be appended onto the DC=Server generated internally.
+(Unix Only) An optional searchbase to refine the LDAP query. This should be the full distinguished name.
 
 .PARAMETER Groups
 An array of Group names to only allow access.


### PR DESCRIPTION
### Description of the Change
Update the Windows AD docs for `-Domain` to specify it should be the NetBIOS domain. Also add a new `-SearchBase` parameter to help refine LDAP queries when using OpenLDAP.

### Related Issue
Resolves #793 

### Examples
The below will search in `OU=CustomUsers,DC=test,DC=example,DC=com` when on *nix using OpenLDAP:

```powershell
Start-PodeServer {
    New-PodeAuthScheme -Form | Add-PodeAuthWindowsAd -Name 'Login' -SearchBase 'OU=CustomUsers,DC=test,DC=example,DC=com'
}
```