### PR TITLE
Add support for IIS applications

### DIFF
--- a/docs/Hosting/IIS.md
+++ b/docs/Hosting/IIS.md
@@ -178,6 +178,22 @@ To change the user your site is running as:
 4. Change the user to either an inbuilt one, or a custom local/domain user
 5. Select OK
 
+## IIS Application
+
+You can host your Pode server as an Application under another Website in IIS by doing the following:
+
+1. In IIS, right click the Website
+2. Select "Add Application..."
+3. Enter a name for your Application under "Alias"
+4. Set the Physical Path to the root directory of your Pode server's script (just the directory, not the ps1 itself)
+5. Select OK
+
+The website will be available at the same binding(s) as the main website, but the URL will need `/<alias>` appended.
+
+For example, if the website has the binding `http://localhost:8080` and the alias of the application is `api`, then you can access the application at `http://localhost:8080/api`.
+
+The server will get a URL path of `/api/etc`, but you can keep your route paths as `/etc`, as Pode will automatically remove the `/api` from `/api/etc`. This lets you host the same server under any alias name.
+
 ## HTTPS/WSS
 
 Although Pode does have support for HTTPS/WSS, when running via IIS it takes control of HTTPS/WSS for us - this is why the endpoints are forced to HTTP/WS.
@@ -266,6 +282,33 @@ If the required header is missing, then Pode responds with a 401. The retrieved 
 
 !!! note
     If the authenticated user is a Local User, then the following properties will be empty: FQDN, Email, and DistinguishedName
+
+### Additional Validation
+
+Similar to the normal [`Add-PodeAuth`](../../Functions/Authentication/Add-PodeAuth), [`Add-PodeAuthIIS`](../../Functions/Authentication/Add-PodeAuthIIS) can be supplied can an optional ScriptBlock parameter. This ScriptBlock is supplied the found User object as a parameter, structured as details above. You can then use this to further check the user, or load additional user information from another storage.
+
+The ScriptBlock has the same return rules as [`Add-PodeAuth`](../../Functions/Authentication/Add-PodeAuth), as can be seen in the [Overview](../../Tutorials/Authentication/Overview).
+
+For example, to return the user back:
+
+```powershell
+Add-PodeAuthIIS -Name 'IISAuth' -Sessionless -ScriptBlock {
+    param($user)
+
+    # check or load extra data
+
+    return @{ User = $user }
+}
+```
+
+Or to fail authentication with an error message:
+
+```powershell
+Add-PodeAuthIIS -Name 'IISAuth' -Sessionless -ScriptBlock {
+    param($user)
+    return @{ Message = 'Authorization failed' }
+}
+```
 
 ## IIS Advanced Kerberos
 
@@ -427,32 +470,6 @@ This can be done using the following example:
     $newIdentity = [Security.Principal.WindowsIdentity]::GetCurrent() | Select-Object -ExpandProperty 'Name'
     Write-PodeTextResponse -Value "You are running this command as the server user $newIdentity"
 })
-```
-### Additional Validation
-
-Similar to the normal [`Add-PodeAuth`](../../Functions/Authentication/Add-PodeAuth), [`Add-PodeAuthIIS`](../../Functions/Authentication/Add-PodeAuthIIS) can be supplied can an optional ScriptBlock parameter. This ScriptBlock is supplied the found User object as a parameter, structured as details above. You can then use this to further check the user, or load additional user information from another storage.
-
-The ScriptBlock has the same return rules as [`Add-PodeAuth`](../../Functions/Authentication/Add-PodeAuth), as can be seen in the [Overview](../../Tutorials/Authentication/Overview).
-
-For example, to return the user back:
-
-```powershell
-Add-PodeAuthIIS -Name 'IISAuth' -Sessionless -ScriptBlock {
-    param($user)
-
-    # check or load extra data
-
-    return @{ User = $user }
-}
-```
-
-Or to fail authentication with an error message:
-
-```powershell
-Add-PodeAuthIIS -Name 'IISAuth' -Sessionless -ScriptBlock {
-    param($user)
-    return @{ Message = 'Authorization failed' }
-}
 ```
 
 ## Azure Web Apps

--- a/src/Pode.psd1
+++ b/src/Pode.psd1
@@ -117,6 +117,7 @@
         'Write-PodeHost',
         'Test-PodeIsIIS',
         'Test-PodeIsHeroku',
+        'Get-PodeIISApplicationPath',
         'New-PodeLockable',
         'Remove-PodeLockable',
         'Get-PodeLockable',

--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -182,7 +182,14 @@ function New-PodeContext
         $ctx.Server.IIS = @{
             Token = $env:ASPNETCORE_TOKEN
             Port = $env:ASPNETCORE_PORT
+            Path = [string]::Empty
             Shutdown = $false
+            IsApp = $false
+        }
+
+        if (![string]::IsNullOrWhiteSpace($env:ASPNETCORE_APPL_PATH) -and ($env:ASPNETCORE_APPL_PATH -ne '/')) {
+            $ctx.Server.IIS.Path = "^$($env:ASPNETCORE_APPL_PATH)"
+            $ctx.Server.IIS.IsApp = $true
         }
     }
 

--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -182,14 +182,18 @@ function New-PodeContext
         $ctx.Server.IIS = @{
             Token = $env:ASPNETCORE_TOKEN
             Port = $env:ASPNETCORE_PORT
-            Path = [string]::Empty
+            Path = @{
+                Raw = '/'
+                Pattern = '^/'
+                IsNonRoot = $false
+            }
             Shutdown = $false
-            IsApp = $false
         }
 
         if (![string]::IsNullOrWhiteSpace($env:ASPNETCORE_APPL_PATH) -and ($env:ASPNETCORE_APPL_PATH -ne '/')) {
-            $ctx.Server.IIS.Path = "^$($env:ASPNETCORE_APPL_PATH)"
-            $ctx.Server.IIS.IsApp = $true
+            $ctx.Server.IIS.Path.Raw = $env:ASPNETCORE_APPL_PATH
+            $ctx.Server.IIS.Path.Pattern = "^$($env:ASPNETCORE_APPL_PATH)"
+            $ctx.Server.IIS.Path.IsNonRoot = $true
         }
     }
 

--- a/src/Private/PodeServer.ps1
+++ b/src/Private/PodeServer.ps1
@@ -149,8 +149,8 @@ function Start-PodeWebServer
                             }
 
                             # if iis, and we have an app path, alter it
-                            if ($PodeContext.Server.IsIIS -and $PodeContext.Server.IIS.IsApp) {
-                                $WebEvent.Path = ($WebEvent.Path -ireplace $PodeContext.Server.IIS.Path, '')
+                            if ($PodeContext.Server.IsIIS -and $PodeContext.Server.IIS.Path.IsNonRoot) {
+                                $WebEvent.Path = ($WebEvent.Path -ireplace $PodeContext.Server.IIS.Path.Pattern, '')
                                 if ([string]::IsNullOrEmpty($WebEvent.Path)) {
                                     $WebEvent.Path = '/'
                                 }

--- a/src/Private/PodeServer.ps1
+++ b/src/Private/PodeServer.ps1
@@ -148,6 +148,14 @@ function Start-PodeWebServer
                                 Ranges = $null
                             }
 
+                            # if iis, and we have an app path, alter it
+                            if ($PodeContext.Server.IsIIS -and $PodeContext.Server.IIS.IsApp) {
+                                $WebEvent.Path = ($WebEvent.Path -ireplace $PodeContext.Server.IIS.Path, '')
+                                if ([string]::IsNullOrEmpty($WebEvent.Path)) {
+                                    $WebEvent.Path = '/'
+                                }
+                            }
+
                             # accept/transfer encoding
                             $WebEvent.TransferEncoding = (Get-PodeTransferEncoding -TransferEncoding (Get-PodeHeader -Name 'Transfer-Encoding') -ThrowError)
                             $WebEvent.AcceptEncoding = (Get-PodeAcceptEncoding -AcceptEncoding (Get-PodeHeader -Name 'Accept-Encoding') -ThrowError)

--- a/src/Public/Utilities.ps1
+++ b/src/Public/Utilities.ps1
@@ -939,6 +939,28 @@ function Test-PodeIsIIS
 
 <#
 .SYNOPSIS
+Returns the IIS application path.
+
+.DESCRIPTION
+Returns the IIS application path, or null if not using IIS.
+
+.EXAMPLE
+$path = Get-PodeIISApplicationPath
+#>
+function Get-PodeIISApplicationPath
+{
+    [CmdletBinding()]
+    param()
+
+    if (!$PodeContext.Server.IsIIS) {
+        return $null
+    }
+
+    return $PodeContext.Server.IIS.Path.Raw
+}
+
+<#
+.SYNOPSIS
 Returns whether or not the server is running via Heroku.
 
 .DESCRIPTION


### PR DESCRIPTION
### Description of the Change
Adds support so Pode can be hosted as an application in IIS under other websites. This is done automatically, letting you keep routes as `/some/path` but call them as `http://localhost:8080/<app-path>/some/path`.

### Related Issue
Resolves #865 
