### PR TITLE
Support for getting count of queued and in-processing requests

### DIFF
--- a/docs/Tutorials/Metrics/Requests.md
+++ b/docs/Tutorials/Metrics/Requests.md
@@ -52,8 +52,14 @@ $code = (Get-PodeRoute -Method Get -Path '/about').Metrics.Requests.StatusCodes[
 
 ## Active
 
-You can retrieve the current count of active requests by using [`Get-PodeServerActiveRequestMetric`](../../../Functions/Metrics/Get-PodeServerActiveRequestMetric). Active requests are ones that are queued internally, ready to be processed:
+You can retrieve the current count of active requests by using [`Get-PodeServerActiveRequestMetric`](../../../Functions/Metrics/Get-PodeServerActiveRequestMetric). Active requests are ones that are queued, or are currently being processed:
 
 ```powershell
 $activeReqs = Get-PodeServerActiveRequestMetric
+```
+
+The default is to return the count of all requests, but you can filter a count of queued or processing via `-CountType`:
+
+```powershell
+$queuedReqs = Get-PodeServerActiveRequestMetric -CountType Queued
 ```

--- a/examples/web-pages-docker.ps1
+++ b/examples/web-pages-docker.ps1
@@ -1,5 +1,9 @@
 Import-Module /usr/local/share/powershell/Modules/Pode/Pode.psm1 -Force -ErrorAction Stop
 
+<#
+docker-compose up --force-recreate --build
+#>
+
 # create a server, and start listening on port 8085
 Start-PodeServer -Threads 2 {
 

--- a/src/Listener/PodeClientSignal.cs
+++ b/src/Listener/PodeClientSignal.cs
@@ -2,17 +2,24 @@ using System;
 
 namespace Pode
 {
-    public class PodeClientSignal
+    public class PodeClientSignal : IDisposable
     {
         public PodeWebSocket WebSocket { get; private set; }
         public string Message { get; private set; }
         public DateTime Timestamp { get; private set; }
+        public PodeListener Listener { get; private set; }
 
-        public PodeClientSignal(PodeWebSocket webSocket, string message)
+        public PodeClientSignal(PodeWebSocket webSocket, string message, PodeListener listener)
         {
             WebSocket = webSocket;
             Message = message;
             Timestamp = DateTime.UtcNow;
+            Listener = listener;
+        }
+
+        public void Dispose()
+        {
+            Listener.RemoveProcessingClientSignal(this);
         }
     }
 }

--- a/src/Listener/PodeContext.cs
+++ b/src/Listener/PodeContext.cs
@@ -327,6 +327,8 @@ namespace Pode
         {
             lock (_lockable)
             {
+                Listener.RemoveProcessingContext(this);
+
                 if (IsClosed)
                 {
                     Request.Dispose();

--- a/src/Listener/PodeServerSignal.cs
+++ b/src/Listener/PodeServerSignal.cs
@@ -2,19 +2,26 @@ using System;
 
 namespace Pode
 {
-    public class PodeServerSignal
+    public class PodeServerSignal : IDisposable
     {
         public string Value { get; private set; }
         public string Path { get; private set; }
         public string ClientId { get; private set; }
         public DateTime Timestamp { get; private set; }
+        public PodeListener Listener { get; private set; }
 
-        public PodeServerSignal(string value, string path, string clientId)
+        public PodeServerSignal(string value, string path, string clientId, PodeListener listener)
         {
             Value = value;
             Path = path;
             ClientId = clientId;
             Timestamp = DateTime.UtcNow;
+            Listener = listener;
+        }
+
+        public void Dispose()
+        {
+            Listener.RemoveProcessingServerSignal(this);
         }
     }
 }

--- a/src/Listener/PodeWsRequest.cs
+++ b/src/Listener/PodeWsRequest.cs
@@ -44,7 +44,7 @@ namespace Pode
 
         public PodeClientSignal NewClientSignal()
         {
-            return new PodeClientSignal(WebSocket, Body);
+            return new PodeClientSignal(WebSocket, Body, Context.Listener);
         }
 
         protected override bool Parse(byte[] bytes)

--- a/src/Private/PodeServer.ps1
+++ b/src/Private/PodeServer.ps1
@@ -316,6 +316,9 @@ function Start-PodeWebServer
                         $_ | Write-PodeErrorLog
                         $_.Exception | Write-PodeErrorLog -CheckInnerException
                     }
+                    finally {
+                        Close-PodeDisposable -Disposable $message
+                    }
                 }
             }
             catch [System.OperationCanceledException] {}
@@ -404,6 +407,7 @@ function Start-PodeWebServer
                     }
                     finally {
                         Update-PodeServerSignalMetrics -SignalEvent $SignalEvent
+                        Close-PodeDisposable -Disposable $context
                     }
                 }
             }

--- a/src/Public/Metrics.ps1
+++ b/src/Public/Metrics.ps1
@@ -117,14 +117,66 @@ function Get-PodeServerSignalMetric
     return $PodeContext.Metrics.Signals.Total
 }
 
+<#
+.SYNOPSIS
+Returns the count of active requests.
+
+.DESCRIPTION
+Returns the count of all, processing, or queued active requests.
+
+.PARAMETER CountType
+The count type to return. (Default: Total)
+
+.EXAMPLE
+Get-PodeServerActiveRequestMetric
+
+.EXAMPLE
+Get-PodeServerActiveRequestMetric -CountType Queued
+#>
 function Get-PodeServerActiveRequestMetric
 {
     [CmdletBinding()]
-    param()
+    param(
+        [Parameter()]
+        [ValidateSet('Total', 'Queued', 'Processing')]
+        [string]
+        $CountType = 'Total'
+    )
 
-    return $PodeContext.Server.WebSockets.Listener.ContextsCount
+    switch ($CountType.ToLowerInvariant()) {
+        'total' {
+            return $PodeContext.Server.WebSockets.Listener.Contexts.Count
+        }
+
+        'queued' {
+            return $PodeContext.Server.WebSockets.Listener.Contexts.QueuedCount
+        }
+
+        'processing' {
+            return $PodeContext.Server.WebSockets.Listener.Contexts.ProcessingCount
+        }
+    }
 }
 
+<#
+.SYNOPSIS
+Returns the count of active signals.
+
+.DESCRIPTION
+Returns the count of all, processing, or queued active signals; for either server or client signals.
+
+.PARAMETER Type
+The type of signal to return. (Default: Total)
+
+.PARAMETER CountType
+The count type to return. (Default: Total)
+
+.EXAMPLE
+Get-PodeServerActiveSignalMetric
+
+.EXAMPLE
+Get-PodeServerActiveSignalMetric -Type Client -CountType Queued
+#>
 function Get-PodeServerActiveSignalMetric
 {
     [CmdletBinding()]
@@ -132,20 +184,61 @@ function Get-PodeServerActiveSignalMetric
         [Parameter()]
         [ValidateSet('Total', 'Server', 'Client')]
         [string]
-        $Type = 'Total'
+        $Type = 'Total',
+
+        [Parameter()]
+        [ValidateSet('Total', 'Queued', 'Processing')]
+        [string]
+        $CountType = 'Total'
     )
 
     switch ($Type.ToLowerInvariant()) {
         'total' {
-            return $PodeContext.Server.WebSockets.Listener.ServerSignalsCount + $PodeContext.Server.WebSockets.Listener.ClientSignalsCount
+            switch ($CountType.ToLowerInvariant()) {
+                'total' {
+                    return $PodeContext.Server.WebSockets.Listener.ServerSignals.Count + $PodeContext.Server.WebSockets.Listener.ClientSignals.Count
+                }
+
+                'queued' {
+                    return $PodeContext.Server.WebSockets.Listener.ServerSignals.QueuedCount + $PodeContext.Server.WebSockets.Listener.ClientSignals.QueuedCount
+                }
+
+                'processing' {
+                    return $PodeContext.Server.WebSockets.Listener.ServerSignals.ProcessingCount + $PodeContext.Server.WebSockets.Listener.ClientSignals.ProcessingCount
+                }
+            }
         }
 
         'server' {
-            return $PodeContext.Server.WebSockets.Listener.ServerSignalsCount
+            switch ($CountType.ToLowerInvariant()) {
+                'total' {
+                    return $PodeContext.Server.WebSockets.Listener.ServerSignals.Count
+                }
+
+                'queued' {
+                    return $PodeContext.Server.WebSockets.Listener.ServerSignals.QueuedCount
+                }
+
+                'processing' {
+                    return $PodeContext.Server.WebSockets.Listener.ServerSignals.ProcessingCount
+                }
+            }
         }
 
         'client' {
-            return $PodeContext.Server.WebSockets.Listener.ClientSignalsCount
+            switch ($CountType.ToLowerInvariant()) {
+                'total' {
+                    return $PodeContext.Server.WebSockets.Listener.ClientSignals.Count
+                }
+
+                'queued' {
+                    return $PodeContext.Server.WebSockets.Listener.ClientSignals.QueuedCount
+                }
+
+                'processing' {
+                    return $PodeContext.Server.WebSockets.Listener.ClientSignals.ProcessingCount
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
### Description of the Change
Adds support for `Get-PodeServerActiveRequestMetric` to also return the count of requests currently being processed, as well as queued. Plus support for getting queued/processing counts separately.

Default count is Total, to keep existing logic the same.

### Related Issue
Resolves #869 

### Examples
```powershell
Get-PodeServerActiveRequestMetric
Get-PodeServerActiveRequestMetric -CountType Queued
```
