### PR TITLE
Fix for single item array being converted to json

### DIFF
--- a/src/Private/Sessions.ps1
+++ b/src/Private/Sessions.ps1
@@ -164,7 +164,7 @@ function Set-PodeSessionDataHash
         $Session.Data = @{}
     }
 
-    $Session.DataHash = (Invoke-PodeSHA256Hash -Value ($Session.Data.Clone() | ConvertTo-Json -Depth 10 -Compress))
+    $Session.DataHash = (Invoke-PodeSHA256Hash -Value (ConvertTo-Json -InputObject $Session.Data.Clone() -Depth 10 -Compress))
 }
 
 function Test-PodeSessionDataHash
@@ -184,7 +184,7 @@ function Test-PodeSessionDataHash
         $Session.Data = @{}
     }
 
-    $hash = (Invoke-PodeSHA256Hash -Value ($Session.Data | ConvertTo-Json -Depth 10 -Compress))
+    $hash = (Invoke-PodeSHA256Hash -Value (ConvertTo-Json -InputObject $Session.Data -Depth 10 -Compress))
     return ($Session.DataHash -eq $hash)
 }
 

--- a/src/Public/Responses.ps1
+++ b/src/Public/Responses.ps1
@@ -711,10 +711,10 @@ function Write-PodeJsonResponse
         'value' {
             if ($Value -isnot [string]) {
                 if ($Depth -le 0) {
-                    $Value = ($Value | ConvertTo-Json -Compress)
+                    $Value = (ConvertTo-Json -InputObject $Value -Compress)
                 }
                 else {
-                    $Value = ($Value | ConvertTo-Json -Depth $Depth -Compress)
+                    $Value = (ConvertTo-Json -InputObject $Value -Depth $Depth -Compress)
                 }
             }
         }
@@ -1428,10 +1428,10 @@ function Send-PodeSignal
 
     if ($Value -isnot [string]) {
         if ($Depth -le 0) {
-            $Value = ($Value | ConvertTo-Json -Compress)
+            $Value = (ConvertTo-Json -InputObject $Value -Compress)
         }
         else {
-            $Value = ($Value | ConvertTo-Json -Depth $Depth -Compress)
+            $Value = (ConvertTo-Json -InputObject $Value -Depth $Depth -Compress)
         }
     }
 

--- a/src/Public/State.ps1
+++ b/src/Public/State.ps1
@@ -301,7 +301,7 @@ function Save-PodeState
     }
 
     # save the state
-    $state | ConvertTo-Json -Depth 10 -Compress:$Compress | Out-File -FilePath $Path -Force | Out-Null
+    ConvertTo-Json -InputObject $state -Depth 10 -Compress:$Compress | Out-File -FilePath $Path -Force | Out-Null
 }
 
 <#


### PR DESCRIPTION
### Description of the Change
Fixes an issue when converting single item arrays to JSON, by supplying the object directly via `-InputObject` rather than piping it in.

### Related Issue
Resolves #845 
