### PR TITLE
Adds the other Use-PodeXYZ functions

### DIFF
--- a/examples/timers.ps1
+++ b/examples/timers.ps1
@@ -59,4 +59,6 @@ Start-PodeServer {
         Invoke-PodeTimer -Name 'forever'
     }
 
+    Use-PodeTimers
+
 }

--- a/examples/timers/timer.ps1
+++ b/examples/timers/timer.ps1
@@ -1,0 +1,3 @@
+Add-PodeTimer -Name 'imported-timer' -Interval 10 -ScriptBlock {
+    'i am imported!' | Out-Default
+}

--- a/src/Pode.psd1
+++ b/src/Pode.psd1
@@ -102,6 +102,7 @@
         'Use-PodeScript',
         'Get-PodeConfig',
         'Add-PodeEndware',
+        'Use-PodeEndware',
         'Import-PodeModule',
         'Import-PodeSnapIn',
         'Protect-PodeValue',
@@ -143,6 +144,7 @@
         'Add-PodeHandler',
         'Remove-PodeHandler',
         'Clear-PodeHandlers',
+        'Use-PodeHandlers',
 
         # schedules
         'Add-PodeSchedule',
@@ -153,6 +155,7 @@
         'Set-PodeScheduleConcurrency',
         'Get-PodeSchedule',
         'Get-PodeScheduleNextTrigger',
+        'Use-PodeSchedules',
 
         # timers
         'Add-PodeTimer',
@@ -161,6 +164,7 @@
         'Invoke-PodeTimer',
         'Edit-PodeTimer',
         'Get-PodeTimer',
+        'Use-PodeTimers',
 
         # middleware
         'Add-PodeMiddleware',
@@ -176,6 +180,7 @@
         'Remove-PodeSession',
         'Save-PodeSession',
         'Get-PodeSessionId',
+        'Use-PodeMiddleware',
 
         # auth
         'New-PodeAuthScheme',
@@ -190,6 +195,7 @@
         'Add-PodeAuthIIS',
         'Add-PodeAuthUserFile',
         'ConvertTo-PodeJwt',
+        'Use-PodeAuth',
 
         # logging
         'New-PodeLoggingMethod',
@@ -203,6 +209,7 @@
         'Write-PodeErrorLog',
         'Write-PodeLog',
         'Protect-PodeLogItem',
+        'Use-PodeLogging',
 
         # core
         'Start-PodeServer',
@@ -251,7 +258,8 @@
         'Unregister-PodeEvent',
         'Test-PodeEvent',
         'Get-PodeEvent',
-        'Clear-PodeEvent'
+        'Clear-PodeEvent',
+        'Use-PodeEvents'
     )
 
     # Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -2582,3 +2582,34 @@ function Read-PodeWebExceptionDetails
         Body = $body
     }
 }
+
+function Use-PodeFolder
+{
+    param(
+        [Parameter()]
+        [string]
+        $Path,
+
+        [Parameter(Mandatory=$true)]
+        [string]
+        $DefaultPath
+    )
+
+    # use default, or custom path
+    if ([string]::IsNullOrWhiteSpace($Path)) {
+        $Path = Join-PodeServerRoot -Folder $DefaultPath
+    }
+    else {
+        $Path = Get-PodeRelativePath -Path $Path -JoinRoot
+    }
+
+    # fail if path not found
+    if (!(Test-PodePath -Path $Path -NoStatus)) {
+        throw "Path to load $($DefaultPath) not found: $($Path)"
+    }
+
+    # get .ps1 files and load them
+    Get-ChildItem -Path $Path -Filter *.ps1 -Force -Recurse | ForEach-Object {
+        Use-PodeScript -Path $_.FullName
+    }
+}

--- a/src/Public/Authentication.ps1
+++ b/src/Public/Authentication.ps1
@@ -1505,3 +1505,31 @@ function ConvertTo-PodeJwt
     $jwt += ".$($sig)"
     return $jwt
 }
+
+<#
+.SYNOPSIS
+Automatically loads auth ps1 files
+
+.DESCRIPTION
+Automatically loads auth ps1 files from either a /auth folder, or a custom folder. Saves space dot-sourcing them all one-by-one.
+
+.PARAMETER Path
+Optional Path to a folder containing ps1 files, can be relative or literal.
+
+.EXAMPLE
+Use-PodeAuth
+
+.EXAMPLE
+Use-PodeAuth -Path './my-auth'
+#>
+function Use-PodeAuth
+{
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [string]
+        $Path
+    )
+
+    Use-PodeFolder -Path $Path -DefaultPath 'auth'
+}

--- a/src/Public/Events.ps1
+++ b/src/Public/Events.ps1
@@ -193,3 +193,31 @@ function Clear-PodeEvent
 
     $null = $PodeContext.Server.Events[$Type].Clear()
 }
+
+<#
+.SYNOPSIS
+Automatically loads event ps1 files
+
+.DESCRIPTION
+Automatically loads event ps1 files from either a /events folder, or a custom folder. Saves space dot-sourcing them all one-by-one.
+
+.PARAMETER Path
+Optional Path to a folder containing ps1 files, can be relative or literal.
+
+.EXAMPLE
+Use-PodeEvents
+
+.EXAMPLE
+Use-PodeEvents -Path './my-events'
+#>
+function Use-PodeEvents
+{
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [string]
+        $Path
+    )
+
+    Use-PodeFolder -Path $Path -DefaultPath 'events'
+}

--- a/src/Public/Handlers.ps1
+++ b/src/Public/Handlers.ps1
@@ -164,3 +164,31 @@ function Clear-PodeHandlers
         }
     }
 }
+
+<#
+.SYNOPSIS
+Automatically loads handler ps1 files
+
+.DESCRIPTION
+Automatically loads handler ps1 files from either a /handler folder, or a custom folder. Saves space dot-sourcing them all one-by-one.
+
+.PARAMETER Path
+Optional Path to a folder containing ps1 files, can be relative or literal.
+
+.EXAMPLE
+Use-PodeHandlers
+
+.EXAMPLE
+Use-PodeHandlers -Path './my-handlers'
+#>
+function Use-PodeHandlers
+{
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [string]
+        $Path
+    )
+
+    Use-PodeFolder -Path $Path -DefaultPath 'handlers'
+}

--- a/src/Public/Logging.ps1
+++ b/src/Public/Logging.ps1
@@ -683,3 +683,31 @@ function Protect-PodeLogItem
 
     return $Item
 }
+
+<#
+.SYNOPSIS
+Automatically loads logging ps1 files
+
+.DESCRIPTION
+Automatically loads logging ps1 files from either a /logging folder, or a custom folder. Saves space dot-sourcing them all one-by-one.
+
+.PARAMETER Path
+Optional Path to a folder containing ps1 files, can be relative or literal.
+
+.EXAMPLE
+Use-PodeLogging
+
+.EXAMPLE
+Use-PodeLogging -Path './my-logging'
+#>
+function Use-PodeLogging
+{
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [string]
+        $Path
+    )
+
+    Use-PodeFolder -Path $Path -DefaultPath 'logging'
+}

--- a/src/Public/Middleware.ps1
+++ b/src/Public/Middleware.ps1
@@ -855,3 +855,31 @@ function Clear-PodeMiddleware
 
     $PodeContext.Server.Middleware = @()
 }
+
+<#
+.SYNOPSIS
+Automatically loads middleware ps1 files
+
+.DESCRIPTION
+Automatically loads middleware ps1 files from either a /middleware folder, or a custom folder. Saves space dot-sourcing them all one-by-one.
+
+.PARAMETER Path
+Optional Path to a folder containing ps1 files, can be relative or literal.
+
+.EXAMPLE
+Use-PodeMiddleware
+
+.EXAMPLE
+Use-PodeMiddleware -Path './my-middleware'
+#>
+function Use-PodeMiddleware
+{
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [string]
+        $Path
+    )
+
+    Use-PodeFolder -Path $Path -DefaultPath 'middleware'
+}

--- a/src/Public/Routes.ps1
+++ b/src/Public/Routes.ps1
@@ -1392,21 +1392,5 @@ function Use-PodeRoutes
         $Path
     )
 
-    # use default ./routes, or custom path
-    if ([string]::IsNullOrWhiteSpace($Path)) {
-        $Path = Join-PodeServerRoot -Folder 'routes'
-    }
-    else {
-        $Path = Get-PodeRelativePath -Path $Path -JoinRoot
-    }
-
-    # fail if path not found
-    if (!(Test-PodePath -Path $Path -NoStatus)) {
-        throw "Path to load routes not found: $($Path)"
-    }
-
-    # get .ps1 files and load them
-    Get-ChildItem -Path $Path -Filter *.ps1 -Force -Recurse | ForEach-Object {
-        Use-PodeScript -Path $_.FullName
-    }
+    Use-PodeFolder -Path $Path -DefaultPath 'routes'
 }

--- a/src/Public/Schedules.ps1
+++ b/src/Public/Schedules.ps1
@@ -490,3 +490,31 @@ function Get-PodeScheduleNextTrigger
 
     return (Get-PodeCronNextEarliestTrigger -Expressions $_schedule.Crons -StartTime $DateTime -EndTime $_schedule.EndTime)
 }
+
+<#
+.SYNOPSIS
+Automatically loads schedule ps1 files
+
+.DESCRIPTION
+Automatically loads schedule ps1 files from either a /schedules folder, or a custom folder. Saves space dot-sourcing them all one-by-one.
+
+.PARAMETER Path
+Optional Path to a folder containing ps1 files, can be relative or literal.
+
+.EXAMPLE
+Use-PodeSchedules
+
+.EXAMPLE
+Use-PodeSchedules -Path './my-schedules'
+#>
+function Use-PodeSchedules
+{
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [string]
+        $Path
+    )
+
+    Use-PodeFolder -Path $Path -DefaultPath 'schedules'
+}

--- a/src/Public/Timers.ps1
+++ b/src/Public/Timers.ps1
@@ -323,3 +323,31 @@ function Get-PodeTimer
     # return
     return $timers
 }
+
+<#
+.SYNOPSIS
+Automatically loads timer ps1 files
+
+.DESCRIPTION
+Automatically loads timer ps1 files from either a /timers folder, or a custom folder. Saves space dot-sourcing them all one-by-one.
+
+.PARAMETER Path
+Optional Path to a folder containing ps1 files, can be relative or literal.
+
+.EXAMPLE
+Use-PodeTimers
+
+.EXAMPLE
+Use-PodeTimers -Path './my-timers'
+#>
+function Use-PodeTimers
+{
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [string]
+        $Path
+    )
+
+    Use-PodeFolder -Path $Path -DefaultPath 'timers'
+}

--- a/src/Public/Utilities.ps1
+++ b/src/Public/Utilities.ps1
@@ -422,6 +422,34 @@ function Add-PodeEndware
 
 <#
 .SYNOPSIS
+Automatically loads endware ps1 files
+
+.DESCRIPTION
+Automatically loads endware ps1 files from either a /endware folder, or a custom folder. Saves space dot-sourcing them all one-by-one.
+
+.PARAMETER Path
+Optional Path to a folder containing ps1 files, can be relative or literal.
+
+.EXAMPLE
+Use-PodeEndware
+
+.EXAMPLE
+Use-PodeEndware -Path './endware'
+#>
+function Use-PodeEndware
+{
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [string]
+        $Path
+    )
+
+    Use-PodeFolder -Path $Path -DefaultPath 'endware'
+}
+
+<#
+.SYNOPSIS
 Imports a Module into the current, and all runspaces that Pode uses.
 
 .DESCRIPTION


### PR DESCRIPTION
### Description of the Change
Adds the other `Use-PodeXYZ` to automatically load all ps1 files in default folders for timers, schedules, logging, etc.

### Related Issue
Resolves #771 

### Examples
```powershell
Use-PodeAuth
Use-PodeEndware
Use-PodeEvents
Use-PodeHandlers
Use-PodeLogging
Use-PodeMiddleware
Use-PodeSchedules
Use-PodeTimers
```
