### PR TITLE
Dispose schedule runspaces

### DIFF
--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -100,6 +100,7 @@ function New-PodeContext
     $ctx.Schedules = @{
         Enabled = ($EnablePool -icontains 'schedules')
         Items = @{}
+        Processes = @{}
     }
 
     $ctx.Tasks = @{
@@ -642,6 +643,8 @@ function Open-PodeRunspacePools
             continue
         }
 
+        $item.Pool.ThreadOptions = [System.Management.Automation.Runspaces.PSThreadOptions]::ReuseThread
+        $item.Pool.CleanupInterval = [timespan]::FromMinutes(5)
         $item.Result = $item.Pool.BeginOpen($null, $null)
     }
 

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -681,6 +681,13 @@ function Close-PodeRunspaces
                 $item.Stopped = $true
             })
 
+            # dispose of schedule runspaces
+            if ($PodeContext.Schedules.Processes.Count -gt 0) {
+                foreach ($key in $PodeContext.Schedules.Processes.Keys.Clone()) {
+                    Close-PodeScheduleInternal -Process $PodeContext.Schedules.Processes[$key]
+                }
+            }
+
             # dispose of task runspaces
             if ($PodeContext.Tasks.Results.Count -gt 0) {
                 foreach ($key in $PodeContext.Tasks.Results.Keys.Clone()) {
@@ -707,6 +714,9 @@ function Close-PodeRunspaces
                 throw $err
             }
         }
+
+        # garbage collect
+        [GC]::Collect()
     }
     catch {
         $_ | Write-PodeErrorLog

--- a/src/Private/Server.ps1
+++ b/src/Private/Server.ps1
@@ -176,8 +176,11 @@ function Restart-PodeInternalServer
 
         $PodeContext.Server.Views.Clear()
         $PodeContext.Timers.Items.Clear()
-        $PodeContext.Schedules.Items.Clear()
         $PodeContext.Server.Logging.Types.Clear()
+
+        # clear schedules
+        $PodeContext.Schedules.Items.Clear()
+        $PodeContext.Schedules.Processes.Clear()
 
         # clear tasks
         $PodeContext.Tasks.Items.Clear()

--- a/src/Private/Tasks.ps1
+++ b/src/Private/Tasks.ps1
@@ -41,6 +41,8 @@ function Start-PodeTaskHousekeeper
                 Close-PodeTaskInternal -Result $result
             }
         }
+
+        $result = $null
     }
 }
 

--- a/tests/unit/Server.Tests.ps1
+++ b/tests/unit/Server.Tests.ps1
@@ -180,6 +180,7 @@ Describe 'Restart-PodeInternalServer' {
                 Items = @{
                     key = 'value'
                 }
+                Processes = @{}
             }
             Tasks = @{
                 Enabled = $true


### PR DESCRIPTION
### Description of the Change
Adds logic similar to Tasks, but for Schedules, so that their runspaces are disposed when completed. Also adds a `[GC]::Collect()` for when the server closes, or is restarted.

### Related Issue
Resolves #932 
