### PR TITLE
Add -Force on Get-PodeSessionId to get unauth sessions

### DIFF
--- a/docs/Tutorials/Middleware/Types/Sessions.md
+++ b/docs/Tutorials/Middleware/Types/Sessions.md
@@ -43,7 +43,7 @@ The inbuilt SessionId generator used for sessions is a GUID, but you can supply 
 
 If supplied, the `-Generator` is a scriptblock that must return a valid string. The string itself should be a random unique value, that can be used as a unique session identifier.
 
-Within a route, or middleware, you can get the current authenticated sessionId using [`Get-PodeSessionId`](../../../../Functions/Middleware/Get-PodeSessionId). If there is no session, or the session is not authenticated, then `$null` is returned. This function can also returned the fully signed sessionId as well.
+Within a route, or middleware, you can get the current authenticated sessionId using [`Get-PodeSessionId`](../../../../Functions/Middleware/Get-PodeSessionId). If there is no session, or the session is not authenticated, then `$null` is returned. This function can also returned the fully signed sessionId as well. If you want the sessionId even if it's not authenticated, then you can supply `-Force` to get the sessionId back.
 
 ### Strict
 

--- a/src/Public/Middleware.ps1
+++ b/src/Public/Middleware.ps1
@@ -359,6 +359,9 @@ You can also have the SessionId returned as signed as well.
 .PARAMETER Signed
 If supplied, the returned SessionId will also be signed.
 
+.PARAMETER Force
+If supplied, the sessionId will be returned regardless of authentication.
+
 .EXAMPLE
 $sessionId = Get-PodeSessionId
 #>
@@ -367,13 +370,16 @@ function Get-PodeSessionId
     [CmdletBinding()]
     param(
         [switch]
-        $Signed
+        $Signed,
+
+        [switch]
+        $Force
     )
 
     $sessionId = $null
 
-    # only return session if authenticated
-    if (!(Test-PodeIsEmpty $WebEvent.Session.Data.Auth.User) -and $WebEvent.Session.Data.Auth.IsAuthenticated) {
+    # only return session if authenticated, or force passed
+    if ($Force -or (!(Test-PodeIsEmpty $WebEvent.Session.Data.Auth.User) -and $WebEvent.Session.Data.Auth.IsAuthenticated)) {
         $sessionId = $WebEvent.Session.Id
 
         # do they want the session signed?


### PR DESCRIPTION
### Description of the Change
Add a `-Force` switch on `Get-PodeSessionId`, which lets you get the current sessionId even if it's unauthenticated.

### Examples
```powershell
$session = Get-PodeSessionId -Force
```
