### PR TITLE
Add -Compress switch to Save-PodeState

### DIFF
--- a/docs/Tutorials/SharedState.md
+++ b/docs/Tutorials/SharedState.md
@@ -88,6 +88,8 @@ When saving the state, you can also use the `-Exclude` or `-Include` parameters 
 
 You can use all the above 3 parameter in conjunction, with `-Exclude` having the highest precedence and `-Scope` having the lowest.
 
+By default the JSON will be saved expanded, but you can saved the JSON as compressed by supplying the `-Compress` switch.
+
 ### Restore
 
 The [`Restore-PodeState`](../../Functions/State/Restore-PodeState) function will restore the current state from the specified file. The file path can either be relative, or a literal path. if you're restoring the state immediately on server start, you don't need to use [`Lock-PodeObject`](../../Functions/Utilities/Lock-PodeObject).

--- a/src/Public/State.ps1
+++ b/src/Public/State.ps1
@@ -207,6 +207,9 @@ An optional array of state object names to exclude from being saved. (This has a
 .PARAMETER Include
 An optional array of state object names to only include when being saved.
 
+.PARAMETER Compress
+If supplied, the saved JSON will be compressed.
+
 .EXAMPLE
 Save-PodeState -Path './state.json'
 
@@ -234,7 +237,10 @@ function Save-PodeState
 
         [Parameter()]
         [string[]]
-        $Include
+        $Include,
+
+        [switch]
+        $Compress
     )
 
     # error if attempting to use outside of the pode server
@@ -295,7 +301,7 @@ function Save-PodeState
     }
 
     # save the state
-    $state | ConvertTo-Json -Depth 10 | Out-File -FilePath $Path -Force | Out-Null
+    $state | ConvertTo-Json -Depth 10 -Compress:$Compress | Out-File -FilePath $Path -Force | Out-Null
 }
 
 <#


### PR DESCRIPTION
### Description of the Change
Adds a new `-Compress` switch to `Save-PodeState` so that the saved JSON file will be compressed.

### Related Issue
Resolves #827 

### Examples
```powershell
Save-PodeState -Path './state.json' -Scope Users -Compress
```
