### PR TITLE
Add helper functions for adding security headers

### DIFF
--- a/docs/Tutorials/Middleware/Overview.md
+++ b/docs/Tutorials/Middleware/Overview.md
@@ -88,15 +88,17 @@ Although you can define your own custom middleware, Pode does have some inbuilt 
 
 | Order | Middleware | Description |
 | ----- | ---------- | ----------- |
-| 1 | **Access Rules** | Allowing/Denying IP addresses (if access rules have been defined) |
-| 2 | **Rate Limiting** | Limiting access to IP addresses (if rate limiting rules have been defined) |
-| 3 | **Static Content** | Static Content, such as images/css/js/html, in the `/public` directory |
-| 4 | **Body Parsing** | Parsing request payload as JSON, XML, or other types |
-| 5 | **Query String** | Getting any query string parameters currently on the request URL |
-| 6 | **Cookie Parsing** | Parse the cookies from the request's header (this only applies to serverless) |
-| 7 | **Custom Middleware** | Runs any defined user defined global Middleware in the order it was created |
-| 8 | **Route Middleware** | Runs any Route level Middleware for the current Route being processed |
-| 9 | **Route** | Finally, the route itself is processed |
+| 1 | **Security Headers** | Add any defined security headers onto the response |
+| 2 | **Access Rules** | Allowing/Denying IP addresses (if access rules have been defined) |
+| 3 | **Rate Limiting** | Limiting access to IP addresses (if rate limiting rules have been defined) |
+| 4 | **Static Content** | Static Content, such as images/css/js/html, in the `/public` directory |
+| 5 | **Body Parsing** | Parsing request payload as JSON, XML, or other types |
+| 6 | **Query String** | Getting any query string parameters currently on the request URL |
+| 7 | **Cookie Parsing** | Parse the cookies from the request's header (this only applies to serverless) |
+| 8 | **Custom Middleware** | Runs any defined user defined global Middleware in the order it was created |
+| 9 | **Route Middleware** | Runs any Route level Middleware for the current Route being processed |
+| 10 | **Route** | Then, the route itself is processed |
+| 11 | **Endware** | Finally, any Endware configured is run |
 
 ## Overriding Inbuilt
 
@@ -108,6 +110,7 @@ Pode has inbuilt Middleware as defined in the order of running above. Sometimes 
 * Body Parsing      - `__pode_mw_body_parsing__`
 * Query String      - `__pode_mw_query_parsing__`
 * Cookie Parsing    - `__pode_mw_cookie_parsing__`
+* Security Headers  - `__pode_mw_security__`
 
 The following example uses rate limiting, and defines Middleware that will override the inbuilt rate limiting logic:
 

--- a/docs/Tutorials/Middleware/Types/Security.md
+++ b/docs/Tutorials/Middleware/Types/Security.md
@@ -91,8 +91,8 @@ Conversely, you could remove the header completely using [`Remove-PodeSecurityCo
 
 The following functions exist:
 
-* [`Set-PodeSecurityAccessControl`]
-* [`Remove-PodeSecurityAccessControl`]
+* [`Set-PodeSecurityAccessControl`](../../../../Functions/Security/Set-PodeSecurityAccessControl)
+* [`Remove-PodeSecurityAccessControl`](../../../../Functions/Security/Remove-PodeSecurityAccessControl)
 
 Specifies the values for the following headers:
 
@@ -111,8 +111,8 @@ Set-PodeSecurityAccessControl -Origin '*' -Methods '*' -Headers '*' -Duration 72
 
 The following functions exist:
 
-* [`Set-PodeSecurityCrossOrigin`]
-* [`Remove-PodeSecurityCrossOrigin`]
+* [`Set-PodeSecurityCrossOrigin`](../../../../Functions/Security/Set-PodeSecurityCrossOrigin)
+* [`Remove-PodeSecurityCrossOrigin`](../../../../Functions/Security/Remove-PodeSecurityCrossOrigin)
 
 Specifies the values for the following headers:
 
@@ -130,8 +130,8 @@ Set-PodeSecurityCrossOrigin -Embed Require-Corp -Open Same-Origin -Resource Same
 
 The following functions exist:
 
-* [`Set-PodeSecurityStrictTransportSecurity`]
-* [`Remove-PodeSecurityStrictTransportSecurity`]
+* [`Set-PodeSecurityStrictTransportSecurity`](../../../../Functions/Security/Set-PodeSecurityStrictTransportSecurity)
+* [`Remove-PodeSecurityStrictTransportSecurity`](../../../../Functions/Security/Remove-PodeSecurityStrictTransportSecurity)
 
 The `Strict-Transport-Security` header enforces the use of HTTPS from the browser. For example:
 
@@ -143,9 +143,9 @@ Set-PodeSecurityStrictTransportSecurity -Duration 31536000 -IncludeSubDomains
 
 The following functions exist:
 
-* [`Add-PodeSecurityContentSecurityPolicy`]
-* [`Set-PodeSecurityContentSecurityPolicy`]
-* [`Remove-PodeSecurityContentSecurityPolicy`]
+* [`Add-PodeSecurityContentSecurityPolicy`](../../../../Functions/Security/Add-PodeSecurityContentSecurityPolicy)
+* [`Set-PodeSecurityContentSecurityPolicy`](../../../../Functions/Security/Set-PodeSecurityContentSecurityPolicy)
+* [`Remove-PodeSecurityContentSecurityPolicy`](../../../../Functions/Security/Remove-PodeSecurityContentSecurityPolicy)
 
 The `Content-Security-Policy` header controls a whitelist of approved sourced from which the browser can load resoures. For example:
 
@@ -157,8 +157,8 @@ Set-PodeSecurityContentSecurityPolicy -Default 'self' -Image 'self', 'data'
 
 The following functions exist:
 
-* [`Set-PodeSecurityPermissionsPolicy`]
-* [`Remove-PodeSecurityPermissionsPolicy`]
+* [`Set-PodeSecurityPermissionsPolicy`](../../../../Functions/Security/Set-PodeSecurityPermissionsPolicy)
+* [`Remove-PodeSecurityPermissionsPolicy`](../../../../Functions/Security/Remove-PodeSecurityPermissionsPolicy)
 
 The `Permissions-Policy` header controls which features/APIs a site can use in the browser. For example:
 
@@ -170,8 +170,8 @@ Set-PodeSecurityPermissionsPolicy -LayoutAnimations 'none' -UnoptimisedImages 'n
 
 The following functions exist:
 
-* [`Set-PodeSecurityFrameOptions`]
-* [`Remove-PodeSecurityFrameOptions`]
+* [`Set-PodeSecurityFrameOptions`](../../../../Functions/Security/Set-PodeSecurityFrameOptions)
+* [`Remove-PodeSecurityFrameOptions`](../../../../Functions/Security/Remove-PodeSecurityFrameOptions)
 
 The `X-Frame-Options` header tells the browser whether your site support framing or not. For example:
 
@@ -183,8 +183,8 @@ Set-PodeSecurityFrameOptions -Type SameOrigin
 
 The following functions exist:
 
-* [`Set-PodeSecurityContentTypeOptions`]
-* [`Remove-PodeSecurityContentTypeOptions`]
+* [`Set-PodeSecurityContentTypeOptions`](../../../../Functions/Security/Set-PodeSecurityContentTypeOptions)
+* [`Remove-PodeSecurityContentTypeOptions`](../../../../Functions/Security/Remove-PodeSecurityContentTypeOptions)
 
 The `Content-Type-Options` header only has one value: `nosniff`. So you enable, you just need to call the Set function, for example:
 
@@ -196,8 +196,8 @@ Set-PodeSecurityContentTypeOptions
 
 The following functions exist:
 
-* [`Set-PodeSecurityReferrerPolicy`]
-* [`Remove-PodeSecurityReferrerPolicy`]
+* [`Set-PodeSecurityReferrerPolicy`](../../../../Functions/Security/Set-PodeSecurityReferrerPolicy)
+* [`Remove-PodeSecurityReferrerPolicy`](../../../../Functions/Security/Remove-PodeSecurityReferrerPolicy)
 
 The `Referrer-Policy` header tells the browser how much information to include in the `Referer` header. For example:
 

--- a/docs/Tutorials/Middleware/Types/Security.md
+++ b/docs/Tutorials/Middleware/Types/Security.md
@@ -1,0 +1,214 @@
+# Security Headers
+
+The security headers middleware runs at the beginning of every request, and if any security headers are defined they will be added onto the response.
+
+The following headers are currently supported, but you can add custom header values:
+
+* Access-Control-Max-Age
+* Access-Control-Allow-Methods
+* Access-Control-Allow-Origin
+* Access-Control-Allow-Headers
+* Cross-Origin-Embedder-Policy
+* Cross-Origin-Resource-Policy
+* Cross-Origin-Opener-Policy
+* Strict-Transport-Security
+* Content-Security-Policy
+* X-XSS-Protection
+* Permissions-Policy
+* X-Frame-Options
+* X-Content-Type-Options
+* Referrer-Policy
+
+## Types
+
+Pode has an inbuilt wrapper to easily toggle all headers with default values: [`Set-PodeSecurity`](../../../../Functions/Security/Set-PodeSecurity). This function lets you specify a `-Type` of either `Simple` or `Strict`. The specified value will setup the headers with the default values defined below. You can also force `X-XSS-Protection` to use blocking mode if you want to support older browsers, or enable `Strict-Transport-Security` via `-UseHsts`.
+
+For example, to configure Simple security with Strict Transport:
+
+```powershell
+Set-PodeSecurity -Type Simple -UseHsts
+```
+
+To remove all configured values, use [`Remove-PodeSecurity`](../../../../Functions/Security/Remove-PodeSecurity).
+
+### Simple
+
+The following values are used for each header when the `Simple` type is supplied:
+
+| Name | Value |
+| ---- | ----- |
+| Access-Control-Max-Age | 7200 |
+| Access-Control-Allow-Origin | * |
+| Access-Control-Allow-Methods | * |
+| Access-Control-Allow-Headers | * |
+| Cross-Origin-Embedder-Policy | require-corp |
+| Cross-Origin-Resource-Policy | same-origin |
+| Cross-Origin-Opener-Policy | same-origin |
+| Content-Security-Policy | default-src 'self' |
+| X-XSS-Protection | 0 |
+| Permissions-Policy | layout-animations=(), oversized-images=(), sync-xhr=(), unoptimized-images=(), unsized-media=() |
+| X-Frame-Options | SAMEORIGIN |
+| X-Content-Type-Options | nosniff |
+| Referred-Policy | strict-origin |
+
+### Strict
+
+The following values are used for each header when the `Strict` type is supplied:
+
+| Name | Value |
+| ---- | ----- |
+| Access-Control-Max-Age | 7200 |
+| Access-Control-Allow-Methods | * |
+| Access-Control-Allow-Origin | * |
+| Access-Control-Allow-Headers | * |
+| Cross-Origin-Embedder-Policy | require-corp |
+| Cross-Origin-Resource-Policy | same-origin |
+| Cross-Origin-Opener-Policy | same-origin |
+| Strict-Transport-Security | max-age=31536000; includeSubDomains |
+| Content-Security-Policy | default-src 'self' |
+| X-XSS-Protection | 0 |
+| Permissions-Policy | layout-animations=(), oversized-images=(), sync-xhr=(), unoptimized-images=(), unsized-media=() |
+| X-Frame-Options | DENY |
+| X-Content-Type-Options | nosniff |
+| Referred-Policy | no-referrer |
+
+## Headers
+
+You can setup the values of headers individually by using their relevant functions.
+
+You can also use [`Set-PodeSecurity`](../../../../Functions/Security/Set-PodeSecurity) to configure all the defaults, and then set/add custom values for a single header. For example, you can configure Simple values, and then add `*.twitter.com` to the `default-src` of the `Content-Security-Policy` header using [`Add-PodeSecurityContentSecurityPolicy`](../../../../Functions/Security/Add-PodeSecurityContentSecurityPolicy):
+
+```powershell
+Set-PodeSecurity -Type Simple
+Add-PodeSecurityContentSecurityPolicy -Default '*.twitter.com'
+```
+
+This will make the 'default-src' value: `'self' *.twitter.com`.
+
+Conversely, you could remove the header completely using [`Remove-PodeSecurityContentSecurityPolicy`](../../../../Functions/Security/Remove-PodeSecurityContentSecurityPolicy), or override the whole value using [`Set-PodeSecurityContentSecurityPolicy`](../../../../Functions/Security/Set-PodeSecurityContentSecurityPolicy).
+
+### Access Control
+
+The following functions exist:
+
+* [`Set-PodeSecurityAccessControl`]
+* [`Remove-PodeSecurityAccessControl`]
+
+Specifies the values for the following headers:
+
+* Access-Control-Max-Age
+* Access-Control-Allow-Methods
+* Access-Control-Allow-Origin
+* Access-Control-Allow-Headers
+
+For example:
+
+```powershell
+Set-PodeSecurityAccessControl -Origin '*' -Methods '*' -Headers '*' -Duration 7200
+```
+
+### Cross Origin
+
+The following functions exist:
+
+* [`Set-PodeSecurityCrossOrigin`]
+* [`Remove-PodeSecurityCrossOrigin`]
+
+Specifies the values for the following headers:
+
+* Cross-Origin-Embedder-Policy
+* Cross-Origin-Resource-Policy
+* Cross-Origin-Opener-Policy
+
+For example:
+
+```powershell
+Set-PodeSecurityCrossOrigin -Embed Require-Corp -Open Same-Origin -Resource Same-Origin
+```
+
+### Strict Transport
+
+The following functions exist:
+
+* [`Set-PodeSecurityStrictTransportSecurity`]
+* [`Remove-PodeSecurityStrictTransportSecurity`]
+
+The `Strict-Transport-Security` header enforces the use of HTTPS from the browser. For example:
+
+```powershell
+Set-PodeSecurityStrictTransportSecurity -Duration 31536000 -IncludeSubDomains
+```
+
+### Content Security
+
+The following functions exist:
+
+* [`Add-PodeSecurityContentSecurityPolicy`]
+* [`Set-PodeSecurityContentSecurityPolicy`]
+* [`Remove-PodeSecurityContentSecurityPolicy`]
+
+The `Content-Security-Policy` header controls a whitelist of approved sourced from which the browser can load resoures. For example:
+
+```powershell
+Set-PodeSecurityContentSecurityPolicy -Default 'self' -Image 'self', 'data'
+```
+
+### Permissions Policy
+
+The following functions exist:
+
+* [`Set-PodeSecurityPermissionsPolicy`]
+* [`Remove-PodeSecurityPermissionsPolicy`]
+
+The `Permissions-Policy` header controls which features/APIs a site can use in the browser. For example:
+
+```powershell
+Set-PodeSecurityPermissionsPolicy -LayoutAnimations 'none' -UnoptimisedImages 'none' -OversizedImages 'none' -SyncXhr 'none' -UnsizedMedia 'none'
+```
+
+### Frame Options
+
+The following functions exist:
+
+* [`Set-PodeSecurityFrameOptions`]
+* [`Remove-PodeSecurityFrameOptions`]
+
+The `X-Frame-Options` header tells the browser whether your site support framing or not. For example:
+
+```powershell
+Set-PodeSecurityFrameOptions -Type SameOrigin
+```
+
+### ContentType Options
+
+The following functions exist:
+
+* [`Set-PodeSecurityContentTypeOptions`]
+* [`Remove-PodeSecurityContentTypeOptions`]
+
+The `Content-Type-Options` header only has one value: `nosniff`. So you enable, you just need to call the Set function, for example:
+
+```powershell
+Set-PodeSecurityContentTypeOptions
+```
+
+### Referrer Policy
+
+The following functions exist:
+
+* [`Set-PodeSecurityReferrerPolicy`]
+* [`Remove-PodeSecurityReferrerPolicy`]
+
+The `Referrer-Policy` header tells the browser how much information to include in the `Referer` header. For example:
+
+```powershell
+Set-PodeSecurityReferrerPolicy -Type Strict-Origin
+```
+
+## Custom
+
+There could be some headers for security that Pode doesn't support, but that you need. In this case you can use [`Add-PodeSecurityHeader`](../../../../Functions/Security/Add-PodeSecurityHeader) to specify a custom header and value that will be added:
+
+```powershell
+Add-PodeSecurityHeader -Name 'X-Security-Header' -Value 'Value'
+```

--- a/docs/Tutorials/OpenAPI.md
+++ b/docs/Tutorials/OpenAPI.md
@@ -312,11 +312,11 @@ Properties are used to create all Parameters and Schemas in OpenAPI. You can use
 
 There are 5 simple property types: Integers, Numbers, Strings, Booleans, and Schemas. Each of which can be created using the following functions:
 
-* [`New-PodeOAIntProperty`]
-* [`New-PodeOANumberProperty`]
-* [`New-PodeOAStringProperty`]
-* [`New-PodeOABoolProperty`]
-* [`New-PodeOASchemaProperty`]
+* [`New-PodeOAIntProperty`](../../Functions/OpenApi/New-PodeOAIntProperty)
+* [`New-PodeOANumberProperty`](../../Functions/OpenApi/New-PodeOANumberProperty)
+* [`New-PodeOAStringProperty`](../../Functions/OpenApi/New-PodeOAStringProperty)
+* [`New-PodeOABoolProperty`](../../Functions/OpenApi/New-PodeOABoolProperty)
+* [`New-PodeOASchemaProperty`](../../Functions/OpenApi/New-PodeOASchemaProperty)
 
 These properties can be created with a Name, and other flags such as Required and/or a Description:
 

--- a/pode.build.ps1
+++ b/pode.build.ps1
@@ -321,11 +321,11 @@ task DocsHelpBuild DocsDeps, {
         $content = (Get-Content -Path $_.FullName | ForEach-Object {
             $line = $_
 
-            while ($line -imatch '\[`(?<name>[a-z]+\-pode[a-z]+)`\](?<char>[^(])') {
+            while ($line -imatch '\[`(?<name>[a-z]+\-pode[a-z]+)`\](?<char>([^(]|$))') {
                 $updated = $true
                 $name = $Matches['name']
                 $char = $Matches['char']
-                $line = ($line -ireplace "\[``$($name)``\][^(]", "[``$($name)``]($('../' * $depth)Functions/$($map[$name])/$($name))$($char)")
+                $line = ($line -ireplace "\[``$($name)``\]([^(]|$)", "[``$($name)``]($('../' * $depth)Functions/$($map[$name])/$($name))$($char)")
             }
 
             $line

--- a/src/Pode.psd1
+++ b/src/Pode.psd1
@@ -58,11 +58,11 @@
 
         # headers
         'Add-PodeHeader',
-        'Add-PodeHeaderByHashtable',
+        'Add-PodeHeaderBulk',
         'Test-PodeHeader',
         'Get-PodeHeader',
         'Set-PodeHeader',
-        'Set-PodeHeaderByHashtable',
+        'Set-PodeHeaderBulk',
         'Test-PodeHeaderSigned',
 
         # state
@@ -272,6 +272,8 @@
 
         # Security
         'Add-PodeSecurityHeader',
+        'Add-PodeSecurityContentSecurityPolicy',
+        'Add-PodeSecurityPermissionPolicy',
         'Remove-PodeSecurity',
         'Remove-PodeSecurityAccessControl',
         'Remove-PodeSecurityContentSecurityPolicy',

--- a/src/Pode.psd1
+++ b/src/Pode.psd1
@@ -11,7 +11,7 @@
     RootModule = 'Pode.psm1'
 
     # Version number of this module.
-    ModuleVersion = '2.6.0' #$version$'
+    ModuleVersion = '$version$'
 
     # ID used to uniquely identify this module
     GUID = 'e3ea217c-fc3d-406b-95d5-4304ab06c6af'

--- a/src/Pode.psd1
+++ b/src/Pode.psd1
@@ -266,7 +266,29 @@
         'Test-PodeEvent',
         'Get-PodeEvent',
         'Clear-PodeEvent',
-        'Use-PodeEvents'
+        'Use-PodeEvents',
+
+        # Security
+        'Add-PodeSecurityHeader',
+        'Remove-PodeSecurity',
+        'Remove-PodeSecurityAccessControl',
+        'Remove-PodeSecurityContentSecurityPolicy',
+        'Remove-PodeSecurityContentTypeOptions',
+        'Remove-PodeSecurityCrossOrigin',
+        'Remove-PodeSecurityFrameOptions',
+        'Remove-PodeSecurityHeader',
+        'Remove-PodeSecurityPermissionPolicy',
+        'Remove-PodeSecurityReferrerPolicy',
+        'Remove-PodeSecurityStrictTransportSecurity',
+        'Set-PodeSecurity',
+        'Set-PodeSecurityAccessControl',
+        'Set-PodeSecurityContentSecurityPolicy',
+        'Set-PodeSecurityContentTypeOptions',
+        'Set-PodeSecurityCrossOrigin',
+        'Set-PodeSecurityFrameOptions',
+        'Set-PodeSecurityPermissionPolicy',
+        'Set-PodeSecurityReferrerPolicy',
+        'Set-PodeSecurityStrictTransportSecurity'
     )
 
     # Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.

--- a/src/Pode.psd1
+++ b/src/Pode.psd1
@@ -58,9 +58,11 @@
 
         # headers
         'Add-PodeHeader',
+        'Add-PodeHeaderByHashtable',
         'Test-PodeHeader',
         'Get-PodeHeader',
         'Set-PodeHeader',
+        'Set-PodeHeaderByHashtable',
         'Test-PodeHeaderSigned',
 
         # state

--- a/src/Pode.psd1
+++ b/src/Pode.psd1
@@ -11,7 +11,7 @@
     RootModule = 'Pode.psm1'
 
     # Version number of this module.
-    ModuleVersion = '$version$'
+    ModuleVersion = '2.6.0' #$version$'
 
     # ID used to uniquely identify this module
     GUID = 'e3ea217c-fc3d-406b-95d5-4304ab06c6af'
@@ -273,7 +273,7 @@
         # Security
         'Add-PodeSecurityHeader',
         'Add-PodeSecurityContentSecurityPolicy',
-        'Add-PodeSecurityPermissionPolicy',
+        'Add-PodeSecurityPermissionsPolicy',
         'Remove-PodeSecurity',
         'Remove-PodeSecurityAccessControl',
         'Remove-PodeSecurityContentSecurityPolicy',
@@ -281,7 +281,7 @@
         'Remove-PodeSecurityCrossOrigin',
         'Remove-PodeSecurityFrameOptions',
         'Remove-PodeSecurityHeader',
-        'Remove-PodeSecurityPermissionPolicy',
+        'Remove-PodeSecurityPermissionsPolicy',
         'Remove-PodeSecurityReferrerPolicy',
         'Remove-PodeSecurityStrictTransportSecurity',
         'Set-PodeSecurity',
@@ -290,7 +290,7 @@
         'Set-PodeSecurityContentTypeOptions',
         'Set-PodeSecurityCrossOrigin',
         'Set-PodeSecurityFrameOptions',
-        'Set-PodeSecurityPermissionPolicy',
+        'Set-PodeSecurityPermissionsPolicy',
         'Set-PodeSecurityReferrerPolicy',
         'Set-PodeSecurityStrictTransportSecurity'
     )

--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -357,6 +357,11 @@ function New-PodeContext
         Stop = [ordered]@{}
     }
 
+    # setup security
+    $ctx.Security = @{
+        Headers = @{}
+    }
+
     # return the new context
     return $ctx
 }

--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -360,6 +360,10 @@ function New-PodeContext
     # setup security
     $ctx.Server.Security = @{
         Headers = @{}
+        Cache = @{
+            ContentSecurity  = @{}
+            PermissionPolicy = @{}
+        }
     }
 
     # return the new context

--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -358,7 +358,7 @@ function New-PodeContext
     }
 
     # setup security
-    $ctx.Security = @{
+    $ctx.Server.Security = @{
         Headers = @{}
     }
 

--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -362,7 +362,7 @@ function New-PodeContext
         Headers = @{}
         Cache = @{
             ContentSecurity  = @{}
-            PermissionPolicy = @{}
+            PermissionsPolicy = @{}
         }
     }
 

--- a/src/Private/Endpoints.ps1
+++ b/src/Private/Endpoints.ps1
@@ -85,6 +85,19 @@ function Get-PodeEndpoints
     return $endpoints
 }
 
+function Test-PodeEndpointProtocol
+{
+    param(
+        [Parameter(Mandatory=$true)]
+        [ValidateSet('Http', 'Https', 'Ws', 'Wss', 'Smtp', 'Tcp')]
+        [string]
+        $Protocol
+    )
+
+    $endpoint = $PodeContext.Server.Endpoints.Values | Where-Object { $_.Protocol -ieq $Protocol }
+    return ($null -ne $endpoint)
+}
+
 function Get-PodeEndpointType
 {
     param(

--- a/src/Private/Events.ps1
+++ b/src/Private/Events.ps1
@@ -8,7 +8,7 @@ function Invoke-PodeEvent
     )
 
     # do nothing if no events
-    if ($PodeContext.Server.Events[$Type].Count -eq 0) {
+    if (($null -eq $PodeContext.Server.Events) -or ($PodeContext.Server.Events[$Type].Count -eq 0)) {
         return
     }
 

--- a/src/Private/Middleware.ps1
+++ b/src/Private/Middleware.ps1
@@ -354,6 +354,24 @@ function Get-PodeCookieMiddleware
     })
 }
 
+function Get-PodeSecurityMiddleware
+{
+    return (Get-PodeInbuiltMiddleware -Name '__pode_mw_security__' -ScriptBlock {
+        # are there any security headers setup?
+        if ($PodeContext.Server.Security.Headers.Count -eq 0) {
+            return $true
+        }
+
+        # add security headers
+        foreach ($key in $PodeContext.Server.Security.Headers.Keys) {
+            Set-PodeHeader -Name $key -Value $PodeContext.Server.Security.Headers[$key]
+        }
+
+        # continue to next middleware/route
+        return $true
+    })
+}
+
 function Initialize-PodeIISMiddleware
 {
     # do nothing if not iis

--- a/src/Private/Middleware.ps1
+++ b/src/Private/Middleware.ps1
@@ -363,7 +363,7 @@ function Get-PodeSecurityMiddleware
         }
 
         # add security headers
-        Set-PodeHeaderByHashtable -Hashtable $PodeContext.Server.Security.Headers
+        Set-PodeHeaderBulk -Value $PodeContext.Server.Security.Headers
 
         # continue to next middleware/route
         return $true

--- a/src/Private/Middleware.ps1
+++ b/src/Private/Middleware.ps1
@@ -363,9 +363,7 @@ function Get-PodeSecurityMiddleware
         }
 
         # add security headers
-        foreach ($key in $PodeContext.Server.Security.Headers.Keys) {
-            Set-PodeHeader -Name $key -Value $PodeContext.Server.Security.Headers[$key]
-        }
+        Set-PodeHeaderByHashtable -Hashtable $PodeContext.Server.Security.Headers
 
         # continue to next middleware/route
         return $true

--- a/src/Private/PodeServer.ps1
+++ b/src/Private/PodeServer.ps1
@@ -9,14 +9,14 @@ function Start-PodeWebServer
 
     # setup any inbuilt middleware
     $inbuilt_middleware = @(
+        (Get-PodeSecurityMiddleware),
         (Get-PodeAccessMiddleware),
         (Get-PodeLimitMiddleware),
         (Get-PodePublicMiddleware),
         (Get-PodeRouteValidateMiddleware),
         (Get-PodeBodyMiddleware),
         (Get-PodeQueryMiddleware),
-        (Get-PodeCookieMiddleware),
-        (Get-PodeSecurityMiddleware)
+        (Get-PodeCookieMiddleware)
     )
 
     $PodeContext.Server.Middleware = ($inbuilt_middleware + $PodeContext.Server.Middleware)

--- a/src/Private/PodeServer.ps1
+++ b/src/Private/PodeServer.ps1
@@ -15,7 +15,8 @@ function Start-PodeWebServer
         (Get-PodeRouteValidateMiddleware),
         (Get-PodeBodyMiddleware),
         (Get-PodeQueryMiddleware),
-        (Get-PodeCookieMiddleware)
+        (Get-PodeCookieMiddleware),
+        (Get-PodeSecurityMiddleware)
     )
 
     $PodeContext.Server.Middleware = ($inbuilt_middleware + $PodeContext.Server.Middleware)

--- a/src/Private/Security.ps1
+++ b/src/Private/Security.ps1
@@ -1063,7 +1063,7 @@ function Protect-PodeContentSecurityKeyword
     return "$($Name) $($values -join ' ')"
 }
 
-function Protect-PodePermissionPolicyKeyword
+function Protect-PodePermissionsPolicyKeyword
 {
     param(
         [Parameter(Mandatory=$true)]
@@ -1079,11 +1079,11 @@ function Protect-PodePermissionPolicyKeyword
     )
 
     # cache it
-    if ($Append -and !(Test-PodeIsEmpty $PodeContext.Server.Security.Cache.PermissionPolicy[$Name])) {
-        $Value += @($PodeContext.Server.Security.Cache.PermissionPolicy[$Name])
+    if ($Append -and !(Test-PodeIsEmpty $PodeContext.Server.Security.Cache.PermissionsPolicy[$Name])) {
+        $Value += @($PodeContext.Server.Security.Cache.PermissionsPolicy[$Name])
     }
 
-    $PodeContext.Server.Security.Cache.PermissionPolicy[$Name] = $Value
+    $PodeContext.Server.Security.Cache.PermissionsPolicy[$Name] = $Value
 
     # do nothing if no value
     if (($null -eq $Value) -or ($Value.Length -eq 0)) {

--- a/src/Private/Security.ps1
+++ b/src/Private/Security.ps1
@@ -998,3 +998,90 @@ function New-PodeSelfSignedCertificate
 
     return $cert
 }
+
+function Protect-PodeContentSecurityKeyword
+{
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Name,
+
+        [Parameter()]
+        [string[]]
+        $Value
+    )
+
+    if (($null -eq $Value) -or ($Value.Length -eq 0)) {
+        return $null
+    }
+
+    $Name = $Name.ToLowerInvariant()
+
+    $keywords = @{
+        none = "'none'"
+        self = "'self'"
+    }
+
+    $schemes = @{
+        http = 'http:'
+        https = 'https:'
+        ws = 'ws:'
+        wss = 'wss:'
+        data = 'data:'
+        file = 'file:'
+    }
+
+    $values = @(foreach ($v in $Value) {
+        if ($keywords.ContainsKey($v)) {
+            $keywords[$v]
+            continue
+        }
+
+        if ($schemes.ContainsKey($v)) {
+            $schemes[$v]
+            continue
+        }
+
+        $v
+    })
+
+    return "$($Name) $($values -join ' ')"
+}
+
+function Protect-PodePermissionPolicyKeyword
+{
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Name,
+
+        [Parameter()]
+        [string[]]
+        $Value
+    )
+
+    if (($null -eq $Value) -or ($Value.Length -eq 0)) {
+        return $null
+    }
+
+    $Name = $Name.ToLowerInvariant()
+
+    if ($Value -icontains 'none') {
+        return "$($Name)=()"
+    }
+
+    $keywords = @{
+        self = $true
+    }
+
+    $values = @(foreach ($v in $Value) {
+        if ($keywords.ContainsKey($v)) {
+            $v
+            continue
+        }
+
+        "`"$($v)`""
+    })
+
+    return "$($Name)=($($values -join ' '))"
+}

--- a/src/Private/Security.ps1
+++ b/src/Private/Security.ps1
@@ -1008,13 +1008,25 @@ function Protect-PodeContentSecurityKeyword
 
         [Parameter()]
         [string[]]
-        $Value
+        $Value,
+
+        [switch]
+        $Append
     )
 
+    # cache it
+    if ($Append -and !(Test-PodeIsEmpty $PodeContext.Server.Security.Cache.ContentSecurity[$Name])) {
+        $Value += @($PodeContext.Server.Security.Cache.ContentSecurity[$Name])
+    }
+
+    $PodeContext.Server.Security.Cache.ContentSecurity[$Name] = $Value
+
+    # do nothing if no value
     if (($null -eq $Value) -or ($Value.Length -eq 0)) {
         return $null
     }
 
+    # keywords
     $Name = $Name.ToLowerInvariant()
 
     $keywords = @(
@@ -1033,6 +1045,7 @@ function Protect-PodeContentSecurityKeyword
         'file'
     )
 
+    # build the value
     $values = @(foreach ($v in $Value) {
         if ($keywords -icontains $v) {
             "'$($v.ToLowerInvariant())'"
@@ -1059,13 +1072,25 @@ function Protect-PodePermissionPolicyKeyword
 
         [Parameter()]
         [string[]]
-        $Value
+        $Value,
+
+        [switch]
+        $Append
     )
 
+    # cache it
+    if ($Append -and !(Test-PodeIsEmpty $PodeContext.Server.Security.Cache.PermissionPolicy[$Name])) {
+        $Value += @($PodeContext.Server.Security.Cache.PermissionPolicy[$Name])
+    }
+
+    $PodeContext.Server.Security.Cache.PermissionPolicy[$Name] = $Value
+
+    # do nothing if no value
     if (($null -eq $Value) -or ($Value.Length -eq 0)) {
         return $null
     }
 
+    # build value
     $Name = $Name.ToLowerInvariant()
 
     if ($Value -icontains 'none') {

--- a/src/Private/Security.ps1
+++ b/src/Private/Security.ps1
@@ -1017,28 +1017,30 @@ function Protect-PodeContentSecurityKeyword
 
     $Name = $Name.ToLowerInvariant()
 
-    $keywords = @{
-        none = "'none'"
-        self = "'self'"
-    }
+    $keywords = @(
+        'none',
+        'self',
+        'unsafe-inline',
+        'unsafe-eval'
+    )
 
-    $schemes = @{
-        http = 'http:'
-        https = 'https:'
-        ws = 'ws:'
-        wss = 'wss:'
-        data = 'data:'
-        file = 'file:'
-    }
+    $schemes = @(
+        'http',
+        'https',
+        'ws',
+        'wss',
+        'data',
+        'file'
+    )
 
     $values = @(foreach ($v in $Value) {
-        if ($keywords.ContainsKey($v)) {
-            $keywords[$v]
+        if ($keywords -icontains $v) {
+            "'$($v.ToLowerInvariant())'"
             continue
         }
 
-        if ($schemes.ContainsKey($v)) {
-            $schemes[$v]
+        if ($schemes -icontains $v) {
+            "$($v.ToLowerInvariant()):"
             continue
         }
 
@@ -1070,12 +1072,12 @@ function Protect-PodePermissionPolicyKeyword
         return "$($Name)=()"
     }
 
-    $keywords = @{
-        self = $true
-    }
+    $keywords = @(
+        'self'
+    )
 
     $values = @(foreach ($v in $Value) {
-        if ($keywords.ContainsKey($v)) {
+        if ($keywords -icontains $v) {
             $v
             continue
         }

--- a/src/Private/Server.ps1
+++ b/src/Private/Server.ps1
@@ -163,8 +163,11 @@ function Restart-PodeInternalServer
         $PodeContext.Server.Middleware = @()
         $PodeContext.Server.Endware = @()
 
-        # clear misc
+        # clear body parsers
         $PodeContext.Server.BodyParsers.Clear()
+
+        # clear security headers
+        $PodeContext.Server.Security.Headers.Clear()
 
         # clear endpoints
         $PodeContext.Server.Endpoints.Clear()

--- a/src/Private/Server.ps1
+++ b/src/Private/Server.ps1
@@ -169,6 +169,10 @@ function Restart-PodeInternalServer
         # clear security headers
         $PodeContext.Server.Security.Headers.Clear()
 
+        $PodeContext.Server.Security.Cache.Keys.Clone() | ForEach-Object {
+            $PodeContext.Server.Security.Cache[$_].Clear()
+        }
+
         # clear endpoints
         $PodeContext.Server.Endpoints.Clear()
         $PodeContext.Server.EndpointsMap.Clear()

--- a/src/Private/Serverless.ps1
+++ b/src/Private/Serverless.ps1
@@ -7,11 +7,11 @@ function Start-PodeAzFuncServer
 
     # setup any inbuilt middleware that works for azure functions
     $inbuilt_middleware = @(
+        (Get-PodeSecurityMiddleware),
         (Get-PodePublicMiddleware),
         (Get-PodeRouteValidateMiddleware),
         (Get-PodeBodyMiddleware),
-        (Get-PodeCookieMiddleware),
-        (Get-PodeSecurityMiddleware)
+        (Get-PodeCookieMiddleware)
     )
 
     $PodeContext.Server.Middleware = ($inbuilt_middleware + $PodeContext.Server.Middleware)
@@ -140,11 +140,11 @@ function Start-PodeAwsLambdaServer
 
     # setup any inbuilt middleware that works for aws lambda
     $inbuilt_middleware = @(
+        (Get-PodeSecurityMiddleware),
         (Get-PodePublicMiddleware),
         (Get-PodeRouteValidateMiddleware),
         (Get-PodeBodyMiddleware),
-        (Get-PodeCookieMiddleware),
-        (Get-PodeSecurityMiddleware)
+        (Get-PodeCookieMiddleware)
     )
 
     $PodeContext.Server.Middleware = ($inbuilt_middleware + $PodeContext.Server.Middleware)

--- a/src/Private/Serverless.ps1
+++ b/src/Private/Serverless.ps1
@@ -10,7 +10,8 @@ function Start-PodeAzFuncServer
         (Get-PodePublicMiddleware),
         (Get-PodeRouteValidateMiddleware),
         (Get-PodeBodyMiddleware),
-        (Get-PodeCookieMiddleware)
+        (Get-PodeCookieMiddleware),
+        (Get-PodeSecurityMiddleware)
     )
 
     $PodeContext.Server.Middleware = ($inbuilt_middleware + $PodeContext.Server.Middleware)
@@ -142,7 +143,8 @@ function Start-PodeAwsLambdaServer
         (Get-PodePublicMiddleware),
         (Get-PodeRouteValidateMiddleware),
         (Get-PodeBodyMiddleware),
-        (Get-PodeCookieMiddleware)
+        (Get-PodeCookieMiddleware),
+        (Get-PodeSecurityMiddleware)
     )
 
     $PodeContext.Server.Middleware = ($inbuilt_middleware + $PodeContext.Server.Middleware)

--- a/src/Public/Headers.ps1
+++ b/src/Public/Headers.ps1
@@ -70,7 +70,7 @@ function Add-PodeHeaderBulk
     param(
         [Parameter(Mandatory=$true)]
         [hashtable]
-        $Value,
+        $Values,
 
         [Parameter()]
         [string]

--- a/src/Public/Headers.ps1
+++ b/src/Public/Headers.ps1
@@ -55,14 +55,14 @@ Appends multiple headers against the Response.
 .DESCRIPTION
 Appends multiple headers against the Response. If the current context is serverless, then this function acts like Set-PodeHeaderBulk.
 
-.PARAMETER Value
+.PARAMETER Values
 A hashtable of headers to be appended.
 
 .PARAMETER Secret
 If supplied, the secret with which to sign the header values.
 
 .EXAMPLE
-Add-PodeHeaderBulk -Value @{ Name1 = 'Value1'; Name2 = 'Value2' }
+Add-PodeHeaderBulk -Values @{ Name1 = 'Value1'; Name2 = 'Value2' }
 #>
 function Add-PodeHeaderBulk
 {
@@ -77,8 +77,8 @@ function Add-PodeHeaderBulk
         $Secret
     )
 
-    foreach ($key in $Value.Keys) {
-        $value = $Value[$key]
+    foreach ($key in $Values.Keys) {
+        $value = $Values[$key]
 
         # sign the value if we have a secret
         if (![string]::IsNullOrWhiteSpace($Secret)) {
@@ -220,14 +220,14 @@ Sets multiple headers on the Response, clearing all current values for the heade
 .DESCRIPTION
 Sets multiple headers on the Response, clearing all current values for the header.
 
-.PARAMETER Value
+.PARAMETER Values
 A hashtable of headers to be set.
 
 .PARAMETER Secret
 If supplied, the secret with which to sign the header values.
 
 .EXAMPLE
-Set-PodeHeaderBulk -Value @{ Name1 = 'Value1'; Name2 = 'Value2' }
+Set-PodeHeaderBulk -Values @{ Name1 = 'Value1'; Name2 = 'Value2' }
 #>
 function Set-PodeHeaderBulk
 {
@@ -235,15 +235,15 @@ function Set-PodeHeaderBulk
     param(
         [Parameter(Mandatory=$true)]
         [hashtable]
-        $Value,
+        $Values,
 
         [Parameter()]
         [string]
         $Secret
     )
 
-    foreach ($key in $Value.Keys) {
-        $value = $Value[$key]
+    foreach ($key in $Values.Keys) {
+        $value = $Values[$key]
 
         # sign the value if we have a secret
         if (![string]::IsNullOrWhiteSpace($Secret)) {

--- a/src/Public/Headers.ps1
+++ b/src/Public/Headers.ps1
@@ -20,7 +20,7 @@ Add-PodeHeader -Name 'X-AuthToken' -Value 'AA-BB-CC-33'
 function Add-PodeHeader
 {
     [CmdletBinding()]
-    param (
+    param(
         [Parameter(Mandatory=$true)]
         [string]
         $Name,
@@ -45,6 +45,37 @@ function Add-PodeHeader
     }
     else {
         $WebEvent.Response.Headers.Add($Name, $Value)
+    }
+}
+
+function Add-PodeHeaderByHashtable
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [hashtable]
+        $Hashtable,
+
+        [Parameter()]
+        [string]
+        $Secret
+    )
+
+    foreach ($key in $Hashtable.Keys) {
+        $value = $Hashtable[$key]
+
+        # sign the value if we have a secret
+        if (![string]::IsNullOrWhiteSpace($Secret)) {
+            $value = (Invoke-PodeValueSign -Value $value -Secret $Secret)
+        }
+
+        # add the header to the response
+        if ($PodeContext.Server.IsServerless) {
+            $WebEvent.Response.Headers[$Name] = $value
+        }
+        else {
+            $WebEvent.Response.Headers.Add($Name, $value)
+        }
     }
 }
 
@@ -138,7 +169,7 @@ Set-PodeHeader -Name 'X-AuthToken' -Value 'AA-BB-CC-33'
 function Set-PodeHeader
 {
     [CmdletBinding()]
-    param (
+    param(
         [Parameter(Mandatory=$true)]
         [string]
         $Name,
@@ -163,6 +194,37 @@ function Set-PodeHeader
     }
     else {
         $WebEvent.Response.Headers.Set($Name, $Value)
+    }
+}
+
+function Set-PodeHeaderByHashtable
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [hashtable]
+        $Hashtable,
+
+        [Parameter()]
+        [string]
+        $Secret
+    )
+
+    foreach ($key in $Hashtable.Keys) {
+        $value = $Hashtable[$key]
+
+        # sign the value if we have a secret
+        if (![string]::IsNullOrWhiteSpace($Secret)) {
+            $value = (Invoke-PodeValueSign -Value $value -Secret $Secret)
+        }
+
+        # set the header on the response
+        if ($PodeContext.Server.IsServerless) {
+            $WebEvent.Response.Headers[$Name] = $value
+        }
+        else {
+            $WebEvent.Response.Headers.Set($Name, $value)
+        }
     }
 }
 

--- a/src/Public/Headers.ps1
+++ b/src/Public/Headers.ps1
@@ -48,21 +48,37 @@ function Add-PodeHeader
     }
 }
 
-function Add-PodeHeaderByHashtable
+<#
+.SYNOPSIS
+Appends multiple headers against the Response.
+
+.DESCRIPTION
+Appends multiple headers against the Response. If the current context is serverless, then this function acts like Set-PodeHeaderBulk.
+
+.PARAMETER Value
+A hashtable of headers to be appended.
+
+.PARAMETER Secret
+If supplied, the secret with which to sign the header values.
+
+.EXAMPLE
+Add-PodeHeaderBulk -Value @{ Name1 = 'Value1'; Name2 = 'Value2' }
+#>
+function Add-PodeHeaderBulk
 {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory=$true)]
         [hashtable]
-        $Hashtable,
+        $Value,
 
         [Parameter()]
         [string]
         $Secret
     )
 
-    foreach ($key in $Hashtable.Keys) {
-        $value = $Hashtable[$key]
+    foreach ($key in $Value.Keys) {
+        $value = $Value[$key]
 
         # sign the value if we have a secret
         if (![string]::IsNullOrWhiteSpace($Secret)) {
@@ -71,10 +87,10 @@ function Add-PodeHeaderByHashtable
 
         # add the header to the response
         if ($PodeContext.Server.IsServerless) {
-            $WebEvent.Response.Headers[$Name] = $value
+            $WebEvent.Response.Headers[$key] = $value
         }
         else {
-            $WebEvent.Response.Headers.Add($Name, $value)
+            $WebEvent.Response.Headers.Add($key, $value)
         }
     }
 }
@@ -197,21 +213,37 @@ function Set-PodeHeader
     }
 }
 
-function Set-PodeHeaderByHashtable
+<#
+.SYNOPSIS
+Sets multiple headers on the Response, clearing all current values for the header.
+
+.DESCRIPTION
+Sets multiple headers on the Response, clearing all current values for the header.
+
+.PARAMETER Value
+A hashtable of headers to be set.
+
+.PARAMETER Secret
+If supplied, the secret with which to sign the header values.
+
+.EXAMPLE
+Set-PodeHeaderBulk -Value @{ Name1 = 'Value1'; Name2 = 'Value2' }
+#>
+function Set-PodeHeaderBulk
 {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory=$true)]
         [hashtable]
-        $Hashtable,
+        $Value,
 
         [Parameter()]
         [string]
         $Secret
     )
 
-    foreach ($key in $Hashtable.Keys) {
-        $value = $Hashtable[$key]
+    foreach ($key in $Value.Keys) {
+        $value = $Value[$key]
 
         # sign the value if we have a secret
         if (![string]::IsNullOrWhiteSpace($Secret)) {
@@ -220,10 +252,10 @@ function Set-PodeHeaderByHashtable
 
         # set the header on the response
         if ($PodeContext.Server.IsServerless) {
-            $WebEvent.Response.Headers[$Name] = $value
+            $WebEvent.Response.Headers[$key] = $value
         }
         else {
-            $WebEvent.Response.Headers.Set($Name, $value)
+            $WebEvent.Response.Headers.Set($key, $value)
         }
     }
 }

--- a/src/Public/Security.ps1
+++ b/src/Public/Security.ps1
@@ -394,7 +394,7 @@ function Set-PodeSecurityReferrerPolicy
         $Type
     )
 
-    Add-PodeSecurityHeader -Name 'Referred-Policy' -Value $Type.ToLowerInvariant()
+    Add-PodeSecurityHeader -Name 'Referrer-Policy' -Value $Type.ToLowerInvariant()
 }
 
 function Remove-PodeSecurityReferrerPolicy
@@ -402,7 +402,7 @@ function Remove-PodeSecurityReferrerPolicy
     [CmdletBinding()]
     param()
 
-    Remove-PodeSecurityHeader -Name 'Referred-Policy'
+    Remove-PodeSecurityHeader -Name 'Referrer-Policy'
 }
 
 function Set-PodeSecurityContentTypeOptions

--- a/src/Public/Security.ps1
+++ b/src/Public/Security.ps1
@@ -21,6 +21,11 @@ function Set-PodeSecurity
     Set-PodeSecurityCrossOrigin -Embed Require-Corp -Open Same-Origin -Resource Same-Origin
     Set-PodeSecurityAccessControl -Origin '*' -Methods '*' -Headers '*' -Duration 7200
 
+    # we only need hsts if there's an https endpoint
+    if (Test-PodeEndpointProtocol -Protocol Https) {
+        Set-PodeSecurityStrictTransportSecurity -Duration 31536000 -IncludeSubDomains
+    }
+
     # type specific headers
     switch ($Type.ToLowerInvariant()) {
         'simple' {
@@ -32,7 +37,6 @@ function Set-PodeSecurity
         'strict' {
             Set-PodeSecurityFrameOptions -Type Deny
             Set-PodeSecurityReferrerPolicy -Type No-Referrer
-            Set-PodeSecurityStrictTransportSecurity -Duration 31536000 -IncludeSubDomains
             Set-PodeSecurityContentSecurityPolicy -Default 'self' -Image 'self', 'data'
         }
     }

--- a/src/Public/Security.ps1
+++ b/src/Public/Security.ps1
@@ -518,22 +518,22 @@ function Set-PodeSecurityAccessControl
     Add-PodeSecurityHeader -Name 'Access-Control-Allow-Origin' -Value $Origin
 
     # methods
-    if (![string]::IsNullOrWhiteSpace($Method)) {
-        if ($Method -icontains '*') {
+    if (![string]::IsNullOrWhiteSpace($Methods)) {
+        if ($Methods -icontains '*') {
             Add-PodeSecurityHeader -Name 'Access-Control-Allow-Methods' -Value '*'
         }
         else {
-            Add-PodeSecurityHeader -Name 'Access-Control-Allow-Methods' -Value ($Method -join ', ').ToUpperInvariant()
+            Add-PodeSecurityHeader -Name 'Access-Control-Allow-Methods' -Value ($Methods -join ', ').ToUpperInvariant()
         }
     }
 
     # headers
-    if (![string]::IsNullOrWhiteSpace($Header)) {
-        if ($Header -icontains '*') {
+    if (![string]::IsNullOrWhiteSpace($Headers)) {
+        if ($Headers -icontains '*') {
             Add-PodeSecurityHeader -Name 'Access-Control-Allow-Headers' -Value '*'
         }
         else {
-            Add-PodeSecurityHeader -Name 'Access-Control-Allow-Headers' -Value ($Header -join ', ').ToUpperInvariant()
+            Add-PodeSecurityHeader -Name 'Access-Control-Allow-Headers' -Value ($Headers -join ', ').ToUpperInvariant()
         }
     }
 

--- a/src/Public/Security.ps1
+++ b/src/Public/Security.ps1
@@ -1,0 +1,94 @@
+function Set-PodeSecurity
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [ValidateSet('Simple', 'Strict')]
+        [string]
+        $Type
+    )
+
+    #TODO:
+    switch ($Type.ToLowerInvariant()) {
+        'simple' {
+            Set-PodeSecurityFrameOptions -Access SameOrigin
+        }
+
+        'strict' {
+            Set-PodeSecurityFrameOptions -Access Deny
+        }
+    }
+}
+
+function Remove-PodeSecurity
+{
+    [CmdletBinding()]
+    param()
+
+    $PodeContext.Server.Security.Headers.Clear()
+}
+
+function Add-PodeSecurityHeader
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Name,
+
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Value
+    )
+
+    $PodeContext.Server.Security.Headers[$Name] = $Value
+}
+
+function Remove-PodeSecurityHeader
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Name
+    )
+
+    $PodeContext.Server.Security.Headers.Remove($Name)
+}
+
+function Set-PodeSecurityFrameOptions
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [ValidateSet('None', 'Deny', 'SameOrigin', 'AllowFrom')]
+        [string]
+        $Access,
+
+        [Parameter()]
+        [string]
+        $Url
+    )
+
+    # set value
+    $value = $Access.ToUpperInvariant()
+
+    # check allow from and url
+    if ($value -ieq 'AllowFrom') {
+        if ([string]::IsNullOrWhiteSpace($Url)) {
+            throw "A URL is required when setting X-Frame-Options to ALLOW-FROM"
+        }
+
+        $value += " $($Url)"
+    }
+
+    Add-PodeSecurityHeader -Name 'X-Frame-Options' -Value $value
+}
+
+function Remove-PodeSecurityFrameOptions
+{
+    [CmdletBinding()]
+    param()
+
+    Remove-PodeSecurityHeader -Name 'X-Frame-Options'
+}

--- a/src/Public/Security.ps1
+++ b/src/Public/Security.ps1
@@ -39,7 +39,7 @@ function Set-PodeSecurity
     # general headers
     Set-PodeSecurityContentTypeOptions
 
-    Set-PodeSecurityPermissionPolicy `
+    Set-PodeSecurityPermissionsPolicy `
         -LayoutAnimations 'none' `
         -UnoptimisedImages 'none' `
         -OversizedImages 'none' `
@@ -550,10 +550,10 @@ function Remove-PodeSecurityContentSecurityPolicy
 
 <#
 .SYNOPSIS
-Set the value to use for the Permission-Policy header.
+Set the value to use for the Permissions-Policy header.
 
 .DESCRIPTION
-Set the value to use for the Permission-Policy header.
+Set the value to use for the Permissions-Policy header.
 
 .PARAMETER Accelerometer
 The values to use for the Accelerometer portion of the header.
@@ -643,9 +643,9 @@ The values to use for the WebShare portion of the header.
 The values to use for the XrSpatialTracking portion of the header.
 
 .EXAMPLE
-Set-PodeSecurityPermissionPolicy -LayoutAnimations 'none' -UnoptimisedImages 'none' -OversizedImages 'none' -SyncXhr 'none' -UnsizedMedia 'none'
+Set-PodeSecurityPermissionsPolicy -LayoutAnimations 'none' -UnoptimisedImages 'none' -OversizedImages 'none' -SyncXhr 'none' -UnsizedMedia 'none'
 #>
-function Set-PodeSecurityPermissionPolicy
+function Set-PodeSecurityPermissionsPolicy
 {
     [CmdletBinding()]
     param(
@@ -768,50 +768,50 @@ function Set-PodeSecurityPermissionPolicy
 
     # build the header's value
     $values = @(
-        Protect-PodePermissionPolicyKeyword -Name 'accelerometer' -Value $Accelerometer
-        Protect-PodePermissionPolicyKeyword -Name 'ambient-light-sensor' -Value $AmbientLightSensor
-        Protect-PodePermissionPolicyKeyword -Name 'autoplay' -Value $Autoplay
-        Protect-PodePermissionPolicyKeyword -Name 'battery' -Value $Battery
-        Protect-PodePermissionPolicyKeyword -Name 'camera' -Value $Camera
-        Protect-PodePermissionPolicyKeyword -Name 'display-capture' -Value $DisplayCapture
-        Protect-PodePermissionPolicyKeyword -Name 'document-domain' -Value $DocumentDomain
-        Protect-PodePermissionPolicyKeyword -Name 'encrypted-media' -Value $EncryptedMedia
-        Protect-PodePermissionPolicyKeyword -Name 'fullscreen' -Value $Fullscreen
-        Protect-PodePermissionPolicyKeyword -Name 'gamepad' -Value $Gamepad
-        Protect-PodePermissionPolicyKeyword -Name 'geolocation' -Value $Geolocation
-        Protect-PodePermissionPolicyKeyword -Name 'gyroscope' -Value $Gyroscope
-        Protect-PodePermissionPolicyKeyword -Name 'layout-animations' -Value $LayoutAnimations
-        Protect-PodePermissionPolicyKeyword -Name 'legacy-image-formats' -Value $LegacyImageFormats
-        Protect-PodePermissionPolicyKeyword -Name 'magnetometer' -Value $Magnetometer
-        Protect-PodePermissionPolicyKeyword -Name 'microphone' -Value $Microphone
-        Protect-PodePermissionPolicyKeyword -Name 'midi' -Value $Midi
-        Protect-PodePermissionPolicyKeyword -Name 'oversized-images' -Value $OversizedImages
-        Protect-PodePermissionPolicyKeyword -Name 'payment' -Value $Payment
-        Protect-PodePermissionPolicyKeyword -Name 'picture-in-picture' -Value $PictureInPicture
-        Protect-PodePermissionPolicyKeyword -Name 'publickey-credentials-get' -Value $PublicKeyCredentials
-        Protect-PodePermissionPolicyKeyword -Name 'speaker-selection' -Value $Speakers
-        Protect-PodePermissionPolicyKeyword -Name 'sync-xhr' -Value $SyncXhr
-        Protect-PodePermissionPolicyKeyword -Name 'unoptimized-images' -Value $UnoptimisedImages
-        Protect-PodePermissionPolicyKeyword -Name 'unsized-media' -Value $UnsizedMedia
-        Protect-PodePermissionPolicyKeyword -Name 'usb' -Value $Usb
-        Protect-PodePermissionPolicyKeyword -Name 'screen-wake-lock' -Value $ScreenWakeLake
-        Protect-PodePermissionPolicyKeyword -Name 'web-share' -Value $WebShare
-        Protect-PodePermissionPolicyKeyword -Name 'xr-spatial-tracking' -Value $XrSpatialTracking
+        Protect-PodePermissionsPolicyKeyword -Name 'accelerometer' -Value $Accelerometer
+        Protect-PodePermissionsPolicyKeyword -Name 'ambient-light-sensor' -Value $AmbientLightSensor
+        Protect-PodePermissionsPolicyKeyword -Name 'autoplay' -Value $Autoplay
+        Protect-PodePermissionsPolicyKeyword -Name 'battery' -Value $Battery
+        Protect-PodePermissionsPolicyKeyword -Name 'camera' -Value $Camera
+        Protect-PodePermissionsPolicyKeyword -Name 'display-capture' -Value $DisplayCapture
+        Protect-PodePermissionsPolicyKeyword -Name 'document-domain' -Value $DocumentDomain
+        Protect-PodePermissionsPolicyKeyword -Name 'encrypted-media' -Value $EncryptedMedia
+        Protect-PodePermissionsPolicyKeyword -Name 'fullscreen' -Value $Fullscreen
+        Protect-PodePermissionsPolicyKeyword -Name 'gamepad' -Value $Gamepad
+        Protect-PodePermissionsPolicyKeyword -Name 'geolocation' -Value $Geolocation
+        Protect-PodePermissionsPolicyKeyword -Name 'gyroscope' -Value $Gyroscope
+        Protect-PodePermissionsPolicyKeyword -Name 'layout-animations' -Value $LayoutAnimations
+        Protect-PodePermissionsPolicyKeyword -Name 'legacy-image-formats' -Value $LegacyImageFormats
+        Protect-PodePermissionsPolicyKeyword -Name 'magnetometer' -Value $Magnetometer
+        Protect-PodePermissionsPolicyKeyword -Name 'microphone' -Value $Microphone
+        Protect-PodePermissionsPolicyKeyword -Name 'midi' -Value $Midi
+        Protect-PodePermissionsPolicyKeyword -Name 'oversized-images' -Value $OversizedImages
+        Protect-PodePermissionsPolicyKeyword -Name 'payment' -Value $Payment
+        Protect-PodePermissionsPolicyKeyword -Name 'picture-in-picture' -Value $PictureInPicture
+        Protect-PodePermissionsPolicyKeyword -Name 'publickey-credentials-get' -Value $PublicKeyCredentials
+        Protect-PodePermissionsPolicyKeyword -Name 'speaker-selection' -Value $Speakers
+        Protect-PodePermissionsPolicyKeyword -Name 'sync-xhr' -Value $SyncXhr
+        Protect-PodePermissionsPolicyKeyword -Name 'unoptimized-images' -Value $UnoptimisedImages
+        Protect-PodePermissionsPolicyKeyword -Name 'unsized-media' -Value $UnsizedMedia
+        Protect-PodePermissionsPolicyKeyword -Name 'usb' -Value $Usb
+        Protect-PodePermissionsPolicyKeyword -Name 'screen-wake-lock' -Value $ScreenWakeLake
+        Protect-PodePermissionsPolicyKeyword -Name 'web-share' -Value $WebShare
+        Protect-PodePermissionsPolicyKeyword -Name 'xr-spatial-tracking' -Value $XrSpatialTracking
     )
 
     $values = ($values -ne $null)
     $value = ($values -join ', ')
 
     # add the header
-    Add-PodeSecurityHeader -Name 'Permission-Policy' -Value $value
+    Add-PodeSecurityHeader -Name 'Permissions-Policy' -Value $value
 }
 
 <#
 .SYNOPSIS
-Adds additional values to already defined values for the Permission-Policy header.
+Adds additional values to already defined values for the Permissions-Policy header.
 
 .DESCRIPTION
-Adds additional values to already defined values for the Permission-Policy header, instead of overriding them.
+Adds additional values to already defined values for the Permissions-Policy header, instead of overriding them.
 
 .PARAMETER Accelerometer
 The values to add for the Accelerometer portion of the header.
@@ -901,9 +901,9 @@ The values to add for the WebShare portion of the header.
 The values to add for the XrSpatialTracking portion of the header.
 
 .EXAMPLE
-Add-PodeSecurityPermissionPolicy -AmbientLightSensor 'none'
+Add-PodeSecurityPermissionsPolicy -AmbientLightSensor 'none'
 #>
-function Add-PodeSecurityPermissionPolicy
+function Add-PodeSecurityPermissionsPolicy
 {
     [CmdletBinding()]
     param(
@@ -1026,60 +1026,60 @@ function Add-PodeSecurityPermissionPolicy
 
     # build the header's value
     $values = @(
-        Protect-PodePermissionPolicyKeyword -Name 'accelerometer' -Value $Accelerometer -Append
-        Protect-PodePermissionPolicyKeyword -Name 'ambient-light-sensor' -Value $AmbientLightSensor -Append
-        Protect-PodePermissionPolicyKeyword -Name 'autoplay' -Value $Autoplay -Append
-        Protect-PodePermissionPolicyKeyword -Name 'battery' -Value $Battery -Append
-        Protect-PodePermissionPolicyKeyword -Name 'camera' -Value $Camera -Append
-        Protect-PodePermissionPolicyKeyword -Name 'display-capture' -Value $DisplayCapture -Append
-        Protect-PodePermissionPolicyKeyword -Name 'document-domain' -Value $DocumentDomain -Append
-        Protect-PodePermissionPolicyKeyword -Name 'encrypted-media' -Value $EncryptedMedia -Append
-        Protect-PodePermissionPolicyKeyword -Name 'fullscreen' -Value $Fullscreen -Append
-        Protect-PodePermissionPolicyKeyword -Name 'gamepad' -Value $Gamepad -Append
-        Protect-PodePermissionPolicyKeyword -Name 'geolocation' -Value $Geolocation -Append
-        Protect-PodePermissionPolicyKeyword -Name 'gyroscope' -Value $Gyroscope -Append
-        Protect-PodePermissionPolicyKeyword -Name 'layout-animations' -Value $LayoutAnimations -Append
-        Protect-PodePermissionPolicyKeyword -Name 'legacy-image-formats' -Value $LegacyImageFormats -Append
-        Protect-PodePermissionPolicyKeyword -Name 'magnetometer' -Value $Magnetometer -Append
-        Protect-PodePermissionPolicyKeyword -Name 'microphone' -Value $Microphone -Append
-        Protect-PodePermissionPolicyKeyword -Name 'midi' -Value $Midi -Append
-        Protect-PodePermissionPolicyKeyword -Name 'oversized-images' -Value $OversizedImages -Append
-        Protect-PodePermissionPolicyKeyword -Name 'payment' -Value $Payment -Append
-        Protect-PodePermissionPolicyKeyword -Name 'picture-in-picture' -Value $PictureInPicture -Append
-        Protect-PodePermissionPolicyKeyword -Name 'publickey-credentials-get' -Value $PublicKeyCredentials -Append
-        Protect-PodePermissionPolicyKeyword -Name 'speaker-selection' -Value $Speakers -Append
-        Protect-PodePermissionPolicyKeyword -Name 'sync-xhr' -Value $SyncXhr -Append
-        Protect-PodePermissionPolicyKeyword -Name 'unoptimized-images' -Value $UnoptimisedImages -Append
-        Protect-PodePermissionPolicyKeyword -Name 'unsized-media' -Value $UnsizedMedia -Append
-        Protect-PodePermissionPolicyKeyword -Name 'usb' -Value $Usb -Append
-        Protect-PodePermissionPolicyKeyword -Name 'screen-wake-lock' -Value $ScreenWakeLake -Append
-        Protect-PodePermissionPolicyKeyword -Name 'web-share' -Value $WebShare -Append
-        Protect-PodePermissionPolicyKeyword -Name 'xr-spatial-tracking' -Value $XrSpatialTracking -Append
+        Protect-PodePermissionsPolicyKeyword -Name 'accelerometer' -Value $Accelerometer -Append
+        Protect-PodePermissionsPolicyKeyword -Name 'ambient-light-sensor' -Value $AmbientLightSensor -Append
+        Protect-PodePermissionsPolicyKeyword -Name 'autoplay' -Value $Autoplay -Append
+        Protect-PodePermissionsPolicyKeyword -Name 'battery' -Value $Battery -Append
+        Protect-PodePermissionsPolicyKeyword -Name 'camera' -Value $Camera -Append
+        Protect-PodePermissionsPolicyKeyword -Name 'display-capture' -Value $DisplayCapture -Append
+        Protect-PodePermissionsPolicyKeyword -Name 'document-domain' -Value $DocumentDomain -Append
+        Protect-PodePermissionsPolicyKeyword -Name 'encrypted-media' -Value $EncryptedMedia -Append
+        Protect-PodePermissionsPolicyKeyword -Name 'fullscreen' -Value $Fullscreen -Append
+        Protect-PodePermissionsPolicyKeyword -Name 'gamepad' -Value $Gamepad -Append
+        Protect-PodePermissionsPolicyKeyword -Name 'geolocation' -Value $Geolocation -Append
+        Protect-PodePermissionsPolicyKeyword -Name 'gyroscope' -Value $Gyroscope -Append
+        Protect-PodePermissionsPolicyKeyword -Name 'layout-animations' -Value $LayoutAnimations -Append
+        Protect-PodePermissionsPolicyKeyword -Name 'legacy-image-formats' -Value $LegacyImageFormats -Append
+        Protect-PodePermissionsPolicyKeyword -Name 'magnetometer' -Value $Magnetometer -Append
+        Protect-PodePermissionsPolicyKeyword -Name 'microphone' -Value $Microphone -Append
+        Protect-PodePermissionsPolicyKeyword -Name 'midi' -Value $Midi -Append
+        Protect-PodePermissionsPolicyKeyword -Name 'oversized-images' -Value $OversizedImages -Append
+        Protect-PodePermissionsPolicyKeyword -Name 'payment' -Value $Payment -Append
+        Protect-PodePermissionsPolicyKeyword -Name 'picture-in-picture' -Value $PictureInPicture -Append
+        Protect-PodePermissionsPolicyKeyword -Name 'publickey-credentials-get' -Value $PublicKeyCredentials -Append
+        Protect-PodePermissionsPolicyKeyword -Name 'speaker-selection' -Value $Speakers -Append
+        Protect-PodePermissionsPolicyKeyword -Name 'sync-xhr' -Value $SyncXhr -Append
+        Protect-PodePermissionsPolicyKeyword -Name 'unoptimized-images' -Value $UnoptimisedImages -Append
+        Protect-PodePermissionsPolicyKeyword -Name 'unsized-media' -Value $UnsizedMedia -Append
+        Protect-PodePermissionsPolicyKeyword -Name 'usb' -Value $Usb -Append
+        Protect-PodePermissionsPolicyKeyword -Name 'screen-wake-lock' -Value $ScreenWakeLake -Append
+        Protect-PodePermissionsPolicyKeyword -Name 'web-share' -Value $WebShare -Append
+        Protect-PodePermissionsPolicyKeyword -Name 'xr-spatial-tracking' -Value $XrSpatialTracking -Append
     )
 
     $values = ($values -ne $null)
     $value = ($values -join ', ')
 
     # add the header
-    Add-PodeSecurityHeader -Name 'Permission-Policy' -Value $value
+    Add-PodeSecurityHeader -Name 'Permissions-Policy' -Value $value
 }
 
 <#
 .SYNOPSIS
-Removes definition for the Permission-Policy header.
+Removes definition for the Permissions-Policy header.
 
 .DESCRIPTION
-Removes definitions for the Permission-Policy header.
+Removes definitions for the Permissions-Policy header.
 
 .EXAMPLE
-Remove-PodeSecurityPermissionPolicy
+Remove-PodeSecurityPermissionsPolicy
 #>
-function Remove-PodeSecurityPermissionPolicy
+function Remove-PodeSecurityPermissionsPolicy
 {
     [CmdletBinding()]
     param()
 
-    Remove-PodeSecurityHeader -Name 'Permission-Policy'
+    Remove-PodeSecurityHeader -Name 'Permissions-Policy'
 }
 
 <#

--- a/src/Public/Security.ps1
+++ b/src/Public/Security.ps1
@@ -10,7 +10,6 @@ function Set-PodeSecurity
 
     # general headers
     Set-PodeSecurityContentTypeOptions
-    Set-PodeSecurityContentSecurityPolicy -Default 'self'
 
     Set-PodeSecurityPermissionPolicy `
         -LayoutAnimations 'none' `
@@ -27,12 +26,14 @@ function Set-PodeSecurity
         'simple' {
             Set-PodeSecurityFrameOptions -Type SameOrigin
             Set-PodeSecurityReferrerPolicy -Type Strict-Origin
+            Set-PodeSecurityContentSecurityPolicy -Default 'self' -Style 'self', 'unsafe-inline' -Scripts 'self', 'unsafe-inline' -Image 'self', 'data'
         }
 
         'strict' {
             Set-PodeSecurityFrameOptions -Type Deny
             Set-PodeSecurityReferrerPolicy -Type No-Referrer
             Set-PodeSecurityStrictTransportSecurity -Duration 31536000 -IncludeSubDomains
+            Set-PodeSecurityContentSecurityPolicy -Default 'self' -Image 'self', 'data'
         }
     }
 }
@@ -487,8 +488,6 @@ function Remove-PodeSecurityCrossOrigin
     Remove-PodeSecurityHeader -Name 'Cross-Origin-Opener-Policy'
     Remove-PodeSecurityHeader -Name 'Cross-Origin-Resource-Policy'
 }
-
-
 
 function Set-PodeSecurityAccessControl
 {

--- a/src/Public/Security.ps1
+++ b/src/Public/Security.ps1
@@ -8,14 +8,31 @@ function Set-PodeSecurity
         $Type
     )
 
-    #TODO:
+    # general headers
+    Set-PodeSecurityContentTypeOptions
+    Set-PodeSecurityContentSecurityPolicy -Default 'self'
+
+    Set-PodeSecurityPermissionPolicy `
+        -LayoutAnimations 'none' `
+        -UnoptimisedImages 'none' `
+        -OversizedImages 'none' `
+        -SyncXhr 'none' `
+        -UnsizedMedia 'none'
+
+    Set-PodeSecurityCrossOrigin -Embed Require-Corp -Open Same-Origin -Resource Same-Origin
+    Set-PodeSecurityAccessControl -Origin '*' -Methods '*' -Headers '*' -Duration 7200
+
+    # type specific headers
     switch ($Type.ToLowerInvariant()) {
         'simple' {
-            Set-PodeSecurityFrameOptions -Access SameOrigin
+            Set-PodeSecurityFrameOptions -Type SameOrigin
+            Set-PodeSecurityReferrerPolicy -Type Strict-Origin
         }
 
         'strict' {
-            Set-PodeSecurityFrameOptions -Access Deny
+            Set-PodeSecurityFrameOptions -Type Deny
+            Set-PodeSecurityReferrerPolicy -Type No-Referrer
+            Set-PodeSecurityStrictTransportSecurity -Duration 31536000 -IncludeSubDomains
         }
     }
 }
@@ -36,12 +53,14 @@ function Add-PodeSecurityHeader
         [string]
         $Name,
 
-        [Parameter(Mandatory=$true)]
+        [Parameter()]
         [string]
         $Value
     )
 
-    $PodeContext.Server.Security.Headers[$Name] = $Value
+    if (![string]::IsNullOrWhiteSpace($Value)) {
+        $PodeContext.Server.Security.Headers[$Name] = $Value
+    }
 }
 
 function Remove-PodeSecurityHeader
@@ -61,28 +80,12 @@ function Set-PodeSecurityFrameOptions
     [CmdletBinding()]
     param(
         [Parameter(Mandatory=$true)]
-        [ValidateSet('None', 'Deny', 'SameOrigin', 'AllowFrom')]
+        [ValidateSet('Deny', 'SameOrigin')]
         [string]
-        $Access,
-
-        [Parameter()]
-        [string]
-        $Url
+        $Type
     )
 
-    # set value
-    $value = $Access.ToUpperInvariant()
-
-    # check allow from and url
-    if ($value -ieq 'AllowFrom') {
-        if ([string]::IsNullOrWhiteSpace($Url)) {
-            throw "A URL is required when setting X-Frame-Options to ALLOW-FROM"
-        }
-
-        $value += " $($Url)"
-    }
-
-    Add-PodeSecurityHeader -Name 'X-Frame-Options' -Value $value
+    Add-PodeSecurityHeader -Name 'X-Frame-Options' -Value $Type.ToUpperInvariant()
 }
 
 function Remove-PodeSecurityFrameOptions
@@ -91,4 +94,471 @@ function Remove-PodeSecurityFrameOptions
     param()
 
     Remove-PodeSecurityHeader -Name 'X-Frame-Options'
+}
+
+function Set-PodeSecurityContentSecurityPolicy
+{
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [string[]]
+        $Default,
+
+        [Parameter()]
+        [string[]]
+        $Child,
+
+        [Parameter()]
+        [string[]]
+        $Connect,
+
+        [Parameter()]
+        [string[]]
+        $Font,
+
+        [Parameter()]
+        [string[]]
+        $Frame,
+
+        [Parameter()]
+        [string[]]
+        $Image,
+
+        [Parameter()]
+        [string[]]
+        $Manifest,
+
+        [Parameter()]
+        [string[]]
+        $Media,
+
+        [Parameter()]
+        [string[]]
+        $Object,
+
+        [Parameter()]
+        [string[]]
+        $Scripts,
+
+        [Parameter()]
+        [string[]]
+        $Style,
+
+        [Parameter()]
+        [string[]]
+        $BaseUri,
+
+        [Parameter()]
+        [string[]]
+        $FormAction,
+
+        [Parameter()]
+        [string[]]
+        $FrameAncestor,
+
+        [Parameter()]
+        [ValidateSet('', 'Allow-Downloads', 'Allow-Downloads-Without-User-Activation', 'Allow-Forms', 'Allow-Modals', 'Allow-Orientation-Lock',
+            'Allow-Pointer-Lock', 'Allow-Popups', 'Allow-Popups-To-Escape-Sandbox', 'Allow-Presentation', 'Allow-Same-Origin', 'Allow-Scripts',
+            'Allow-Storage-Access-By-User-Activation', 'Allow-Top-Navigation', 'Allow-Top-Navigation-By-User-Activation', 'None')]
+        [string]
+        $Sandbox = 'None',
+
+        [switch]
+        $UpgradeInsecureRequests
+    )
+
+    # build the header's value
+    $values = @(
+        Protect-PodeContentSecurityKeyword -Name 'default-src' -Value $Default
+        Protect-PodeContentSecurityKeyword -Name 'child-src' -Value $Child
+        Protect-PodeContentSecurityKeyword -Name 'connect-src' -Value $Connect
+        Protect-PodeContentSecurityKeyword -Name 'font-src' -Value $Font
+        Protect-PodeContentSecurityKeyword -Name 'frame-src' -Value $Frame
+        Protect-PodeContentSecurityKeyword -Name 'img-src' -Value $Image
+        Protect-PodeContentSecurityKeyword -Name 'manifest-src' -Value $Manifest
+        Protect-PodeContentSecurityKeyword -Name 'media-src' -Value $Media
+        Protect-PodeContentSecurityKeyword -Name 'object-src' -Value $Object
+        Protect-PodeContentSecurityKeyword -Name 'script-src' -Value $Scripts
+        Protect-PodeContentSecurityKeyword -Name 'style-src' -Value $Style
+        Protect-PodeContentSecurityKeyword -Name 'base-uri' -Value $BaseUri
+        Protect-PodeContentSecurityKeyword -Name 'form-action' -Value $FormAction
+        Protect-PodeContentSecurityKeyword -Name 'frame-ancestors' -Value $FrameAncestor
+    )
+
+    if ($Sandbox -ine 'None') {
+        $values += "sandbox $($Sandbox.ToLowerInvariant())".Trim()
+    }
+
+    if ($UpgradeInsecureRequests) {
+        $values += 'upgrade-insecure-requests'
+    }
+
+    $values = ($values -ne $null)
+    $value = ($values -join '; ')
+
+    # add the header
+    Add-PodeSecurityHeader -Name 'Content-Security-Policy' -Value $value
+
+    # this is done to explicitly disable XSS auditors in browsers
+    # as having it enabled has now been found to cause more vulnerabilities
+    Add-PodeSecurityHeader -Name 'X-XSS-Protection' -Value "0"
+}
+
+function Remove-PodeSecurityContentSecurityPolicy
+{
+    [CmdletBinding()]
+    param()
+
+    Remove-PodeSecurityHeader -Name 'Content-Security-Policy'
+    Remove-PodeSecurityHeader -Name 'X-XSS-Protection'
+}
+
+function Set-PodeSecurityPermissionPolicy
+{
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [string[]]
+        $Accelerometer,
+
+        [Parameter()]
+        [string[]]
+        $AmbientLightSensor,
+
+        [Parameter()]
+        [string[]]
+        $Autoplay,
+
+        [Parameter()]
+        [string[]]
+        $Battery,
+
+        [Parameter()]
+        [string[]]
+        $Camera,
+
+        [Parameter()]
+        [string[]]
+        $DisplayCapture,
+
+        [Parameter()]
+        [string[]]
+        $DocumentDomain,
+
+        [Parameter()]
+        [string[]]
+        $EncryptedMedia,
+
+        [Parameter()]
+        [string[]]
+        $Fullscreen,
+
+        [Parameter()]
+        [string[]]
+        $Gamepad,
+
+        [Parameter()]
+        [string[]]
+        $Geolocation,
+
+        [Parameter()]
+        [string[]]
+        $Gyroscope,
+
+        [Parameter()]
+        [string[]]
+        $LayoutAnimations,
+
+        [Parameter()]
+        [string[]]
+        $LegacyImageFormats,
+
+        [Parameter()]
+        [string[]]
+        $Magnetometer,
+
+        [Parameter()]
+        [string[]]
+        $Microphone,
+
+        [Parameter()]
+        [string[]]
+        $Midi,
+
+        [Parameter()]
+        [string[]]
+        $OversizedImages,
+
+        [Parameter()]
+        [string[]]
+        $Payment,
+
+        [Parameter()]
+        [string[]]
+        $PictureInPicture,
+
+        [Parameter()]
+        [string[]]
+        $PublicKeyCredentials,
+
+        [Parameter()]
+        [string[]]
+        $Speakers,
+
+        [Parameter()]
+        [string[]]
+        $SyncXhr,
+
+        [Parameter()]
+        [string[]]
+        $UnoptimisedImages,
+
+        [Parameter()]
+        [string[]]
+        $UnsizedMedia,
+
+        [Parameter()]
+        [string[]]
+        $Usb,
+
+        [Parameter()]
+        [string[]]
+        $ScreenWakeLake,
+
+        [Parameter()]
+        [string[]]
+        $WebShare,
+
+        [Parameter()]
+        [string[]]
+        $XrSpatialTracking
+    )
+
+    # build the header's value
+    $values = @(
+        Protect-PodePermissionPolicyKeyword -Name 'accelerometer' -Value $Accelerometer
+        Protect-PodePermissionPolicyKeyword -Name 'ambient-light-sensor' -Value $AmbientLightSensor
+        Protect-PodePermissionPolicyKeyword -Name 'autoplay' -Value $Autoplay
+        Protect-PodePermissionPolicyKeyword -Name 'battery' -Value $Battery
+        Protect-PodePermissionPolicyKeyword -Name 'camera' -Value $Camera
+        Protect-PodePermissionPolicyKeyword -Name 'display-capture' -Value $DisplayCapture
+        Protect-PodePermissionPolicyKeyword -Name 'document-domain' -Value $DocumentDomain
+        Protect-PodePermissionPolicyKeyword -Name 'encrypted-media' -Value $EncryptedMedia
+        Protect-PodePermissionPolicyKeyword -Name 'fullscreen' -Value $Fullscreen
+        Protect-PodePermissionPolicyKeyword -Name 'gamepad' -Value $Gamepad
+        Protect-PodePermissionPolicyKeyword -Name 'geolocation' -Value $Geolocation
+        Protect-PodePermissionPolicyKeyword -Name 'gyroscope' -Value $Gyroscope
+        Protect-PodePermissionPolicyKeyword -Name 'layout-animations' -Value $LayoutAnimations
+        Protect-PodePermissionPolicyKeyword -Name 'legacy-image-formats' -Value $LegacyImageFormats
+        Protect-PodePermissionPolicyKeyword -Name 'magnetometer' -Value $Magnetometer
+        Protect-PodePermissionPolicyKeyword -Name 'microphone' -Value $Microphone
+        Protect-PodePermissionPolicyKeyword -Name 'midi' -Value $Midi
+        Protect-PodePermissionPolicyKeyword -Name 'oversized-images' -Value $OversizedImages
+        Protect-PodePermissionPolicyKeyword -Name 'payment' -Value $Payment
+        Protect-PodePermissionPolicyKeyword -Name 'picture-in-picture' -Value $PictureInPicture
+        Protect-PodePermissionPolicyKeyword -Name 'publickey-credentials-get' -Value $PublicKeyCredentials
+        Protect-PodePermissionPolicyKeyword -Name 'speaker-selection' -Value $Speakers
+        Protect-PodePermissionPolicyKeyword -Name 'sync-xhr' -Value $SyncXhr
+        Protect-PodePermissionPolicyKeyword -Name 'unoptimized-images' -Value $UnoptimisedImages
+        Protect-PodePermissionPolicyKeyword -Name 'unsized-media' -Value $UnsizedMedia
+        Protect-PodePermissionPolicyKeyword -Name 'usb' -Value $Usb
+        Protect-PodePermissionPolicyKeyword -Name 'screen-wake-lock' -Value $ScreenWakeLake
+        Protect-PodePermissionPolicyKeyword -Name 'web-share' -Value $WebShare
+        Protect-PodePermissionPolicyKeyword -Name 'xr-spatial-tracking' -Value $XrSpatialTracking
+    )
+
+    $values = ($values -ne $null)
+    $value = ($values -join ', ')
+
+    # add the header
+    Add-PodeSecurityHeader -Name 'Permission-Policy' -Value $value
+}
+
+function Remove-PodeSecurityPermissionPolicy
+{
+    [CmdletBinding()]
+    param()
+
+    Remove-PodeSecurityHeader -Name 'Permission-Policy'
+}
+
+function Set-PodeSecurityReferrerPolicy
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [ValidateSet('No-Referrer', 'No-Referrer-When-Downgrade', 'Same-Origin', 'Origin', 'Strict-Origin',
+            'Origin-When-Cross-Origin', 'Strict-Origin-When-Cross-Origin', 'Unsafe-Url')]
+        [string]
+        $Type
+    )
+
+    Add-PodeSecurityHeader -Name 'Referred-Policy' -Value $Type.ToLowerInvariant()
+}
+
+function Remove-PodeSecurityReferrerPolicy
+{
+    [CmdletBinding()]
+    param()
+
+    Remove-PodeSecurityHeader -Name 'Referred-Policy'
+}
+
+function Set-PodeSecurityContentTypeOptions
+{
+    [CmdletBinding()]
+    param()
+
+    Add-PodeSecurityHeader -Name 'X-Content-Type-Options' -Value 'nosniff'
+}
+
+function Remove-PodeSecurityContentTypeOptions
+{
+    [CmdletBinding()]
+    param()
+
+    Remove-PodeSecurityHeader -Name 'X-Content-Type-Options'
+}
+
+function Set-PodeSecurityStrictTransportSecurity
+{
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [int]
+        $Duration = 31536000,
+
+        [switch]
+        $IncludeSubDomains
+    )
+
+    if ($Duration -le 0) {
+        throw "Invalid Strict-Transport-Security duration supplied: $($Duration). Should be greater than 0"
+    }
+
+    $value = "max-age=$($Duration)"
+    
+    if ($IncludeSubDomains) {
+        $value += "; includeSubDomains"
+    }
+
+    Add-PodeSecurityHeader -Name 'Strict-Transport-Security' -Value $value
+}
+
+function Remove-PodeSecurityStrictTransportSecurity
+{
+    [CmdletBinding()]
+    param()
+
+    Remove-PodeSecurityHeader -Name 'Strict-Transport-Security'
+}
+
+function Set-PodeSecurityCrossOrigin
+{
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [ValidateSet('', 'Unsafe-None', 'Require-Corp')]
+        [string]
+        $Embed = '',
+
+        [Parameter()]
+        [ValidateSet('', 'Unsafe-None', 'Same-Origin-Allow-Popups', 'Same-Origin')]
+        [string]
+        $Open = '',
+
+        [Parameter()]
+        [ValidateSet('', 'Same-Site', 'Same-Origin', 'Cross-Origin')]
+        [string]
+        $Resource = ''
+    )
+
+    Add-PodeSecurityHeader -Name 'Cross-Origin-Embedder-Policy' -Value $Embed.ToLowerInvariant()
+    Add-PodeSecurityHeader -Name 'Cross-Origin-Opener-Policy' -Value $Open.ToLowerInvariant()
+    Add-PodeSecurityHeader -Name 'Cross-Origin-Resource-Policy' -Value $Resource.ToLowerInvariant()
+}
+
+function Remove-PodeSecurityCrossOrigin
+{
+    [CmdletBinding()]
+    param()
+
+    Remove-PodeSecurityHeader -Name 'Cross-Origin-Embedder-Policy'
+    Remove-PodeSecurityHeader -Name 'Cross-Origin-Opener-Policy'
+    Remove-PodeSecurityHeader -Name 'Cross-Origin-Resource-Policy'
+}
+
+
+
+function Set-PodeSecurityAccessControl
+{
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [string]
+        $Origin,
+
+        [Parameter()]
+        [ValidateSet('', 'Delete', 'Get', 'Head', 'Merge', 'Options', 'Patch', 'Post', 'Put', 'Trace', '*')]
+        [string[]]
+        $Methods = '',
+
+        [Parameter()]
+        [string[]]
+        $Headers,
+
+        [Parameter()]
+        [int]
+        $Duration = 7200,
+
+        [switch]
+        $Credentials
+    )
+
+    # origin
+    Add-PodeSecurityHeader -Name 'Access-Control-Allow-Origin' -Value $Origin
+
+    # methods
+    if (![string]::IsNullOrWhiteSpace($Method)) {
+        if ($Method -icontains '*') {
+            Add-PodeSecurityHeader -Name 'Access-Control-Allow-Methods' -Value '*'
+        }
+        else {
+            Add-PodeSecurityHeader -Name 'Access-Control-Allow-Methods' -Value ($Method -join ', ').ToUpperInvariant()
+        }
+    }
+
+    # headers
+    if (![string]::IsNullOrWhiteSpace($Header)) {
+        if ($Header -icontains '*') {
+            Add-PodeSecurityHeader -Name 'Access-Control-Allow-Headers' -Value '*'
+        }
+        else {
+            Add-PodeSecurityHeader -Name 'Access-Control-Allow-Headers' -Value ($Header -join ', ').ToUpperInvariant()
+        }
+    }
+
+    # duration
+    if ($Duration -le 0) {
+        throw "Invalid Access-Control-Max-Age duration supplied: $($Duration). Should be greater than 0"
+    }
+
+    Add-PodeSecurityHeader -Name 'Access-Control-Max-Age' -Value $Duration
+
+    # creds
+    if ($Credentials) {
+        Add-PodeSecurityHeader -Name 'Access-Control-Allow-Credentials' -Value 'true'
+    }
+}
+
+function Remove-PodeSecurityAccessControl
+{
+    [CmdletBinding()]
+    param()
+
+    Remove-PodeSecurityHeader -Name 'Access-Control-Allow-Origin'
+    Remove-PodeSecurityHeader -Name 'Access-Control-Allow-Methods'
+    Remove-PodeSecurityHeader -Name 'Access-Control-Allow-Headers'
+    Remove-PodeSecurityHeader -Name 'Access-Control-Max-Age'
+    Remove-PodeSecurityHeader -Name 'Access-Control-Allow-Credentials'
 }

--- a/src/Public/Security.ps1
+++ b/src/Public/Security.ps1
@@ -1,3 +1,25 @@
+<#
+.SYNOPSIS
+Sets inbuilt definitions for security headers.
+
+.DESCRIPTION
+Sets inbuilt definitions for security headers, in either Simple or Strict types.
+
+.PARAMETER Type
+The Type of security to use.
+
+.PARAMETER UseHsts
+If supplied, the Strict-Transport-Security header will be set.
+
+.PARAMETER XssBlock
+If supplied, the X-XSS-Protection header will be set to blocking mode. (Default: Off)
+
+.EXAMPLE
+Set-PodeSecurity -Type Simple
+
+.EXAMPLE
+Set-PodeSecurity -Type Strict -UseHsts
+#>
 function Set-PodeSecurity
 {
     [CmdletBinding()]
@@ -47,6 +69,16 @@ function Set-PodeSecurity
     }
 }
 
+<#
+.SYNOPSIS
+Removes definitions for all security headers.
+
+.DESCRIPTION
+Removes definitions for all security headers.
+
+.EXAMPLE
+Remove-PodeSecurity
+#>
 function Remove-PodeSecurity
 {
     [CmdletBinding()]
@@ -55,6 +87,22 @@ function Remove-PodeSecurity
     $PodeContext.Server.Security.Headers.Clear()
 }
 
+<#
+.SYNOPSIS
+Add definition for specified security header.
+
+.DESCRIPTION
+Add definition for specified security header.
+
+.PARAMETER Name
+The Name of the security header.
+
+.PARAMETER Value
+The Value of the security header.
+
+.EXAMPLE
+Add-PodeSecurityHeader -Name 'X-Header-Name' -Value 'SomeValue'
+#>
 function Add-PodeSecurityHeader
 {
     [CmdletBinding()]
@@ -73,6 +121,19 @@ function Add-PodeSecurityHeader
     }
 }
 
+<#
+.SYNOPSIS
+Removes definition for specified security header.
+
+.DESCRIPTION
+Removes definition for specified security header.
+
+.PARAMETER Name
+The Name of the security header.
+
+.EXAMPLE
+Remove-PodeSecurityHeader -Name 'X-Header-Name'
+#>
 function Remove-PodeSecurityHeader
 {
     [CmdletBinding()]
@@ -85,6 +146,19 @@ function Remove-PodeSecurityHeader
     $PodeContext.Server.Security.Headers.Remove($Name)
 }
 
+<#
+.SYNOPSIS
+Set a value for the X-Frame-Options header.
+
+.DESCRIPTION
+Set a value for the X-Frame-Options header.
+
+.PARAMETER Type
+The Type to use.
+
+.EXAMPLE
+Set-PodeSecurityFrameOptions -Type SameOrigin
+#>
 function Set-PodeSecurityFrameOptions
 {
     [CmdletBinding()]
@@ -98,6 +172,16 @@ function Set-PodeSecurityFrameOptions
     Add-PodeSecurityHeader -Name 'X-Frame-Options' -Value $Type.ToUpperInvariant()
 }
 
+<#
+.SYNOPSIS
+Removes definition for the X-Frame-Options header.
+
+.DESCRIPTION
+Removes definition for the X-Frame-Options header.
+
+.EXAMPLE
+Remove-PodeSecurityFrameOptions
+#>
 function Remove-PodeSecurityFrameOptions
 {
     [CmdletBinding()]
@@ -106,6 +190,67 @@ function Remove-PodeSecurityFrameOptions
     Remove-PodeSecurityHeader -Name 'X-Frame-Options'
 }
 
+<#
+.SYNOPSIS
+Set the value to use for the Content-Security-Policy and X-XSS-Protection headers.
+
+.DESCRIPTION
+Set the value to use for the Content-Security-Policy and X-XSS-Protection headers.
+
+.PARAMETER Default
+The values to use for the Default portion of the header.
+
+.PARAMETER Child
+The values to use for the Child portion of the header.
+
+.PARAMETER Connect
+The values to use for the Connect portion of the header.
+
+.PARAMETER Font
+The values to use for the Font portion of the header.
+
+.PARAMETER Frame
+The values to use for the Frame portion of the header.
+
+.PARAMETER Image
+The values to use for the Image portion of the header.
+
+.PARAMETER Manifest
+The values to use for the Manifest portion of the header.
+
+.PARAMETER Media
+The values to use for the Media portion of the header.
+
+.PARAMETER Object
+The values to use for the Object portion of the header.
+
+.PARAMETER Scripts
+The values to use for the Scripts portion of the header.
+
+.PARAMETER Style
+The values to use for the Style portion of the header.
+
+.PARAMETER BaseUri
+The values to use for the BaseUri portion of the header.
+
+.PARAMETER FormAction
+The values to use for the FormAction portion of the header.
+
+.PARAMETER FrameAncestor
+The values to use for the FrameAncestor portion of the header.
+
+.PARAMETER Sandbox
+The value to use for the Sandbox portion of the header.
+
+.PARAMETER UpgradeInsecureRequests
+If supplied, the header will have the upgrade-insecure-requests value added.
+
+.PARAMETER XssBlock
+If supplied, the X-XSS-Protection header will be set to blocking mode. (Default: Off)
+
+.EXAMPLE
+Set-PodeSecurityContentSecurityPolicy -Default 'self'
+#>
 function Set-PodeSecurityContentSecurityPolicy
 {
     [CmdletBinding()]
@@ -222,6 +367,64 @@ function Set-PodeSecurityContentSecurityPolicy
     }
 }
 
+<#
+.SYNOPSIS
+Adds additional values to already defined values for the Content-Security-Policy header.
+
+.DESCRIPTION
+Adds additional values to already defined values for the Content-Security-Policy header, instead of overriding them.
+
+.PARAMETER Default
+The values to add for the Default portion of the header.
+
+.PARAMETER Child
+The values to add for the Child portion of the header.
+
+.PARAMETER Connect
+The values to add for the Connect portion of the header.
+
+.PARAMETER Font
+The values to add for the Font portion of the header.
+
+.PARAMETER Frame
+The values to add for the Frame portion of the header.
+
+.PARAMETER Image
+The values to add for the Image portion of the header.
+
+.PARAMETER Manifest
+The values to add for the Manifest portion of the header.
+
+.PARAMETER Media
+The values to add for the Media portion of the header.
+
+.PARAMETER Object
+The values to add for the Object portion of the header.
+
+.PARAMETER Scripts
+The values to add for the Scripts portion of the header.
+
+.PARAMETER Style
+The values to add for the Style portion of the header.
+
+.PARAMETER BaseUri
+The values to add for the BaseUri portion of the header.
+
+.PARAMETER FormAction
+The values to add for the FormAction portion of the header.
+
+.PARAMETER FrameAncestor
+The values to add for the FrameAncestor portion of the header.
+
+.PARAMETER Sandbox
+The value to use for the Sandbox portion of the header.
+
+.PARAMETER UpgradeInsecureRequests
+If supplied, the header will have the upgrade-insecure-requests value added.
+
+.EXAMPLE
+Add-PodeSecurityContentSecurityPolicy -Default '*.twitter.com' -Image 'data'
+#>
 function Add-PodeSecurityContentSecurityPolicy
 {
     [CmdletBinding()]
@@ -326,6 +529,16 @@ function Add-PodeSecurityContentSecurityPolicy
     Add-PodeSecurityHeader -Name 'Content-Security-Policy' -Value $value
 }
 
+<#
+.SYNOPSIS
+Removes definition for the Content-Security-Policy and X-XSS-Protection headers.
+
+.DESCRIPTION
+Removes definition for the Content-Security-Policy and X-XSS-Protection headers.
+
+.EXAMPLE
+Remove-PodeSecurityContentSecurityPolicy
+#>
 function Remove-PodeSecurityContentSecurityPolicy
 {
     [CmdletBinding()]
@@ -335,6 +548,103 @@ function Remove-PodeSecurityContentSecurityPolicy
     Remove-PodeSecurityHeader -Name 'X-XSS-Protection'
 }
 
+<#
+.SYNOPSIS
+Set the value to use for the Permission-Policy header.
+
+.DESCRIPTION
+Set the value to use for the Permission-Policy header.
+
+.PARAMETER Accelerometer
+The values to use for the Accelerometer portion of the header.
+
+.PARAMETER AmbientLightSensor
+The values to use for the AmbientLightSensor portion of the header.
+
+.PARAMETER Autoplay
+The values to use for the Autoplay portion of the header.
+
+.PARAMETER Battery
+The values to use for the Battery portion of the header.
+
+.PARAMETER Camera
+The values to use for the Camera portion of the header.
+
+.PARAMETER DisplayCapture
+The values to use for the DisplayCapture portion of the header.
+
+.PARAMETER DocumentDomain
+The values to use for the DocumentDomain portion of the header.
+
+.PARAMETER EncryptedMedia
+The values to use for the EncryptedMedia portion of the header.
+
+.PARAMETER Fullscreen
+The values to use for the Fullscreen portion of the header.
+
+.PARAMETER Gamepad
+The values to use for the Gamepad portion of the header.
+
+.PARAMETER Geolocation
+The values to use for the Geolocation portion of the header.
+
+.PARAMETER Gyroscope
+The values to use for the Gyroscope portion of the header.
+
+.PARAMETER LayoutAnimations
+The values to use for the LayoutAnimations portion of the header.
+
+.PARAMETER LegacyImageFormats
+The values to use for the LegacyImageFormats portion of the header.
+
+.PARAMETER Magnetometer
+The values to use for the Magnetometer portion of the header.
+
+.PARAMETER Microphone
+The values to use for the Microphone portion of the header.
+
+.PARAMETER Midi
+The values to use for the Midi portion of the header.
+
+.PARAMETER OversizedImages
+The values to use for the OversizedImages portion of the header.
+
+.PARAMETER Payment
+The values to use for the Payment portion of the header.
+
+.PARAMETER PictureInPicture
+The values to use for the PictureInPicture portion of the header.
+
+.PARAMETER PublicKeyCredentials
+The values to use for the PublicKeyCredentials portion of the header.
+
+.PARAMETER Speakers
+The values to use for the Speakers portion of the header.
+
+.PARAMETER SyncXhr
+The values to use for the SyncXhr portion of the header.
+
+.PARAMETER UnoptimisedImages
+The values to use for the UnoptimisedImages portion of the header.
+
+.PARAMETER UnsizedMedia
+The values to use for the UnsizedMedia portion of the header.
+
+.PARAMETER Usb
+The values to use for the Usb portion of the header.
+
+.PARAMETER ScreenWakeLake
+The values to use for the ScreenWakeLake portion of the header.
+
+.PARAMETER WebShare
+The values to use for the WebShare portion of the header.
+
+.PARAMETER XrSpatialTracking
+The values to use for the XrSpatialTracking portion of the header.
+
+.EXAMPLE
+Set-PodeSecurityPermissionPolicy -LayoutAnimations 'none' -UnoptimisedImages 'none' -OversizedImages 'none' -SyncXhr 'none' -UnsizedMedia 'none'
+#>
 function Set-PodeSecurityPermissionPolicy
 {
     [CmdletBinding()]
@@ -496,6 +806,103 @@ function Set-PodeSecurityPermissionPolicy
     Add-PodeSecurityHeader -Name 'Permission-Policy' -Value $value
 }
 
+<#
+.SYNOPSIS
+Adds additional values to already defined values for the Permission-Policy header.
+
+.DESCRIPTION
+Adds additional values to already defined values for the Permission-Policy header, instead of overriding them.
+
+.PARAMETER Accelerometer
+The values to add for the Accelerometer portion of the header.
+
+.PARAMETER AmbientLightSensor
+The values to add for the AmbientLightSensor portion of the header.
+
+.PARAMETER Autoplay
+The values to add for the Autoplay portion of the header.
+
+.PARAMETER Battery
+The values to add for the Battery portion of the header.
+
+.PARAMETER Camera
+The values to add for the Camera portion of the header.
+
+.PARAMETER DisplayCapture
+The values to add for the DisplayCapture portion of the header.
+
+.PARAMETER DocumentDomain
+The values to add for the DocumentDomain portion of the header.
+
+.PARAMETER EncryptedMedia
+The values to add for the EncryptedMedia portion of the header.
+
+.PARAMETER Fullscreen
+The values to add for the Fullscreen portion of the header.
+
+.PARAMETER Gamepad
+The values to add for the Gamepad portion of the header.
+
+.PARAMETER Geolocation
+The values to add for the Geolocation portion of the header.
+
+.PARAMETER Gyroscope
+The values to add for the Gyroscope portion of the header.
+
+.PARAMETER LayoutAnimations
+The values to add for the LayoutAnimations portion of the header.
+
+.PARAMETER LegacyImageFormats
+The values to add for the LegacyImageFormats portion of the header.
+
+.PARAMETER Magnetometer
+The values to add for the Magnetometer portion of the header.
+
+.PARAMETER Microphone
+The values to add for the Microphone portion of the header.
+
+.PARAMETER Midi
+The values to add for the Midi portion of the header.
+
+.PARAMETER OversizedImages
+The values to add for the OversizedImages portion of the header.
+
+.PARAMETER Payment
+The values to add for the Payment portion of the header.
+
+.PARAMETER PictureInPicture
+The values to add for the PictureInPicture portion of the header.
+
+.PARAMETER PublicKeyCredentials
+The values to add for the PublicKeyCredentials portion of the header.
+
+.PARAMETER Speakers
+The values to add for the Speakers portion of the header.
+
+.PARAMETER SyncXhr
+The values to add for the SyncXhr portion of the header.
+
+.PARAMETER UnoptimisedImages
+The values to add for the UnoptimisedImages portion of the header.
+
+.PARAMETER UnsizedMedia
+The values to add for the UnsizedMedia portion of the header.
+
+.PARAMETER Usb
+The values to add for the Usb portion of the header.
+
+.PARAMETER ScreenWakeLake
+The values to add for the ScreenWakeLake portion of the header.
+
+.PARAMETER WebShare
+The values to add for the WebShare portion of the header.
+
+.PARAMETER XrSpatialTracking
+The values to add for the XrSpatialTracking portion of the header.
+
+.EXAMPLE
+Add-PodeSecurityPermissionPolicy -AmbientLightSensor 'none'
+#>
 function Add-PodeSecurityPermissionPolicy
 {
     [CmdletBinding()]
@@ -657,6 +1064,16 @@ function Add-PodeSecurityPermissionPolicy
     Add-PodeSecurityHeader -Name 'Permission-Policy' -Value $value
 }
 
+<#
+.SYNOPSIS
+Removes definition for the Permission-Policy header.
+
+.DESCRIPTION
+Removes definitions for the Permission-Policy header.
+
+.EXAMPLE
+Remove-PodeSecurityPermissionPolicy
+#>
 function Remove-PodeSecurityPermissionPolicy
 {
     [CmdletBinding()]
@@ -665,6 +1082,19 @@ function Remove-PodeSecurityPermissionPolicy
     Remove-PodeSecurityHeader -Name 'Permission-Policy'
 }
 
+<#
+.SYNOPSIS
+Set a value for the Referrer-Policy header.
+
+.DESCRIPTION
+Set a value for the Referrer-Policy header.
+
+.PARAMETER Type
+The Type to use.
+
+.EXAMPLE
+Set-PodeSecurityReferrerPolicy -Type No-Referrer
+#>
 function Set-PodeSecurityReferrerPolicy
 {
     [CmdletBinding()]
@@ -679,6 +1109,16 @@ function Set-PodeSecurityReferrerPolicy
     Add-PodeSecurityHeader -Name 'Referrer-Policy' -Value $Type.ToLowerInvariant()
 }
 
+<#
+.SYNOPSIS
+Removes definition for the Referrer-Policy header.
+
+.DESCRIPTION
+Removes definitions for the Referrer-Policy header.
+
+.EXAMPLE
+Remove-PodeSecurityReferrerPolicy
+#>
 function Remove-PodeSecurityReferrerPolicy
 {
     [CmdletBinding()]
@@ -687,6 +1127,16 @@ function Remove-PodeSecurityReferrerPolicy
     Remove-PodeSecurityHeader -Name 'Referrer-Policy'
 }
 
+<#
+.SYNOPSIS
+Set a value for the X-Content-Type-Options header.
+
+.DESCRIPTION
+Set a value for the X-Content-Type-Options header to "nosniff".
+
+.EXAMPLE
+Set-PodeSecurityContentTypeOptions
+#>
 function Set-PodeSecurityContentTypeOptions
 {
     [CmdletBinding()]
@@ -695,6 +1145,16 @@ function Set-PodeSecurityContentTypeOptions
     Add-PodeSecurityHeader -Name 'X-Content-Type-Options' -Value 'nosniff'
 }
 
+<#
+.SYNOPSIS
+Removes definition for the X-Content-Type-Options header.
+
+.DESCRIPTION
+Removes definitions for the X-Content-Type-Options header.
+
+.EXAMPLE
+Remove-PodeSecurityContentTypeOptions
+#>
 function Remove-PodeSecurityContentTypeOptions
 {
     [CmdletBinding()]
@@ -703,6 +1163,22 @@ function Remove-PodeSecurityContentTypeOptions
     Remove-PodeSecurityHeader -Name 'X-Content-Type-Options'
 }
 
+<#
+.SYNOPSIS
+Set a value for the Strict-Transport-Security header.
+
+.DESCRIPTION
+Set a value for the Strict-Transport-Security header.
+
+.PARAMETER Duration
+The Duration the browser to respect the header in seconds. (Default: 1 year)
+
+.PARAMETER IncludeSubDomains
+If supplied, the header will have includeSubDomains.
+
+.EXAMPLE
+Set-PodeSecurityStrictTransportSecurity -Duration 86400 -IncludeSubDomains
+#>
 function Set-PodeSecurityStrictTransportSecurity
 {
     [CmdletBinding()]
@@ -728,6 +1204,16 @@ function Set-PodeSecurityStrictTransportSecurity
     Add-PodeSecurityHeader -Name 'Strict-Transport-Security' -Value $value
 }
 
+<#
+.SYNOPSIS
+Removes definition for the Strict-Transport-Security header.
+
+.DESCRIPTION
+Removes definitions for the Strict-Transport-Security header.
+
+.EXAMPLE
+Remove-PodeSecurityStrictTransportSecurity
+#>
 function Remove-PodeSecurityStrictTransportSecurity
 {
     [CmdletBinding()]
@@ -736,6 +1222,25 @@ function Remove-PodeSecurityStrictTransportSecurity
     Remove-PodeSecurityHeader -Name 'Strict-Transport-Security'
 }
 
+<#
+.SYNOPSIS
+Removes definitions for the Cross-Origin headers.
+
+.DESCRIPTION
+Removes definitions for the Cross-Origin headers: Cross-Origin-Embedder-Policy, Cross-Origin-Opener-Policy, Cross-Origin-Resource-Policy
+
+.PARAMETER Embed
+Specifies a value for Cross-Origin-Embedder-Policy.
+
+.PARAMETER Open
+Specifies a value for Cross-Origin-Opener-Policy.
+
+.PARAMETER Resource
+Specifies a value for Cross-Origin-Resource-Policy.
+
+.EXAMPLE
+Set-PodeSecurityCrossOrigin -Embed Require-Corp -Open Same-Origin -Resource Same-Origin
+#>
 function Set-PodeSecurityCrossOrigin
 {
     [CmdletBinding()]
@@ -761,6 +1266,16 @@ function Set-PodeSecurityCrossOrigin
     Add-PodeSecurityHeader -Name 'Cross-Origin-Resource-Policy' -Value $Resource.ToLowerInvariant()
 }
 
+<#
+.SYNOPSIS
+Removes definitions for the Cross-Origin headers.
+
+.DESCRIPTION
+Removes definitions for the Cross-Origin headers: Cross-Origin-Embedder-Policy, Cross-Origin-Opener-Policy, Cross-Origin-Resource-Policy
+
+.EXAMPLE
+Remove-PodeSecurityCrossOrigin
+#>
 function Remove-PodeSecurityCrossOrigin
 {
     [CmdletBinding()]
@@ -771,6 +1286,31 @@ function Remove-PodeSecurityCrossOrigin
     Remove-PodeSecurityHeader -Name 'Cross-Origin-Resource-Policy'
 }
 
+<#
+.SYNOPSIS
+Set definitions for Access-Control headers.
+
+.DESCRIPTION
+Removes definitions for the Access-Control headers: Access-Control-Allow-Origin, Access-Control-Allow-Methods, Access-Control-Allow-Headers, Access-Control-Max-Age, Access-Control-Allow-Credentials
+
+.PARAMETER Origin
+Specifies a value for Access-Control-Allow-Origin.
+
+.PARAMETER Methods
+Specifies a value for Access-Control-Allow-Methods.
+
+.PARAMETER Headers
+Specifies a value for Access-Control-Allow-Headers.
+
+.PARAMETER Duration
+Specifies a value for Access-Control-Max-Age in seconds. (Default: 7200)
+
+.PARAMETER Credentials
+Specifies a value for Access-Control-Allow-Credentials
+
+.EXAMPLE
+Set-PodeSecurityAccessControl -Origin '*' -Methods '*' -Headers '*' -Duration 7200
+#>
 function Set-PodeSecurityAccessControl
 {
     [CmdletBinding()]
@@ -832,6 +1372,16 @@ function Set-PodeSecurityAccessControl
     }
 }
 
+<#
+.SYNOPSIS
+Removes definitions for the Access-Control headers.
+
+.DESCRIPTION
+Removes definitions for the Access-Control headers: Access-Control-Allow-Origin, Access-Control-Allow-Methods, Access-Control-Allow-Headers, Access-Control-Max-Age, Access-Control-Allow-Credentials
+
+.EXAMPLE
+Remove-PodeSecurityAccessControl
+#>
 function Remove-PodeSecurityAccessControl
 {
     [CmdletBinding()]

--- a/tests/unit/Server.Tests.ps1
+++ b/tests/unit/Server.Tests.ps1
@@ -155,6 +155,10 @@ Describe 'Restart-PodeInternalServer' {
                 }
                 Security = @{
                     Headers = @{}
+                    Cache = @{
+                        ContentSecurity  = @{}
+                        PermissionPolicy = @{}
+                    }
                 }
             };
             Metrics = @{

--- a/tests/unit/Server.Tests.ps1
+++ b/tests/unit/Server.Tests.ps1
@@ -153,6 +153,9 @@ Describe 'Restart-PodeInternalServer' {
                 Events = @{
                     Start = @{}
                 }
+                Security = @{
+                    Headers = @{}
+                }
             };
             Metrics = @{
                 Server = @{

--- a/tests/unit/Server.Tests.ps1
+++ b/tests/unit/Server.Tests.ps1
@@ -157,7 +157,7 @@ Describe 'Restart-PodeInternalServer' {
                     Headers = @{}
                     Cache = @{
                         ContentSecurity  = @{}
-                        PermissionPolicy = @{}
+                        PermissionsPolicy = @{}
                     }
                 }
             };


### PR DESCRIPTION
### Description of the Change
Adds support for helper functions for setting/configuring security HTTP headers. The following headers are supported:

```plain
Access-Control-Max-Age
Access-Control-Allow-Methods
Access-Control-Allow-Origin
Access-Control-Allow-Headers
Cross-Origin-Embedder-Policy
Cross-Origin-Resource-Policy
Cross-Origin-Opener-Policy
Strict-Transport-Security
Content-Security-Policy
X-XSS-Protection
Permissions-Policy
X-Frame-Options
X-Content-Type-Options
Referrer-Policy
```

With `Set-PodeSecurity -Type Simple`, these are the default headers:
```plain
Access-Control-Max-Age: 7200
Access-Control-Allow-Origin: *
Access-Control-Allow-Methods: *
Access-Control-Allow-Headers: *

Cross-Origin-Embedder-Policy: require-corp
Cross-Origin-Resource-Policy: same-origin
Cross-Origin-Opener-Policy: same-origin

Content-Security-Policy: default-src 'self'
X-XSS-Protection: 0

Permissions-Policy: layout-animations=(), oversized-images=(), sync-xhr=(), unoptimized-images=(), unsized-media=()

X-Frame-Options: SAMEORIGIN
X-Content-Type-Options: nosniff
Referred-Policy: strict-origin
```

and with `Set-PodeSecurity -Type Strict`:
```plain
Access-Control-Max-Age: 7200
Access-Control-Allow-Methods: *
Access-Control-Allow-Origin: *
Access-Control-Allow-Headers: *

Cross-Origin-Embedder-Policy: require-corp
Cross-Origin-Resource-Policy: same-origin
Cross-Origin-Opener-Policy: same-origin

Strict-Transport-Security: max-age=31536000; includeSubDomains
Content-Security-Policy: default-src 'self'
X-XSS-Protection: 0

Permissions-Policy: layout-animations=(), oversized-images=(), sync-xhr=(), unoptimized-images=(), unsized-media=()

X-Frame-Options: DENY
X-Content-Type-Options: nosniff
Referred-Policy: no-referrer
```

You can build your own headers by using:
* `Set-PodeSecurityAccessControl`
* `Set-PodeSecurityContentSecurityPolicy`
* `Add-PodeSecurityContentSecurityPolicy`
* `Set-PodeSecurityContentTypeOptions`
* `Set-PodeSecurityCrossOrigin`
* `Set-PodeSecurityFrameOptions`
* `Set-PodeSecurityPermissionPolicy`
* `Add-PodeSecurityPermissionsPolicy`
* `Set-PodeSecurityReferrerPolicy`
* `Set-PodeSecurityStrictTransportSecurity`

And you can remove headers using:
* `Remove-PodeSecurityAccessControl`
* `Remove-PodeSecurityContentSecurityPolicy`
* `Remove-PodeSecurityContentTypeOptions`
* `Remove-PodeSecurityCrossOrigin`
* `Remove-PodeSecurityFrameOptions`
* `Remove-PodeSecurityHeader`
* `Remove-PodeSecurityPermissionsPolicy`
* `Remove-PodeSecurityReferrerPolicy`
* `Remove-PodeSecurityStrictTransportSecurity`

You can add extra custom security headers to be added by default using `Add-PodeSecurityHeader`.

### Related Issue
Resolves #894 
