### PR TITLE
Add new crash event hook

### DIFF
--- a/docs/Tutorials/Events.md
+++ b/docs/Tutorials/Events.md
@@ -6,6 +6,7 @@ Pode lets you register scripts to be run when certain server events are triggere
 * Terminate
 * Restart
 * Browser
+* Crash
 
 ## Overview
 
@@ -48,3 +49,7 @@ Scripts registered to the `Restart` event will all be invoked whenever an intern
 ### Browser
 
 Scripts registered to the `Browser` event will all be invoked whenever the server is told to open a browser, ie: when `Ctrl+B` is pressed.
+
+### Crash
+
+Scripts registered to the `Crash` event will all be invoked if the server ever terminates due to an exception being thrown.

--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -337,6 +337,7 @@ function New-PodeContext
         Terminate = [ordered]@{}
         Restart = [ordered]@{}
         Browser = [ordered]@{}
+        Crash = [ordered]@{}
     }
 
     # return the new context

--- a/src/Private/Events.ps1
+++ b/src/Private/Events.ps1
@@ -2,7 +2,7 @@ function Invoke-PodeEvent
 {
     param(
         [Parameter(Mandatory=$true)]
-        [ValidateSet('Start', 'Terminate', 'Restart', 'Browser')]
+        [ValidateSet('Start', 'Terminate', 'Restart', 'Browser', 'Crash')]
         [string]
         $Type
     )

--- a/src/Public/Core.ps1
+++ b/src/Public/Core.ps1
@@ -196,6 +196,7 @@ function Start-PodeServer
         $PodeContext.Tokens.Cancellation.Cancel()
     }
     catch {
+        Invoke-PodeEvent -Type Crash
         $ShowDoneMessage = $false
         throw
     }

--- a/src/Public/Events.ps1
+++ b/src/Public/Events.ps1
@@ -25,7 +25,7 @@ function Register-PodeEvent
     [CmdletBinding()]
     param(
         [Parameter(Mandatory=$true)]
-        [ValidateSet('Start', 'Terminate', 'Restart', 'Browser')]
+        [ValidateSet('Start', 'Terminate', 'Restart', 'Browser', 'Crash')]
         [string]
         $Type,
 
@@ -80,7 +80,7 @@ function Unregister-PodeEvent
     [CmdletBinding()]
     param(
         [Parameter(Mandatory=$true)]
-        [ValidateSet('Start', 'Terminate', 'Restart', 'Browser')]
+        [ValidateSet('Start', 'Terminate', 'Restart', 'Browser', 'Crash')]
         [string]
         $Type,
 
@@ -119,7 +119,7 @@ function Test-PodeEvent
     [CmdletBinding()]
     param(
         [Parameter(Mandatory=$true)]
-        [ValidateSet('Start', 'Terminate', 'Restart', 'Browser')]
+        [ValidateSet('Start', 'Terminate', 'Restart', 'Browser', 'Crash')]
         [string]
         $Type,
 
@@ -152,7 +152,7 @@ function Get-PodeEvent
     [CmdletBinding()]
     param(
         [Parameter(Mandatory=$true)]
-        [ValidateSet('Start', 'Terminate', 'Restart', 'Browser')]
+        [ValidateSet('Start', 'Terminate', 'Restart', 'Browser', 'Crash')]
         [string]
         $Type,
 
@@ -182,7 +182,7 @@ function Clear-PodeEvent
     [CmdletBinding()]
     param(
         [Parameter(Mandatory=$true)]
-        [ValidateSet('Start', 'Terminate', 'Restart', 'Browser')]
+        [ValidateSet('Start', 'Terminate', 'Restart', 'Browser', 'Crash')]
         [string]
         $Type
     )


### PR DESCRIPTION
### Description of the Change
Adds new Crash event hook that runs scripts whenever the server is stopped via an exception being thrown.

### Related Issue
Resolves #825 

### Examples
```powershell
Register-PodeEvent -Type Crash -Name Example -ScriptBlock {
    # logic
}
```
