### PR TITLE
Add LastTriggerTime for schedules/timers

### DIFF
--- a/docs/Tutorials/Schedules.md
+++ b/docs/Tutorials/Schedules.md
@@ -137,6 +137,7 @@ The following is the structure of the Schedule object internally, as well as the
 | CronsRaw | string[] | The raw cron expressions that were supplied |
 | Limit | int | The number of times the Schedule should run - 0 if running infinitely |
 | Count | int | The number of times the Schedule has run |
+| LastTriggerTime | datetime | The datetime the Schedule was last triggered |
 | NextTriggerTime | datetime | The datetime the Schedule will next be triggered |
 | Script | scriptblock | The scriptblock of the Schedule |
 | Arguments | hashtable | The arguments supplied from ArgumentList |

--- a/docs/Tutorials/Timers.md
+++ b/docs/Tutorials/Timers.md
@@ -87,6 +87,7 @@ The following is the structure of the Timer object internally, as well as the ob
 | Limit | int | The number of times the Timer should run - 0 if running forever |
 | Skip | int | The number of times the Timer should skip being triggered |
 | Count | int | The number of times the Timer has run |
+| LastTriggerTime | datetime | The datetime the Timer was last triggered |
 | NextTriggerTime | datetime | The datetime the Timer will next be triggered |
 | Script | scriptblock | The scriptblock of the Timer |
 | Arguments | object[] | The arguments supplied from ArgumentList |

--- a/examples/schedules.ps1
+++ b/examples/schedules.ps1
@@ -13,8 +13,11 @@ Start-PodeServer {
     # schedule minutely using predefined cron
     $message = 'Hello, world!'
     Add-PodeSchedule -Name 'predefined' -Cron '@minutely' -Limit 2 -ScriptBlock {
+        param($Event)
         $using:message | Out-Default
         Get-PodeSchedule -Name 'predefined' | Out-Default
+        "Last: $($Event.Sender.LastTriggerTime)" | Out-Default
+        "Next: $($Event.Sender.NextTriggerTime)" | Out-Default
     }
 
     Add-PodeSchedule -Name 'from-file' -Cron '@minutely' -FilePath './scripts/schedule.ps1'

--- a/examples/timers.ps1
+++ b/examples/timers.ps1
@@ -17,6 +17,8 @@ Start-PodeServer {
         Lock-PodeObject -Object $TimerEvent.Lockable -ScriptBlock {
             "Look I'm locked!" | Out-PodeHost
         }
+        "Last: $($TimerEvent.Sender.LastTriggerTime)" | Out-Default
+        "Next: $($TimerEvent.Sender.NextTriggerTime)" | Out-Default
         '- - -' | Out-PodeHost
     } -Limit 5
 

--- a/src/Public/Core.ps1
+++ b/src/Public/Core.ps1
@@ -1269,6 +1269,7 @@ function Add-PodeTimer
         Count = 0
         Skip = $Skip
         NextTriggerTime = $NextTriggerTime
+        LastTriggerTime = $null
         Script = $ScriptBlock
         UsingVariables = $usingVars
         Arguments = $ArgumentList
@@ -1592,6 +1593,7 @@ function Add-PodeSchedule
         Limit = $Limit
         Count = 0
         NextTriggerTime = $nextTrigger
+        LastTriggerTime = $null
         Script = $ScriptBlock
         UsingVariables = $usingVars
         Arguments = (Protect-PodeValue -Value $ArgumentList -Default @{})


### PR DESCRIPTION
### Description of the Change
Adds `LastTriggerTime` to a Schedule/Timer object, which can be checked via both `Get-PodeSchedule` and `Get-PodeTimer`. This time starts as null, and is set to the NextTriggerTime before it's updated. If NextTriggerTime is null then LastTriggerTime is set to the current time.

### Related Issue
Resolves #817 
