### PR TITLE
Fix for importing modules into runspaces

### DIFF
--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -461,7 +461,8 @@ function Import-PodeModulesIntoRunspaceState
             continue
         }
 
-        $path = (Get-Module -Name $module | Sort-Object -Property Version -Descending | Select-Object -First 1 -ExpandProperty Path)
+        # import the module
+        $path = Find-PodeModuleFile -Name $module
         $PodeContext.RunspaceState.ImportPSModule($path)
     }
 }

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -2613,3 +2613,26 @@ function Use-PodeFolder
         Use-PodeScript -Path $_.FullName
     }
 }
+
+function Find-PodeModuleFile
+{
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Name,
+
+        [switch]
+        $ListAvailable
+    )
+
+    # get module and check psd1, then psm1
+    $mod = (Get-Module -Name $Name -ListAvailable:$ListAvailable | Sort-Object -Property Version -Descending | Select-Object -First 1)
+
+    # if the path isn't already a psd1 do this
+    $path = Join-Path $mod.ModuleBase "$($mod.Name).psd1"
+    if (!(Test-Path $path)) {
+        $path = $mod.Path
+    }
+
+    return $path
+}

--- a/src/Public/Utilities.ps1
+++ b/src/Public/Utilities.ps1
@@ -494,7 +494,7 @@ function Import-PodeModule
                 $Path = (Get-ChildItem ([System.IO.Path]::Combine($modulePath, '*', "$($Name).ps*1")) -Recurse -Force | Select-Object -First 1).FullName
             }
             else {
-                $Path = (Get-Module -Name $Name -ListAvailable | Select-Object -First 1).Path
+                $Path = Find-PodeModuleFile -Name $Name -ListAvailable
             }
         }
 


### PR DESCRIPTION
### Description of the Change
Fixes an bug with importing modules into runspaces, where only the psm1/dll was ever imported and not a module's psd1. This led to some modules not being fully imported.

### Related Issue
Resolves #892 
