### PR TITLE
Add new Stop event hook

### DIFF
--- a/docs/Tutorials/Events.md
+++ b/docs/Tutorials/Events.md
@@ -7,6 +7,7 @@ Pode lets you register scripts to be run when certain server events are triggere
 * Restart
 * Browser
 * Crash
+* Stop
 
 ## Overview
 
@@ -52,4 +53,8 @@ Scripts registered to the `Browser` event will all be invoked whenever the serve
 
 ### Crash
 
-Scripts registered to the `Crash` event will all be invoked if the server ever terminates due to an exception being thrown.
+Scripts registered to the `Crash` event will all be invoked if the server ever terminates due to an exception being thrown. If a Crash event it triggered, then Terminate will not be triggered.
+
+### Stop
+
+Scripts registered to the `Stop` event will all be invoked when the server stops and closes. This event will be fired after either the Terminate or Crash events - which ever one causes the server to ultimately stop.

--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -338,6 +338,7 @@ function New-PodeContext
         Restart = [ordered]@{}
         Browser = [ordered]@{}
         Crash = [ordered]@{}
+        Stop = [ordered]@{}
     }
 
     # return the new context

--- a/src/Private/Events.ps1
+++ b/src/Private/Events.ps1
@@ -2,7 +2,7 @@ function Invoke-PodeEvent
 {
     param(
         [Parameter(Mandatory=$true)]
-        [ValidateSet('Start', 'Terminate', 'Restart', 'Browser', 'Crash')]
+        [ValidateSet('Start', 'Terminate', 'Restart', 'Browser', 'Crash', 'Stop')]
         [string]
         $Type
     )

--- a/src/Public/Core.ps1
+++ b/src/Public/Core.ps1
@@ -201,6 +201,8 @@ function Start-PodeServer
         throw
     }
     finally {
+        Invoke-PodeEvent -Type Stop
+
         # clean the runspaces and tokens
         Close-PodeServerInternal -ShowDoneMessage:$ShowDoneMessage
 

--- a/src/Public/Events.ps1
+++ b/src/Public/Events.ps1
@@ -25,7 +25,7 @@ function Register-PodeEvent
     [CmdletBinding()]
     param(
         [Parameter(Mandatory=$true)]
-        [ValidateSet('Start', 'Terminate', 'Restart', 'Browser', 'Crash')]
+        [ValidateSet('Start', 'Terminate', 'Restart', 'Browser', 'Crash', 'Stop')]
         [string]
         $Type,
 
@@ -80,7 +80,7 @@ function Unregister-PodeEvent
     [CmdletBinding()]
     param(
         [Parameter(Mandatory=$true)]
-        [ValidateSet('Start', 'Terminate', 'Restart', 'Browser', 'Crash')]
+        [ValidateSet('Start', 'Terminate', 'Restart', 'Browser', 'Crash', 'Stop')]
         [string]
         $Type,
 
@@ -119,7 +119,7 @@ function Test-PodeEvent
     [CmdletBinding()]
     param(
         [Parameter(Mandatory=$true)]
-        [ValidateSet('Start', 'Terminate', 'Restart', 'Browser', 'Crash')]
+        [ValidateSet('Start', 'Terminate', 'Restart', 'Browser', 'Crash', 'Stop')]
         [string]
         $Type,
 
@@ -152,7 +152,7 @@ function Get-PodeEvent
     [CmdletBinding()]
     param(
         [Parameter(Mandatory=$true)]
-        [ValidateSet('Start', 'Terminate', 'Restart', 'Browser', 'Crash')]
+        [ValidateSet('Start', 'Terminate', 'Restart', 'Browser', 'Crash', 'Stop')]
         [string]
         $Type,
 
@@ -182,7 +182,7 @@ function Clear-PodeEvent
     [CmdletBinding()]
     param(
         [Parameter(Mandatory=$true)]
-        [ValidateSet('Start', 'Terminate', 'Restart', 'Browser', 'Crash')]
+        [ValidateSet('Start', 'Terminate', 'Restart', 'Browser', 'Crash', 'Stop')]
         [string]
         $Type
     )


### PR DESCRIPTION
### Description of the Change
Scripts registered to the `Stop` event will all be invoked when the server stops and closes. This event will be fired after either the Terminate or Crash events - which ever one causes the server to ultimately stop.

### Related Issue
Resolves #837 

### Examples
```powershell
Register-PodeEvent -Type Stop -Name '<name>' -ScriptBlock {
    # inform a portal, write a log, etc
}
```