### PR TITLE
Add PKCE support for OAuth2

### DIFF
--- a/docs/Tutorials/Authentication/Inbuilt/AzureAD.md
+++ b/docs/Tutorials/Authentication/Inbuilt/AzureAD.md
@@ -2,7 +2,7 @@
 
 The Azure AD authentication is just a wrapper around the inbuilt [OAuth2](../OAuth2) authentication.
 
-Both the `authorization_code` and `password` grant types are supported. The `password` type is only supported on Work/School accounts, and on accounts with MFA disabled.
+Both the `authorization_code` and `password` grant types are supported. The `password` type is only supported on Work/School accounts, and on accounts with MFA disabled. There is also support for PKCE, via `-UsePKCE` if sessions are enabled.
 
 ## Setup
 
@@ -11,7 +11,8 @@ Before using Azure AD authentication in Pode, you first need to register a new a
 * In the Azure Portal, open up the Azure Active Directory
 * Then select "App Registrations" in the menu, followed by "New Registration" at the top
 * Enter a name for the app, followed by the redirect URL
-    * the default is redirect is `<host>/oauth2/callback` (such as `http://localhost:8080/oauth2/callback`)
+    * Platform should be "Web"
+    * The default redirect is `<host>/oauth2/callback` (such as `http://localhost:8080/oauth2/callback`)
 * Click create
     * Make a note of the "Client ID" and "Tenant"
 * Then select "Certificates & Secrets"
@@ -19,6 +20,20 @@ Before using Azure AD authentication in Pode, you first need to register a new a
     * Make a note of the generate secret
 
 With the Client and Tenant ID, plus the Client Secret, you can now setup Azure AD authentication in Pode.
+
+### PKCE
+
+If you're using PKCE, then the flow changes a little bit:
+
+* In the Azure Portal, open up the Azure Active Directory
+* Then select "App Registrations" in the menu, followed by "New Registration" at the top
+* Enter a name for the app, followed by the redirect URL
+    * Platform should be "Single-page application"
+    * The default redirect is `<host>/oauth2/callback` (such as `http://localhost:8080/oauth2/callback`)
+* Click create
+    * Make a note of the "Client ID" and "Tenant"
+
+With just the Client and Tenant ID you're good to go; PKCE doesn't require a Client Secret to work.
 
 ### Authorisation Code
 

--- a/docs/Tutorials/Authentication/Inbuilt/Twitter.md
+++ b/docs/Tutorials/Authentication/Inbuilt/Twitter.md
@@ -1,0 +1,116 @@
+# Twitter
+
+The Twitter authentication is just a wrapper around the inbuilt [OAuth2](../OAuth2) authentication.
+
+Only the `authorization_code` grant type is supported, and there's also support for PKCE, via `-UsePKCE` if sessions are enabled.
+
+## Setup
+
+Before using Twitter authentication in Pode, you first need to register a new app within Twitter:
+
+* Make sure to have a Twitter Developer account, and open the Developer Portal
+* Create a new, or select an existing app
+* In the app's settings, select "Edit" on OAuth2 under "User authentication settings"
+    * Enable "OAuth 2.0"
+    * Set the Type of App to "Web App"
+    * The default redirect is `<host>/oauth2/callback` (such as `http://localhost:8080/oauth2/callback`)
+    * Enter some Website URL
+    * Click "Save"
+* Make a note of the Client ID and Secret presented
+
+With the Client ID and Secret, you can now setup Twitter authentication in Pode.
+
+### PKCE
+
+If you're using PKCE, then the flow changes a little bit:
+
+* Make sure to have a Twitter Developer account, and open the Developer Portal
+* Create a new, or select an existing app
+* In the app's settings, select "Edit" on OAuth2 under "User authentication settings"
+    * Enable "OAuth 2.0"
+    * Set the Type of App to "Single page App"
+    * The default redirect is `<host>/oauth2/callback` (such as `http://localhost:8080/oauth2/callback`)
+    * Enter some Website URL
+    * Click "Save"
+* Make a note of the Client ID presented
+
+With just the Client ID you're good to go; PKCE doesn't require a Client Secret to work.
+
+### Authorisation Code
+
+To setup and start using Twitter authentication in Pode you use `New-PodeAuthTwitterScheme`, and then pipe this into the [`Add-PodeAuth`](../../../../Functions/Authentication/Add-PodeAuth) function:
+
+```powershell
+Start-PodeServer {
+    $scheme = New-PodeAuthTwitterScheme -ClientID '<clientId>' -ClientSecret '<clientSecret>'
+
+    $scheme | Add-PodeAuth -Name 'Login' -FailureUrl '/login' -SuccessUrl '/' -ScriptBlock {
+        param($user, $accessToken, $refreshToken, $response)
+
+        # check if the user is valid
+
+        return @{ User = $user.data }
+    }
+}
+```
+
+If you don't specify a `-RedirectUrl`, then an internal default one is created as `/oauth2/callback` on the first endpoint.
+
+When a user accesses your site unauthenticated, they will be to Twitter to login and approve your app, and then redirected back to your site.
+
+## Middleware
+
+Once configured you can start using Twitter Authentication to validate incoming Requests. You can either configure the validation to happen on every Route as global Middleware, or as custom Route Middleware.
+
+The following will use Twitter Authentication to validate every request on every Route:
+
+```powershell
+Start-PodeServer {
+    Add-PodeAuthMiddleware -Name 'GlobalAuthValidation' -Authentication 'Login'
+}
+```
+
+Whereas the following example will use Twitter Authentication to only validate requests on specific a Route:
+
+```powershell
+Start-PodeServer {
+    Add-PodeRoute -Method Get -Path '/about' -Authentication 'Login' -ScriptBlock {
+        # logic
+    }
+}
+```
+
+## Full Example
+
+The following full example of Twitter authentication. This will setup and configure authentication, redirect a user to Twitter for validation and approval, and then validate on a specific Route:
+
+```powershell
+Start-PodeServer {
+    Add-PodeEndpoint -Address * -Port 8080 -Protocol Http
+    Set-PodeViewEngine -Type Pode
+
+    # setup authentication to validate a user
+    $scheme = New-PodeAuthTwitterScheme -ClientID '<clientId>' -ClientSecret '<clientSecret>'
+
+    $scheme | Add-PodeAuth -Name 'Login' -FailureUrl '/login' -SuccessUrl '/' -ScriptBlock {
+        param($user, $accessToken, $refreshToken, $response)
+
+        # check if the user is valid
+
+        return @{ User = $user.data }
+    }
+
+    # home page:
+    # redirects to login page if not authenticated
+    Add-PodeRoute -Method Get -Path '/' -Authentication Login -ScriptBlock {
+        Write-PodeViewResponse -Path 'home' -Data @{ Username = $WebEvent.Auth.User.name }
+    }
+
+    # login - this will just redirect to twitter
+    # NOTE: you do not need the -Login switch
+    Add-PodeRoute -Method Get -Path '/login' -Authentication Login
+
+    # logout
+    Add-PodeRoute -Method Post -Path '/logout' -Authentication Login -Logout
+}
+```

--- a/docs/Tutorials/Authentication/Methods/OAuth2.md
+++ b/docs/Tutorials/Authentication/Methods/OAuth2.md
@@ -6,7 +6,7 @@ To use this scheme, you'll need to supply an Authorise/Token URL, as well as set
 
 ## Setup
 
-Before using the OAuth2 authentication in Pode, you first need to register a new app within your service of choice. This registration will supply you with the required Client ID and Secret.
+Before using the OAuth2 authentication in Pode, you first need to register a new app within your service of choice. This registration will supply you with the required Client ID and Secret (if you're using [PKCE](#PKCE) then the Client Secret is optional).
 
 To setup and start using OAuth2 authentication in Pode you use `New-PodeAuthScheme -OAuth2`, and then pipe this into the [`Add-PodeAuth`](../../../../Functions/Authentication/Add-PodeAuth) function.
 
@@ -102,6 +102,34 @@ Add-PodeRoute -Method Get -Path '/login' -Authentication Login -Login -ScriptBlo
 
 Add-PodeRoute -Method Post -Path '/login' -Authentication Login -Login
 ```
+
+## PKCE
+
+!!! important
+    When using PKCE, you will need to enable the use of [sessions](../../../Middleware/Types/Sessions) in Pode.
+
+If your app is setup as a "Single Page Application" then you'll be able to use PKCE in your OAuth2 requests. To enable Pode's OAuth2 authentication to use PKCE, supply the `-UsePKCE` switch:
+
+```powershell
+Start-PodeServer {
+    $scheme = New-PodeAuthScheme `
+        -OAuth2 `
+        -ClientID '<clientId>' `
+        -AuthoriseUrl 'https://some-service.com/oauth2/authorize' `
+        -TokenUrl 'https://some-service.com/oauth2/token' `
+        -UsePKCE
+
+    $scheme | Add-PodeAuth -Name 'Login' -FailureUrl '/login' -SuccessUrl '/' -ScriptBlock {
+        param($user, $accessToken, $refreshToken, $response)
+
+        # check if the user is valid
+
+        return @{ User = $user }
+    }
+}
+```
+
+When using PKCE the `-ClientSecret` is optional, and doesn't need to be supplied.
 
 ## Middleware
 

--- a/src/Pode.psd1
+++ b/src/Pode.psd1
@@ -187,6 +187,7 @@
         # auth
         'New-PodeAuthScheme',
         'New-PodeAuthAzureADScheme',
+        'New-PodeAuthTwitterScheme',
         'Add-PodeAuth',
         'Get-PodeAuth',
         'Clear-PodeAuth',

--- a/src/Private/Authentication.ps1
+++ b/src/Private/Authentication.ps1
@@ -98,86 +98,102 @@ function Get-PodeAuthOAuth2Type
 
         # if there's a code query param, or inner scheme, get access token
         if ($hasInnerScheme -or ![string]::IsNullOrWhiteSpace($WebEvent.Query['code'])) {
-            # build tokenUrl query with client info
-            $body = "client_id=$($options.Client.ID)"
-            $body += "&grant_type=$($grantType)"
-
-            if (![string]::IsNullOrEmpty($options.Client.Secret)) {
-                $body += "&client_secret=$([System.Web.HttpUtility]::UrlEncode($options.Client.Secret))"
-            }
-
-            # add PKCE code verifier
-            if ($options.UsePKCE) {
-                $body += "&code_verifier=$($WebEvent.Session.Data['__pode_oauth_code_verifier__'])"
-            }
-
-            # if there's an inner scheme, get the username/password, and set query
-            if ($hasInnerScheme) {
-                $body += "&username=$($schemes[-1][0])"
-                $body += "&password=$($schemes[-1][1])"
-                $body += "&scope=$([System.Web.HttpUtility]::UrlEncode($scopes))"
-            }
-
-            # otherwise, set query for auth_code
-            else {
-                $redirectUrl = Get-PodeOAuth2RedirectHost -RedirectUrl $options.Urls.Redirect
-                $body += "&code=$($WebEvent.Query['code'])"
-                $body += "&redirect_uri=$([System.Web.HttpUtility]::UrlEncode($redirectUrl))"
-            }
-
-            # POST the tokenUrl
             try {
-                $result = Invoke-RestMethod -Method Post -Uri $options.Urls.Token -Body $body -ContentType 'application/x-www-form-urlencoded' -ErrorAction Stop
-            }
-            catch [System.Net.WebException], [System.Net.Http.HttpRequestException] {
-                $response = Read-PodeWebExceptionDetails -ErrorRecord $_
-                $result = ($response.Body | ConvertFrom-Json)
-            }
-            finally {
-                # clear PKCE
-                if ($options.UsePKCE) {
-                    $null = $WebEvent.Session.Data.Remove('__pode_oauth_code_verifier__')
-                }
-            }
-
-            if (![string]::IsNullOrWhiteSpace($result.error)) {
-                return @{
-                    Message = "$($result.error): $($result.error_description)"
-                    Code = 401
-                }
-            }
-
-            # get user details - if url supplied
-            if (![string]::IsNullOrWhiteSpace($options.Urls.User)) {
-                try {
-                    $user = Invoke-RestMethod -Method Post -Uri $options.Urls.User -Headers @{ Authorization = "Bearer $($result.access_token)" }
-                }
-                catch [System.Net.WebException], [System.Net.Http.HttpRequestException] {
-                    $response = Read-PodeWebExceptionDetails -ErrorRecord $_
-                    $user = ($response.Body | ConvertFrom-Json)
-                }
-
-                if (![string]::IsNullOrWhiteSpace($user.error)) {
+                # ensure the state is valid
+                if ((Test-PodeSessionsInUse) -and ($WebEvent.Query['state'] -ne $WebEvent.Session.Data['__pode_oauth_state__'])) {
                     return @{
-                        Message = "$($user.error): $($user.error_description)"
+                        Message = "OAuth2 state returned is invalid"
                         Code = 401
                     }
                 }
-            }
-            elseif (![string]::IsNullOrWhiteSpace($result.id_token)) {
-                try {
-                    $user = ConvertFrom-PodeJwt -Token $result.id_token -IgnoreSignature
+
+                # build tokenUrl query with client info
+                $body = "client_id=$($options.Client.ID)"
+                $body += "&grant_type=$($grantType)"
+
+                if (![string]::IsNullOrEmpty($options.Client.Secret)) {
+                    $body += "&client_secret=$([System.Web.HttpUtility]::UrlEncode($options.Client.Secret))"
                 }
-                catch {
+
+                # add PKCE code verifier
+                if ($options.UsePKCE) {
+                    $body += "&code_verifier=$($WebEvent.Session.Data['__pode_oauth_code_verifier__'])"
+                }
+
+                # if there's an inner scheme, get the username/password, and set query
+                if ($hasInnerScheme) {
+                    $body += "&username=$($schemes[-1][0])"
+                    $body += "&password=$($schemes[-1][1])"
+                    $body += "&scope=$([System.Web.HttpUtility]::UrlEncode($scopes))"
+                }
+
+                # otherwise, set query for auth_code
+                else {
+                    $redirectUrl = Get-PodeOAuth2RedirectHost -RedirectUrl $options.Urls.Redirect
+                    $body += "&code=$($WebEvent.Query['code'])"
+                    $body += "&redirect_uri=$([System.Web.HttpUtility]::UrlEncode($redirectUrl))"
+                }
+
+                # POST the tokenUrl
+                try {
+                    $result = Invoke-RestMethod -Method Post -Uri $options.Urls.Token -Body $body -ContentType 'application/x-www-form-urlencoded' -ErrorAction Stop
+                }
+                catch [System.Net.WebException], [System.Net.Http.HttpRequestException] {
+                    $response = Read-PodeWebExceptionDetails -ErrorRecord $_
+                    $result = ($response.Body | ConvertFrom-Json)
+                }
+
+                # was there an error?
+                if (![string]::IsNullOrWhiteSpace($result.error)) {
+                    return @{
+                        Message = "$($result.error): $($result.error_description)"
+                        Code = 401
+                    }
+                }
+
+                # get user details - if url supplied
+                if (![string]::IsNullOrWhiteSpace($options.Urls.User.Url)) {
+                    try {
+                        $user = Invoke-RestMethod -Method $options.Urls.User.Method -Uri $options.Urls.User.Url -Headers @{ Authorization = "Bearer $($result.access_token)" }
+                    }
+                    catch [System.Net.WebException], [System.Net.Http.HttpRequestException] {
+                        $response = Read-PodeWebExceptionDetails -ErrorRecord $_
+                        $user = ($response.Body | ConvertFrom-Json)
+                    }
+
+                    if (![string]::IsNullOrWhiteSpace($user.error)) {
+                        return @{
+                            Message = "$($user.error): $($user.error_description)"
+                            Code = 401
+                        }
+                    }
+                }
+                elseif (![string]::IsNullOrWhiteSpace($result.id_token)) {
+                    try {
+                        $user = ConvertFrom-PodeJwt -Token $result.id_token -IgnoreSignature
+                    }
+                    catch {
+                        $user = @{ Provider = 'OAuth2' }
+                    }
+                }
+                else {
                     $user = @{ Provider = 'OAuth2' }
                 }
-            }
-            else {
-                $user = @{ Provider = 'OAuth2' }
-            }
 
-            # return the user for the validator
-            return @($user, $result.access_token, $result.refresh_token, $result)
+                # return the user for the validator
+                return @($user, $result.access_token, $result.refresh_token, $result)
+            }
+            finally {
+                if ($null -ne $WebEvent.Session.Data) {
+                    # clear state
+                    $WebEvent.Session.Data.Remove('__pode_oauth_state__')
+
+                    # clear PKCE
+                    if ($options.UsePKCE) {
+                        $WebEvent.Session.Data.Remove('__pode_oauth_code_verifier__')
+                    }
+                }
+            }
         }
 
         # redirect to the authUrl - only if no inner scheme supplied
@@ -192,9 +208,17 @@ function Get-PodeAuthOAuth2Type
             $query += "&response_mode=query"
             $query += "&scope=$([System.Web.HttpUtility]::UrlEncode($scopes))"
 
+            # add csrf state
+            if (Test-PodeSessionsInUse) {
+                $guid = New-PodeGuid
+                $WebEvent.Session.Data['__pode_oauth_state__'] = $guid
+                $query += "&state=$($guid)"
+            }
+
             # build a code verifier for PKCE, and add to query
             if ($options.UsePKCE) {
-                $codeVerifier = New-PodeGuid -Secure
+                $guid = New-PodeGuid
+                $codeVerifier = "$($guid)-$($guid)"
                 $WebEvent.Session.Data['__pode_oauth_code_verifier__'] = $codeVerifier
 
                 $codeChallenge = ConvertTo-PodeBase64UrlValue -Value (Invoke-PodeSHA256Hash -Value $codeVerifier) -NoConvert
@@ -1039,7 +1063,7 @@ function Get-PodeAuthMiddlewareScript
 
         # route options for using sessions
         $sessionless = $auth.Sessionless
-        $usingSessions = (!(Test-PodeIsEmpty $WebEvent.Session))
+        $usingSessions = (Test-PodeSessionsInUse)
         $useHeaders = [bool]($WebEvent.Session.Properties.UseHeaders)
         $loginRoute = $opts.Login
 

--- a/src/Private/Cryptography.ps1
+++ b/src/Private/Cryptography.ps1
@@ -308,17 +308,17 @@ function New-PodeJwtSignature
     switch ($Algorithm.ToUpperInvariant()) {
         'HS256' {
             $sig = Invoke-PodeHMACSHA256Hash -Value $Token -SecretBytes $SecretBytes
-            $sig = ConvertTo-PodeJwtBase64Value -Value $sig -NoConvert
+            $sig = ConvertTo-PodeBase64UrlValue -Value $sig -NoConvert
         }
 
         'HS384' {
             $sig = Invoke-PodeHMACSHA384Hash -Value $Token -SecretBytes $SecretBytes
-            $sig = ConvertTo-PodeJwtBase64Value -Value $sig -NoConvert
+            $sig = ConvertTo-PodeBase64UrlValue -Value $sig -NoConvert
         }
 
         'HS512' {
             $sig = Invoke-PodeHMACSHA512Hash -Value $Token -SecretBytes $SecretBytes
-            $sig = ConvertTo-PodeJwtBase64Value -Value $sig -NoConvert
+            $sig = ConvertTo-PodeBase64UrlValue -Value $sig -NoConvert
         }
 
         'NONE' {
@@ -333,7 +333,7 @@ function New-PodeJwtSignature
     return $sig
 }
 
-function ConvertTo-PodeJwtBase64Value
+function ConvertTo-PodeBase64UrlValue
 {
     param(
         [Parameter(Mandatory=$true)]

--- a/src/Private/Sessions.ps1
+++ b/src/Private/Sessions.ps1
@@ -328,6 +328,11 @@ function Test-PodeSessionsConfigured
     return (($null -ne $PodeContext.Server.Sessions) -and ($PodeContext.Server.Sessions.Count -gt 0))
 }
 
+function Test-PodeSessionsInUse
+{
+    return (($null -ne $WebEvent.Session) -and ($WebEvent.Session.Count -gt 0))
+}
+
 function Get-PodeSessionData
 {
     param(

--- a/src/Public/Authentication.ps1
+++ b/src/Public/Authentication.ps1
@@ -597,9 +597,6 @@ The Client Secret from registering a new app (this is optional when using PKCE).
 .PARAMETER RedirectUrl
 An optional OAuth2 Redirect URL (default: <host>/oauth2/callback)
 
-.PARAMETER InnerScheme
-An optional authentication Scheme (from New-PodeAuthScheme) that will be called prior to this Scheme.
-
 .PARAMETER Middleware
 An array of ScriptBlocks for optional Middleware to run before the Scheme's scriptblock.
 
@@ -625,10 +622,6 @@ function New-PodeAuthTwitterScheme
         [string]
         $RedirectUrl,
 
-        [Parameter(ValueFromPipeline=$true)]
-        [hashtable]
-        $InnerScheme,
-
         [Parameter()]
         [object[]]
         $Middleware,
@@ -646,7 +639,6 @@ function New-PodeAuthTwitterScheme
         -UserUrl "https://api.twitter.com/2/users/me" `
         -UserUrlMethod 'Get' `
         -RedirectUrl $RedirectUrl `
-        -InnerScheme $InnerScheme `
         -Middleware $Middleware `
         -Scope 'tweet.read', 'users.read' `
         -UsePKCE:$UsePKCE)


### PR DESCRIPTION
### Description of the Change
Adds PKCE support for OAuth2 authentication (including on Azure AD, and a new inbuilt Twitter OAuth2 scheme).

To use PKCE sessions need to be enabled, as the code_verified is cached temporarily in the session between redirects. If PKCE is used, then the Client Secret is optional. The app in the OAuth provider also need to be flagged as a "Single page app".

To use PKCE, a new `-UsePKCE` switch is now on `New-PodeAuthScheme`, including `New-PodeAuthAzureADScheme` and `New-PodeAuthTwitterScheme`.

### Related Issue
Resolves #867 

### Examples
```powershell
Start-PodeServer {
    $scheme = New-PodeAuthScheme `
        -OAuth2 `
        -ClientID '<clientId>' `
        -AuthoriseUrl 'https://some-service.com/oauth2/authorize' `
        -TokenUrl 'https://some-service.com/oauth2/token' `
        -UsePKCE
    $scheme | Add-PodeAuth -Name 'Login' -FailureUrl '/login' -SuccessUrl '/' -ScriptBlock {
        param($user, $accessToken, $refreshToken, $response)
        # check if the user is valid
        return @{ User = $user }
    }
}
```
