### PR TITLE
Fix for route creation order

### DIFF
--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -254,18 +254,18 @@ function New-PodeContext
 
     # routes for pages and api
     $ctx.Server.Routes = @{
-        'delete'    = @{}
-        'get'       = @{}
-        'head'      = @{}
-        'merge'     = @{}
-        'options'   = @{}
-        'patch'     = @{}
-        'post'      = @{}
-        'put'       = @{}
-        'trace'     = @{}
-        'static'    = @{}
-        'signal'    = @{}
-        '*'         = @{}
+        'delete'    = [ordered]@{}
+        'get'       = [ordered]@{}
+        'head'      = [ordered]@{}
+        'merge'     = [ordered]@{}
+        'options'   = [ordered]@{}
+        'patch'     = [ordered]@{}
+        'post'      = [ordered]@{}
+        'put'       = [ordered]@{}
+        'trace'     = [ordered]@{}
+        'static'    = [ordered]@{}
+        'signal'    = [ordered]@{}
+        '*'         = [ordered]@{}
     }
 
     # custom view paths

--- a/src/Public/Routes.ps1
+++ b/src/Public/Routes.ps1
@@ -612,7 +612,7 @@ function Remove-PodeRoute
     $Path = Update-PodeRoutePlaceholders -Path $Path
 
     # ensure route does exist
-    if (!$PodeContext.Server.Routes[$Method].ContainsKey($Path)) {
+    if (!$PodeContext.Server.Routes[$Method].Contains($Path)) {
         return
     }
 
@@ -662,7 +662,7 @@ function Remove-PodeStaticRoute
     $Path = Update-PodeRouteSlashes -Path $Path -Static
 
     # ensure route does exist
-    if (!$PodeContext.Server.Routes[$Method].ContainsKey($Path)) {
+    if (!$PodeContext.Server.Routes[$Method].Contains($Path)) {
         return
     }
 
@@ -712,7 +712,7 @@ function Remove-PodeSignalRoute
     $Path = Update-PodeRouteSlashes -Path $Path
 
     # ensure route does exist
-    if (!$PodeContext.Server.Routes[$Method].ContainsKey($Path)) {
+    if (!$PodeContext.Server.Routes[$Method].Contains($Path)) {
         return
     }
 


### PR DESCRIPTION
### Description of the Change
Adds `[ordered]` to the route hashtables, so that route creation order is preserved.

### Related Issue
Resolves #905 