### PR TITLE
Allow -Secret on Convert-Jwt functions to be byte[] or string

### DIFF
--- a/docs/Tutorials/Authentication/Methods/JWT.md
+++ b/docs/Tutorials/Authentication/Methods/JWT.md
@@ -95,7 +95,7 @@ eyJ0eXAiOiJKV1QiLCJhbGciOiJoczI1NiJ9.eyJleHAiOjE2MjI1NTMyMTQsIm5hbWUiOiJKb2huIER
 
 Pode has a [`ConvertFrom-PodeJwt`](../../../../Functions/Authentication/ConvertFrom-PodeJwt) that can be used to parse a valid JWT. Only the algorithms at the top of this page are supported for verifying the signature. You can skip signature verification by passing `-IgnoreSignature`. On success, the payload of the JWT is returned.
 
-For example, if the created JWT was suplplied:
+For example, if the created JWT was supplied:
 
 ```powershell
 ConvertFrom-PodeJwt -Token 'eyJ0eXAiOiJKV1QiLCJhbGciOiJoczI1NiJ9.eyJleHAiOjE2MjI1NTMyMTQsIm5hbWUiOiJKb2huIERvZSIsInN1YiI6IjEyMyJ9.LP-O8OKwix91a-SZwVK35gEClLZQmsORbW0un2Z4RkY' -Secret 'abc'


### PR DESCRIPTION
### Description of the Change
Allow the `-Secret` parameter on `ConvertFrom-PodeJwt` and `ConvertTo-PodeJwt` to accept both string and byte[] values.

### Related Issue
Resolves #877 

### Examples
* String:
```powershell
ConvertFrom-PodeJwt -Token 'eyJ0eXAiOiJKV1QiLCJhbGciOiJoczI1NiJ9.eyJleHAiOjE2MjI1NTMyMTQsIm5hbWUiOiJKb2huIERvZSIsInN1YiI6IjEyMyJ9.LP-O8OKwix91a-SZwVK35gEClLZQmsORbW0un2Z4RkY' -Secret 'abc'
```

* Byte[]:
```powershell
ConvertFrom-PodeJwt -Token 'eyJ0eXAiOiJKV1QiLCJhbGciOiJoczI1NiJ9.eyJleHAiOjE2MjI1NTMyMTQsIm5hbWUiOiJKb2huIERvZSIsInN1YiI6IjEyMyJ9.LP-O8OKwix91a-SZwVK35gEClLZQmsORbW0un2Z4RkY' -Secret ([System.Text.Encoding]::UTF8.GetBytes('abc'))
```
