### PR TITLE
Use -Threads to create more client signal threads for websockets

### DIFF
--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -521,7 +521,7 @@ function New-PodeRunspacePools
 
     # web socket runspace - if we have any ws/s endpoints
     if (Test-PodeEndpoints -Type Ws) {
-        $PodeContext.RunspacePools.Signals = [runspacefactory]::CreateRunspacePool(1, 3, $PodeContext.RunspaceState, $Host)
+        $PodeContext.RunspacePools.Signals = [runspacefactory]::CreateRunspacePool(1, ($PodeContext.Threads.General + 2), $PodeContext.RunspaceState, $Host)
     }
 
     # setup schedule runspace pool

--- a/src/Private/PodeServer.ps1
+++ b/src/Private/PodeServer.ps1
@@ -325,7 +325,11 @@ function Start-PodeWebServer
         $clientScript = {
             param(
                 [Parameter(Mandatory=$true)]
-                $Listener
+                $Listener,
+
+                [Parameter(Mandatory=$true)]
+                [int]
+                $ThreadId
             )
 
             try {
@@ -401,7 +405,10 @@ function Start-PodeWebServer
             }
         }
 
-        Add-PodeRunspace -Type Signals -ScriptBlock $clientScript -Parameters @{ 'Listener' = $listener }
+        # start the runspace for listening on x-number of threads
+        1..$PodeContext.Threads.General | ForEach-Object {
+            Add-PodeRunspace -Type Signals -ScriptBlock $clientScript -Parameters @{ 'Listener' = $listener; 'ThreadId' = $_ }
+        }
     }
 
     # script to keep web server listening until cancelled

--- a/src/Public/Core.ps1
+++ b/src/Public/Core.ps1
@@ -19,7 +19,7 @@ For 'Service' type Servers, will invoke the ScriptBlock every X seconds.
 An optional name for the Server (intended for future ideas).
 
 .PARAMETER Threads
-The numbers of threads to use for Web and TCP servers.
+The numbers of threads to use for Web, SMTP, and TCP servers.
 
 .PARAMETER RootPath
 An override for the Server's root path.


### PR DESCRIPTION
### Description of the Change
Use the `-Threads` on `Start-PodeServer` to also create additional client signal threads for websockets - but only if a websocket endpoint has been created.

### Examples
The following, if using a websocket endpoint, will now also creation additional client signal threads for dealing with inbound signals.

```powershell
Start-PodeServer -Threads 2 {
    Add-PodeEndpoint -Address * -Port 8091 -Protocol Ws
}
```
