### PR TITLE
Add -Merge switch to Restore-PodeState

### DIFF
--- a/docs/Tutorials/SharedState.md
+++ b/docs/Tutorials/SharedState.md
@@ -100,6 +100,8 @@ Start-PodeServer {
 }
 ```
 
+By default, restoring from a state file will overwrite the current state. You can change this so the restored state is merged instead by using the `-Merge` switch. (Note: if you restore a key that already exists in state, this will still overwrite that key).
+
 ## Full Example
 
 The following is a full example of using the State functions. It is a simple Timer that creates and updates a `hashtable` variable, and then a Route is used to retrieve that variable. There is also another route that will remove the variable from the state. The state is also saved on every iteration of the timer, and restored on server start:

--- a/src/Public/State.ps1
+++ b/src/Public/State.ps1
@@ -308,6 +308,9 @@ Restores the shared state from some JSON file.
 .PARAMETER Path
 The path to a JSON file that contains the state information.
 
+.PARAMETER Merge
+If supplied, the state loaded from the JSON file will be merged with the current state, instead of overwriting it.
+
 .EXAMPLE
 Restore-PodeState -Path './state.json'
 #>
@@ -317,7 +320,10 @@ function Restore-PodeState
     param(
         [Parameter(Mandatory=$true)]
         [string]
-        $Path
+        $Path,
+
+        [switch]
+        $Merge
     )
 
     # error if attempting to use outside of the pode server
@@ -363,7 +369,14 @@ function Restore-PodeState
     }
 
     # set the scope to the main context
-    $PodeContext.Server.State = $state.Clone()
+    if ($Merge) {
+        foreach ($_key in $state.Clone().Keys) {
+            $PodeContext.Server.State[$_key] = $state[$_key]
+        }
+    }
+    else {
+        $PodeContext.Server.State = $state.Clone()
+    }
 }
 
 <#


### PR DESCRIPTION
### Description of the Change
Adds a new `-Merge` switch to `Restore-PodeState`, so that instead of overwriting the current state it is merged with the state.

### Related Issue
Resolves #828 

### Examples
```powershell
Restore-PodeState -Path './state.json' -Merge
```

