### PR TITLE
Add -ArgumentList support on Invoke-PodeSchedule/Timer

### DIFF
--- a/docs/Tutorials/Schedules.md
+++ b/docs/Tutorials/Schedules.md
@@ -129,6 +129,20 @@ You can manually trigger a schedule by using [`Invoke-PodeSchedule`](../../Funct
 Invoke-PodeSchedule -Name 'schedule-name'
 ```
 
+You can also pass further optional arguments that will be supplied to the schedules's scriptblock by using `-ArgumentList`, which is a hashtable of parameters that will be supplied:
+
+```powershell
+Add-PodeSchedule -Name 'date' -Cron '@minutely' -ScriptBlock {
+    param($Date)
+    Write-Host $Date
+}
+
+Invoke-PodeSchedule -Name 'date' -ArgumentList @{ Date = [DateTime]::Now }
+```
+
+!!! note
+    Remember that names of items in the hashtable, and the name of the parameter in the scriptblock must be identical.
+
 ## Schedule Object
 
 !!! warning

--- a/docs/Tutorials/Timers.md
+++ b/docs/Tutorials/Timers.md
@@ -17,6 +17,18 @@ Add-PodeTimer -Name 'date' -Interval 5 -ScriptBlock {
 }
 ```
 
+## Arguments
+
+You can supply custom arguments to be passed to your timers by using the `-ArgumentList` parameter. This parameter takes an array of objects, which will be splatted onto the timer's scriptblock:
+
+```powershell
+Add-PodeTimer -Name 'example' -Interval 5 -ArgumentList 'Item1', 'Item2' -ScriptBlock {
+    param($i1, $i2)
+
+    # $i1 will be 'Item1'
+}
+```
+
 ## Delayed Start
 
 The `-Skip <int>` parameter will cause the Timer to skip its first initial triggers. For example, if you have a Timer run every 10 seconds, and you pass `-Skip 5`, then the timer will first run after 50 seconds (10secs * skip 5).
@@ -79,6 +91,30 @@ You can manually trigger a timer by using [`Invoke-PodeTimer`](../../Functions/T
 
 ```powershell
 Invoke-PodeTimer -Name 'timer-name'
+```
+
+You can also pass further optional arguments that will be supplied to the timer's scriptblock by using `-ArgumentList`, which is an array of objects that will be splatted:
+
+```powershell
+Add-PodeTimer -Name 'date' -Interval 5 -ScriptBlock {
+    param($date)
+    Write-Host $date
+}
+
+Invoke-PodeTimer -Name 'date' -ArgumentList ([DateTime]::Now)
+```
+
+If you supply an `-ArgumentList` on `Add-PodeTimer` and on `Invoke-PodeTimer`, then the main timer arguments are splatted first:
+
+```powershell
+Add-PodeTimer -Name 'example' -Interval 5 -ArgumentList 'Item1', 'Item2' -ScriptBlock {
+    param($i1, $i2, $a1, $a2)
+
+    # $i1 will be 'Item1'
+    # $a1 will be 'Arg1'
+}
+
+Invoke-PodeTimer -Name 'date' -ArgumentList 'Arg1', 'Arg2'
 ```
 
 ## Timer Object

--- a/examples/schedules.ps1
+++ b/examples/schedules.ps1
@@ -13,11 +13,13 @@ Start-PodeServer {
     # schedule minutely using predefined cron
     $message = 'Hello, world!'
     Add-PodeSchedule -Name 'predefined' -Cron '@minutely' -Limit 2 -ScriptBlock {
-        param($Event)
+        param($Event, $Message1, $Message2)
         $using:message | Out-Default
         Get-PodeSchedule -Name 'predefined' | Out-Default
         "Last: $($Event.Sender.LastTriggerTime)" | Out-Default
         "Next: $($Event.Sender.NextTriggerTime)" | Out-Default
+        "Message1: $($Message1)" | Out-Default
+        "Message2: $($Message2)" | Out-Default
     }
 
     Add-PodeSchedule -Name 'from-file' -Cron '@minutely' -FilePath './scripts/schedule.ps1'
@@ -45,7 +47,10 @@ Start-PodeServer {
 
     # adhoc invoke a schedule's logic
     Add-PodeRoute -Method Get -Path '/api/run' -ScriptBlock {
-        Invoke-PodeSchedule -Name 'predefined'
+        Invoke-PodeSchedule -Name 'predefined' -ArgumentList @{
+            Message1 = 'Hello!'
+            Message2 = 'Bye!'
+        }
     }
 
 }

--- a/examples/timers.ps1
+++ b/examples/timers.ps1
@@ -12,6 +12,7 @@ Start-PodeServer {
     # runs forever, looping every 5secs
     $message = 'Hello, world'
     Add-PodeTimer -Name 'forever' -Interval 5 -ScriptBlock {
+        param($msg1, $msg2)
         '- - -' | Out-PodeHost
         $using:message | Out-PodeHost
         Lock-PodeObject -ScriptBlock {
@@ -19,6 +20,8 @@ Start-PodeServer {
         }
         "Last: $($TimerEvent.Sender.LastTriggerTime)" | Out-Default
         "Next: $($TimerEvent.Sender.NextTriggerTime)" | Out-Default
+        "Message1: $($msg1)" | Out-Default
+        "Message2: $($msg2)" | Out-Default
         '- - -' | Out-PodeHost
     } -Limit 5
 
@@ -56,7 +59,7 @@ Start-PodeServer {
 
     # adhoc invoke a timer's logic
     Add-PodeRoute -Method Get -Path '/api/run' -ScriptBlock {
-        Invoke-PodeTimer -Name 'forever'
+        Invoke-PodeTimer -Name 'forever' -ArgumentList 'Hello!', 'Bye!'
     }
 
     Use-PodeTimers

--- a/src/Private/Schedules.ps1
+++ b/src/Private/Schedules.ps1
@@ -123,7 +123,11 @@ function Invoke-PodeInternalScheduleLogic
 {
     param(
         [Parameter(Mandatory=$true)]
-        $Schedule
+        $Schedule,
+
+        [Parameter()]
+        [hashtable]
+        $ArgumentList = $null
     )
 
     try {
@@ -135,12 +139,19 @@ function Invoke-PodeInternalScheduleLogic
             }
         }
 
-        # add any custom args as params
+        # add any schedule args
         foreach ($key in $Schedule.Arguments.Keys) {
             $parameters[$key] = $Schedule.Arguments[$key]
         }
 
-        # add any using variables as params
+        # add adhoc schedule invoke args
+        if (($null -ne $ArgumentList) -and ($ArgumentList.Count -gt 0)) {
+            foreach ($key in $ArgumentList.Keys) {
+                $parameters[$key] = $ArgumentList[$key]
+            }
+        }
+
+        # add any using variables
         if ($null -ne $Schedule.UsingVariables) {
             foreach ($usingVar in $Schedule.UsingVariables) {
                 $parameters[$usingVar.NewName] = $usingVar.Value

--- a/src/Private/Timers.ps1
+++ b/src/Private/Timers.ps1
@@ -64,7 +64,11 @@ function Invoke-PodeInternalTimer
 {
     param(
         [Parameter(Mandatory=$true)]
-        $Timer
+        $Timer,
+
+        [Parameter()]
+        [object[]]
+        $ArgumentList = $null
     )
 
     try {
@@ -73,7 +77,18 @@ function Invoke-PodeInternalTimer
             Sender = $Timer
         }
 
-        $_args = @($Timer.Arguments)
+        # add main timer args
+        $_args = @()
+        if (($null -ne $Timer.Arguments) -and ($Timer.Arguments.Length -gt 0)) {
+            $_args += $Timer.Arguments
+        }
+
+        # add adhoc timer invoke args
+        if (($null -ne $ArgumentList) -and ($ArgumentList.Length -gt 0)) {
+            $_args += $ArgumentList
+        }
+
+        # add timer $using args
         if ($null -ne $Timer.UsingVariables) {
             $_vars = @()
             foreach ($_var in $Timer.UsingVariables) {
@@ -82,6 +97,7 @@ function Invoke-PodeInternalTimer
             $_args = $_vars + $_args
         }
 
+        # invoke timer
         Invoke-PodeScriptBlock -ScriptBlock $Timer.Script -Arguments $_args -Scoped -Splat
     }
     catch {

--- a/src/Public/Schedules.ps1
+++ b/src/Public/Schedules.ps1
@@ -194,6 +194,9 @@ Adhoc invoke a Schedule's logic outside of its defined cron-expression. This inv
 .PARAMETER Name
 The Name of the Schedule.
 
+.PARAMETER ArgumentList
+A hashtable of arguments to supply to the Schedule's ScriptBlock.
+
 .EXAMPLE
 Invoke-PodeSchedule -Name 'schedule-name'
 #>
@@ -203,7 +206,11 @@ function Invoke-PodeSchedule
     param(
         [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
         [string]
-        $Name
+        $Name,
+
+        [Parameter()]
+        [hashtable]
+        $ArgumentList = $null
     )
 
     # ensure the schedule exists
@@ -212,7 +219,7 @@ function Invoke-PodeSchedule
     }
 
     # run schedule logic
-    Invoke-PodeInternalScheduleLogic -Schedule ($PodeContext.Schedules[$Name])
+    Invoke-PodeInternalScheduleLogic -Schedule $PodeContext.Schedules[$Name] -ArgumentList $ArgumentList
 }
 
 <#

--- a/src/Public/Timers.ps1
+++ b/src/Public/Timers.ps1
@@ -146,6 +146,9 @@ Adhoc invoke a Timer's logic outside of its defined interval. This invocation do
 .PARAMETER Name
 The Name of the Timer.
 
+.PARAMETER ArgumentList
+An array of arguments to supply to the Timer's ScriptBlock.
+
 .EXAMPLE
 Invoke-PodeTimer -Name 'timer-name'
 #>
@@ -155,7 +158,11 @@ function Invoke-PodeTimer
     param(
         [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
         [string]
-        $Name
+        $Name,
+
+        [Parameter()]
+        [object[]]
+        $ArgumentList = $null
     )
 
     # ensure the timer exists
@@ -164,7 +171,7 @@ function Invoke-PodeTimer
     }
 
     # run timer logic
-    Invoke-PodeInternalTimer -Timer ($PodeContext.Timers[$Name])
+    Invoke-PodeInternalTimer -Timer $PodeContext.Timers[$Name] -ArgumentList $ArgumentList
 }
 
 <#


### PR DESCRIPTION
### Description of the Change
Adds an `-ArgumentList` parameter onto `Invoke-PodeSchedule` and `Invoke-PodeTimer`, to allow the passing of adhoc parameters.

### Related Issue
Resolves #891 

### Examples
```powershell
Add-PodeSchedule -Name 'date' -Cron '@minutely' -ScriptBlock {
    param($Date)
    Write-Host $Date
}
Invoke-PodeSchedule -Name 'date' -ArgumentList @{ Date = [DateTime]::Now }
```
