### PR TITLE
Quick tweak to the default permissions policy defaults

### DIFF
--- a/docs/Tutorials/Middleware/Types/Security.md
+++ b/docs/Tutorials/Middleware/Types/Security.md
@@ -46,7 +46,7 @@ The following values are used for each header when the `Simple` type is supplied
 | Cross-Origin-Opener-Policy | same-origin |
 | Content-Security-Policy | default-src 'self' |
 | X-XSS-Protection | 0 |
-| Permissions-Policy | layout-animations=(), oversized-images=(), sync-xhr=(), unoptimized-images=(), unsized-media=() |
+| Permissions-Policy | accelerometer=(), autoplay=(self), camera=(), display-capture=(self), fullscreen=(self), geolocation=(self), gyroscope=(self), magnetometer=(self), microphone=(), payment=(), picture-in-picture=(self), sync-xhr=(), usb=() |
 | X-Frame-Options | SAMEORIGIN |
 | X-Content-Type-Options | nosniff |
 | Referred-Policy | strict-origin |
@@ -67,7 +67,7 @@ The following values are used for each header when the `Strict` type is supplied
 | Strict-Transport-Security | max-age=31536000; includeSubDomains |
 | Content-Security-Policy | default-src 'self' |
 | X-XSS-Protection | 0 |
-| Permissions-Policy | layout-animations=(), oversized-images=(), sync-xhr=(), unoptimized-images=(), unsized-media=() |
+| Permissions-Policy | accelerometer=(), autoplay=(self), camera=(), display-capture=(self), fullscreen=(self), geolocation=(self), gyroscope=(self), magnetometer=(self), microphone=(), payment=(), picture-in-picture=(self), sync-xhr=(), usb=() |
 | X-Frame-Options | DENY |
 | X-Content-Type-Options | nosniff |
 | Referred-Policy | no-referrer |
@@ -163,7 +163,7 @@ The following functions exist:
 The `Permissions-Policy` header controls which features/APIs a site can use in the browser. For example:
 
 ```powershell
-Set-PodeSecurityPermissionsPolicy -LayoutAnimations 'none' -UnoptimisedImages 'none' -OversizedImages 'none' -SyncXhr 'none' -UnsizedMedia 'none'
+Set-PodeSecurityPermissionsPolicy -SyncXhr 'none' -Camera 'none' -Geolocation 'self'
 ```
 
 ### Frame Options

--- a/examples/web-pages-docker.ps1
+++ b/examples/web-pages-docker.ps1
@@ -5,6 +5,7 @@ Start-PodeServer -Threads 2 {
 
     # listen on *:8085
     Add-PodeEndpoint -Address * -Port 8085 -Protocol Http
+    Set-PodeSecurity -Type Simple
 
     # set view engine to pode renderer
     Set-PodeViewEngine -Type Pode

--- a/src/Private/Security.ps1
+++ b/src/Private/Security.ps1
@@ -1080,7 +1080,9 @@ function Protect-PodePermissionsPolicyKeyword
 
     # cache it
     if ($Append -and !(Test-PodeIsEmpty $PodeContext.Server.Security.Cache.PermissionsPolicy[$Name])) {
-        $Value += @($PodeContext.Server.Security.Cache.PermissionsPolicy[$Name])
+        if (($Value.Length -eq 0) -or (@($PodeContext.Server.Security.Cache.PermissionsPolicy[$Name])[0] -ine 'none')) {
+            $Value += @($PodeContext.Server.Security.Cache.PermissionsPolicy[$Name])
+        }
     }
 
     $PodeContext.Server.Security.Cache.PermissionsPolicy[$Name] = $Value

--- a/src/Public/Security.ps1
+++ b/src/Public/Security.ps1
@@ -40,11 +40,19 @@ function Set-PodeSecurity
     Set-PodeSecurityContentTypeOptions
 
     Set-PodeSecurityPermissionsPolicy `
-        -LayoutAnimations 'none' `
-        -UnoptimisedImages 'none' `
-        -OversizedImages 'none' `
         -SyncXhr 'none' `
-        -UnsizedMedia 'none'
+        -Fullscreen 'self' `
+        -Camera 'none' `
+        -Geolocation 'self' `
+        -PictureInPicture 'self' `
+        -Accelerometer 'none' `
+        -Microphone 'none' `
+        -Usb 'none' `
+        -Autoplay 'self' `
+        -Payment 'none' `
+        -Magnetometer 'self' `
+        -Gyroscope 'self' `
+        -DisplayCapture 'self'
 
     Set-PodeSecurityCrossOrigin -Embed Require-Corp -Open Same-Origin -Resource Same-Origin
     Set-PodeSecurityAccessControl -Origin '*' -Methods '*' -Headers '*' -Duration 7200
@@ -591,6 +599,9 @@ The values to use for the Geolocation portion of the header.
 .PARAMETER Gyroscope
 The values to use for the Gyroscope portion of the header.
 
+.PARAMETER InterestCohort
+The values to use for the InterestCohort portal of the header.
+
 .PARAMETER LayoutAnimations
 The values to use for the LayoutAnimations portion of the header.
 
@@ -699,6 +710,10 @@ function Set-PodeSecurityPermissionsPolicy
 
         [Parameter()]
         [string[]]
+        $InterestCohort,
+
+        [Parameter()]
+        [string[]]
         $LayoutAnimations,
 
         [Parameter()]
@@ -780,6 +795,7 @@ function Set-PodeSecurityPermissionsPolicy
         Protect-PodePermissionsPolicyKeyword -Name 'gamepad' -Value $Gamepad
         Protect-PodePermissionsPolicyKeyword -Name 'geolocation' -Value $Geolocation
         Protect-PodePermissionsPolicyKeyword -Name 'gyroscope' -Value $Gyroscope
+        Protect-PodePermissionsPolicyKeyword -Name 'interest-cohort' -Value $InterestCohort
         Protect-PodePermissionsPolicyKeyword -Name 'layout-animations' -Value $LayoutAnimations
         Protect-PodePermissionsPolicyKeyword -Name 'legacy-image-formats' -Value $LegacyImageFormats
         Protect-PodePermissionsPolicyKeyword -Name 'magnetometer' -Value $Magnetometer
@@ -848,6 +864,9 @@ The values to add for the Geolocation portion of the header.
 
 .PARAMETER Gyroscope
 The values to add for the Gyroscope portion of the header.
+
+.PARAMETER InterestCohort
+The values to use for the InterestCohort portal of the header.
 
 .PARAMETER LayoutAnimations
 The values to add for the LayoutAnimations portion of the header.
@@ -957,6 +976,10 @@ function Add-PodeSecurityPermissionsPolicy
 
         [Parameter()]
         [string[]]
+        $InterestCohort,
+
+        [Parameter()]
+        [string[]]
         $LayoutAnimations,
 
         [Parameter()]
@@ -1038,6 +1061,7 @@ function Add-PodeSecurityPermissionsPolicy
         Protect-PodePermissionsPolicyKeyword -Name 'gamepad' -Value $Gamepad -Append
         Protect-PodePermissionsPolicyKeyword -Name 'geolocation' -Value $Geolocation -Append
         Protect-PodePermissionsPolicyKeyword -Name 'gyroscope' -Value $Gyroscope -Append
+        Protect-PodePermissionsPolicyKeyword -Name 'interest-cohort' -Value $InterestCohort -Append
         Protect-PodePermissionsPolicyKeyword -Name 'layout-animations' -Value $LayoutAnimations -Append
         Protect-PodePermissionsPolicyKeyword -Name 'legacy-image-formats' -Value $LegacyImageFormats -Append
         Protect-PodePermissionsPolicyKeyword -Name 'magnetometer' -Value $Magnetometer -Append


### PR DESCRIPTION
Quick tweak to the default values for the Permissions-Policy header, plus adding `interest-cohort` as well.

The defaults are now:
```plain
accelerometer=(), autoplay=(self), camera=(), display-capture=(self), fullscreen=(self), geolocation=(self), gyroscope=(self), magnetometer=(self), microphone=(), payment=(), picture-in-picture=(self), sync-xhr=(), usb=()
```