### PR TITLE
Add metric functions to get active requests/signals count

### DIFF
--- a/docs/Tutorials/Metrics/Requests.md
+++ b/docs/Tutorials/Metrics/Requests.md
@@ -1,8 +1,8 @@
 # Requests
 
-Pode keeps a count of the total number of Requests processed by the server. This count is kept both server-wide, and against each individual Route; the counts are also split into two: one for the total number of requests, and one for the total number of requests per status code.
+Pode keeps a count of the total number of Requests processed by the server. This count is kept both server-wide, and against each individual Route; the counts are also split into two: one for the total number of requests, and one for the total number of requests per status code. These counts are preserved through internal Pode server restarts.
 
-These counts are preserved through internal Pode server restarts.
+The current count of active requests are also available.
 
 ## Server
 
@@ -48,4 +48,12 @@ And to get the total count for a specific status code for a Route:
 
 ```powershell
 $code = (Get-PodeRoute -Method Get -Path '/about').Metrics.Requests.StatusCodes['200']
+```
+
+## Active
+
+You can retrieve the current count of active requests by using [`Get-PodeServerActiveRequestMetric`](../../../Functions/Metrics/Get-PodeServerActiveRequestMetric). Active requests are ones that are queued internally, ready to be processed:
+
+```powershell
+$activeReqs = Get-PodeServerActiveRequestMetric
 ```

--- a/src/Listener/PodeListener.cs
+++ b/src/Listener/PodeListener.cs
@@ -17,9 +17,24 @@ namespace Pode
         public CancellationToken CancellationToken { get; private set; }
 
         private IList<PodeSocket> Sockets;
+
         private BlockingCollection<PodeContext> Contexts;
+        public int ContextsCount
+        {
+            get => Contexts.Count;
+        }
+
         private BlockingCollection<PodeServerSignal> ServerSignals;
+        public int ServerSignalsCount
+        {
+            get => ServerSignals.Count;
+        }
+
         private BlockingCollection<PodeClientSignal> ClientSignals;
+        public int ClientSignalsCount
+        {
+            get => ClientSignals.Count;
+        }
 
         private int _requestTimeout = 30;
         public int RequestTimeout

--- a/src/Pode.psd1
+++ b/src/Pode.psd1
@@ -249,6 +249,8 @@
         'Get-PodeServerRestartCount',
         'Get-PodeServerRequestMetric',
         'Get-PodeServerSignalMetric',
+        'Get-PodeServerActiveRequestMetric',
+        'Get-PodeServerActiveSignalMetric',
 
         # AutoImport
         'Export-PodeModule',

--- a/src/Public/Metrics.ps1
+++ b/src/Public/Metrics.ps1
@@ -116,3 +116,36 @@ function Get-PodeServerSignalMetric
 
     return $PodeContext.Metrics.Signals.Total
 }
+
+function Get-PodeServerActiveRequestMetric
+{
+    [CmdletBinding()]
+    param()
+
+    return $PodeContext.Server.WebSockets.Listener.ContextsCount
+}
+
+function Get-PodeServerActiveSignalMetric
+{
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [ValidateSet('Total', 'Server', 'Client')]
+        [string]
+        $Type = 'Total'
+    )
+
+    switch ($Type.ToLowerInvariant()) {
+        'total' {
+            return $PodeContext.Server.WebSockets.Listener.ServerSignalsCount + $PodeContext.Server.WebSockets.Listener.ClientSignalsCount
+        }
+
+        'server' {
+            return $PodeContext.Server.WebSockets.Listener.ServerSignalsCount
+        }
+
+        'client' {
+            return $PodeContext.Server.WebSockets.Listener.ClientSignalsCount
+        }
+    }
+}


### PR DESCRIPTION
### Description of the Change
Adds metric functions to get count of currently active requests/signals

### Related Issue
Resolves #869 

### Examples
```powershell
$activeReqs = Get-PodeServerActiveRequestMetric
```