### PR TITLE
Fix OpenAPI definition from [ordered] updated

### DIFF
--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -983,7 +983,7 @@ function Remove-PodeNullKeysFromHashtable
             continue
         }
 
-        if ($Hashtable[$key] -is [string] -and [string]::IsNullOrEmpty($Hashtable[$key])) {
+        if (($Hashtable[$key] -is [string]) -and [string]::IsNullOrEmpty($Hashtable[$key])) {
             $null = $Hashtable.Remove($key)
             continue
         }
@@ -995,7 +995,7 @@ function Remove-PodeNullKeysFromHashtable
             }
 
             foreach ($item in $Hashtable[$key]) {
-                if ($item -is [hashtable]) {
+                if (($item -is [hashtable]) -or ($item -is [System.Collections.Specialized.OrderedDictionary])) {
                     $item | Remove-PodeNullKeysFromHashtable
                 }
             }
@@ -1003,7 +1003,7 @@ function Remove-PodeNullKeysFromHashtable
             continue
         }
 
-        if ($Hashtable[$key] -is [hashtable]) {
+        if (($Hashtable[$key] -is [hashtable]) -or ($Hashtable[$key] -is [System.Collections.Specialized.OrderedDictionary])) {
             $Hashtable[$key] | Remove-PodeNullKeysFromHashtable
             continue
         }

--- a/src/Public/Utilities.ps1
+++ b/src/Public/Utilities.ps1
@@ -685,7 +685,7 @@ function Test-PodeIsEmpty
         return ($Value.Length -eq 0)
     }
 
-    if ($Value -is [hashtable]) {
+    if (($Value -is [hashtable]) -or ($Value -is [System.Collections.Specialized.OrderedDictionary])) {
         return ($Value.Count -eq 0)
     }
 


### PR DESCRIPTION
### Description of the Change
Fixes the removal of empty/null properties in an OpenAPI definition, after changing the path map to be `[ordered]`.

### Related Issue
Resolves #917 
