### PR TITLE
Fix for loading server file when calling from relative path

### DIFF
--- a/src/Public/Core.ps1
+++ b/src/Public/Core.ps1
@@ -129,7 +129,7 @@ function Start-PodeServer
     try {
         # if we have a filepath, resolve it - and extract a root path from it
         if ($PSCmdlet.ParameterSetName -ieq 'file') {
-            $FilePath = Get-PodeRelativePath -Path $FilePath -Resolve -TestPath
+            $FilePath = Get-PodeRelativePath -Path $FilePath -Resolve -TestPath -JoinRoot -RootPath $MyInvocation.PSScriptRoot
 
             # if not already supplied, set root path
             if ([string]::IsNullOrWhiteSpace($RootPath)) {


### PR DESCRIPTION
### Description of the Change
Fixes a bug with `-FilePath` on `Start-PodeServer`, where if you called the script with the server in using a relative path (ie: `./examples/server.ps1`), the file was incorrectly loaded.

### Related Issue
Resolves #934 