### PR TITLE
Fix for listening on IPv6

### DIFF
--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -165,7 +165,7 @@ function Get-PodeHostIPRegex
         $Type
     )
 
-    $ip_rgx = '\[[a-f0-9\:]+\]|((\d+\.){3}\d+)|\:\:\d+|\*|all'
+    $ip_rgx = '\[[a-f0-9\:]+\]|((\d+\.){3}\d+)|\:\:\d*|\*|all'
     $host_rgx = '([a-z]|\*\.)(([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])\.)*([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])+'
 
     switch ($Type.ToLowerInvariant())

--- a/tests/unit/Helpers.Tests.ps1
+++ b/tests/unit/Helpers.Tests.ps1
@@ -183,11 +183,11 @@ Describe 'Get-PodeHostIPRegex' {
     }
 
     It 'Returns valid IP regex' {
-        Get-PodeHostIPRegex -Type IP | Should Be '(?<host>(\[[a-f0-9\:]+\]|((\d+\.){3}\d+)|\:\:\d+|\*|all))'
+        Get-PodeHostIPRegex -Type IP | Should Be '(?<host>(\[[a-f0-9\:]+\]|((\d+\.){3}\d+)|\:\:\d*|\*|all))'
     }
 
     It 'Returns valid IP and Hostname regex' {
-        Get-PodeHostIPRegex -Type Both | Should Be '(?<host>(\[[a-f0-9\:]+\]|((\d+\.){3}\d+)|\:\:\d+|\*|all|([a-z]|\*\.)(([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])\.)*([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])+))'
+        Get-PodeHostIPRegex -Type Both | Should Be '(?<host>(\[[a-f0-9\:]+\]|((\d+\.){3}\d+)|\:\:\d*|\*|all|([a-z]|\*\.)(([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])\.)*([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])+))'
     }
 }
 


### PR DESCRIPTION
### Description of the Change
Fixes regex which prevented Pode from successfully listening on IPv6 localhost addresses.

### Related Issue
Resolves #915

### Examples
```powershell
Start-PodeServer -ScriptBlock {
    Add-PodeEndpoint -Address '[::]' -Port 34001 -Protocol http
}
```

or 
```powershell
Start-PodeServer -ScriptBlock {
    Add-PodeEndpoint -Address '[fd7a:b11c:d3bb:0:f491:d771:f34e:65fa]' -Port 34001 -Protocol http
}
```