### PR TITLE
Adds support for building OAuth2 schemes from OIDC Discovery URLs

### DIFF
--- a/docs/Tutorials/Authentication/Methods/OAuth2.md
+++ b/docs/Tutorials/Authentication/Methods/OAuth2.md
@@ -163,12 +163,12 @@ For example, if you were using Google OAuth2 with PKCE, then the following examp
 $scheme = ConvertFrom-PodeOIDCDiscovery -Url 'https://accounts.google.com' -ClientId '<client_id>' -UsePKCE
 
 $scheme | Add-PodeAuth -Name 'Login' -FailureUrl '/login' -SuccessUrl '/' -ScriptBlock {
-        param($user, $accessToken, $refreshToken, $response)
+    param($user, $accessToken, $refreshToken, $response)
 
-        # check if the user is valid
+    # check if the user is valid
 
-        return @{ User = $user }
-    }
+    return @{ User = $user }
+}
 ```
 
 If the `-Url` supplied doesn't end with `/.well-known/openid-configuration`, then Pode will append it to the URL automatically.

--- a/docs/Tutorials/Authentication/Methods/OAuth2.md
+++ b/docs/Tutorials/Authentication/Methods/OAuth2.md
@@ -1,8 +1,8 @@
-# OAuth2
+# OAuth 2.0 & OIDC
 
-The OAuth2 authentication lets you setup authentication with other services that support OAuth2.
+The OAuth2 authentication lets you setup authentication with services that support OAuth 2.0.
 
-To use this scheme, you'll need to supply an Authorise/Token URL, as well as setup a app registration to acquire a Client ID and Secret.
+To use this scheme, you'll need to supply an Authorise/Token URL, as well as setup a app registration to acquire a Client ID and Secret. There is also support for converting an OpenID Connect Discovery URL to a Pode OAuth2 scheme.
 
 ## Setup
 
@@ -152,6 +152,26 @@ Start-PodeServer {
     }
 }
 ```
+
+## OIDC Discovery
+
+If the provider you're wanting to use OAuth2 for supports OpenID Connect Discovery, and has an appropriate `/.well-known/openid-configuration` endpoint, then you can use this with [`ConvertFrom-PodeOIDCDiscovery`](../../../../Functions/Authentication/ConvertFrom-PodeOIDCDiscovery) to automatically build a Pode OAuth2 scheme.
+
+For example, if you were using Google OAuth2 with PKCE, then the following example would build an OAuth2 scheme:
+
+```powershell
+$scheme = ConvertFrom-PodeOIDCDiscovery -Url 'https://accounts.google.com' -ClientId '<client_id>' -UsePKCE
+
+$scheme | Add-PodeAuth -Name 'Login' -FailureUrl '/login' -SuccessUrl '/' -ScriptBlock {
+        param($user, $accessToken, $refreshToken, $response)
+
+        # check if the user is valid
+
+        return @{ User = $user }
+    }
+```
+
+If the `-Url` supplied doesn't end with `/.well-known/openid-configuration`, then Pode will append it to the URL automatically.
 
 ## Full Example
 

--- a/examples/web-auth-oauth2-oidc.ps1
+++ b/examples/web-auth-oauth2-oidc.ps1
@@ -5,12 +5,12 @@ Import-Module "$($path)/src/Pode.psm1" -Force -ErrorAction Stop
 # Import-Module Pode
 
 <#
-This examples shows how to use session persistant authentication using Azure AD and OAuth2
+This examples shows how to use session persistant authentication using Google Cloud and OpenID Connect Discovery
 
-Navigating to the 'http://localhost:8085' endpoint in your browser will auto-rediect you to Azure.
-There, login to Azure and you'll be redirected back to the home page
+Navigating to the 'http://localhost:8085' endpoint in your browser will auto-rediect you to Google.
+There, login to Google account and you'll be redirected back to the home page
 
-Note: You'll need to register a new app in Azure, and note you clientId, secret, and tenant
+Note: You'll need to register a new project/app in Google Cloud, and note your clientId and secret
       in the variables below.
 #>
 
@@ -27,12 +27,12 @@ Start-PodeServer -Threads 2 {
     # setup session details
     Enable-PodeSessionMiddleware -Duration 120 -Extend
 
-    # setup auth against Azure AD (the following are from registering an app in the portal)
+    # setup auth against Google Cloud (the following are from registering an app in the portal)
     $clientId = '<client-id-from-portal>'
     $clientSecret = '<client-secret-from-portal>'
-    $tenantId = '<tenant-from-portal>'
+    $url = 'https://accounts.google.com/.well-known/openid-configuration'
 
-    $scheme = New-PodeAuthAzureADScheme -Tenant $tenantId -ClientId $clientId -ClientSecret $clientSecret
+    $scheme = ConvertFrom-PodeOIDCDiscovery -Url $url -ClientId $clientId -ClientSecret $clientSecret
     $scheme | Add-PodeAuth -Name 'Login' -FailureUrl '/login' -SuccessUrl '/' -ScriptBlock {
         param($user, $accessToken, $refreshToken)
         return @{ User = $user }
@@ -51,7 +51,7 @@ Start-PodeServer -Threads 2 {
     }
 
 
-    # login - this will just redirect to azure
+    # login - this will just redirect to google
     Add-PodeRoute -Method Get -Path '/login' -Authentication Login
 
 

--- a/src/Pode.psd1
+++ b/src/Pode.psd1
@@ -200,6 +200,7 @@
         'ConvertTo-PodeJwt',
         'ConvertFrom-PodeJwt',
         'Use-PodeAuth',
+        'ConvertFrom-PodeOIDCDiscovery',
 
         # logging
         'New-PodeLoggingMethod',

--- a/src/Private/Authentication.ps1
+++ b/src/Private/Authentication.ps1
@@ -86,6 +86,7 @@ function Get-PodeAuthOAuth2Type
             return @{
                 Message = $WebEvent.Query['error']
                 Code = 401
+                IsErrored = $true
             }
         }
 
@@ -104,6 +105,7 @@ function Get-PodeAuthOAuth2Type
                     return @{
                         Message = "OAuth2 state returned is invalid"
                         Code = 401
+                        IsErrored = $true
                     }
                 }
 
@@ -148,6 +150,7 @@ function Get-PodeAuthOAuth2Type
                     return @{
                         Message = "$($result.error): $($result.error_description)"
                         Code = 401
+                        IsErrored = $true
                     }
                 }
 
@@ -165,6 +168,7 @@ function Get-PodeAuthOAuth2Type
                         return @{
                             Message = "$($user.error): $($user.error_description)"
                             Code = 401
+                            IsErrored = $true
                         }
                     }
                 }
@@ -245,7 +249,11 @@ function Get-PodeAuthOAuth2Type
         }
 
         # hmm, this is unexpected
-        return @{ Code = 500 }
+        return @{
+            Message = 'Well, this is awkward...'
+            Code = 500
+            IsErrored = $true
+        }
     }
 }
 
@@ -1211,6 +1219,7 @@ function Get-PodeAuthMiddlewareScript
                 }
             }
 
+            $isErrored = [bool]$result.IsErrored
             return (Set-PodeAuthStatus `
                 -StatusCode $_code `
                 -Description $result.Message `
@@ -1218,7 +1227,8 @@ function Get-PodeAuthMiddlewareScript
                 -Failure $auth.Failure `
                 -Success $auth.Success `
                 -LoginRoute:$loginRoute `
-                -Sessionless:$sessionless)
+                -Sessionless:$sessionless `
+                -NoFailureRedirect:$isErrored)
         }
 
         # assign the user to the session, and wire up a quick method
@@ -1308,7 +1318,10 @@ function Set-PodeAuthStatus
         $Sessionless,
 
         [switch]
-        $NoSuccessRedirect
+        $NoSuccessRedirect,
+
+        [switch]
+        $NoFailureRedirect
     )
 
     # if we have any headers, set them
@@ -1330,7 +1343,7 @@ function Set-PodeAuthStatus
         }
 
         # check if we have a failure url redirect
-        if (![string]::IsNullOrWhiteSpace($Failure.Url)) {
+        if (!$NoFailureRedirect -and ![string]::IsNullOrWhiteSpace($Failure.Url)) {
             if ($Success.UseOrigin -and ($WebEvent.Method -ieq 'get')) {
                 Set-PodeCookie -Name 'pode.redirecturl' -Value $WebEvent.Request.Url.PathAndQuery
             }

--- a/src/Public/Authentication.ps1
+++ b/src/Public/Authentication.ps1
@@ -1808,6 +1808,9 @@ If supplied, OAuth2 authentication will use PKCE code verifiers.
 
 .EXAMPLE
 ConvertFrom-PodeOIDCDiscovery -Url 'https://accounts.google.com/.well-known/openid-configuration' -ClientId some_id -UsePKCE
+
+.EXAMPLE
+ConvertFrom-PodeOIDCDiscovery -Url 'https://accounts.google.com' -ClientId some_id -UsePKCE
 #>
 function ConvertFrom-PodeOIDCDiscovery
 {

--- a/src/Public/Authentication.ps1
+++ b/src/Public/Authentication.ps1
@@ -1825,7 +1825,7 @@ function ConvertFrom-PodeOIDCDiscovery
         [string]
         $ClientId,
 
-        [Parameter(Mandatory=$true)]
+        [Parameter()]
         [string]
         $ClientSecret,
 


### PR DESCRIPTION
### Description of the Change
Adds support for building an OAuth2 scheme in Pode from an OpenID Connect Discovery URL via `ConvertFrom-PodeOIDCDiscovery`.

The `-Url` should end with `/.well-known/openid-configuration`, if not then Pode will automatically append it.

This will get the authorise, token and userinfo URLs, as well as scopes, code_verify hashing methods (if `-UsePKCE` is supplied), and checks response_types and grant_types.

### Related Issue
Resolves #868 

### Examples
```powershell
$scheme = ConvertFrom-PodeOIDCDiscovery -Url 'https://accounts.google.com' -ClientId '<client_id>' -UsePKCE

$scheme | Add-PodeAuth -Name 'Login' -FailureUrl '/login' -SuccessUrl '/' -ScriptBlock {
    param($user, $accessToken, $refreshToken, $response)

    # check if the user is valid

    return @{ User = $user }
}
```
