### PR TITLE
Only create RunspacePools when needed, and add parameter to force enable some pools

### DIFF
--- a/docs/Tutorials/Schedules.md
+++ b/docs/Tutorials/Schedules.md
@@ -6,9 +6,7 @@ Schedule triggers are defined using [`cron expressions`](../Misc/CronExpressions
 
 ## Create a Schedule
 
-To create a new Schedule in your server you use the Schedule functions.
-
-To create a basic Schedule, the following example will work; this will trigger at '00:05' every Tuesday outputting the current date/time:
+You can create a new schedule using [`Add-PodeSchedule`](../../Functions/Schedules/Add-PodeSchedule). To create a basic Schedule, the following example will work; this will trigger at '00:05' every Tuesday outputting the current date/time:
 
 ```powershell
 Add-PodeSchedule -Name 'date' -Cron '5 0 * * TUE' -ScriptBlock {
@@ -29,6 +27,20 @@ You can also supply multiple cron expressions for the same Schedule. For example
 ```powershell
 Add-PodeSchedule -Name 'date' -Cron @('@minutely', '@hourly') -ScriptBlock {
     Write-Host "$([DateTime]::Now)"
+}
+```
+
+Usually all schedules are created within the main `Start-PodeServer` scope, however it is possible to create adhoc schedules with routes/etc. If you create adhoc schedules in this manor, you might notice that they don't run; this is because the Runspace that schedules use to run won't have been configured. You can configure by using `-EnablePool` on [`Start-PodeServer`](../../Functions/Core/Start-PodeServer):
+
+```powershell
+Start-PodeServer -EnablePool Schedules {
+    Add-PodeEndpoint -Address * -Port 8080 -Protocol Http
+
+    Add-PodeRoute -Method Get -Path '/create-schedule' -ScriptBlock {
+        Add-PodeSchedule -Name 'example' -Cron '@minutely' -ScriptBlock {
+            # logic
+        }
+    }
 }
 ```
 

--- a/docs/Tutorials/Timers.md
+++ b/docs/Tutorials/Timers.md
@@ -3,17 +3,29 @@
 A Timer in Pode is a short-running async task. All timers in Pode run in the same runspace along side your main server logic - so aim to keep them as short running as possible. Timers have unique names, and iterate on a defined number of seconds.
 
 !!! warning
-    Since all timers are run within the same runspace, it is wise to keep them as short running as possible. If you require a long-running task we recommend you use [Schedules](../Schedules) instead.
+    Since all timers are run within the same runspace, it is wise to keep them as short running as possible. If you require a long-running task it's recommend to use [Schedules](../Schedules) instead.
 
 ## Create a Timer
 
-To create a new Timer in your server you use the Timer functions.
-
-To create a basic Timer, the following example will work; this will loop every 5 seconds outputting the date/time:
+You can create a new timer using [`Add-PodeTimer`](../../Functions/Timers/Add-PodeTimer). To create a basic Timer, the following example will work; this will loop every 5 seconds outputting the date/time:
 
 ```powershell
 Add-PodeTimer -Name 'date' -Interval 5 -ScriptBlock {
     Write-Host "$([DateTime]::Now)"
+}
+```
+
+Usually all timers are created within the main `Start-PodeServer` scope, however it is possible to create adhoc timers with routes/etc. If you create adhoc timers in this manor, you might notice that they don't run; this is because the Runspace that timers use to run won't have been configured. You can configure by using `-EnablePool` on [`Start-PodeServer`](../../Functions/Core/Start-PodeServer):
+
+```powershell
+Start-PodeServer -EnablePool Timers {
+    Add-PodeEndpoint -Address * -Port 8080 -Protocol Http
+
+    Add-PodeRoute -Method Get -Path '/create-timer' -ScriptBlock {
+        Add-PodeTimer -Name 'example' -Interval 5 -ScriptBlock {
+            # logic
+        }
+    }
 }
 ```
 

--- a/examples/schedules-routes.ps1
+++ b/examples/schedules-routes.ps1
@@ -1,0 +1,19 @@
+$path = Split-Path -Parent -Path (Split-Path -Parent -Path $MyInvocation.MyCommand.Path)
+Import-Module "$($path)/src/Pode.psm1" -Force -ErrorAction Stop
+
+# or just:
+# Import-Module Pode
+
+# create a server, and start listening on port 8085
+Start-PodeServer -EnablePool Schedules {
+
+    Add-PodeEndpoint -Address * -Port 8081 -Protocol Http
+
+    # create a new schdule via a route
+    Add-PodeRoute -Method Get -Path '/api/schedule' -ScriptBlock {
+        Add-PodeSchedule -Name 'example' -Cron '@minutely' -ScriptBlock {
+            'hello there' | out-default
+        }
+    }
+
+}

--- a/examples/timers-route.ps1
+++ b/examples/timers-route.ps1
@@ -1,0 +1,19 @@
+$path = Split-Path -Parent -Path (Split-Path -Parent -Path $MyInvocation.MyCommand.Path)
+Import-Module "$($path)/src/Pode.psm1" -Force -ErrorAction Stop
+
+# or just:
+# Import-Module Pode
+
+# create a basic server
+Start-PodeServer -EnablePool Timers {
+
+    Add-PodeEndpoint -Address * -Port 8081 -Protocol Http
+
+    # create a new timer via a route
+    Add-PodeRoute -Method Get -Path '/api/timer' -ScriptBlock {
+        Add-PodeTimer -Name 'example' -Interval 5 -ScriptBlock {
+            'hello there' | out-default
+        }
+    }
+
+}

--- a/src/Private/Gui.ps1
+++ b/src/Private/Gui.ps1
@@ -1,9 +1,14 @@
+function Test-PodeGuiEnabled
+{
+    return ($PodeContext.Server.Gui.Enabled -and
+        !$PodeContext.Server.IsServerless -and
+        !$PodeContext.Server.IsIIS -and
+        !$PodeContext.Server.IsHeroku)
+}
+
 function Start-PodeGuiRunspace {
     # do nothing if gui not enabled, or running as serverless
-    if (!$PodeContext.Server.Gui.Enabled -or
-        $PodeContext.Server.IsServerless -or
-        $PodeContext.Server.IsIIS -or
-        $PodeContext.Server.IsHeroku) {
+    if (!(Test-PodeGuiEnabled)) {
         return
     }
 
@@ -116,6 +121,7 @@ function Start-PodeGuiRunspace {
             }
 
             # display the form
+            Write-PodeHost "Opening GUI" -ForegroundColor Yellow
             $null = $form.ShowDialog()
             Start-Sleep -Seconds 1
         }

--- a/src/Private/Logging.ps1
+++ b/src/Private/Logging.ps1
@@ -324,10 +324,19 @@ function Add-PodeRequestLogEndware
     }
 }
 
+function Test-PodeLoggersExist
+{
+    if (($null -eq $PodeContext.Server.Logging) -or ($null -eq $PodeContext.Server.Logging.Types)) {
+        return $false
+    }
+
+    return (($PodeContext.Server.Logging.Types.Count -gt 0) -or ($PodeContext.Server.Logging.Enabled))
+}
+
 function Start-PodeLoggingRunspace
 {
     # skip if there are no loggers configured, or logging is disabled
-    if (($PodeContext.Server.Logging.Types.Count -eq 0) -or (!$PodeContext.Server.Logging.Enabled)) {
+    if (!(Test-PodeLoggersExist)) {
         return
     }
 

--- a/src/Private/Schedules.ps1
+++ b/src/Private/Schedules.ps1
@@ -7,12 +7,17 @@ function Find-PodeSchedule
         $Name
     )
 
-    return $PodeContext.Schedules[$Name]
+    return $PodeContext.Schedules.Items[$Name]
+}
+
+function Test-PodeSchedulesExist
+{
+    return (($null -ne $PodeContext.Schedules) -and (($PodeContext.Schedules.Enabled) -or ($PodeContext.Schedules.Items.Count -gt 0)))
 }
 
 function Start-PodeScheduleRunspace
 {
-    if ((Get-PodeCount $PodeContext.Schedules) -eq 0) {
+    if (!(Test-PodeSchedulesExist)) {
         return
     }
 
@@ -20,7 +25,7 @@ function Start-PodeScheduleRunspace
         # select the schedules that trigger on-start
         $_now = [DateTime]::Now
 
-        $PodeContext.Schedules.Values |
+        $PodeContext.Schedules.Items.Values |
             Where-Object {
                 $_.OnStart
             } | ForEach-Object {
@@ -38,7 +43,7 @@ function Start-PodeScheduleRunspace
             $_now = [DateTime]::Now
 
             # select the schedules that need triggering
-            $PodeContext.Schedules.Values |
+            $PodeContext.Schedules.Items.Values |
                 Where-Object {
                     !$_.Completed -and
                     (($null -eq $_.StartTime) -or ($_.StartTime -le $_now)) -and
@@ -68,7 +73,7 @@ function Complete-PodeInternalSchedules
     )
 
     # add any schedules to remove that have exceeded their end time
-    $Schedules = @($PodeContext.Schedules.Values |
+    $Schedules = @($PodeContext.Schedules.Items.Values |
         Where-Object { (($null -ne $_.EndTime) -and ($_.EndTime -lt $Now)) })
 
     if (($null -eq $Schedules) -or ($Schedules.Length -eq 0)) {

--- a/src/Private/Server.ps1
+++ b/src/Private/Server.ps1
@@ -172,8 +172,8 @@ function Restart-PodeInternalServer
         }
 
         $PodeContext.Server.Views.Clear()
-        $PodeContext.Timers.Clear()
-        $PodeContext.Schedules.Clear()
+        $PodeContext.Timers.Items.Clear()
+        $PodeContext.Schedules.Items.Clear()
         $PodeContext.Server.Logging.Types.Clear()
 
         # auto-importers

--- a/src/Private/Timers.ps1
+++ b/src/Private/Timers.ps1
@@ -1,18 +1,23 @@
 function Find-PodeTimer
 {
-    param (
+    param(
         [Parameter(Mandatory=$true)]
         [ValidateNotNullOrEmpty()]
         [string]
         $Name
     )
 
-    return $PodeContext.Timers[$Name]
+    return $PodeContext.Timers.Items[$Name]
+}
+
+function Test-PodeTimersExist
+{
+    return (($null -ne $PodeContext.Timers) -and (($PodeContext.Timers.Enabled) -or ($PodeContext.Timers.Items.Count -gt 0)))
 }
 
 function Start-PodeTimerRunspace
 {
-    if ((Get-PodeCount $PodeContext.Timers) -eq 0) {
+    if (!(Test-PodeTimersExist)) {
         return
     }
 
@@ -22,7 +27,7 @@ function Start-PodeTimerRunspace
             $_now = [DateTime]::Now
 
             # only run timers that haven't completed, and have a next trigger in the past
-            $PodeContext.Timers.Values | Where-Object {
+            $PodeContext.Timers.Items.Values | Where-Object {
                 !$_.Completed -and ($_.OnStart -or ($_.NextTriggerTime -le $_now))
             } | ForEach-Object {
                 $_.OnStart = $false

--- a/src/Public/Core.ps1
+++ b/src/Public/Core.ps1
@@ -46,6 +46,9 @@ Open the web Server's default endpoint in your default browser.
 .PARAMETER CurrentPath
 Sets the Server's root path to be the current working path - for -FilePath only.
 
+.PARAMETER EnablePool
+Tells Pode to configure certain RunspacePools when they're being used adhoc, such as Timers or Schedules.
+
 .EXAMPLE
 Start-PodeServer { /* logic */ }
 

--- a/src/Public/Core.ps1
+++ b/src/Public/Core.ps1
@@ -100,6 +100,11 @@ function Start-PodeServer
         [string]
         $ListenerType = [string]::Empty,
 
+        [Parameter()]
+        [ValidateSet('Timers', 'Schedules')]
+        [string[]]
+        $EnablePool,
+
         [switch]
         $DisableTermination,
 
@@ -151,6 +156,7 @@ function Start-PodeServer
             -ServerRoot (Protect-PodeValue -Value $RootPath -Default $MyInvocation.PSScriptRoot) `
             -ServerlessType $ServerlessType `
             -ListenerType $ListenerType `
+            -EnablePool $EnablePool `
             -StatusPageExceptions $StatusPageExceptions `
             -DisableTermination:$DisableTermination `
             -Quiet:$Quiet
@@ -605,7 +611,7 @@ function Show-PodeGui
 
     # only valid for Windows PowerShell
     if ((Test-PodeIsPSCore) -and ($PSVersionTable.PSVersion.Major -eq 6)) {
-        throw 'Show-PodeGui is currently only available for Windows PowerShell, and PowerShell 7 on Windows'
+        throw 'Show-PodeGui is currently only available for Windows PowerShell, and PowerShell 7+ on Windows'
     }
 
     # enable the gui and set general settings

--- a/src/Public/Schedules.ps1
+++ b/src/Public/Schedules.ps1
@@ -47,7 +47,7 @@ Add-PodeSchedule -Name 'Args' -Cron '@minutely' -ScriptBlock { /* logic */ } -Ar
 function Add-PodeSchedule
 {
     [CmdletBinding(DefaultParameterSetName='Script')]
-    param (
+    param(
         [Parameter(Mandatory=$true)]
         [string]
         $Name,
@@ -88,7 +88,7 @@ function Add-PodeSchedule
     Test-PodeIsServerless -FunctionName 'Add-PodeSchedule' -ThrowError
 
     # ensure the schedule doesn't already exist
-    if ($PodeContext.Schedules.ContainsKey($Name)) {
+    if ($PodeContext.Schedules.Items.ContainsKey($Name)) {
         throw "[Schedule] $($Name): Schedule already defined"
     }
 
@@ -122,7 +122,8 @@ function Add-PodeSchedule
     $parsedCrons = ConvertFrom-PodeCronExpressions -Expressions @($Cron)
     $nextTrigger = Get-PodeCronNextEarliestTrigger -Expressions $parsedCrons -StartTime $StartTime -EndTime $EndTime
 
-    $PodeContext.Schedules[$Name] = @{
+    $PodeContext.Schedules.Enabled = $true
+    $PodeContext.Schedules.Items[$Name] = @{
         Name = $Name
         StartTime = $StartTime
         EndTime = $EndTime
@@ -214,12 +215,12 @@ function Invoke-PodeSchedule
     )
 
     # ensure the schedule exists
-    if (!$PodeContext.Schedules.ContainsKey($Name)) {
+    if (!$PodeContext.Schedules.Items.ContainsKey($Name)) {
         throw "Schedule '$($Name)' does not exist"
     }
 
     # run schedule logic
-    Invoke-PodeInternalScheduleLogic -Schedule $PodeContext.Schedules[$Name] -ArgumentList $ArgumentList
+    Invoke-PodeInternalScheduleLogic -Schedule $PodeContext.Schedules.Items[$Name] -ArgumentList $ArgumentList
 }
 
 <#
@@ -244,7 +245,7 @@ function Remove-PodeSchedule
         $Name
     )
 
-    $null = $PodeContext.Schedules.Remove($Name)
+    $null = $PodeContext.Schedules.Items.Remove($Name)
 }
 
 <#
@@ -262,7 +263,7 @@ function Clear-PodeSchedules
     [CmdletBinding()]
     param()
 
-    $PodeContext.Schedules.Clear()
+    $PodeContext.Schedules.Items.Clear()
 }
 
 <#
@@ -312,11 +313,11 @@ function Edit-PodeSchedule
     )
 
     # ensure the schedule exists
-    if (!$PodeContext.Schedules.ContainsKey($Name)) {
+    if (!$PodeContext.Schedules.Items.ContainsKey($Name)) {
         throw "Schedule '$($Name)' does not exist"
     }
 
-    $_schedule = $PodeContext.Schedules[$Name]
+    $_schedule = $PodeContext.Schedules.Items[$Name]
 
     # edit cron if supplied
     if (!(Test-PodeIsEmpty $Cron)) {
@@ -380,7 +381,7 @@ function Get-PodeSchedule
         $EndTime = $null
     )
 
-    $schedules = $PodeContext.Schedules.Values
+    $schedules = $PodeContext.Schedules.Items.Values
 
     # further filter by schedule names
     if (($null -ne $Name) -and ($Name.Length -gt 0)) {
@@ -475,11 +476,11 @@ function Get-PodeScheduleNextTrigger
     )
 
     # ensure the schedule exists
-    if (!$PodeContext.Schedules.ContainsKey($Name)) {
+    if (!$PodeContext.Schedules.Items.ContainsKey($Name)) {
         throw "Schedule '$($Name)' does not exist"
     }
 
-    $_schedule = $PodeContext.Schedules[$Name]
+    $_schedule = $PodeContext.Schedules.Items[$Name]
 
     # ensure date is after start/before end
     if (($null -ne $DateTime) -and ($null -ne $_schedule.StartTime) -and ($DateTime -lt $_schedule.StartTime)) {

--- a/src/Public/Timers.ps1
+++ b/src/Public/Timers.ps1
@@ -81,7 +81,7 @@ function Add-PodeTimer
     Test-PodeIsServerless -FunctionName 'Add-PodeTimer' -ThrowError
 
     # ensure the timer doesn't already exist
-    if ($PodeContext.Timers.ContainsKey($Name)) {
+    if ($PodeContext.Timers.Items.ContainsKey($Name)) {
         throw "[Timer] $($Name): Timer already defined"
     }
 
@@ -119,7 +119,8 @@ function Add-PodeTimer
     }
 
     # add the timer
-    $PodeContext.Timers[$Name] = @{
+    $PodeContext.Timers.Enabled = $true
+    $PodeContext.Timers.Items[$Name] = @{
         Name = $Name
         Interval = $Interval
         Limit = $Limit
@@ -166,12 +167,12 @@ function Invoke-PodeTimer
     )
 
     # ensure the timer exists
-    if (!$PodeContext.Timers.ContainsKey($Name)) {
+    if (!$PodeContext.Timers.Items.ContainsKey($Name)) {
         throw "Timer '$($Name)' does not exist"
     }
 
     # run timer logic
-    Invoke-PodeInternalTimer -Timer $PodeContext.Timers[$Name] -ArgumentList $ArgumentList
+    Invoke-PodeInternalTimer -Timer $PodeContext.Timers.Items[$Name] -ArgumentList $ArgumentList
 }
 
 <#
@@ -196,7 +197,7 @@ function Remove-PodeTimer
         $Name
     )
 
-    $null = $PodeContext.Timers.Remove($Name)
+    $null = $PodeContext.Timers.Items.Remove($Name)
 }
 
 <#
@@ -214,7 +215,7 @@ function Clear-PodeTimers
     [CmdletBinding()]
     param()
 
-    $PodeContext.Timers.Clear()
+    $PodeContext.Timers.Items.Clear()
 }
 
 <#
@@ -261,11 +262,11 @@ function Edit-PodeTimer
     )
 
     # ensure the timer exists
-    if (!$PodeContext.Timers.ContainsKey($Name)) {
+    if (!$PodeContext.Timers.Items.ContainsKey($Name)) {
         throw "Timer '$($Name)' does not exist"
     }
 
-    $_timer = $PodeContext.Timers[$Name]
+    $_timer = $PodeContext.Timers.Items[$Name]
 
     # edit interval if supplied
     if ($Interval -gt 0) {
@@ -312,7 +313,7 @@ function Get-PodeTimer
         $Name
     )
 
-    $timers = $PodeContext.Timers.Values
+    $timers = $PodeContext.Timers.Items.Values
 
     # further filter by timer names
     if (($null -ne $Name) -and ($Name.Length -gt 0)) {

--- a/tests/unit/Context.Tests.ps1
+++ b/tests/unit/Context.Tests.ps1
@@ -499,11 +499,11 @@ Describe 'New-PodeAutoRestartServer' {
     It 'Do not create any restart schedules' {
         Mock 'Get-PodeConfig' { return @{} }
 
-        $PodeContext = @{ 'Timers' = @{}; 'Schedules' = @{}; }
+        $PodeContext = @{ 'Timers' = @{ Items = @{} }; 'Schedules' = @{ Items = @{} }; }
         New-PodeAutoRestartServer
 
-        $PodeContext.Timers.Count | Should Be 0
-        $PodeContext.Schedules.Count | Should Be 0
+        $PodeContext.Timers.Items.Count | Should Be 0
+        $PodeContext.Schedules.Items.Count | Should Be 0
     }
 
     It 'Creates a timer for a period server restart' {
@@ -515,12 +515,12 @@ Describe 'New-PodeAutoRestartServer' {
             }
         } }
 
-        $PodeContext = @{ 'Timers' = @{}; 'Schedules' = @{}; }
+        $PodeContext = @{ 'Timers' = @{ Items = @{} }; 'Schedules' = @{ Items = @{} }; }
         New-PodeAutoRestartServer
 
-        $PodeContext.Timers.Count | Should Be 1
-        $PodeContext.Schedules.Count | Should Be 0
-        $PodeContext.Timers.Keys[0] | Should Be '__pode_restart_period__'
+        $PodeContext.Timers.Items.Count | Should Be 1
+        $PodeContext.Schedules.Items.Count | Should Be 0
+        $PodeContext.Timers.Items.Keys[0] | Should Be '__pode_restart_period__'
     }
 
     It 'Creates a schedule for a timed server restart' {
@@ -532,12 +532,12 @@ Describe 'New-PodeAutoRestartServer' {
             }
         } }
 
-        $PodeContext = @{ 'Timers' = @{}; 'Schedules' = @{}; }
+        $PodeContext = @{ 'Timers' = @{ Items = @{} }; 'Schedules' = @{ Items = @{} }; }
         New-PodeAutoRestartServer
 
-        $PodeContext.Timers.Count | Should Be 0
-        $PodeContext.Schedules.Count | Should Be 1
-        $PodeContext.Schedules.Keys[0] | Should Be '__pode_restart_times__'
+        $PodeContext.Timers.Items.Count | Should Be 0
+        $PodeContext.Schedules.Items.Count | Should Be 1
+        $PodeContext.Schedules.Items.Keys[0] | Should Be '__pode_restart_times__'
     }
 
     It 'Creates a schedule for a cron server restart' {
@@ -549,12 +549,12 @@ Describe 'New-PodeAutoRestartServer' {
             }
         } }
 
-        $PodeContext = @{ 'Timers' = @{}; 'Schedules' = @{}; }
+        $PodeContext = @{ 'Timers' = @{ Items = @{} }; 'Schedules' = @{ Items = @{} }; }
         New-PodeAutoRestartServer
 
-        $PodeContext.Timers.Count | Should Be 0
-        $PodeContext.Schedules.Count | Should Be 1
-        $PodeContext.Schedules.Keys[0] | Should Be '__pode_restart_crons__'
+        $PodeContext.Timers.Items.Count | Should Be 0
+        $PodeContext.Schedules.Items.Count | Should Be 1
+        $PodeContext.Schedules.Items.Keys[0] | Should Be '__pode_restart_crons__'
     }
 
     It 'Creates a timer and schedule for a period and cron server restart' {
@@ -567,13 +567,13 @@ Describe 'New-PodeAutoRestartServer' {
             }
         } }
 
-        $PodeContext = @{ 'Timers' = @{}; 'Schedules' = @{}; }
+        $PodeContext = @{ 'Timers' = @{ Items = @{} }; 'Schedules' = @{ Items = @{} }; }
         New-PodeAutoRestartServer
 
-        $PodeContext.Timers.Count | Should Be 1
-        $PodeContext.Schedules.Count | Should Be 1
-        $PodeContext.Timers.Keys[0] | Should Be '__pode_restart_period__'
-        $PodeContext.Schedules.Keys[0] | Should Be '__pode_restart_crons__'
+        $PodeContext.Timers.Items.Count | Should Be 1
+        $PodeContext.Schedules.Items.Count | Should Be 1
+        $PodeContext.Timers.Items.Keys[0] | Should Be '__pode_restart_period__'
+        $PodeContext.Schedules.Items.Keys[0] | Should Be '__pode_restart_crons__'
     }
 
     It 'Creates a timer and schedule for a period and timed server restart' {
@@ -586,13 +586,13 @@ Describe 'New-PodeAutoRestartServer' {
             }
         } }
 
-        $PodeContext = @{ 'Timers' = @{}; 'Schedules' = @{}; }
+        $PodeContext = @{ 'Timers' = @{ Items = @{} }; 'Schedules' = @{ Items = @{} }; }
         New-PodeAutoRestartServer
 
-        $PodeContext.Timers.Count | Should Be 1
-        $PodeContext.Schedules.Count | Should Be 1
-        $PodeContext.Timers.Keys[0] | Should Be '__pode_restart_period__'
-        $PodeContext.Schedules.Keys[0] | Should Be '__pode_restart_times__'
+        $PodeContext.Timers.Items.Count | Should Be 1
+        $PodeContext.Schedules.Items.Count | Should Be 1
+        $PodeContext.Timers.Items.Keys[0] | Should Be '__pode_restart_period__'
+        $PodeContext.Schedules.Items.Keys[0] | Should Be '__pode_restart_times__'
     }
 
     It 'Creates two schedules for a cron and timed server restart' {
@@ -605,10 +605,10 @@ Describe 'New-PodeAutoRestartServer' {
             }
         } }
 
-        $PodeContext = @{ 'Timers' = @{}; 'Schedules' = @{}; }
+        $PodeContext = @{ 'Timers' = @{ Items = @{} }; 'Schedules' = @{ Items = @{} }; }
         New-PodeAutoRestartServer
 
-        $PodeContext.Timers.Count | Should Be 0
-        $PodeContext.Schedules.Count | Should Be 2
+        $PodeContext.Timers.Items.Count | Should Be 0
+        $PodeContext.Schedules.Items.Count | Should Be 2
     }
 }

--- a/tests/unit/Schedules.Tests.ps1
+++ b/tests/unit/Schedules.Tests.ps1
@@ -15,12 +15,12 @@ Describe 'Find-PodeSchedule' {
 
     Context 'Valid values supplied' {
         It 'Returns null as the schedule does not exist' {
-            $PodeContext = @{ 'Schedules' = @{}; }
+            $PodeContext = @{ 'Schedules' = @{ Items = @{} }; }
             Find-PodeSchedule -Name 'test' | Should Be $null
         }
 
         It 'Returns schedule for name' {
-            $PodeContext = @{ 'Schedules' = @{ 'test' = @{ 'Name' = 'test'; }; }; }
+            $PodeContext = @{ 'Schedules' = @{ Items = @{ 'test' = @{ 'Name' = 'test'; }; } }; }
             $result = (Find-PodeSchedule -Name 'test')
 
             $result | Should BeOfType System.Collections.Hashtable
@@ -34,31 +34,31 @@ Describe 'Add-PodeSchedule' {
     Mock 'Get-PodeCronNextEarliestTrigger' { [datetime]::new(2020, 1, 1) }
 
     It 'Throws error because schedule already exists' {
-        $PodeContext = @{ 'Schedules' = @{ 'test' = $null }; }
+        $PodeContext = @{ 'Schedules' = @{ Items = @{ 'test' = $null }; } }
         { Add-PodeSchedule -Name 'test' -Cron '@hourly' -ScriptBlock {} } | Should Throw 'already defined'
     }
 
     It 'Throws error because end time in the past' {
-        $PodeContext = @{ 'Schedules' = @{}; }
+        $PodeContext = @{ 'Schedules' = @{ Items = @{} }; }
         $end = ([DateTime]::Now.AddHours(-1))
         { Add-PodeSchedule -Name 'test' -Cron '@hourly' -ScriptBlock {} -EndTime $end } | Should Throw 'the EndTime value must be in the future'
     }
 
     It 'Throws error because start time is after end time' {
-        $PodeContext = @{ 'Schedules' = @{}; }
+        $PodeContext = @{ 'Schedules' = @{ Items = @{} }; }
         $start = ([DateTime]::Now.AddHours(3))
         $end = ([DateTime]::Now.AddHours(1))
         { Add-PodeSchedule -Name 'test' -Cron '@hourly' -ScriptBlock {} -StartTime $start -EndTime $end } | Should Throw 'starttime after the endtime'
     }
 
     It 'Adds new schedule supplying everything' {
-        $PodeContext = @{ 'Schedules' = @{}; }
+        $PodeContext = @{ 'Schedules' = @{ Items = @{} }; }
         $start = ([DateTime]::Now.AddHours(3))
         $end = ([DateTime]::Now.AddHours(5))
 
         Add-PodeSchedule -Name 'test' -Cron '@hourly' -ScriptBlock { Write-Host 'hello' } -StartTime $start -EndTime $end
 
-        $schedule = $PodeContext.Schedules['test']
+        $schedule = $PodeContext.Schedules.Items['test']
         $schedule | Should Not Be $null
         $schedule.Name | Should Be 'test'
         $schedule.StartTime | Should Be $start
@@ -69,12 +69,12 @@ Describe 'Add-PodeSchedule' {
     }
 
     It 'Adds new schedule with no start time' {
-        $PodeContext = @{ 'Schedules' = @{}; }
+        $PodeContext = @{ 'Schedules' = @{ Items = @{} }; }
         $end = ([DateTime]::Now.AddHours(5))
 
         Add-PodeSchedule -Name 'test' -Cron '@hourly' -ScriptBlock { Write-Host 'hello' } -EndTime $end
 
-        $schedule = $PodeContext.Schedules['test']
+        $schedule = $PodeContext.Schedules.Items['test']
         $schedule | Should Not Be $null
         $schedule.Name | Should Be 'test'
         $schedule.StartTime | Should Be $null
@@ -85,12 +85,12 @@ Describe 'Add-PodeSchedule' {
     }
 
     It 'Adds new schedule with no end time' {
-        $PodeContext = @{ 'Schedules' = @{}; }
+        $PodeContext = @{ 'Schedules' = @{ Items = @{} }; }
         $start = ([DateTime]::Now.AddHours(3))
 
         Add-PodeSchedule -Name 'test' -Cron '@hourly' -ScriptBlock { Write-Host 'hello' } -StartTime $start
 
-        $schedule = $PodeContext.Schedules['test']
+        $schedule = $PodeContext.Schedules.Items['test']
         $schedule | Should Not Be $null
         $schedule.Name | Should Be 'test'
         $schedule.StartTime | Should Be $start
@@ -101,11 +101,11 @@ Describe 'Add-PodeSchedule' {
     }
 
     It 'Adds new schedule with just a cron' {
-        $PodeContext = @{ 'Schedules' = @{}; }
+        $PodeContext = @{ 'Schedules' = @{ Items = @{} }; }
 
         Add-PodeSchedule -Name 'test' -Cron '@hourly' -ScriptBlock { Write-Host 'hello' }
 
-        $schedule = $PodeContext.Schedules['test']
+        $schedule = $PodeContext.Schedules.Items['test']
         $schedule | Should Not Be $null
         $schedule.Name | Should Be 'test'
         $schedule.StartTime | Should Be $null
@@ -116,13 +116,13 @@ Describe 'Add-PodeSchedule' {
     }
 
     It 'Adds new schedule with two crons' {
-        $PodeContext = @{ 'Schedules' = @{}; }
+        $PodeContext = @{ 'Schedules' = @{ Items = @{} }; }
         $start = ([DateTime]::Now.AddHours(3))
         $end = ([DateTime]::Now.AddHours(5))
 
         Add-PodeSchedule -Name 'test' -Cron @('@minutely', '@hourly') -ScriptBlock { Write-Host 'hello' } -StartTime $start -EndTime $end
 
-        $schedule = $PodeContext.Schedules['test']
+        $schedule = $PodeContext.Schedules.Items['test']
         $schedule | Should Not Be $null
         $schedule.Name | Should Be 'test'
         $schedule.StartTime | Should Be $start
@@ -135,13 +135,13 @@ Describe 'Add-PodeSchedule' {
 
 Describe 'Get-PodeSchedule' {
     It 'Returns no schedules' {
-        $PodeContext = @{ Schedules = @{} }
+        $PodeContext = @{ Schedules = @{ Items = @{} } }
         $schedules = Get-PodeSchedule
         $schedules.Length | Should Be 0
     }
 
     It 'Returns 1 schedule by name' {
-        $PodeContext = @{ Schedules = @{} }
+        $PodeContext = @{ Schedules = @{ Items = @{} } }
         $start = ([DateTime]::Now.AddHours(3))
         $end = ([DateTime]::Now.AddHours(5))
 
@@ -156,7 +156,7 @@ Describe 'Get-PodeSchedule' {
     }
 
     It 'Returns 1 schedule by start time' {
-        $PodeContext = @{ Schedules = @{} }
+        $PodeContext = @{ Schedules = @{ Items = @{} } }
         $start = ([DateTime]::Now.AddHours(3))
         $end = ([DateTime]::Now.AddHours(5))
 
@@ -171,7 +171,7 @@ Describe 'Get-PodeSchedule' {
     }
 
     It 'Returns 1 schedule by end time' {
-        $PodeContext = @{ Schedules = @{} }
+        $PodeContext = @{ Schedules = @{ Items = @{} } }
         $start = ([DateTime]::Now.AddHours(3))
         $end = ([DateTime]::Now.AddHours(5))
 
@@ -186,7 +186,7 @@ Describe 'Get-PodeSchedule' {
     }
 
     It 'Returns 1 schedule by both start and end time' {
-        $PodeContext = @{ Schedules = @{} }
+        $PodeContext = @{ Schedules = @{ Items = @{} } }
         $start = ([DateTime]::Now.AddHours(3))
         $end = ([DateTime]::Now.AddHours(5))
 
@@ -201,7 +201,7 @@ Describe 'Get-PodeSchedule' {
     }
 
     It 'Returns no schedules by end time before start' {
-        $PodeContext = @{ Schedules = @{} }
+        $PodeContext = @{ Schedules = @{ Items = @{} } }
         $start = ([DateTime]::Now.AddHours(3))
         $end = ([DateTime]::Now.AddHours(5))
 
@@ -211,7 +211,7 @@ Describe 'Get-PodeSchedule' {
     }
 
     It 'Returns no schedules by start time after end' {
-        $PodeContext = @{ Schedules = @{} }
+        $PodeContext = @{ Schedules = @{ Items = @{} } }
         $start = ([DateTime]::Now.AddHours(3))
         $end = ([DateTime]::Now.AddHours(5))
 
@@ -221,7 +221,7 @@ Describe 'Get-PodeSchedule' {
     }
 
     It 'Returns no schedules by where end just before end' {
-        $PodeContext = @{ Schedules = @{} }
+        $PodeContext = @{ Schedules = @{ Items = @{} } }
         $start = ([DateTime]::Now.AddHours(3))
         $end = ([DateTime]::Now.AddHours(5))
 
@@ -231,7 +231,7 @@ Describe 'Get-PodeSchedule' {
     }
 
     It 'Returns 2 schedules by name' {
-        $PodeContext = @{ Schedules = @{} }
+        $PodeContext = @{ Schedules = @{ Items = @{} } }
         $start = ([DateTime]::Now.AddHours(3))
         $end = ([DateTime]::Now.AddHours(5))
 
@@ -244,7 +244,7 @@ Describe 'Get-PodeSchedule' {
     }
 
     It 'Returns all schedules' {
-        $PodeContext = @{ Schedules = @{} }
+        $PodeContext = @{ Schedules = @{ Items = @{} } }
         $start = ([DateTime]::Now.AddHours(3))
         $end = ([DateTime]::Now.AddHours(5))
 
@@ -259,7 +259,7 @@ Describe 'Get-PodeSchedule' {
 
 Describe 'Get-PodeScheduleNextTrigger' {
     It 'Returns next trigger time' {
-        $PodeContext = @{ Schedules = @{} }
+        $PodeContext = @{ Schedules = @{ Items = @{} } }
         $start = ([DateTime]::Now.AddHours(3))
         $end = ([DateTime]::Now.AddHours(5))
 
@@ -272,7 +272,7 @@ Describe 'Get-PodeScheduleNextTrigger' {
     }
 
     It 'Returns next trigger time from date' {
-        $PodeContext = @{ Schedules = @{} }
+        $PodeContext = @{ Schedules = @{ Items = @{} } }
         $start = ([DateTime]::Now.AddHours(3))
         $end = ([DateTime]::Now.AddHours(5))
 
@@ -287,55 +287,55 @@ Describe 'Get-PodeScheduleNextTrigger' {
 
 Describe 'Remove-PodeSchedule' {
     It 'Adds new schedule and then removes it' {
-        $PodeContext = @{ 'Schedules' = @{}; }
+        $PodeContext = @{ 'Schedules' = @{ Items = @{} }; }
 
         Add-PodeSchedule -Name 'test' -Cron '@hourly' -ScriptBlock { Write-Host 'hello' }
 
-        $PodeContext.Schedules['test'] | Should Not Be $null
+        $PodeContext.Schedules.Items['test'] | Should Not Be $null
 
         Remove-PodeSchedule -Name 'test'
 
-        $PodeContext.Schedules['test'] | Should Be $null
+        $PodeContext.Schedules.Items['test'] | Should Be $null
     }
 }
 
 
 Describe 'Clear-PodeSchedules' {
     It 'Adds new schedules and then removes them' {
-        $PodeContext = @{ 'Schedules' = @{}; }
+        $PodeContext = @{ 'Schedules' = @{ Items = @{} }; }
 
         Add-PodeSchedule -Name 'test1' -Cron '@hourly' -ScriptBlock { Write-Host 'hello1' }
         Add-PodeSchedule -Name 'test2' -Cron '@hourly' -ScriptBlock { Write-Host 'hello2' }
 
-        $PodeContext.Schedules['test1'] | Should Not Be $null
-        $PodeContext.Schedules['test2'] | Should Not Be $null
+        $PodeContext.Schedules.Items['test1'] | Should Not Be $null
+        $PodeContext.Schedules.Items['test2'] | Should Not Be $null
 
         Clear-PodeSchedules
 
-        $PodeContext.Schedules.Count | Should Be 0
+        $PodeContext.Schedules.Items.Count | Should Be 0
     }
 }
 
 Describe 'Edit-PodeSchedule' {
     It 'Adds a new schedule, then edits the cron' {
-        $PodeContext = @{ 'Schedules' = @{}; }
+        $PodeContext = @{ 'Schedules' = @{ Items = @{} }; }
         Add-PodeSchedule -Name 'test1' -Cron '@hourly' -ScriptBlock { Write-Host 'hello1' }
-        $PodeContext.Schedules['test1'].Crons.Length | Should Be 1
-        $PodeContext.Schedules['test1'].Script.ToString() | Should Be ({ Write-Host 'hello1' }).ToString()
+        $PodeContext.Schedules.Items['test1'].Crons.Length | Should Be 1
+        $PodeContext.Schedules.Items['test1'].Script.ToString() | Should Be ({ Write-Host 'hello1' }).ToString()
 
         Edit-PodeSchedule -Name 'test1' -Cron @('@minutely', '@hourly')
-        $PodeContext.Schedules['test1'].Crons.Length | Should Be 2
-        $PodeContext.Schedules['test1'].Script.ToString() | Should Be ({ Write-Host 'hello1' }).ToString()
+        $PodeContext.Schedules.Items['test1'].Crons.Length | Should Be 2
+        $PodeContext.Schedules.Items['test1'].Script.ToString() | Should Be ({ Write-Host 'hello1' }).ToString()
     }
 
     It 'Adds a new schedule, then edits the script' {
-        $PodeContext = @{ 'Schedules' = @{}; }
+        $PodeContext = @{ 'Schedules' = @{ Items = @{} }; }
         Add-PodeSchedule -Name 'test1' -Cron '@hourly' -ScriptBlock { Write-Host 'hello1' }
-        $PodeContext.Schedules['test1'].Crons.Length | Should Be 1
-        $PodeContext.Schedules['test1'].Script.ToString() | Should Be ({ Write-Host 'hello1' }).ToString()
+        $PodeContext.Schedules.Items['test1'].Crons.Length | Should Be 1
+        $PodeContext.Schedules.Items['test1'].Script.ToString() | Should Be ({ Write-Host 'hello1' }).ToString()
 
         Edit-PodeSchedule -Name 'test1' -ScriptBlock { Write-Host 'hello2' }
-        $PodeContext.Schedules['test1'].Crons.Length | Should Be 1
-        $PodeContext.Schedules['test1'].Script.ToString() | Should Be ({ Write-Host 'hello2' }).ToString()
+        $PodeContext.Schedules.Items['test1'].Crons.Length | Should Be 1
+        $PodeContext.Schedules.Items['test1'].Script.ToString() | Should Be ({ Write-Host 'hello2' }).ToString()
     }
 }

--- a/tests/unit/Server.Tests.ps1
+++ b/tests/unit/Server.Tests.ps1
@@ -169,8 +169,18 @@ Describe 'Restart-PodeInternalServer' {
                     RestartCount = 0
                 }
             }
-            Timers = @{ 'key' = 'value' }
-            Schedules = @{ 'key' = 'value' }
+            Timers = @{
+                Enabled = $true
+                Items = @{
+                    key = 'value'
+                }
+            }
+            Schedules = @{
+                Enabled = $true
+                Items = @{
+                    key = 'value'
+                }
+            }
         }
 
         Restart-PodeInternalServer | Out-Null
@@ -184,8 +194,8 @@ Describe 'Restart-PodeInternalServer' {
         $PodeContext.Server.State.Count | Should Be 0
         $PodeContext.Server.Configuration | Should Be $null
 
-        $PodeContext.Timers.Count | Should Be 0
-        $PodeContext.Schedules.Count | Should Be 0
+        $PodeContext.Timers.Items.Count | Should Be 0
+        $PodeContext.Schedules.Items.Count | Should Be 0
 
         $PodeContext.Server.ViewEngine.Type | Should Be 'html'
         $PodeContext.Server.ViewEngine.Extension | Should Be 'html'

--- a/tests/unit/Sessions.Tests.ps1
+++ b/tests/unit/Sessions.Tests.ps1
@@ -197,10 +197,10 @@ Describe 'Get-PodeSessionInMemStore' {
 
 Describe 'Set-PodeSessionInMemClearDown' {
     It 'Adds a new schedule for clearing down' {
-        $PodeContext = @{ 'Schedules' = @{}}
+        $PodeContext = @{ 'Schedules' = @{ Items = @{} } }
         Set-PodeSessionInMemClearDown
-        $PodeContext.Schedules.Count | Should Be 1
-        $PodeContext.Schedules.Contains('__pode_session_inmem_cleanup__') | Should Be $true
+        $PodeContext.Schedules.Items.Count | Should Be 1
+        $PodeContext.Schedules.Items.Contains('__pode_session_inmem_cleanup__') | Should Be $true
     }
 }
 

--- a/tests/unit/Timers.Tests.ps1
+++ b/tests/unit/Timers.Tests.ps1
@@ -15,12 +15,12 @@ Describe 'Find-PodeTimer' {
 
     Context 'Valid values supplied' {
         It 'Returns null as the timer does not exist' {
-            $PodeContext = @{ 'Timers' = @{}; }
+            $PodeContext = @{ 'Timers' = @{ Items = @{} }; }
             Find-PodeTimer -Name 'test' | Should Be $null
         }
 
         It 'Returns timer for name' {
-            $PodeContext = @{ 'Timers' = @{ 'test' = @{ 'Name' = 'test'; }; }; }
+            $PodeContext = @{ 'Timers' = @{ Items = @{ 'test' = @{ 'Name' = 'test'; }; } }; }
             $result = (Find-PodeTimer -Name 'test')
 
             $result | Should BeOfType System.Collections.Hashtable
@@ -31,35 +31,35 @@ Describe 'Find-PodeTimer' {
 
 Describe 'Add-PodeTimer' {
     It 'Throws error because timer already exists' {
-        $PodeContext = @{ 'Timers' = @{ 'test' = $null }; }
+        $PodeContext = @{ 'Timers' = @{ Items = @{ 'test' = $null }; } }
         { Add-PodeTimer -Name 'test' -Interval 1 -ScriptBlock {} } | Should Throw 'already defined'
     }
 
     It 'Throws error because interval is 0' {
-        $PodeContext = @{ 'Timers' = @{}; }
+        $PodeContext = @{ 'Timers' = @{ Items = @{} }; }
         { Add-PodeTimer -Name 'test' -Interval 0 -ScriptBlock {} } | Should Throw 'interval must be greater than 0'
     }
 
     It 'Throws error because interval is less than 0' {
-        $PodeContext = @{ 'Timers' = @{}; }
+        $PodeContext = @{ 'Timers' = @{ Items = @{} }; }
         { Add-PodeTimer -Name 'test' -Interval -1 -ScriptBlock {} } | Should Throw 'interval must be greater than 0'
     }
 
     It 'Throws error because limit is negative' {
-        $PodeContext = @{ 'Timers' = @{}; }
+        $PodeContext = @{ 'Timers' = @{ Items = @{} }; }
         { Add-PodeTimer -Name 'test' -Interval 1 -ScriptBlock {} -Limit -1 } | Should Throw 'negative limit'
     }
 
     It 'Throws error because skip is negative' {
-        $PodeContext = @{ 'Timers' = @{}; }
+        $PodeContext = @{ 'Timers' = @{ Items = @{} }; }
         { Add-PodeTimer -Name 'test' -Interval 1 -ScriptBlock {} -Skip -1 } | Should Throw 'negative skip'
     }
 
     It 'Adds new timer to session with no limit' {
-        $PodeContext = @{ 'Timers' = @{}; }
+        $PodeContext = @{ 'Timers' = @{ Items = @{} }; }
         Add-PodeTimer -Name 'test' -Interval 1 -ScriptBlock { Write-Host 'hello' } -Limit 0 -Skip 1
 
-        $timer = $PodeContext.Timers['test']
+        $timer = $PodeContext.Timers.Items['test']
         $timer | Should Not Be $null
         $timer.Name | Should Be 'test'
         $timer.Interval | Should Be 1
@@ -72,10 +72,10 @@ Describe 'Add-PodeTimer' {
     }
 
     It 'Adds new timer to session with limit' {
-        $PodeContext = @{ 'Timers' = @{}; }
+        $PodeContext = @{ 'Timers' = @{ Items = @{} }; }
         Add-PodeTimer -Name 'test' -Interval 3 -ScriptBlock { Write-Host 'hello' } -Limit 2 -Skip 1
 
-        $timer = $PodeContext.Timers['test']
+        $timer = $PodeContext.Timers.Items['test']
         $timer | Should Not Be $null
         $timer.Name | Should Be 'test'
         $timer.Interval | Should Be 3
@@ -90,13 +90,13 @@ Describe 'Add-PodeTimer' {
 
 Describe 'Get-PodeTimer' {
     It 'Returns no timers' {
-        $PodeContext = @{ Timers = @{} }
+        $PodeContext = @{ Timers = @{ Items = @{} } }
         $timers = Get-PodeTimer
         $timers.Length | Should Be 0
     }
 
     It 'Returns 1 timer by name' {
-        $PodeContext = @{ Timers = @{} }
+        $PodeContext = @{ Timers = @{ Items = @{} } }
 
         Add-PodeTimer -Name 'test1' -Interval 1 -ScriptBlock { Write-Host 'hello' } -Limit 0 -Skip 1
         $timers = Get-PodeTimer
@@ -109,7 +109,7 @@ Describe 'Get-PodeTimer' {
     }
 
     It 'Returns 2 timers by name' {
-        $PodeContext = @{ Timers = @{} }
+        $PodeContext = @{ Timers = @{ Items = @{} } }
 
         Add-PodeTimer -Name 'test1' -Interval 1 -ScriptBlock { Write-Host 'hello' } -Limit 0 -Skip 1
         Add-PodeTimer -Name 'test2' -Interval 1 -ScriptBlock { Write-Host 'hello' } -Limit 0 -Skip 1
@@ -120,7 +120,7 @@ Describe 'Get-PodeTimer' {
     }
 
     It 'Returns all timers' {
-        $PodeContext = @{ Timers = @{} }
+        $PodeContext = @{ Timers = @{ Items = @{} } }
 
         Add-PodeTimer -Name 'test1' -Interval 1 -ScriptBlock { Write-Host 'hello' } -Limit 0 -Skip 1
         Add-PodeTimer -Name 'test2' -Interval 1 -ScriptBlock { Write-Host 'hello' } -Limit 0 -Skip 1
@@ -133,54 +133,54 @@ Describe 'Get-PodeTimer' {
 
 Describe 'Remove-PodeTimer' {
     It 'Adds new timer and then removes it' {
-        $PodeContext = @{ 'Timers' = @{}; }
+        $PodeContext = @{ 'Timers' = @{ Items = @{} }; }
         Add-PodeTimer -Name 'test' -Interval 1 -ScriptBlock { Write-Host 'hello' }
 
-        $timer = $PodeContext.Timers['test']
+        $timer = $PodeContext.Timers.Items['test']
         $timer.Name | Should Be 'test'
         $timer.Script.ToString() | Should Be ({ Write-Host 'hello' }).ToString()
 
         Remove-PodeTimer -Name 'test'
 
-        $timer = $PodeContext.Timers['test']
+        $timer = $PodeContext.Timers.Items['test']
         $timer | Should Be $null
     }
 }
 
 Describe 'Clear-PodeTimers' {
     It 'Adds new timers and then removes them' {
-        $PodeContext = @{ 'Timers' = @{}; }
+        $PodeContext = @{ 'Timers' = @{ Items = @{} }; }
         Add-PodeTimer -Name 'test1' -Interval 1 -ScriptBlock { Write-Host 'hello1' }
         Add-PodeTimer -Name 'test2' -Interval 1 -ScriptBlock { Write-Host 'hello2' }
 
-        $PodeContext.Timers.Count | Should Be 2
+        $PodeContext.Timers.Items.Count | Should Be 2
 
         Clear-PodeTimers
 
-        $PodeContext.Timers.Count | Should Be 0
+        $PodeContext.Timers.Items.Count | Should Be 0
     }
 }
 
 Describe 'Edit-PodeTimer' {
     It 'Adds a new timer, then edits the interval' {
-        $PodeContext = @{ 'Timers' = @{}; }
+        $PodeContext = @{ 'Timers' = @{ Items = @{} }; }
         Add-PodeTimer -Name 'test1' -Interval 1 -ScriptBlock { Write-Host 'hello1' }
-        $PodeContext.Timers['test1'].Interval | Should Be 1
-        $PodeContext.Timers['test1'].Script.ToString() | Should Be ({ Write-Host 'hello1' }).ToString()
+        $PodeContext.Timers.Items['test1'].Interval | Should Be 1
+        $PodeContext.Timers.Items['test1'].Script.ToString() | Should Be ({ Write-Host 'hello1' }).ToString()
 
         Edit-PodeTimer -Name 'test1' -Interval 3
-        $PodeContext.Timers['test1'].Interval | Should Be 3
-        $PodeContext.Timers['test1'].Script.ToString() | Should Be ({ Write-Host 'hello1' }).ToString()
+        $PodeContext.Timers.Items['test1'].Interval | Should Be 3
+        $PodeContext.Timers.Items['test1'].Script.ToString() | Should Be ({ Write-Host 'hello1' }).ToString()
     }
 
     It 'Adds a new timer, then edits the script' {
-        $PodeContext = @{ 'Timers' = @{}; }
+        $PodeContext = @{ 'Timers' = @{ Items = @{} }; }
         Add-PodeTimer -Name 'test1' -Interval 1 -ScriptBlock { Write-Host 'hello1' }
-        $PodeContext.Timers['test1'].Interval | Should Be 1
-        $PodeContext.Timers['test1'].Script.ToString() | Should Be ({ Write-Host 'hello1' }).ToString()
+        $PodeContext.Timers.Items['test1'].Interval | Should Be 1
+        $PodeContext.Timers.Items['test1'].Script.ToString() | Should Be ({ Write-Host 'hello1' }).ToString()
 
         Edit-PodeTimer -Name 'test1' -ScriptBlock { Write-Host 'hello2' }
-        $PodeContext.Timers['test1'].Interval | Should Be 1
-        $PodeContext.Timers['test1'].Script.ToString() | Should Be ({ Write-Host 'hello2' }).ToString()
+        $PodeContext.Timers.Items['test1'].Interval | Should Be 1
+        $PodeContext.Timers.Items['test1'].Script.ToString() | Should Be ({ Write-Host 'hello2' }).ToString()
     }
 }


### PR DESCRIPTION
### Description of the Change
Prevents some runspace pools from being configured when they aren't needed, but also adds in a way of configuring some pools for when they are needed.

For example, the schedules runspace pool was always being configured - even if no schedules had been configured. Now, the pool will only been configured if there are schedules. Also, there's a new `-EnablePool` parameter on `Start-PodeServer`; this allows forcing a pool to be configured if you create schedules in an adhoc manor.

The following runspaces are no longer configured when not needed:
* Timers
* Schedules
* Logging
* GUI

And the following runspaces can be force enabled:
* Timers
* Schedules

### Related Issue
Resolves #910 

### Examples
Timers:
```powershell
Start-PodeServer -EnablePool Timers {
    Add-PodeEndpoint -Address * -Port 8080 -Protocol Http
    Add-PodeRoute -Method Get -Path '/create-timer' -ScriptBlock {
        Add-PodeTimer -Name 'example' -Interval 5 -ScriptBlock {
            # logic
        }
    }
}
```

Schedules:
```powershell
Start-PodeServer -EnablePool Schedules {
    Add-PodeEndpoint -Address * -Port 8080 -Protocol Http
    Add-PodeRoute -Method Get -Path '/create-schedule' -ScriptBlock {
        Add-PodeSchedule -Name 'example' -Cron '@minutely' -ScriptBlock {
            # logic
        }
    }
}
```
