### PR TITLE
Add multiple endpoint and SSL support for SMTP endpoints

### DIFF
--- a/docs/Hosting/AwsLambda.md
+++ b/docs/Hosting/AwsLambda.md
@@ -101,7 +101,7 @@ Start-PodeServer -Request $LambdaInput -ServerlessType AwsLambda -RootPath '/tmp
 
 ### Static Content
 
-Unlike Azure Functions, static content in AWS Functions can be served up in the normal way - assuming your function can recieve multiple routes.
+Unlike Azure Functions, static content in AWS Functions can be served up in the normal way - assuming your function can receive multiple routes.
 
 For example, if you have a CSS stylesheet at `/tmp/www/styles/main.css.pode`, then your `index.pode` view would get this as such:
 

--- a/docs/Tutorials/WebSockets.md
+++ b/docs/Tutorials/WebSockets.md
@@ -114,12 +114,12 @@ $('#form').submit(function(e) {
 })
 ```
 
-This will send the message to the server, which will in-turn broadcast it to all other clients. To broadcast the message to just clients connected on a specific path, such as `/recieve`:
+This will send the message to the server, which will in-turn broadcast it to all other clients. To broadcast the message to just clients connected on a specific path, such as `/receive`:
 
 ```javascript
 $('#form').submit(function(e) {
     e.preventDefault();
-    ws.send(JSON.stringify({ message: $('#input').val(), path: '/recieve' }));
+    ws.send(JSON.stringify({ message: $('#input').val(), path: '/receive' }));
     $('#input').val('');
 })
 ```

--- a/examples/mail-server.ps1
+++ b/examples/mail-server.ps1
@@ -14,8 +14,8 @@ Send-MailMessage -SmtpServer localhost -To 'to@pode.com' -From 'from@pode.com' -
 Start-PodeServer -Threads 2 {
 
     Add-PodeEndpoint -Address localhost -Protocol Smtp
-    Add-PodeEndpoint -Address localhost -Port 587 -Protocol Smtps -SelfSigned -TlsMode Explicit
-    Add-PodeEndpoint -Address localhost -Port 465 -Protocol Smtps -SelfSigned -TlsMode Implicit
+    Add-PodeEndpoint -Address localhost -Protocol Smtps -SelfSigned -TlsMode Explicit
+    Add-PodeEndpoint -Address localhost -Protocol Smtps -SelfSigned -TlsMode Implicit
 
     # enable logging
     New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging -Levels Error, Debug

--- a/examples/mail-server.ps1
+++ b/examples/mail-server.ps1
@@ -7,15 +7,18 @@ Import-Module "$($path)/src/Pode.psm1" -Force -ErrorAction Stop
 <#
 Example call:
 Send-MailMessage -SmtpServer localhost -To 'to@pode.com' -From 'from@pode.com' -Body 'Hello' -Subject 'Hi there' -Port 25
+Send-MailMessage -SmtpServer localhost -To 'to@pode.com' -From 'from@pode.com' -Body 'Hello' -Subject 'Hi there' -Port 587 -UseSSL
 #>
 
 # create a server, and start listening on port 25
 Start-PodeServer -Threads 2 {
 
     Add-PodeEndpoint -Address localhost -Protocol Smtp
+    Add-PodeEndpoint -Address localhost -Port 587 -Protocol Smtps -SelfSigned -TlsMode Explicit
+    Add-PodeEndpoint -Address localhost -Port 465 -Protocol Smtps -SelfSigned -TlsMode Implicit
 
     # enable logging
-    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging -Levels Error, Debug
 
     # allow the local ip
     #Add-PodeAccessRule -Access Allow -Type IP -Values 127.0.0.1

--- a/examples/mail-server.ps1
+++ b/examples/mail-server.ps1
@@ -7,6 +7,8 @@ Import-Module "$($path)/src/Pode.psm1" -Force -ErrorAction Stop
 <#
 Example call:
 Send-MailMessage -SmtpServer localhost -To 'to@pode.com' -From 'from@pode.com' -Body 'Hello' -Subject 'Hi there' -Port 25
+
+[System.Net.ServicePointManager]::ServerCertificateValidationCallback = { return $true }
 Send-MailMessage -SmtpServer localhost -To 'to@pode.com' -From 'from@pode.com' -Body 'Hello' -Subject 'Hi there' -Port 587 -UseSSL
 #>
 

--- a/examples/web-gzip-request.ps1
+++ b/examples/web-gzip-request.ps1
@@ -12,7 +12,7 @@ Start-PodeServer -Threads 2 {
 
     New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
 
-    # GET request that recieves gzip'd json
+    # GET request that receives gzip'd json
     Add-PodeRoute -Method Post -Path '/users' -ScriptBlock {
         Write-PodeJsonResponse -Value $WebEvent.Data
     }

--- a/src/Listener/PodeHelpers.cs
+++ b/src/Listener/PodeHelpers.cs
@@ -35,20 +35,36 @@ namespace Pode
             // write the exception to terminal
             Console.WriteLine($"[{level}] {ex.GetType().Name}: {ex.Message}");
             Console.WriteLine(ex.StackTrace);
+
+            if (ex.InnerException != null)
+            {
+                Console.WriteLine($"[{level}] {ex.InnerException.GetType().Name}: {ex.InnerException.Message}");
+                Console.WriteLine(ex.InnerException.StackTrace);
+            }
         }
 
-        public static void HandleAggregateException(AggregateException aex, PodeListener listener = default(PodeListener), PodeLoggingLevel level = PodeLoggingLevel.Error)
+        public static void HandleAggregateException(AggregateException aex, PodeListener listener = default(PodeListener), PodeLoggingLevel level = PodeLoggingLevel.Error, bool handled = false)
         {
-            aex.Handle((ex) =>
+            try
             {
-                if (ex is IOException || ex is OperationCanceledException)
+                aex.Handle((ex) =>
                 {
-                    return true;
-                }
+                    if (ex is IOException || ex is OperationCanceledException)
+                    {
+                        return true;
+                    }
 
-                PodeHelpers.WriteException(ex, listener, level);
-                return false;
-            });
+                    PodeHelpers.WriteException(ex, listener, level);
+                    return false;
+                });
+            }
+            catch
+            {
+                if (!handled)
+                {
+                    throw;
+                }
+            }
         }
 
         public static void WriteErrorMessage(string message, PodeListener listener = default(PodeListener), PodeLoggingLevel level = PodeLoggingLevel.Error, PodeContext context = default(PodeContext))

--- a/src/Listener/PodeHttpRequest.cs
+++ b/src/Listener/PodeHttpRequest.cs
@@ -54,8 +54,8 @@ namespace Pode
                 || (IsWebSocket && !HttpMethod.Equals("GET", StringComparison.InvariantCultureIgnoreCase)));
         }
 
-        public PodeHttpRequest(Socket socket)
-            : base(socket)
+        public PodeHttpRequest(Socket socket, PodeSocket podeSocket)
+            : base(socket, podeSocket)
         {
             Protocol = "HTTP/1.1";
             Type = PodeProtocolType.Http;

--- a/src/Listener/PodeRequest.cs
+++ b/src/Listener/PodeRequest.cs
@@ -84,6 +84,11 @@ namespace Pode
 
         public void UpgradeToSSL()
         {
+            if (SslUpgraded)
+            {
+                return;
+            }
+
             var ssl = new SslStream(InputStream, false, new RemoteCertificateValidationCallback(ValidateCertificateCallback));
             ssl.AuthenticateAsServerAsync(Certificate, AllowClientCertificate, Protocols, false).Wait(Context.Listener.CancellationToken);
             InputStream = ssl;

--- a/src/Listener/PodeSmtpCommand.cs
+++ b/src/Listener/PodeSmtpCommand.cs
@@ -1,0 +1,14 @@
+namespace Pode
+{
+    public enum PodeSmtpCommand
+    {
+        None,
+        Ehlo,
+        Helo,
+        Data,
+        Quit,
+        StartTls,
+        RcptTo,
+        MailFrom
+    }
+}

--- a/src/Listener/PodeSmtpStartType.cs
+++ b/src/Listener/PodeSmtpStartType.cs
@@ -1,0 +1,9 @@
+namespace Pode
+{
+    public enum PodeSmtpStartType
+    {
+        None,
+        Helo,
+        Ehlo
+    }
+}

--- a/src/Listener/PodeSocket.cs
+++ b/src/Listener/PodeSocket.cs
@@ -20,6 +20,7 @@ namespace Pode
         public X509Certificate Certificate { get; private set; }
         public bool AllowClientCertificate { get; private set; }
         public SslProtocols Protocols { get; private set; }
+        public PodeTlsMode TlsMode { get; private set; }
         public Socket Socket { get; private set; }
 
         private ConcurrentQueue<SocketAsyncEventArgs> AcceptConnections;
@@ -41,13 +42,19 @@ namespace Pode
 
         public bool HasHostnames => Hostnames.Any();
 
-        public PodeSocket(IPAddress ipAddress, int port, SslProtocols protocols, PodeProtocolType type, X509Certificate certificate = null, bool allowClientCertificate = false)
+        public string Hostname
+        {
+            get => (HasHostnames ? Hostnames[0] : IPAddress.ToString());
+        }
+
+        public PodeSocket(IPAddress ipAddress, int port, SslProtocols protocols, PodeProtocolType type, X509Certificate certificate = null, bool allowClientCertificate = false, PodeTlsMode tlsMode = PodeTlsMode.Implicit)
             : base(type)
         {
             IPAddress = ipAddress;
             Port = port;
             Certificate = certificate;
             AllowClientCertificate = allowClientCertificate;
+            TlsMode = tlsMode;
             Protocols = protocols;
             Hostnames = new List<string>();
             Endpoint = new IPEndPoint(ipAddress, port);
@@ -224,7 +231,7 @@ namespace Pode
             catch (IOException) {}
             catch (AggregateException aex)
             {
-                PodeHelpers.HandleAggregateException(aex, Listener);
+                PodeHelpers.HandleAggregateException(aex, Listener, PodeLoggingLevel.Error, true);
             }
             catch (Exception ex)
             {

--- a/src/Listener/PodeTlsMode.cs
+++ b/src/Listener/PodeTlsMode.cs
@@ -1,0 +1,8 @@
+namespace Pode
+{
+    public enum PodeTlsMode
+    {
+        Implicit,
+        Explicit
+    }
+}

--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -282,9 +282,9 @@ function New-PodeContext
 
     # handlers for tcp
     $ctx.Server.Handlers = @{
-        'tcp' = @{};
-        'smtp' = @{};
-        'service' = @{};
+        tcp     = @{}
+        smtp    = @{}
+        service = @{}
     }
 
     # setup basic access placeholders
@@ -353,14 +353,14 @@ function New-PodeContext
 
     # runspace pools
     $ctx.RunspacePools = @{
-        Main = $null
-        Web = $null
-        Smtp = $null
-        Tcp = $null
-        Signals = $null
-        Schedules = $null
-        Gui = $null
-        Tasks = $null
+        Main        = $null
+        Web         = $null
+        Smtp        = $null
+        Tcp         = $null
+        Signals     = $null
+        Schedules   = $null
+        Gui         = $null
+        Tasks       = $null
     }
 
     # session state

--- a/src/Private/Endpoints.ps1
+++ b/src/Private/Endpoints.ps1
@@ -184,7 +184,7 @@ function Find-PodeEndpointName
 
     # add a default port to the address if missing
     if (!$Address.Contains(':')) {
-        $port = Get-PodeDefaultPort -Protocol $Protocol -Real
+        $port = Get-PodeDefaultPort -Protocol $Protocol -Real -TlsMode Implicit
         $Address = "$($Address):$($port)"
     }
 

--- a/src/Private/Endpoints.ps1
+++ b/src/Private/Endpoints.ps1
@@ -73,7 +73,7 @@ function Get-PodeEndpoints
             }
 
             'smtp' {
-                $endpoints += @($PodeContext.Server.Endpoints.Values | Where-Object { @('smtp') -icontains $_.Protocol })
+                $endpoints += @($PodeContext.Server.Endpoints.Values | Where-Object { @('smtp', 'smtps') -icontains $_.Protocol })
             }
 
             'tcp' {
@@ -89,7 +89,7 @@ function Test-PodeEndpointProtocol
 {
     param(
         [Parameter(Mandatory=$true)]
-        [ValidateSet('Http', 'Https', 'Ws', 'Wss', 'Smtp', 'Tcp')]
+        [ValidateSet('Http', 'Https', 'Ws', 'Wss', 'Smtp', 'Smtps', 'Tcp')]
         [string]
         $Protocol
     )
@@ -102,7 +102,7 @@ function Get-PodeEndpointType
 {
     param(
         [Parameter()]
-        [ValidateSet('Http', 'Https', 'Smtp', 'Tcp', 'Ws', 'Wss')]
+        [ValidateSet('Http', 'Https', 'Smtp', 'Smtps', 'Tcp', 'Ws', 'Wss')]
         [string]
         $Protocol
     )
@@ -110,6 +110,7 @@ function Get-PodeEndpointType
     switch ($Protocol) {
         { $_ -iin @('http', 'https') } { 'Http' }
         { $_ -iin @('ws', 'wss') } { 'Ws' }
+        { $_ -iin @('smtp', 'smtps') } { 'Smtp' }
         default { $Protocol }
     }
 }
@@ -118,7 +119,7 @@ function Get-PodeEndpointRunspacePoolName
 {
     param(
         [Parameter()]
-        [ValidateSet('Http', 'Https', 'Smtp', 'Tcp', 'Ws', 'Wss')]
+        [ValidateSet('Http', 'Https', 'Smtp', 'Smtps', 'Tcp', 'Ws', 'Wss')]
         [string]
         $Protocol
     )
@@ -126,6 +127,7 @@ function Get-PodeEndpointRunspacePoolName
     switch ($Protocol) {
         { $_ -iin @('http', 'https') } { 'Web' }
         { $_ -iin @('ws', 'wss') } { 'Signals' }
+        { $_ -iin @('smtp', 'smtps') } { 'Smtp' }
         default { $Protocol }
     }
 }

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -2218,6 +2218,11 @@ function Get-PodeDefaultPort
         [string]
         $Protocol,
 
+        [Parameter()]
+        [ValidateSet('Implicit', 'Explicit')]
+        [string]
+        $TlsMode = 'Implicit',
+
         [switch]
         $Real
     )
@@ -2225,14 +2230,14 @@ function Get-PodeDefaultPort
     # are we after the real default ports?
     if ($Real) {
         return (@{
-            Http    = 80
-            Https   = 443
-            Smtp    = 25
-            Smtps   = 465
-            Tcp     = 9001
-            Ws      = 80
-            Wss     = 443
-        })[$Protocol.ToLowerInvariant()]
+            Http    = @{ Implicit = 80 }
+            Https   = @{ Implicit = 443 }
+            Smtp    = @{ Implicit = 25 }
+            Smtps   = @{ Implicit = 465; Explicit = 587 }
+            Tcp     = @{ Implicit = 9001 }
+            Ws      = @{ Implicit = 80 }
+            Wss     = @{ Implicit = 443 }
+        })[$Protocol.ToLowerInvariant()][$TlsMode.ToLowerInvariant()]
     }
 
     # if we running as iis, return the ASPNET port
@@ -2247,14 +2252,14 @@ function Get-PodeDefaultPort
 
     # otherwise, get the port for the protocol
     return (@{
-        Http    = 8080
-        Https   = 8443
-        Smtp    = 25
-        Smtps   = 465 #TODO: this needs to toggle based on implicit/explicit
-        Tcp     = 9001
-        Ws      = 9080
-        Wss     = 9443
-    })[$Protocol.ToLowerInvariant()]
+        Http    = @{ Implicit = 8080 }
+        Https   = @{ Implicit = 8443 }
+        Smtp    = @{ Implicit = 25 }
+        Smtps   = @{ Implicit = 465; Explicit = 587 }
+        Tcp     = @{ Implicit = 9001 }
+        Ws      = @{ Implicit = 9080 }
+        Wss     = @{ Implicit = 9443 }
+    })[$Protocol.ToLowerInvariant()][$TlsMode.ToLowerInvariant()]
 }
 
 function Set-PodeServerHeader

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -2214,7 +2214,7 @@ function Get-PodeDefaultPort
 {
     param(
         [Parameter()]
-        [ValidateSet('Http', 'Https', 'Smtp', 'Tcp', 'Ws', 'Wss')]
+        [ValidateSet('Http', 'Https', 'Smtp', 'Smtps', 'Tcp', 'Ws', 'Wss')]
         [string]
         $Protocol,
 
@@ -2228,6 +2228,7 @@ function Get-PodeDefaultPort
             Http    = 80
             Https   = 443
             Smtp    = 25
+            Smtps   = 465
             Tcp     = 9001
             Ws      = 80
             Wss     = 443
@@ -2249,6 +2250,7 @@ function Get-PodeDefaultPort
         Http    = 8080
         Https   = 8443
         Smtp    = 25
+        Smtps   = 465 #TODO: this needs to toggle based on implicit/explicit
         Tcp     = 9001
         Ws      = 9080
         Wss     = 9443

--- a/src/Private/PodeServer.ps1
+++ b/src/Private/PodeServer.ps1
@@ -176,14 +176,14 @@ function Start-PodeWebServer
 
                             # invoke global and route middleware
                             if ((Invoke-PodeMiddleware -Middleware $PodeContext.Server.Middleware -Route $WebEvent.Path)) {
-                                # has thr request been aborted
+                                # has the request been aborted
                                 if ($Request.IsAborted) {
                                     throw $Request.Error
                                 }
 
                                 if ((Invoke-PodeMiddleware -Middleware $WebEvent.Route.Middleware))
                                 {
-                                    # has thr request been aborted
+                                    # has the request been aborted
                                     if ($Request.IsAborted) {
                                         throw $Request.Error
                                     }

--- a/src/Private/Security.ps1
+++ b/src/Private/Security.ps1
@@ -2,7 +2,7 @@ using namespace System.Security.Cryptography
 
 function Test-PodeIPLimit
 {
-    param (
+    param(
         [Parameter(Mandatory=$true)]
         [ValidateNotNull()]
         $IP
@@ -264,7 +264,7 @@ function Test-PodeEndpointLimit
 
 function Test-PodeIPAccess
 {
-    param (
+    param(
         [Parameter(Mandatory=$true)]
         [ValidateNotNull()]
         $IP

--- a/src/Public/Core.ps1
+++ b/src/Public/Core.ps1
@@ -807,7 +807,7 @@ function Add-PodeEndpoint
         [Parameter(ParameterSetName='CertSelf')]
         [ValidateSet('Implicit', 'Explicit')]
         [string]
-        $TlsMode = "Implicit",
+        $TlsMode = 'Implicit',
 
         [Parameter()]
         [string]
@@ -945,7 +945,7 @@ function Add-PodeEndpoint
     # set the port for the context, if 0 use a default port for protocol
     $obj.Port = $_endpoint.Port
     if (([int]$obj.Port) -eq 0) {
-        $obj.Port = Get-PodeDefaultPort -Protocol $Protocol
+        $obj.Port = Get-PodeDefaultPort -Protocol $Protocol -TlsMode $TlsMode
     }
 
     if ($obj.IsIPAddress) {

--- a/tests/unit/Context.Tests.ps1
+++ b/tests/unit/Context.Tests.ps1
@@ -324,10 +324,24 @@ Describe 'Add-PodeEndpoint' {
             { Add-PodeEndpoint -Address 'pode.foo.com' -Port 80 -Protocol 'HTTP' -Name 'Example' } | Should Throw 'already been defined'
         }
 
-        It 'Throws error when adding two SMTP endpoints' {
+        It 'Add two endpoints to listen on, one of SMTP and one of SMTPS' {
             $PodeContext.Server = @{ Endpoints = @{}; EndpointsMap = @{}; 'Type' = $null }
-            Add-PodeEndpoint -Address '127.0.0.1' -Port 80 -Protocol 'SMTP'
-            { Add-PodeEndpoint -Address 'pode.foo.com' -Port 80 -Protocol 'SMTP' } | Should Throw 'already been defined'
+            Add-PodeEndpoint -Address '127.0.0.1' -Port 25 -Protocol 'SMTP' -Name 'Smtp'
+            Add-PodeEndpoint -Address 'pode.mail.com' -Port 465 -Protocol 'SMTPS' -Name 'Smtps'
+
+            $PodeContext.Server.Types | Should Be 'SMTP'
+            $PodeContext.Server.Endpoints | Should Not Be $null
+            $PodeContext.Server.Endpoints.Count | Should Be 2
+
+            $endpoint = $PodeContext.Server.Endpoints['Smtp']
+            $endpoint.Port | Should Be 25
+            $endpoint.HostName | Should Be ''
+            $endpoint.Address.ToString() | Should Be '127.0.0.1'
+
+            $endpoint = $PodeContext.Server.Endpoints['Smtps']
+            $endpoint.Port | Should Be 465
+            $endpoint.HostName | Should Be 'pode.mail.com'
+            $endpoint.Address.ToString() | Should Be '127.0.0.1'
         }
 
         It 'Throws error when adding two TCP endpoints' {

--- a/tests/unit/Helpers.Tests.ps1
+++ b/tests/unit/Helpers.Tests.ps1
@@ -1405,8 +1405,12 @@ Describe 'Get-PodeDefaultPort' {
         Get-PodeDefaultPort -Protocol Smtp | Should Be 25
     }
 
-    It 'Returns default port for smtps' {
-        Get-PodeDefaultPort -Protocol Smtp | Should Be 465
+    It 'Returns default port for smtps - implicit' {
+        Get-PodeDefaultPort -Protocol Smtps -TlsMode Implicit | Should Be 465
+    }
+
+    It 'Returns default port for smtps - explicit' {
+        Get-PodeDefaultPort -Protocol Smtps -TlsMode Explicit | Should Be 587
     }
 
     It 'Returns default port for tcp' {

--- a/tests/unit/Helpers.Tests.ps1
+++ b/tests/unit/Helpers.Tests.ps1
@@ -1405,6 +1405,10 @@ Describe 'Get-PodeDefaultPort' {
         Get-PodeDefaultPort -Protocol Smtp | Should Be 25
     }
 
+    It 'Returns default port for smtps' {
+        Get-PodeDefaultPort -Protocol Smtp | Should Be 465
+    }
+
     It 'Returns default port for tcp' {
         Get-PodeDefaultPort -Protocol Tcp | Should Be 9001
     }


### PR DESCRIPTION
### Description of the Change
This adds multiple endpoint support, and SSL support, for SMTP endpoints.

On `Add-PodeEndpoint` the `-Protocol` parameter now has a new option of `Smtps`, and accepts the certificate/self-signed parameters. When supplied the default port is 465 for implicit TLS, or you can use the new `-TlsMode` parameter to toggle between implicit or explicit TLS (for explicit the default port is 587).

Implicit TLS is the default for all SSL endpoints, and only SMTPS accepts the Explicit option on `-TlsMode`.

### Related Issue
Resolves #901 

### Examples
The following example sets up multiple endpoints for SMTP, including 1 endpoint for implicit TLS, and one for explicit TLS:
```powershell
Add-PodeEndpoint -Address localhost -Protocol Smtp
Add-PodeEndpoint -Address localhost -Protocol Smtps -SelfSigned -TlsMode Explicit
Add-PodeEndpoint -Address localhost -Protocol Smtps -SelfSigned -TlsMode Implicit
```

An example of send email to the explicit TLS endpoint:
```powershell
[System.Net.ServicePointManager]::ServerCertificateValidationCallback = { return $true }
Send-MailMessage -SmtpServer localhost -To 'to@pode.com' -From 'from@pode.com' -Body 'Hello' -Subject 'Hi there' -Port 587 -UseSSL
```

Note: .NET only supports sending emails to explicit TLS endpoints.
