### PR TITLE
Use the global lockable by default in Lock-PodeObject

### DIFF
--- a/docs/Tutorials/SharedState.md
+++ b/docs/Tutorials/SharedState.md
@@ -25,7 +25,7 @@ An example of setting a hashtable variable in the state is as follows:
 ```powershell
 Start-PodeServer {
     Add-PodeTimer -Name 'do-something' -Interval 5 -ScriptBlock {
-        Lock-PodeObject -Object $TimerEvent.Lockable -ScriptBlock {
+        Lock-PodeObject -ScriptBlock {
             Set-PodeState -Name 'data' -Value @{ 'Name' = 'Rick Sanchez' } | Out-Null
         }
     }
@@ -43,7 +43,7 @@ Start-PodeServer {
     Add-PodeTimer -Name 'do-something' -Interval 5 -ScriptBlock {
         $value = $null
 
-        Lock-PodeObject -Object $TimerEvent.Lockable -ScriptBlock {
+        Lock-PodeObject -ScriptBlock {
             $value = (Get-PodeState -Name 'data')
         }
 
@@ -61,7 +61,7 @@ An example of removing a variable from the state is as follows:
 ```powershell
 Start-PodeServer {
     Add-PodeTimer -Name 'do-something' -Interval 5 -ScriptBlock {
-        Lock-PodeObject -Object $TimerEvent.Lockable -ScriptBlock {
+        Lock-PodeObject -ScriptBlock {
             Remove-PodeState -Name 'data' | Out-Null
         }
     }
@@ -77,7 +77,7 @@ An example of saving the current state every hour is as follows:
 ```powershell
 Start-PodeServer {
     Add-PodeSchedule -Name 'save-state' -Cron '@hourly' -ScriptBlock {
-        Lock-PodeObject -Object $lockable -ScriptBlock {
+        Lock-PodeObject -ScriptBlock {
             Save-PodeState -Path './state.json'
         }
     }
@@ -121,8 +121,7 @@ Start-PodeServer {
     # timer to add a random number to the shared state
     Add-PodeTimer -Name 'forever' -Interval 2 -ScriptBlock {
         # ensure we're thread safe
-        Lock-PodeObject -Object $TimerEvent.Lockable -ScriptBlock {
-
+        Lock-PodeObject -ScriptBlock {
             # attempt to get the hashtable from the state
             $hash = (Get-PodeState -Name 'hash')
 
@@ -137,8 +136,7 @@ Start-PodeServer {
     # route to return the value of the hashtable from shared state
     Add-PodeRoute -Method Get -Path '/' -ScriptBlock {
         # again, ensure we're thread safe
-        Lock-PodeObject -Object $WebEvent.Lockable -ScriptBlock {
-
+        Lock-PodeObject -ScriptBlock {
             # get the hashtable from the state and return it
             $hash = (Get-PodeState -Name 'hash')
             Write-PodeJsonResponse -Value $hash
@@ -148,8 +146,7 @@ Start-PodeServer {
     # route to remove the hashtable from shared state
     Add-PodeRoute -Method Delete -Path '/' -ScriptBlock {
         # ensure we're thread safe
-        Lock-PodeObject -Object $WebEvent.Lockable -ScriptBlock {
-
+        Lock-PodeObject -ScriptBlock {
             # remove the hashtable from the state
             Remove-PodeState -Name 'hash' | Out-Null
         }

--- a/docs/Tutorials/Threading.md
+++ b/docs/Tutorials/Threading.md
@@ -20,7 +20,7 @@ In event objects, like `$WebEvent`, there is a global `Lockable` object that you
 
 ```powershell
 Add-PodeRoute -Method Get -Path '/save' -ScriptBlock {
-    Lock-PodeObject -Object $WebEvent.Lockable -ScriptBlock {
+    Lock-PodeObject -ScriptBlock {
         Save-PodeState -Path './state.json'
     }
 }
@@ -54,7 +54,7 @@ Start-PodeServer -Threads 2 {
 
     # lock global, sleep for 10secs
     Add-PodeRoute -Method Get -Path '/route1' -ScriptBlock {
-        Lock-PodeObject -Object $WebEvent.Lockable -ScriptBlock {
+        Lock-PodeObject -ScriptBlock {
             Start-Sleep -Seconds 10
         }
 

--- a/examples/lockables.ps1
+++ b/examples/lockables.ps1
@@ -26,7 +26,7 @@ Start-PodeServer -Threads 2 {
     }
 
     Add-PodeRoute -Method Get -Path '/global-route1' -ScriptBlock {
-        Lock-PodeObject -Object $WebEvent.Lockable -ScriptBlock {
+        Lock-PodeObject -ScriptBlock {
             Start-Sleep -Seconds 10
         }
 

--- a/examples/looping-service.ps1
+++ b/examples/looping-service.ps1
@@ -9,7 +9,7 @@ Start-PodeServer -Interval 3 {
 
     Add-PodeHandler -Type Service -Name 'Hello' -ScriptBlock {
         Write-Host 'hello, world!'
-        Lock-PodeObject -Object $ServiceEvent.Lockable -ScriptBlock {
+        Lock-PodeObject -ScriptBlock {
             "Look I'm locked!" | Out-PodeHost
         }
     }

--- a/examples/shared-state.ps1
+++ b/examples/shared-state.ps1
@@ -29,7 +29,7 @@ Start-PodeServer {
     Add-PodeTimer -Name 'forever' -Interval 2 -ScriptBlock {
         $hash = $null
 
-        Lock-PodeObject -Object $TimerEvent.Lockable -ScriptBlock {
+        Lock-PodeObject -ScriptBlock {
             $hash = (Get-PodeState -Name 'hash1')
             $hash.values += (Get-Random -Minimum 0 -Maximum 10)
             Save-PodeState -Path './state.json' -Scope Scope1 #-Exclude 'hash1'
@@ -38,7 +38,7 @@ Start-PodeServer {
 
     # route to retrieve and return the value of the hashtable from global state
     Add-PodeRoute -Method Get -Path '/array' -ScriptBlock {
-        Lock-PodeObject -Object $WebEvent.Lockable -ScriptBlock {
+        Lock-PodeObject -ScriptBlock {
             $hash = (Get-PodeState 'hash1')
             Write-PodeJsonResponse -Value $hash
         }
@@ -46,7 +46,7 @@ Start-PodeServer {
 
     # route to remove the hashtable from global state
     Add-PodeRoute -Method Delete -Path '/array' -ScriptBlock {
-        Lock-PodeObject -Object $WebEvent.Lockable -ScriptBlock {
+        Lock-PodeObject -ScriptBlock {
             $hash = (Set-PodeState -Name 'hash1' -Value @{})
             $hash.values = @()
         }

--- a/examples/timers.ps1
+++ b/examples/timers.ps1
@@ -14,7 +14,7 @@ Start-PodeServer {
     Add-PodeTimer -Name 'forever' -Interval 5 -ScriptBlock {
         '- - -' | Out-PodeHost
         $using:message | Out-PodeHost
-        Lock-PodeObject -Object $TimerEvent.Lockable -ScriptBlock {
+        Lock-PodeObject -ScriptBlock {
             "Look I'm locked!" | Out-PodeHost
         }
         "Last: $($TimerEvent.Sender.LastTriggerTime)" | Out-Default

--- a/src/Public/Utilities.ps1
+++ b/src/Public/Utilities.ps1
@@ -125,7 +125,7 @@ Places a temporary lock on a object while a ScriptBlock is invoked.
 Places a temporary lock on a object while a ScriptBlock is invoked.
 
 .PARAMETER Object
-The object to lock.
+The object to lock, if no object is supplied then the global lockable is used by default.
 
 .PARAMETER ScriptBlock
 The ScriptBlock to invoke.
@@ -135,6 +135,9 @@ If supplied, any values from the ScriptBlock will be returned.
 
 .PARAMETER CheckGlobal
 If supplied, will check the global Lockable object and wait until it's freed-up before locking the passed object.
+
+.EXAMPLE
+Lock-PodeObject -ScriptBlock { /* logic */ }
 
 .EXAMPLE
 Lock-PodeObject -Object $SomeArray -ScriptBlock { /* logic */ }
@@ -147,7 +150,7 @@ function Lock-PodeObject
     [CmdletBinding()]
     [OutputType([object])]
     param (
-        [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
+        [Parameter(ValueFromPipeline=$true)]
         [object]
         $Object,
 
@@ -163,7 +166,7 @@ function Lock-PodeObject
     )
 
     if ($null -eq $Object) {
-        return
+        $Object = $PodeContext.Lockables.Global
     }
 
     if ($Object -is [valuetype]) {


### PR DESCRIPTION
### Description of the Change
If no `-Object` is supplied to `Lock-PodeObject`, then the global lockable object Pode creates is used by default.

### Related Issue
Resolves #836 

### Examples
If relevant, include any examples of using what you have changed.
