### PR TITLE
Adds various updates for OAuth2 scheme

### DIFF
--- a/docs/Tutorials/Authentication/Methods/AzureAD.md
+++ b/docs/Tutorials/Authentication/Methods/AzureAD.md
@@ -29,7 +29,7 @@ Start-PodeServer {
     $scheme = New-PodeAuthAzureADScheme -ClientID '<clientId>' -ClientSecret '<clientSecret>' -Tenant '<tenant>'
 
     $scheme | Add-PodeAuth -Name 'Login' -FailureUrl '/login' -SuccessUrl '/' -ScriptBlock {
-        param($user, $accessToken, $refreshToken)
+        param($user, $accessToken, $refreshToken, $response)
 
         # check if the user is valid
 
@@ -53,7 +53,7 @@ Start-PodeServer {
     $scheme = New-PodeAuthAzureADScheme -ClientID '<clientId>' -ClientSecret '<clientSecret>' -Tenant '<tenant>' -InnerScheme $form
 
     $scheme | Add-PodeAuth -Name 'Login' -FailureUrl '/login' -SuccessUrl '/' -ScriptBlock {
-        param($user, $accessToken, $refreshToken)
+        param($user, $accessToken, $refreshToken, $response)
 
         # check if the user is valid
 
@@ -86,7 +86,7 @@ $basic = New-PodeAuthSceme -Basic
 $schemeBasic = New-PodeAuthAzureADScheme -ClientID '<clientId>' -ClientSecret '<clientSecret>' -Tenant '<tenant>' -InnerScheme $basic
 
 $authLogin = {
-    param($user, $accessToken, $refreshToken)
+    param($user, $accessToken, $refreshToken, $response)
     # check user
 }
 
@@ -129,7 +129,7 @@ Start-PodeServer {
     $scheme = New-PodeAuthAzureADScheme -ClientID '<clientId>' -ClientSecret '<clientSecret>' -Tenant '<tenant>'
 
     $scheme | Add-PodeAuth -Name 'Login' -FailureUrl '/login' -SuccessUrl '/' -ScriptBlock {
-        param($user, $accessToken, $refreshToken)
+        param($user, $accessToken, $refreshToken, $response)
 
         # check if the user is valid
 

--- a/docs/Tutorials/Authentication/Methods/JWT.md
+++ b/docs/Tutorials/Authentication/Methods/JWT.md
@@ -90,3 +90,23 @@ This return the following JWT:
 ```plain
 eyJ0eXAiOiJKV1QiLCJhbGciOiJoczI1NiJ9.eyJleHAiOjE2MjI1NTMyMTQsIm5hbWUiOiJKb2huIERvZSIsInN1YiI6IjEyMyJ9.LP-O8OKwix91a-SZwVK35gEClLZQmsORbW0un2Z4RkY
 ```
+
+## Parse JWT
+
+Pode has a [`ConvertFrom-PodeJwt`](../../../../Functions/Authentication/ConvertFrom-PodeJwt) that can be used to parse a valid JWT. Only the algorithms at the top of this page are supported for verifying the signature. You can skip signature verification by passing `-IgnoreSignature`. On success, the payload of the JWT is returned.
+
+For example, if the created JWT was suplplied:
+
+```powershell
+ConvertFrom-PodeJwt -Token 'eyJ0eXAiOiJKV1QiLCJhbGciOiJoczI1NiJ9.eyJleHAiOjE2MjI1NTMyMTQsIm5hbWUiOiJKb2huIERvZSIsInN1YiI6IjEyMyJ9.LP-O8OKwix91a-SZwVK35gEClLZQmsORbW0un2Z4RkY' -Secret 'abc'
+```
+
+then the following would be returned:
+
+```powershell
+@{
+    sub = '123'
+    name = 'John Doe'
+    exp = 1636657408
+}
+```

--- a/docs/Tutorials/Authentication/Methods/OAuth2.md
+++ b/docs/Tutorials/Authentication/Methods/OAuth2.md
@@ -34,7 +34,7 @@ Start-PodeServer {
         -TokenUrl 'https://some-service.com/oauth2/token'
 
     $scheme | Add-PodeAuth -Name 'Login' -FailureUrl '/login' -SuccessUrl '/' -ScriptBlock {
-        param($user, $accessToken, $refreshToken)
+        param($user, $accessToken, $refreshToken, $response)
 
         # check if the user is valid
 
@@ -45,9 +45,9 @@ Start-PodeServer {
 
 If you don't specify a `-RedirectUrl`, then an internal default one is created as `/oauth2/callback` on the first endpoint.
 
-When a user accesses your site unauthenticated, they will be redirected to the service to login, and then redirected back to your site. Pode will supply to your `Add-PodeAuth` the user object (if available), and the access/refresh tokens.
+When a user accesses your site unauthenticated, they will be redirected to the service to login, and then redirected back to your site. Pode will supply to your `Add-PodeAuth` the user object (if available), and the access/refresh tokens, and the raw token response object.
 
-You can optional specify a `-UserUrl` endpoint, if the service supports it, and Pode will use this to acquire user details. If one is not supplied, the `$user` object supplied to `Add-PodeAuth`'s ScriptBlock will be an basic hashtable:
+You can optional specify a `-UserUrl` endpoint, if the service supports it, and Pode will use this to acquire user details. If one is not supplied then Pode will attempt to parse the id_token from the `-AuthoriseUrl` for the user details, otherwise the `$user` object supplied to `Add-PodeAuth`'s ScriptBlock will be an basic hashtable:
 
 ```powershell
 @{
@@ -82,7 +82,7 @@ Start-PodeServer {
         -InnerScheme $form
 
     $scheme | Add-PodeAuth -Name 'Login' -FailureUrl '/login' -SuccessUrl '/' -ScriptBlock {
-        param($user, $accessToken, $refreshToken)
+        param($user, $accessToken, $refreshToken, $response)
 
         # check if the user is valid
 
@@ -143,7 +143,7 @@ Start-PodeServer {
         -TokenUrl 'https://some-service.com/oauth2/token'
 
     $scheme | Add-PodeAuth -Name 'Login' -FailureUrl '/login' -SuccessUrl '/' -ScriptBlock {
-        param($user, $accessToken, $refreshToken)
+        param($user, $accessToken, $refreshToken, $response)
 
         # check if the user is valid
 

--- a/docs/Tutorials/Authentication/Overview.md
+++ b/docs/Tutorials/Authentication/Overview.md
@@ -114,6 +114,14 @@ WWW-Authenticate: Basic realm="Enter creds to access site"
 !!! note
     If no Realm was set then it would just look as follows: `WWW-Authenticate: Basic`
 
+#### Redirecting
+
+When building custom authenticators, it might be required that you have to redirect mid-auth and stop processing the current request. To achieve this you can return the following from the scriptblock of `New-PodeAuthScheme` or `Add-PodeAuth`:
+
+```powershell
+return @{ IsRedirected = $true }
+```
+
 ### Routes/Middleware
 
 To use an authentication on a specific route, you can use the `-Authentication` parameter on the [`Add-PodeRoute`](../../../Functions/Routes/Add-PodeRoute) function; this takes the Name supplied to the `-Name` parameter on [`Add-PodeAuth`](../../../Functions/Authentication/Add-PodeAuth). This will set the authentication up to run before other route middleware.

--- a/docs/Tutorials/SharedState.md
+++ b/docs/Tutorials/SharedState.md
@@ -32,7 +32,7 @@ Start-PodeServer {
 }
 ```
 
-Alternatively you could use the `$state:` variable scope to set a variable in state. This variable will be scopeless, so if you need scope then use [`Set-PodeState`]. `$state:` can be used anywhere, but keep in mind that like `$session:` Pode can only remap the this in scriptblocks it's aware of; so using it in a function of a custom module won't work. Similar to the example above:
+Alternatively you could use the `$state:` variable scope to set a variable in state. This variable will be scopeless, so if you need scope then use [`Set-PodeState`](../../Functions/State/Set-PodeState). `$state:` can be used anywhere, but keep in mind that like `$session:` Pode can only remap the this in scriptblocks it's aware of; so using it in a function of a custom module won't work. Similar to the example above:
 
 ```powershell
 Start-PodeServer {

--- a/src/Pode.psd1
+++ b/src/Pode.psd1
@@ -190,6 +190,7 @@
         'Add-PodeAuthIIS',
         'Add-PodeAuthUserFile',
         'ConvertTo-PodeJwt',
+        'ConvertFrom-PodeJwt',
 
         # logging
         'New-PodeLoggingMethod',

--- a/src/Private/Authentication.ps1
+++ b/src/Private/Authentication.ps1
@@ -151,7 +151,12 @@ function Get-PodeAuthOAuth2Type
                 }
             }
             elseif (![string]::IsNullOrWhiteSpace($result.id_token)) {
-                $user = ConvertFrom-PodeJwt -Token $result.id_token -IgnoreSignature
+                try {
+                    $user = ConvertFrom-PodeJwt -Token $result.id_token -IgnoreSignature
+                }
+                catch {
+                    $user = @{ Provider = 'OAuth2' }
+                }
             }
             else {
                 $user = @{ Provider = 'OAuth2' }
@@ -174,6 +179,9 @@ function Get-PodeAuthOAuth2Type
             $url = $options.Urls.Authorise
             if (!$url.Contains('?')) {
                 $url += '?'
+            }
+            else {
+                $url += '&'
             }
 
             Move-PodeResponseUrl -Url "$($url)$($query)"

--- a/src/Private/Authentication.ps1
+++ b/src/Private/Authentication.ps1
@@ -1046,6 +1046,13 @@ function Get-PodeAuthMiddlewareScript
         try {
             $result = $null
 
+            # run pre-auth middleware
+            if ($null -ne $auth.Scheme.Middleware) {
+                if (!(Invoke-PodeMiddleware -WebEvent $WebEvent -Middleware $auth.Scheme.Middleware)) {
+                    return $false
+                }
+            }
+
             # run auth scheme script to parse request for data
             $_args = @($auth.Scheme.Arguments)
             if ($null -ne $auth.Scheme.ScriptBlock.UsingVariables) {

--- a/src/Private/Authentication.ps1
+++ b/src/Private/Authentication.ps1
@@ -1048,7 +1048,7 @@ function Get-PodeAuthMiddlewareScript
 
             # run pre-auth middleware
             if ($null -ne $auth.Scheme.Middleware) {
-                if (!(Invoke-PodeMiddleware -WebEvent $WebEvent -Middleware $auth.Scheme.Middleware)) {
+                if (!(Invoke-PodeMiddleware -Middleware $auth.Scheme.Middleware)) {
                     return $false
                 }
             }

--- a/src/Private/Authentication.ps1
+++ b/src/Private/Authentication.ps1
@@ -150,12 +150,15 @@ function Get-PodeAuthOAuth2Type
                     }
                 }
             }
+            elseif (![string]::IsNullOrWhiteSpace($result.id_token)) {
+                $user = ConvertFrom-PodeJwt -Token $result.id_token -IgnoreSignature
+            }
             else {
                 $user = @{ Provider = 'OAuth2' }
             }
 
             # return the user for the validator
-            return @($user, $result.access_token, $result.refresh_token)
+            return @($user, $result.access_token, $result.refresh_token, $result)
         }
 
         # redirect to the authUrl - only if no inner scheme supplied
@@ -168,7 +171,12 @@ function Get-PodeAuthOAuth2Type
             $query += "&response_mode=query"
             $query += "&scope=$([System.Web.HttpUtility]::UrlEncode($scopes))"
 
-            Move-PodeResponseUrl -Url "$($options.Urls.Authorise)?$($query)"
+            $url = $options.Urls.Authorise
+            if (!$url.Contains('?')) {
+                $url += '?'
+            }
+
+            Move-PodeResponseUrl -Url "$($url)$($query)"
             return @{ IsRedirected = $true }
         }
 

--- a/src/Private/Endware.ps1
+++ b/src/Private/Endware.ps1
@@ -1,10 +1,6 @@
 function Invoke-PodeEndware
 {
     param (
-        [Parameter(Mandatory=$true)]
-        [ValidateNotNull()]
-        $WebEvent,
-
         [Parameter()]
         $Endware
     )

--- a/src/Private/Middleware.ps1
+++ b/src/Private/Middleware.ps1
@@ -2,7 +2,6 @@ function Invoke-PodeMiddleware
 {
     param (
         [Parameter(Mandatory=$true)]
-        [ValidateNotNull()]
         $WebEvent,
 
         [Parameter()]
@@ -53,6 +52,9 @@ function Invoke-PodeMiddleware
             }
 
             $continue = Invoke-PodeScriptBlock -ScriptBlock $midware.Logic -Arguments $_args -Return -Scoped -Splat
+            if ($null -eq $continue) {
+                $continue = $true
+            }
         }
         catch {
             Set-PodeResponseStatus -Code 500 -Exception $_

--- a/src/Private/Middleware.ps1
+++ b/src/Private/Middleware.ps1
@@ -1,9 +1,6 @@
 function Invoke-PodeMiddleware
 {
     param (
-        [Parameter(Mandatory=$true)]
-        $WebEvent,
-
         [Parameter()]
         $Middleware,
 

--- a/src/Private/PodeServer.ps1
+++ b/src/Private/PodeServer.ps1
@@ -165,13 +165,13 @@ function Start-PodeWebServer
                             }
 
                             # invoke global and route middleware
-                            if ((Invoke-PodeMiddleware -WebEvent $WebEvent -Middleware $PodeContext.Server.Middleware -Route $WebEvent.Path)) {
+                            if ((Invoke-PodeMiddleware -Middleware $PodeContext.Server.Middleware -Route $WebEvent.Path)) {
                                 # has thr request been aborted
                                 if ($Request.IsAborted) {
                                     throw $Request.Error
                                 }
 
-                                if ((Invoke-PodeMiddleware -WebEvent $WebEvent -Middleware $WebEvent.Route.Middleware))
+                                if ((Invoke-PodeMiddleware -Middleware $WebEvent.Route.Middleware))
                                 {
                                     # has thr request been aborted
                                     if ($Request.IsAborted) {
@@ -227,7 +227,7 @@ function Start-PodeWebServer
 
                         # invoke endware specifc to the current web event
                         $_endware = ($WebEvent.OnEnd + @($PodeContext.Server.Endware))
-                        Invoke-PodeEndware -WebEvent $WebEvent -Endware $_endware
+                        Invoke-PodeEndware -Endware $_endware
                     }
                     finally {
                         $WebEvent = $null

--- a/src/Private/Routes.ps1
+++ b/src/Private/Routes.ps1
@@ -524,18 +524,10 @@ function Find-PodeRouteContentType
     return $ContentType
 }
 
-function ConvertTo-PodeRouteMiddleware
+function ConvertTo-PodeMiddleware
 {
     [OutputType([hashtable[]])]
     param(
-        [Parameter(Mandatory=$true)]
-        [string]
-        $Method,
-
-        [Parameter(Mandatory=$true)]
-        [string]
-        $Path,
-
         [Parameter()]
         [object[]]
         $Middleware,
@@ -554,17 +546,17 @@ function ConvertTo-PodeRouteMiddleware
     @($Middleware) | ForEach-Object {
         # check middleware is a type valid
         if (($_ -isnot [scriptblock]) -and ($_ -isnot [hashtable])) {
-            throw "One of the Route Middlewares supplied for the '[$($Method)] $($Path)' Route is an invalid type. Expected either ScriptBlock or Hashtable, but got: $($_.GetType().Name)"
+            throw "One of the Middlewares supplied is an invalid type. Expected either a ScriptBlock or Hashtable, but got: $($_.GetType().Name)"
         }
 
         # if middleware is hashtable, ensure the keys are valid (logic is a scriptblock)
         if ($_ -is [hashtable]) {
             if ($null -eq $_.Logic) {
-                throw "A Hashtable Middleware supplied for the '[$($Method)] $($Path)' Route has no Logic defined"
+                throw "A Hashtable Middleware supplied has no Logic defined"
             }
 
             if ($_.Logic -isnot [scriptblock]) {
-                throw "A Hashtable Middleware supplied for the '[$($Method)] $($Path)' Route has an invalid Logic type. Expected ScriptBlock, but got: $($_.Logic.GetType().Name)"
+                throw "A Hashtable Middleware supplied has an invalid Logic type. Expected ScriptBlock, but got: $($_.Logic.GetType().Name)"
             }
         }
     }

--- a/src/Private/Serverless.ps1
+++ b/src/Private/Serverless.ps1
@@ -80,8 +80,8 @@ function Start-PodeAzFuncServer
             Set-PodeServerHeader -Type 'Kestrel'
 
             # invoke global and route middleware
-            if ((Invoke-PodeMiddleware -WebEvent $WebEvent -Middleware $PodeContext.Server.Middleware -Route $WebEvent.Path)) {
-                if ((Invoke-PodeMiddleware -WebEvent $WebEvent -Middleware $WebEvent.Route.Middleware))
+            if ((Invoke-PodeMiddleware -Middleware $PodeContext.Server.Middleware -Route $WebEvent.Path)) {
+                if ((Invoke-PodeMiddleware -Middleware $WebEvent.Route.Middleware))
                 {
                     # invoke the route
                     if ($null -ne $WebEvent.StaticContent) {
@@ -119,7 +119,7 @@ function Start-PodeAzFuncServer
 
         # invoke endware specifc to the current web event
         $_endware = ($WebEvent.OnEnd + @($PodeContext.Server.Endware))
-        Invoke-PodeEndware -WebEvent $WebEvent -Endware $_endware
+        Invoke-PodeEndware -Endware $_endware
 
         # close and send the response
         Push-OutputBinding -Name Response -Value $response
@@ -200,8 +200,8 @@ function Start-PodeAwsLambdaServer
             Set-PodeServerHeader -Type 'Lambda'
 
             # invoke global and route middleware
-            if ((Invoke-PodeMiddleware -WebEvent $WebEvent -Middleware $PodeContext.Server.Middleware -Route $WebEvent.Path)) {
-                if ((Invoke-PodeMiddleware -WebEvent $WebEvent -Middleware $WebEvent.Route.Middleware))
+            if ((Invoke-PodeMiddleware -Middleware $PodeContext.Server.Middleware -Route $WebEvent.Path)) {
+                if ((Invoke-PodeMiddleware -Middleware $WebEvent.Route.Middleware))
                 {
                     # invoke the route
                     if ($null -ne $WebEvent.StaticContent) {
@@ -239,7 +239,7 @@ function Start-PodeAwsLambdaServer
 
         # invoke endware specifc to the current web event
         $_endware = ($WebEvent.OnEnd + @($PodeContext.Server.Endware))
-        Invoke-PodeEndware -WebEvent $WebEvent -Endware $_endware
+        Invoke-PodeEndware -Endware $_endware
 
         # close and send the response
         if (![string]::IsNullOrWhiteSpace($response.ContentType)) {

--- a/src/Public/Authentication.ps1
+++ b/src/Public/Authentication.ps1
@@ -41,6 +41,9 @@ The name of scope of the protected area.
 .PARAMETER Type
 The scheme type for custom Authentication types. Default is HTTP.
 
+.PARAMETER Middleware
+An array of ScriptBlocks for optional Middleware to run before the Scheme's scriptblock.
+
 .PARAMETER PostValidator
 The PostValidator is a scriptblock that is invoked after user validation.
 
@@ -170,6 +173,10 @@ function New-PodeAuthScheme
         [string]
         $Type = 'Http',
 
+        [Parameter()]
+        [object[]]
+        $Middleware,
+
         [Parameter(ParameterSetName='Custom')]
         [scriptblock]
         $PostValidator,
@@ -255,6 +262,9 @@ function New-PodeAuthScheme
     # default realm
     $_realm = 'User'
 
+    # convert any middleware into valid hashtables
+    $Middleware = @(ConvertTo-PodeMiddleware -Middleware $Middleware -PSSession $PSCmdlet.SessionState)
+
     # configure the auth scheme
     switch ($PSCmdlet.ParameterSetName.ToLowerInvariant()) {
         'basic' {
@@ -266,6 +276,7 @@ function New-PodeAuthScheme
                     UsingVariables = $null
                 }
                 PostValidator = $null
+                Middleware = $Middleware
                 InnerScheme = $InnerScheme
                 Scheme = 'http'
                 Arguments = @{
@@ -285,6 +296,7 @@ function New-PodeAuthScheme
                     UsingVariables = $null
                 }
                 PostValidator = $null
+                Middleware = $Middleware
                 InnerScheme = $InnerScheme
                 Scheme = 'http'
                 Arguments = @{}
@@ -303,6 +315,7 @@ function New-PodeAuthScheme
                     Script = (Get-PodeAuthDigestPostValidator)
                     UsingVariables = $null
                 }
+                Middleware = $Middleware
                 InnerScheme = $InnerScheme
                 Scheme = 'http'
                 Arguments = @{
@@ -328,6 +341,7 @@ function New-PodeAuthScheme
                     Script = (Get-PodeAuthBearerPostValidator)
                     UsingVariables = $null
                 }
+                Middleware = $Middleware
                 Scheme = 'http'
                 InnerScheme = $InnerScheme
                 Arguments = @{
@@ -348,6 +362,7 @@ function New-PodeAuthScheme
                     UsingVariables = $null
                 }
                 PostValidator = $null
+                Middleware = $Middleware
                 InnerScheme = $InnerScheme
                 Scheme = 'http'
                 Arguments = @{
@@ -377,6 +392,7 @@ function New-PodeAuthScheme
                     UsingVariables = $null
                 }
                 PostValidator = $null
+                Middleware = $Middleware
                 Scheme = 'oauth2'
                 InnerScheme = $InnerScheme
                 Arguments = @{
@@ -418,6 +434,7 @@ function New-PodeAuthScheme
                     UsingVariables = $null
                 }
                 PostValidator = $null
+                Middleware = $Middleware
                 InnerScheme = $InnerScheme
                 Scheme = 'apiKey'
                 Arguments = @{
@@ -453,6 +470,7 @@ function New-PodeAuthScheme
                     Script = $PostValidator
                     UsingVariables = $usingPostVars
                 }
+                Middleware = $Middleware
                 Arguments = $ArgumentList
             }
         }
@@ -481,6 +499,9 @@ An optional OAuth2 Redirect URL (default: <host>/oauth2/callback)
 .PARAMETER InnerScheme
 An optional authentication Scheme (from New-PodeAuthScheme) that will be called prior to this Scheme.
 
+.PARAMETER Middleware
+An array of ScriptBlocks for optional Middleware to run before the Scheme's scriptblock.
+
 .EXAMPLE
 New-PodeAuthAzureADScheme -Tenant 123-456-678 -ClientId abcdef -ClientSecret 1234.abc
 #>
@@ -507,7 +528,11 @@ function New-PodeAuthAzureADScheme
 
         [Parameter(ValueFromPipeline=$true)]
         [hashtable]
-        $InnerScheme
+        $InnerScheme,
+
+        [Parameter()]
+        [object[]]
+        $Middleware
     )
 
     return (New-PodeAuthScheme `
@@ -518,7 +543,8 @@ function New-PodeAuthAzureADScheme
         -TokenUrl "https://login.microsoftonline.com/$($Tenant)/oauth2/v2.0/token" `
         -UserUrl "https://graph.microsoft.com/oidc/userinfo" `
         -RedirectUrl $RedirectUrl `
-        -InnerScheme $InnerScheme)
+        -InnerScheme $InnerScheme `
+        -Middleware $Middleware)
 }
 
 <#
@@ -998,6 +1024,9 @@ The URL to redirect to when authentication succeeds when logging in.
 .PARAMETER ScriptBlock
 Optional ScriptBlock that is passed the found user object for further validation.
 
+.PARAMETER Middleware
+An array of ScriptBlocks for optional Middleware to run before the Scheme's scriptblock.
+
 .PARAMETER Sessionless
 If supplied, authenticated users will not be stored in sessions, and sessions will not be used.
 
@@ -1051,6 +1080,10 @@ function Add-PodeAuthIIS
         [scriptblock]
         $ScriptBlock,
 
+        [Parameter()]
+        [object[]]
+        $Middleware,
+
         [switch]
         $Sessionless,
 
@@ -1085,7 +1118,7 @@ function Add-PodeAuthIIS
     }
 
     # create the auth scheme for getting the token header
-    $scheme = New-PodeAuthScheme -Custom -ScriptBlock {
+    $scheme = New-PodeAuthScheme -Custom -Middleware $Middleware -ScriptBlock {
         param($options)
 
         $header = 'MS-ASPNETCORE-WINAUTHTOKEN'

--- a/src/Public/Routes.ps1
+++ b/src/Public/Routes.ps1
@@ -167,7 +167,7 @@ function Add-PodeRoute
     $ScriptBlock = Invoke-PodeSessionScriptConversion -ScriptBlock $ScriptBlock
 
     # convert any middleware into valid hashtables
-    $Middleware = @(ConvertTo-PodeRouteMiddleware -Method $Method -Path $Path -Middleware $Middleware -PSSession $PSCmdlet.SessionState)
+    $Middleware = @(ConvertTo-PodeMiddleware -Middleware $Middleware -PSSession $PSCmdlet.SessionState)
 
     # if an auth name was supplied, setup the auth as the first middleware
     if (![string]::IsNullOrWhiteSpace($Authentication)) {
@@ -380,7 +380,7 @@ function Add-PodeStaticRoute
     }
 
     # convert any middleware into valid hashtables
-    $Middleware = @(ConvertTo-PodeRouteMiddleware -Method $Method -Path $Path -Middleware $Middleware -PSSession $PSCmdlet.SessionState)
+    $Middleware = @(ConvertTo-PodeMiddleware -Middleware $Middleware -PSSession $PSCmdlet.SessionState)
 
     # if an auth name was supplied, setup the auth as the first middleware
     if (![string]::IsNullOrWhiteSpace($Authentication)) {

--- a/tests/unit/Endware.Tests.ps1
+++ b/tests/unit/Endware.Tests.ps1
@@ -4,18 +4,18 @@ Get-ChildItem "$($src)/*.ps1" -Recurse | Resolve-Path | ForEach-Object { . $_ }
 
 Describe 'Invoke-PodeEndware' {
     It 'Returns for no endware' {
-        (Invoke-PodeEndware -WebEvent @{} -Endware @()) | Out-Null
+        (Invoke-PodeEndware -Endware @()) | Out-Null
     }
 
     It 'Runs the logic for a single endware' {
         Mock Invoke-PodeScriptBlock { }
-        Invoke-PodeEndware -WebEvent @{} -Endware @(@{ Logic = { 'test' | Out-Null } })
+        Invoke-PodeEndware -Endware @(@{ Logic = { 'test' | Out-Null } })
         Assert-MockCalled Invoke-PodeScriptBlock -Times 1 -Scope It
     }
 
     It 'Runs the logic for 2 endwares' {
         Mock Invoke-PodeScriptBlock { }
-        Invoke-PodeEndware -WebEvent @{} -Endware @(
+        Invoke-PodeEndware -Endware @(
             @{ Logic = { 'test' | Out-Null } },
             @{ Logic = { 'test2' | Out-Null } }
         )
@@ -26,7 +26,7 @@ Describe 'Invoke-PodeEndware' {
         Mock Invoke-PodeScriptBlock { throw 'some error' }
         Mock Write-PodeErrorLog { }
 
-        Invoke-PodeEndware -WebEvent @{} -Endware @(@{ Logic = { 'test' | Out-Null } })
+        Invoke-PodeEndware -Endware @(@{ Logic = { 'test' | Out-Null } })
 
         Assert-MockCalled Invoke-PodeScriptBlock -Times 1 -Scope It
         Assert-MockCalled Write-PodeErrorLog -Times 1 -Scope It

--- a/tests/unit/Middleware.Tests.ps1
+++ b/tests/unit/Middleware.Tests.ps1
@@ -156,7 +156,7 @@ Describe 'Middleware' {
 
 Describe 'Invoke-PodeMiddleware' {
     It 'Returns true for no middleware' {
-        (Invoke-PodeMiddleware -WebEvent @{} -Middleware @()) | Should Be $true
+        (Invoke-PodeMiddleware -Middleware @()) | Should Be $true
     }
 
     It 'Runs the logic for a single middleware and returns true' {
@@ -167,7 +167,7 @@ Describe 'Invoke-PodeMiddleware' {
             'Logic' = { 'test' | Out-Null };
         }
 
-        Invoke-PodeMiddleware -WebEvent $WebEvent -Middleware @($midware) | Should Be $true
+        Invoke-PodeMiddleware -Middleware @($midware) | Should Be $true
 
         Assert-MockCalled Invoke-PodeScriptBlock -Times 1 -Scope It
     }
@@ -181,7 +181,7 @@ Describe 'Invoke-PodeMiddleware' {
             'Logic' = { 'test' | Out-Null };
         }
 
-        Invoke-PodeMiddleware -WebEvent $WebEvent -Middleware @($midware) -Route '/' | Should Be $true
+        Invoke-PodeMiddleware -Middleware @($midware) -Route '/' | Should Be $true
 
         Assert-MockCalled Invoke-PodeScriptBlock -Times 1 -Scope It
     }
@@ -200,7 +200,7 @@ Describe 'Invoke-PodeMiddleware' {
             'Logic' = { 'test2' | Out-Null };
         }
 
-        Invoke-PodeMiddleware -WebEvent $WebEvent -Middleware @($midware1, $midware2) | Should Be $true
+        Invoke-PodeMiddleware -Middleware @($midware1, $midware2) | Should Be $true
 
         Assert-MockCalled Invoke-PodeScriptBlock -Times 2 -Scope It
     }
@@ -213,7 +213,7 @@ Describe 'Invoke-PodeMiddleware' {
             'Logic' = { 'test' | Out-Null };
         }
 
-        Invoke-PodeMiddleware -WebEvent $WebEvent -Middleware @($midware) | Should Be $false
+        Invoke-PodeMiddleware -Middleware @($midware) | Should Be $false
 
         Assert-MockCalled Invoke-PodeScriptBlock -Times 1 -Scope It
     }
@@ -229,7 +229,7 @@ Describe 'Invoke-PodeMiddleware' {
             'Logic' = { 'test' | Out-Null };
         }
 
-        Invoke-PodeMiddleware -WebEvent $WebEvent -Middleware @($midware) | Should Be $false
+        Invoke-PodeMiddleware -Middleware @($midware) | Should Be $false
 
         Assert-MockCalled Invoke-PodeScriptBlock -Times 1 -Scope It
         Assert-MockCalled Set-PodeResponseStatus -Times 1 -Scope It

--- a/tests/unit/Routes.Tests.ps1
+++ b/tests/unit/Routes.Tests.ps1
@@ -1012,28 +1012,28 @@ Describe 'Find-PodeRouteContentType' {
     }
 }
 
-Describe 'ConvertTo-PodeRouteMiddleware' {
+Describe 'ConvertTo-PodeMiddleware' {
     $_PSSession = @{}
 
     It 'Returns no middleware' {
-        @(ConvertTo-PodeRouteMiddleware -Method Get -Path '/users' -PSSession $_PSSession) | Should Be $null
+        @(ConvertTo-PodeMiddleware -PSSession $_PSSession) | Should Be $null
     }
 
     It 'Errors for invalid middleware type' {
-        { ConvertTo-PodeRouteMiddleware -Method Get -Path '/users' -Middleware 'string' -PSSession $_PSSession } | Should Throw 'invalid type'
+        { ConvertTo-PodeMiddleware -Middleware 'string' -PSSession $_PSSession } | Should Throw 'invalid type'
     }
 
     It 'Errors for invalid middleware hashtable - no logic' {
-        { ConvertTo-PodeRouteMiddleware -Method Get -Path '/users' -Middleware @{} -PSSession $_PSSession } | Should Throw 'no logic defined'
+        { ConvertTo-PodeMiddleware -Middleware @{} -PSSession $_PSSession } | Should Throw 'no logic defined'
     }
 
     It 'Errors for invalid middleware hashtable - logic not scriptblock' {
-        { ConvertTo-PodeRouteMiddleware -Method Get -Path '/users' -Middleware @{ Logic = 'string' } -PSSession $_PSSession } | Should Throw 'invalid logic type'
+        { ConvertTo-PodeMiddleware -Middleware @{ Logic = 'string' } -PSSession $_PSSession } | Should Throw 'invalid logic type'
     }
 
     It 'Returns hashtable for single hashtable middleware' {
         $middleware = @{ Logic = { Write-Host 'Hello' } }
-        $converted = @(ConvertTo-PodeRouteMiddleware -Method Get -Path '/users' -Middleware $middleware -PSSession $_PSSession)
+        $converted = @(ConvertTo-PodeMiddleware -Middleware $middleware -PSSession $_PSSession)
         $converted.Length | Should Be 1
         $converted[0].Logic.ToString() | Should Be ($middleware.Logic.ToString())
     }
@@ -1042,7 +1042,7 @@ Describe 'ConvertTo-PodeRouteMiddleware' {
         $middleware1 = @{ Logic = { Write-Host 'Hello1' } }
         $middleware2 = @{ Logic = { Write-Host 'Hello2' } }
 
-        $converted = @(ConvertTo-PodeRouteMiddleware -Method Get -Path '/users' -Middleware @($middleware1, $middleware2) -PSSession $_PSSession)
+        $converted = @(ConvertTo-PodeMiddleware -Middleware @($middleware1, $middleware2) -PSSession $_PSSession)
 
         $converted.Length | Should Be 2
         $converted[0].Logic.ToString() | Should Be ($middleware1.Logic.ToString())
@@ -1051,7 +1051,7 @@ Describe 'ConvertTo-PodeRouteMiddleware' {
 
     It 'Converts single scriptblock middleware to hashtable' {
         $middleware = { Write-Host 'Hello' }
-        $converted = @(ConvertTo-PodeRouteMiddleware -Method Get -Path '/users' -Middleware $middleware -PSSession $_PSSession)
+        $converted = @(ConvertTo-PodeMiddleware -Middleware $middleware -PSSession $_PSSession)
         $converted.Length | Should Be 1
         $converted[0].Logic.ToString() | Should Be ($middleware.ToString())
     }
@@ -1060,7 +1060,7 @@ Describe 'ConvertTo-PodeRouteMiddleware' {
         $middleware1 = { Write-Host 'Hello1' }
         $middleware2 = { Write-Host 'Hello2' }
 
-        $converted = @(ConvertTo-PodeRouteMiddleware -Method Get -Path '/users' -Middleware @($middleware1, $middleware2) -PSSession $_PSSession)
+        $converted = @(ConvertTo-PodeMiddleware -Middleware @($middleware1, $middleware2) -PSSession $_PSSession)
 
         $converted.Length | Should Be 2
         $converted[0].Logic.ToString() | Should Be ($middleware1.ToString())
@@ -1071,7 +1071,7 @@ Describe 'ConvertTo-PodeRouteMiddleware' {
         $middleware1 = @{ Logic = { Write-Host 'Hello1' } }
         $middleware2 = { Write-Host 'Hello2' }
 
-        $converted = @(ConvertTo-PodeRouteMiddleware -Method Get -Path '/users' -Middleware @($middleware1, $middleware2) -PSSession $_PSSession)
+        $converted = @(ConvertTo-PodeMiddleware -Middleware @($middleware1, $middleware2) -PSSession $_PSSession)
 
         $converted.Length | Should Be 2
         $converted[0].Logic.ToString() | Should Be ($middleware1.Logic.ToString())


### PR DESCRIPTION
### Description of the Change
* Makes it possible to add custom query parameters onto the `-AuthoriseUrl`.
* Make the `ConvertFrom-PodeJwt` function public.
* Lets you specify `-Middleware` on `New-PodeAuthScheme`, which will run before scheme/validator, and only when auth is needed.
* If no `-UserUrl` supplied, check if the token URL returned an id_token, and parse that for the user object.
* Removes the unneeded `-WebEvent` when invoking Middleware/Endware.

### Related Issue
Resolves #830 
