### PR TITLE
Bump mkdocs versions, and add announcement bar

### DIFF
--- a/mkdocs-overrides/main.html
+++ b/mkdocs-overrides/main.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+
+{% block announce %}
+  Pode's official documentation is hosted on <a href="https://badgerati.github.io/Pode">GitHub</a>. If you're seeing this elsewhere, like readthedocs, please use the docs on GitHub 😊
+{% endblock %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,9 +4,12 @@ theme:
   name: material
   logo: images/icon.png
   favicon: images/favicon.ico
+  custom_dir: mkdocs-overrides
   features:
     - navigation.tabs
     - navigation.tabs.sticky
+    - navigation.tracking
+    - navigation.top
   font:
     text: Fira Sans
     code: Fira Code

--- a/pode.build.ps1
+++ b/pode.build.ps1
@@ -9,12 +9,12 @@ param (
 
 $Versions = @{
     Pester = '4.8.0'
-    MkDocs = '1.1.2'
+    MkDocs = '1.2.3'
     PSCoveralls = '1.0.0'
     SevenZip = '18.5.0.20180730'
     DotNetCore = '3.1.5'
     Checksum = '0.2.0'
-    MkDocsTheme = '7.1.6'
+    MkDocsTheme = '8.1.2'
     PlatyPS = '0.14.0'
 }
 


### PR DESCRIPTION
### Description of the Change
Bumps mkdocs to v1.2.3, and the material theme for mkdocs to v8.1.2.

Also adds an announcement bar to the top of the docs, so people viewing the docs elsewhere, like readthedocs, know where the official docs are hosted. This is done as the Functions pages aren't available elsewhere.

### Related Issue
Resolves #805 
Resolves #881 
