### PR TITLE
Adds a new Out-PodeVariable

### DIFF
--- a/docs/Tutorials/Misc/Outputs.md
+++ b/docs/Tutorials/Misc/Outputs.md
@@ -1,0 +1,13 @@
+# Outputs
+
+## Variables
+
+You can tell Pode to create variables with values when the server stops by using [`Out-PodeVariable`](../../../Functions/Utilities/Out-PodeVariable), for example:
+
+```powershell
+Out-PodeVariable -Name VariableName -Value 'Some_Variable_Value'
+```
+
+The `-Value` of the variable can be any object type, and when the server is stopped these variables will be created and available in the command line.
+
+If you were to run the able example, this means that when the server is stopped, you will have access to a `$VariableName` variable on the CLI.

--- a/examples/web-pages.ps1
+++ b/examples/web-pages.ps1
@@ -55,6 +55,12 @@ Start-PodeServer -Threads 2 {
         Write-PodeViewResponse -Path 'simple' -Data @{ 'numbers' = @(1, 2, 3); }
     }
 
+    # Set an output variable
+    Add-PodeRoute -Method Post -Path '/variable' -ScriptBlock {
+        Out-PodeVariable -Name $WebEvent.Data.Name -Value $WebEvent.Data.Value
+        Out-PodeVariable -Name Pode_Complex_Object -Value @{ Name = 'Joe'; Age = 42 }
+    }
+
     # GET request throws fake "500" server error status code
     Add-PodeRoute -Method Get -Path '/error' -ScriptBlock {
         Set-PodeResponseStatus -Code 500

--- a/src/Pode.psd1
+++ b/src/Pode.psd1
@@ -120,6 +120,7 @@
         'Remove-PodeLockable',
         'Get-PodeLockable',
         'Test-PodeLockable',
+        'Out-PodeVariable',
 
         # routes
         'Add-PodeRoute',

--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -212,6 +212,11 @@ function New-PodeContext
     # shared state between runspaces
     $ctx.Server.State = @{}
 
+    # output details, like variables, to be set once the server stops
+    $ctx.Server.Output = @{
+        Variables = @{}
+    }
+
     # view engine for rendering pages
     $ctx.Server.ViewEngine = @{
         Type = 'html'
@@ -765,5 +770,16 @@ function New-PodeAutoRestartServer
         Add-PodeSchedule -Name '__pode_restart_crons__' -Cron @($crons) -ScriptBlock {
             $PodeContext.Tokens.Restart.Cancel()
         }
+    }
+}
+
+function Set-PodeOutputVariables
+{
+    if (Test-PodeIsEmpty $PodeContext.Server.Output.Variables) {
+        return
+    }
+
+    foreach ($key in $PodeContext.Server.Output.Variables.Keys) {
+        Set-Variable -Name $key -Value $PodeContext.Server.Output.Variables[$key] -Force -Scope Global
     }
 }

--- a/src/Private/Server.ps1
+++ b/src/Private/Server.ps1
@@ -200,6 +200,9 @@ function Restart-PodeInternalServer
         # clear up shared state
         $PodeContext.Server.State.Clear()
 
+        # clear up output
+        $PodeContext.Server.Output.Variables.Clear()
+
         # reset type if smtp/tcp
         $PodeContext.Server.Types = @()
 

--- a/src/Public/Core.ps1
+++ b/src/Public/Core.ps1
@@ -201,6 +201,9 @@ function Start-PodeServer
         throw
     }
     finally {
+        # set output values
+        Set-PodeOutputVariables
+
         # clean the runspaces and tokens
         Close-PodeServerInternal -ShowDoneMessage:$ShowDoneMessage
 

--- a/src/Public/Utilities.ps1
+++ b/src/Public/Utilities.ps1
@@ -1025,3 +1025,35 @@ function Test-PodeLockable
 
     return $PodeContext.Lockables.Custom.ContainsKey($Name)
 }
+
+<#
+.SYNOPSIS
+Defines variables to be created when the Pode server stops.
+
+.DESCRIPTION
+Allows you to define a variable, with a value, that should be created on the in the main scope after the Pode server is stopped.
+
+.PARAMETER Name
+The Name of the variable to be set
+
+.PARAMETER Value
+The Value of the variable to be set
+
+.EXAMPLE
+Out-PodeVariable -Name ExampleVar -Value @{ Name = 'Bob' }
+#>
+function Out-PodeVariable
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Name,
+
+        [Parameter(ValueFromPipeline=$true)]
+        [object]
+        $Value
+    )
+
+    $PodeContext.Server.Output.Variables[$Name] = $Value
+}

--- a/tests/unit/Server.Tests.ps1
+++ b/tests/unit/Server.Tests.ps1
@@ -125,7 +125,7 @@ Describe 'Restart-PodeInternalServer' {
                 Sessions = @{ 'key' = 'value' };
                 Authentications = @{ 'key' = 'value' };
                 State = @{ 'key' = 'value' };
-                Outputs = @{
+                Output = @{
                     Variables = @{ 'key' = 'value' }
                 }
                 Configuration = @{ 'key' = 'value' };

--- a/tests/unit/Server.Tests.ps1
+++ b/tests/unit/Server.Tests.ps1
@@ -125,6 +125,9 @@ Describe 'Restart-PodeInternalServer' {
                 Sessions = @{ 'key' = 'value' };
                 Authentications = @{ 'key' = 'value' };
                 State = @{ 'key' = 'value' };
+                Outputs = @{
+                    Variables = @{ 'key' = 'value' }
+                }
                 Configuration = @{ 'key' = 'value' };
                 Sockets = @{
                     Listeners = @()


### PR DESCRIPTION
### Description of the Change
Adds a new `Out-PodeVariable` which allows you to create variables when the server stops, and are available on the CLI.

### Related Issue
Resolves #813 

### Examples
```powershell
Out-PodeVariable -Name VariableName -Value 'Some_Variable_Value'
```

If you were to run the able example, this means that when the server is stopped, you will have access to a `$VariableName` variable on the CLI.
