### PR TITLE
Open/Close RunspacePools async, and load modules in pipeline so BeginInvoke blocks less

### DIFF
--- a/examples/server.psd1
+++ b/examples/server.psd1
@@ -43,6 +43,9 @@
             Functions = @{
                 ExportOnly = $true
             }
+            Modules = @{
+                ExportOnly = $true
+            }
         }
         Request = @{
             Timeout = 30

--- a/examples/web-pages.ps1
+++ b/examples/web-pages.ps1
@@ -10,7 +10,7 @@ Import-Module "$($path)/src/Pode.psm1" -Force -ErrorAction Stop
 # Import-Module Pode
 
 # create a server, and start listening on port 8085
-Start-PodeServer -Threads 2 {
+Start-PodeServer -Threads 2 -Verbose {
     # listen on localhost:8085
     Add-PodeEndpoint -Address * -Port 8090 -Protocol Http -Name '8090Address'
     Add-PodeEndpoint -Address * -Port $Port -Protocol Http -Name '8085Address' -RedirectTo '8090Address'

--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -376,7 +376,7 @@ function New-PodeContext
 function New-PodeRunspaceState
 {
     # create the state, and add the pode module
-    $state = [initialsessionstate]::CreateDefault2()
+    $state = [initialsessionstate]::CreateDefault()
     $state.ImportPSModule($PodeContext.Server.PodeModulePath)
 
     # load the vars into the share state

--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -357,6 +357,9 @@ function New-PodeContext
         Stop = [ordered]@{}
     }
 
+    # modules
+    $ctx.Server.Modules = @{}
+
     # return the new context
     return $ctx
 }
@@ -364,7 +367,7 @@ function New-PodeContext
 function New-PodeRunspaceState
 {
     # create the state, and add the pode module
-    $state = [initialsessionstate]::CreateDefault()
+    $state = [initialsessionstate]::CreateDefault2()
     $state.ImportPSModule($PodeContext.Server.PodeModulePath)
 
     # load the vars into the share state
@@ -463,7 +466,7 @@ function Import-PodeModulesIntoRunspaceState
 
         # import the module
         $path = Find-PodeModuleFile -Name $module
-        $PodeContext.RunspaceState.ImportPSModule($path)
+        $PodeContext.Server.Modules[$module] = $path
     }
 }
 
@@ -514,35 +517,57 @@ function New-PodeRunspacePools
 
     # main runspace - for timers, schedules, etc
     $totalThreadCount = ($threadsCounts.Values | Measure-Object -Sum).Sum
-    $PodeContext.RunspacePools.Main = [runspacefactory]::CreateRunspacePool(1, $totalThreadCount, $PodeContext.RunspaceState, $Host)
+    $PodeContext.RunspacePools.Main = @{
+        Pool = [runspacefactory]::CreateRunspacePool(1, $totalThreadCount, $PodeContext.RunspaceState, $Host)
+        Ready = $false
+    }
 
     # web runspace - if we have any http/s endpoints
     if (Test-PodeEndpoints -Type Http) {
-        $PodeContext.RunspacePools.Web = [runspacefactory]::CreateRunspacePool(1, ($PodeContext.Threads.General + 1), $PodeContext.RunspaceState, $Host)
+        $PodeContext.RunspacePools.Web = @{
+            Pool = [runspacefactory]::CreateRunspacePool(1, ($PodeContext.Threads.General + 1), $PodeContext.RunspaceState, $Host)
+            Ready = $false
+        }
     }
 
     # smtp runspace - if we have any smtp endpoints
     if (Test-PodeEndpoints -Type Smtp) {
-        $PodeContext.RunspacePools.Smtp = [runspacefactory]::CreateRunspacePool(1, ($PodeContext.Threads.General + 1), $PodeContext.RunspaceState, $Host)
+        $PodeContext.RunspacePools.Smtp = @{
+            Pool = [runspacefactory]::CreateRunspacePool(1, ($PodeContext.Threads.General + 1), $PodeContext.RunspaceState, $Host)
+            Ready = $false
+        }
     }
 
     # tcp runspace - if we have any tcp endpoints
     if (Test-PodeEndpoints -Type Tcp) {
-        $PodeContext.RunspacePools.Tcp = [runspacefactory]::CreateRunspacePool(1, ($PodeContext.Threads.General + 1), $PodeContext.RunspaceState, $Host)
+        $PodeContext.RunspacePools.Tcp = @{
+            Pool = [runspacefactory]::CreateRunspacePool(1, ($PodeContext.Threads.General + 1), $PodeContext.RunspaceState, $Host)
+            Ready = $false
+        }
     }
 
     # web socket runspace - if we have any ws/s endpoints
     if (Test-PodeEndpoints -Type Ws) {
-        $PodeContext.RunspacePools.Signals = [runspacefactory]::CreateRunspacePool(1, ($PodeContext.Threads.General + 2), $PodeContext.RunspaceState, $Host)
+        $PodeContext.RunspacePools.Signals = @{
+            Pool = [runspacefactory]::CreateRunspacePool(1, ($PodeContext.Threads.General + 2), $PodeContext.RunspaceState, $Host)
+            Ready = $false
+        }
     }
 
     # setup schedule runspace pool
-    $PodeContext.RunspacePools.Schedules = [runspacefactory]::CreateRunspacePool(1, $PodeContext.Threads.Schedules, $PodeContext.RunspaceState, $Host)
+    $PodeContext.RunspacePools.Schedules = @{
+        Pool = [runspacefactory]::CreateRunspacePool(1, $PodeContext.Threads.Schedules, $PodeContext.RunspaceState, $Host)
+        Ready = $false
+    }
 
     # setup gui runspace pool (only for non-ps-core)
     if (!$PodeContext.Server.IsServerless -and !((Test-PodeIsPSCore) -and ($PSVersionTable.PSVersion.Major -eq 6))) {
-        $PodeContext.RunspacePools.Gui = [runspacefactory]::CreateRunspacePool(1, 1, $PodeContext.RunspaceState, $Host)
-        $PodeContext.RunspacePools.Gui.ApartmentState = 'STA'
+        $PodeContext.RunspacePools.Gui = @{
+            Pool = [runspacefactory]::CreateRunspacePool(1, 1, $PodeContext.RunspaceState, $Host)
+            Ready = $false
+        }
+
+        $PodeContext.RunspacePools.Gui.Pool.ApartmentState = 'STA'
     }
 }
 
@@ -552,11 +577,122 @@ function Open-PodeRunspacePools
         return
     }
 
+    $start = [datetime]::Now
+    Write-Verbose "Opening RunspacePools"
+
+    # open pools async
     foreach ($key in $PodeContext.RunspacePools.Keys) {
-        if ($null -ne $PodeContext.RunspacePools[$key]) {
-            $PodeContext.RunspacePools[$key].Open()
+        $item = $PodeContext.RunspacePools[$key]
+        if ($null -eq $item) {
+            continue
+        }
+
+        $item.Result = $item.Pool.BeginOpen($null, $null)
+    }
+
+    # wait for them all to open
+    $queue = @($PodeContext.RunspacePools.Keys)
+
+    while ($queue.Length -gt 0) {
+        foreach ($key in $queue) {
+            $item = $PodeContext.RunspacePools[$key]
+            if ($null -eq $item) {
+                $queue = ($queue | Where-Object { $_ -ine $key })
+                continue
+            }
+
+            if ($item.Pool.RunspacePoolStateInfo.State -iin @('Opened', 'Broken')) {
+                $queue = ($queue | Where-Object { $_ -ine $key })
+                Write-Verbose "RunspacePool for $($key): $($item.Pool.RunspacePoolStateInfo.State) [duration: $(([datetime]::Now - $start).TotalSeconds)s]"
+            }
+        }
+
+        if ($queue.Length -gt 0) {
+            Start-Sleep -Milliseconds 100
         }
     }
+
+    # report errors for failed pools
+    foreach ($key in $PodeContext.RunspacePools.Keys) {
+        $item = $PodeContext.RunspacePools[$key]
+        if ($null -eq $item) {
+            continue
+        }
+
+        if ($item.Pool.RunspacePoolStateInfo.State -ieq 'broken') {
+            $item.Pool.EndOpen($item.Result) | Out-Default
+            throw "Failed to open RunspacePool: $($key)"
+        }
+    }
+
+    Write-Verbose "RunspacePools opened [duration: $(([datetime]::Now - $start).TotalSeconds)s]"
+}
+
+function Close-PodeRunspacePools
+{
+    if ($PodeContext.Server.IsServerless -or ($null -eq $PodeContext.RunspacePools)) {
+        return
+    }
+
+    $start = [datetime]::Now
+    Write-Verbose "Closing RunspacePools"
+
+    # close pools async
+    foreach ($key in $PodeContext.RunspacePools.Keys) {
+        $item = $PodeContext.RunspacePools[$key]
+        if (($null -eq $item) -or ($item.Pool.IsDisposed)) {
+            continue
+        }
+
+        $item.Result = $item.Pool.BeginClose($null, $null)
+    }
+
+    # wait for them all to close
+    $queue = @($PodeContext.RunspacePools.Keys)
+
+    while ($queue.Length -gt 0) {
+        foreach ($key in $queue) {
+            $item = $PodeContext.RunspacePools[$key]
+            if ($null -eq $item) {
+                $queue = ($queue | Where-Object { $_ -ine $key })
+                continue
+            }
+
+            if ($item.Pool.RunspacePoolStateInfo.State -iin @('Closed', 'Broken')) {
+                $queue = ($queue | Where-Object { $_ -ine $key })
+                Write-Verbose "RunspacePool for $($key): $($item.Pool.RunspacePoolStateInfo.State) [duration: $(([datetime]::Now - $start).TotalSeconds)s]"
+            }
+        }
+
+        if ($queue.Length -gt 0) {
+            Start-Sleep -Milliseconds 100
+        }
+    }
+
+    # report errors for failed pools
+    foreach ($key in $PodeContext.RunspacePools.Keys) {
+        $item = $PodeContext.RunspacePools[$key]
+        if ($null -eq $item) {
+            continue
+        }
+
+        if ($item.Pool.RunspacePoolStateInfo.State -ieq 'broken') {
+            $item.Pool.EndClose($item.Result) | Out-Default
+            throw "Failed to close RunspacePool: $($key)"
+        }
+    }
+
+    # dispose pools
+    foreach ($key in $PodeContext.RunspacePools.Keys) {
+        $item = $PodeContext.RunspacePools[$key]
+        if (($null -eq $item) -or ($item.Pool.IsDisposed)) {
+            continue
+        }
+
+        Close-PodeDisposable -Disposable $item.Pool
+    }
+
+    Write-Verbose "RunspacePools closed [duration: $(([datetime]::Now - $start).TotalSeconds)s]"
 }
 
 function New-PodeStateContext

--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -519,14 +519,14 @@ function New-PodeRunspacePools
     $totalThreadCount = ($threadsCounts.Values | Measure-Object -Sum).Sum
     $PodeContext.RunspacePools.Main = @{
         Pool = [runspacefactory]::CreateRunspacePool(1, $totalThreadCount, $PodeContext.RunspaceState, $Host)
-        Ready = $false
+        State = 'Waiting'
     }
 
     # web runspace - if we have any http/s endpoints
     if (Test-PodeEndpoints -Type Http) {
         $PodeContext.RunspacePools.Web = @{
             Pool = [runspacefactory]::CreateRunspacePool(1, ($PodeContext.Threads.General + 1), $PodeContext.RunspaceState, $Host)
-            Ready = $false
+            State = 'Waiting'
         }
     }
 
@@ -534,7 +534,7 @@ function New-PodeRunspacePools
     if (Test-PodeEndpoints -Type Smtp) {
         $PodeContext.RunspacePools.Smtp = @{
             Pool = [runspacefactory]::CreateRunspacePool(1, ($PodeContext.Threads.General + 1), $PodeContext.RunspaceState, $Host)
-            Ready = $false
+            State = 'Waiting'
         }
     }
 
@@ -542,7 +542,7 @@ function New-PodeRunspacePools
     if (Test-PodeEndpoints -Type Tcp) {
         $PodeContext.RunspacePools.Tcp = @{
             Pool = [runspacefactory]::CreateRunspacePool(1, ($PodeContext.Threads.General + 1), $PodeContext.RunspaceState, $Host)
-            Ready = $false
+            State = 'Waiting'
         }
     }
 
@@ -550,21 +550,21 @@ function New-PodeRunspacePools
     if (Test-PodeEndpoints -Type Ws) {
         $PodeContext.RunspacePools.Signals = @{
             Pool = [runspacefactory]::CreateRunspacePool(1, ($PodeContext.Threads.General + 2), $PodeContext.RunspaceState, $Host)
-            Ready = $false
+            State = 'Waiting'
         }
     }
 
     # setup schedule runspace pool
     $PodeContext.RunspacePools.Schedules = @{
         Pool = [runspacefactory]::CreateRunspacePool(1, $PodeContext.Threads.Schedules, $PodeContext.RunspaceState, $Host)
-        Ready = $false
+        State = 'Waiting'
     }
 
     # setup gui runspace pool (only for non-ps-core)
     if (!$PodeContext.Server.IsServerless -and !((Test-PodeIsPSCore) -and ($PSVersionTable.PSVersion.Major -eq 6))) {
         $PodeContext.RunspacePools.Gui = @{
             Pool = [runspacefactory]::CreateRunspacePool(1, 1, $PodeContext.RunspaceState, $Host)
-            Ready = $false
+            State = 'Waiting'
         }
 
         $PodeContext.RunspacePools.Gui.Pool.ApartmentState = 'STA'

--- a/src/Private/Endpoints.ps1
+++ b/src/Private/Endpoints.ps1
@@ -101,6 +101,22 @@ function Get-PodeEndpointType
     }
 }
 
+function Get-PodeEndpointRunspacePoolName
+{
+    param(
+        [Parameter()]
+        [ValidateSet('Http', 'Https', 'Smtp', 'Tcp', 'Ws', 'Wss')]
+        [string]
+        $Protocol
+    )
+
+    switch ($Protocol) {
+        { $_ -iin @('http', 'https') } { 'Web' }
+        { $_ -iin @('ws', 'wss') } { 'Signals' }
+        default { $Protocol }
+    }
+}
+
 function Test-PodeEndpoints
 {
     param(

--- a/src/Private/Gui.ps1
+++ b/src/Private/Gui.ps1
@@ -22,7 +22,7 @@ function Start-PodeGuiRunspace {
             # poll the server for a response
             $count = 0
 
-            while ($true) {
+            while (!$PodeContext.Tokens.Cancellation.IsCancellationRequested) {
                 try {
                     $null = Invoke-WebRequest -Method Get -Uri $uri -UseBasicParsing -ErrorAction Stop
                     if (!$?) {

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -864,7 +864,7 @@ function Add-PodePSDrives
 function Import-PodeModules
 {
     foreach ($path in $PodeContext.Server.Modules.Values) {
-        $null = Import-Module $path -DisableNameChecking -ErrorAction Stop
+        $null = Import-Module $path -DisableNameChecking -Scope Global -ErrorAction Stop
     }
 }
 

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -590,6 +590,9 @@ function Open-PodeRunspace
         if ($PodeContext.RunspacePools[$Type].State -ieq 'waiting') {
             $PodeContext.RunspacePools[$Type].State = 'Error'
         }
+
+        $_ | Out-Default
+        $_.ScriptStackTrace | Out-Default
         throw
     }
 }

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -556,7 +556,7 @@ function Add-PodeRunspace
 
         # do we need to remember this pipeline? sorry, what did you say?
         if ($Forget) {
-            $null =  $ps.BeginInvoke()
+            $null = $ps.BeginInvoke()
         }
         else {
             $PodeContext.Runspaces += @{

--- a/src/Private/Logging.ps1
+++ b/src/Private/Logging.ps1
@@ -332,7 +332,7 @@ function Start-PodeLoggingRunspace
     }
 
     $script = {
-        while ($true)
+        while (!$PodeContext.Tokens.Cancellation.IsCancellationRequested)
         {
             # if there are no logs to process, just sleep for a few seconds - but after checking the batch
             if ($PodeContext.LogsToProcess.Count -eq 0) {

--- a/src/Private/PodeServer.ps1
+++ b/src/Private/PodeServer.ps1
@@ -449,7 +449,7 @@ function Start-PodeWebServer
         $waitType = 'Signals'
     }
 
-    Add-PodeRunspace -Type $waitType -ScriptBlock $waitScript -Parameters @{ 'Listener' = $listener }
+    Add-PodeRunspace -Type $waitType -ScriptBlock $waitScript -Parameters @{ 'Listener' = $listener } -NoProfile
 
     # browse to the first endpoint, if flagged
     if ($Browse) {

--- a/src/Private/PodeServer.ps1
+++ b/src/Private/PodeServer.ps1
@@ -42,6 +42,7 @@ function Start-PodeWebServer
             Url = $_.Url
             Protocol = $_.Protocol
             Type = $_.Type
+            Pool = $_.Runspace.PoolName
         }
 
         # add endpoint to list
@@ -455,7 +456,12 @@ function Start-PodeWebServer
         Start-Process $endpoints[0].Url
     }
 
-    return @($endpoints.Url)
+    return @(foreach ($endpoint in $endpoints) {
+        @{
+            Url  = $endpoint.Url
+            Pool = $endpoint.Pool
+        }
+    })
 }
 
 function New-PodeListener

--- a/src/Private/Schedules.ps1
+++ b/src/Private/Schedules.ps1
@@ -33,7 +33,7 @@ function Start-PodeScheduleRunspace
         # first, sleep for a period of time to get to 00 seconds (start of minute)
         Start-Sleep -Seconds (60 - [DateTime]::Now.Second)
 
-        while ($true)
+        while (!$PodeContext.Tokens.Cancellation.IsCancellationRequested)
         {
             $_now = [DateTime]::Now
 
@@ -56,7 +56,7 @@ function Start-PodeScheduleRunspace
         }
     }
 
-    Add-PodeRunspace -Type Main -ScriptBlock $script
+    Add-PodeRunspace -Type Main -ScriptBlock $script -NoProfile
 }
 
 function Complete-PodeInternalSchedules

--- a/src/Private/Server.ps1
+++ b/src/Private/Server.ps1
@@ -106,11 +106,17 @@ function Start-PodeInternalServer
                 $start = [datetime]::Now
                 Write-Verbose "Waiting for the $($pool) RunspacePool to be Ready"
 
-                while (!$PodeContext.RunspacePools[$pool].Ready) {
+                # wait
+                while ($PodeContext.RunspacePools[$pool].State -ieq 'Waiting') {
                     Start-Sleep -Milliseconds 100
                 }
 
-                Write-Verbose "$($pool) RunspacePool Ready [duration: $(([datetime]::Now - $start).TotalSeconds)s]"
+                Write-Verbose "$($pool) RunspacePool $($PodeContext.RunspacePools[$pool].State) [duration: $(([datetime]::Now - $start).TotalSeconds)s]"
+
+                # errored?
+                if ($PodeContext.RunspacePools[$pool].State -ieq 'error') {
+                    throw "$($pool) RunspacePool failed to load"
+                }
             }
         }
 

--- a/src/Private/SmtpServer.ps1
+++ b/src/Private/SmtpServer.ps1
@@ -171,7 +171,7 @@ function Start-PodeSmtpServer
         }
     }
 
-    Add-PodeRunspace -Type Smtp -ScriptBlock $waitScript -Parameters @{ 'Listener' = $listener }
+    Add-PodeRunspace -Type Smtp -ScriptBlock $waitScript -Parameters @{ 'Listener' = $listener } -NoProfile
 
     # state where we're running
     return @(@{

--- a/src/Private/SmtpServer.ps1
+++ b/src/Private/SmtpServer.ps1
@@ -174,5 +174,8 @@ function Start-PodeSmtpServer
     Add-PodeRunspace -Type Smtp -ScriptBlock $waitScript -Parameters @{ 'Listener' = $listener }
 
     # state where we're running
-    return @("smtp://$($endpoint.FriendlyName):$($port)")
+    return @(@{
+        Url  = "smtp://$($endpoint.FriendlyName):$($port)"
+        Pool = $endpoint.Runspace.PoolName
+    })
 }

--- a/src/Private/TcpServer.ps1
+++ b/src/Private/TcpServer.ps1
@@ -125,7 +125,7 @@ function Start-PodeTcpServer
         }
     }
 
-    Add-PodeRunspace -Type Tcp -ScriptBlock $waitScript -Parameters @{ 'Listener' = $listener }
+    Add-PodeRunspace -Type Tcp -ScriptBlock $waitScript -Parameters @{ 'Listener' = $listener } -NoProfile
 
     # state where we're running
     return @(@{

--- a/src/Private/TcpServer.ps1
+++ b/src/Private/TcpServer.ps1
@@ -128,5 +128,8 @@ function Start-PodeTcpServer
     Add-PodeRunspace -Type Tcp -ScriptBlock $waitScript -Parameters @{ 'Listener' = $listener }
 
     # state where we're running
-    return @("tcp://$($endpoint.FriendlyName):$($port)")
+    return @(@{
+        Url  = "tcp://$($endpoint.FriendlyName):$($port)"
+        Pool = $endpoint.Runspace.PoolName
+    })
 }

--- a/src/Private/Timers.ps1
+++ b/src/Private/Timers.ps1
@@ -17,7 +17,7 @@ function Start-PodeTimerRunspace
     }
 
     $script = {
-        while ($true)
+        while (!$PodeContext.Tokens.Cancellation.IsCancellationRequested)
         {
             $_now = [DateTime]::Now
 

--- a/src/Public/Core.ps1
+++ b/src/Public/Core.ps1
@@ -894,6 +894,9 @@ function Add-PodeEndpoint
         Ssl = (@('https', 'wss') -icontains $Protocol)
         Protocol = $Protocol.ToLowerInvariant()
         Type = $type.ToLowerInvariant()
+        Runspace = @{
+            PoolName = (Get-PodeEndpointRunspacePoolName -Protocol $Protocol)
+        }
         Default = $Default.IsPresent
         Certificate = @{
             Raw = $X509Certificate

--- a/src/Public/Schedules.ps1
+++ b/src/Public/Schedules.ps1
@@ -170,7 +170,7 @@ function Set-PodeScheduleConcurrency
     # ensure max > min
     $_min = 1
     if ($null -ne $PodeContext.RunspacePools.Schedules) {
-        $_min = $PodeContext.RunspacePools.Schedules.GetMinRunspaces()
+        $_min = $PodeContext.RunspacePools.Schedules.Pool.GetMinRunspaces()
     }
 
     if ($_min -gt $Maximum) {
@@ -180,7 +180,7 @@ function Set-PodeScheduleConcurrency
     # set the max schedules
     $PodeContext.Threads.Schedules = $Maximum
     if ($null -ne $PodeContext.RunspacePools.Schedules) {
-        $PodeContext.RunspacePools.Schedules.SetMaxRunspaces($Maximum)
+        $PodeContext.RunspacePools.Schedules.Pool.SetMaxRunspaces($Maximum)
     }
 }
 

--- a/tests/unit/Server.Tests.ps1
+++ b/tests/unit/Server.Tests.ps1
@@ -5,6 +5,7 @@ Get-ChildItem "$($src)/*.ps1" -Recurse | Resolve-Path | ForEach-Object { . $_ }
 $PodeContext = @{
     Server = $null
     Metrics = @{ Server = @{ StartTime = [datetime]::UtcNow } }
+    RunspacePools = @{}
 }
 
 Describe 'Start-PodeInternalServer' {
@@ -26,6 +27,7 @@ Describe 'Start-PodeInternalServer' {
     Mock Import-PodeSnapinsIntoRunspaceState { }
     Mock Import-PodeFunctionsIntoRunspaceState { }
     Mock Invoke-PodeEvent { }
+    Mock Write-Verbose { }
 
     It 'Calls one-off script logic' {
         $PodeContext.Server = @{ Types = ([string]::Empty); Logic = {} }
@@ -102,33 +104,33 @@ Describe 'Restart-PodeInternalServer' {
             };
             Server = @{
                 Routes = @{
-                    GET = @{ 'key' = 'value' };
-                    POST = @{ 'key' = 'value' };
-                };
+                    GET = @{ 'key' = 'value' }
+                    POST = @{ 'key' = 'value' }
+                }
                 Handlers = @{
-                    TCP = @{ };
-                };
+                    TCP = @{ }
+                }
                 Logging = @{
-                    Types = @{ 'key' = 'value' };
-                };
-                Middleware = @{ 'key' = 'value' };
-                Endpoints = @{ 'key' = 'value' };
-                EndpointsMap = @{ 'key' = 'value' };
-                Endware = @{ 'key' = 'value' };
+                    Types = @{ 'key' = 'value' }
+                }
+                Middleware = @{ 'key' = 'value' }
+                Endpoints = @{ 'key' = 'value' }
+                EndpointsMap = @{ 'key' = 'value' }
+                Endware = @{ 'key' = 'value' }
                 ViewEngine = @{
-                    Type = 'pode';
-                    Extension = 'pode';
-                    Script = $null;
-                    IsDynamic = $true;
-                };
-                Cookies = @{};
-                Sessions = @{ 'key' = 'value' };
-                Authentications = @{ 'key' = 'value' };
-                State = @{ 'key' = 'value' };
+                    Type = 'pode'
+                    Extension = 'pode'
+                    Script = $null
+                    IsDynamic = $true
+                }
+                Cookies = @{}
+                Sessions = @{ 'key' = 'value' }
+                Authentications = @{ 'key' = 'value' }
+                State = @{ 'key' = 'value' }
                 Output = @{
                     Variables = @{ 'key' = 'value' }
                 }
-                Configuration = @{ 'key' = 'value' };
+                Configuration = @{ 'key' = 'value' }
                 Sockets = @{
                     Listeners = @()
                     Queues = @{
@@ -149,18 +151,19 @@ Describe 'Restart-PodeInternalServer' {
                     Snapins = @{ Exported = @() }
                     Functions = @{ Exported = @() }
                 }
-                Views = @{ 'key' = 'value' };
+                Views = @{ 'key' = 'value' }
                 Events = @{
                     Start = @{}
                 }
-            };
+                Modules = @{}
+            }
             Metrics = @{
                 Server = @{
                     RestartCount = 0
                 }
             }
             Timers = @{ 'key' = 'value' }
-            Schedules = @{ 'key' = 'value' };
+            Schedules = @{ 'key' = 'value' }
         }
 
         Restart-PodeInternalServer | Out-Null


### PR DESCRIPTION
### Description of the Change
Hefty change to the way Pode starts up and closes. This makes it so that RunspacePools are now opened/closed asynchronously, and moves module loading to the pipeline level rather than the runspace level. This allows a server to start-up faster, and doesn't block on starting a runspace pipeline.

The "Listening on" message will now appear when all RunspacePools have opened, and at least 1 runspace that runs and endpoint (http, smtp, etc) has started.

Loading the modules in the pipeline works the same as loading them in the runspace - in that once they're imported, re-using a runspace won't re-import everything again, but this way BeginInvoke doesn't forever block on slow loading modules.

### Related Issue
Resolves #896 
