### PR TITLE
 for some OpenAPI properties being dropped

### DIFF
--- a/src/Public/OpenApi.ps1
+++ b/src/Public/OpenApi.ps1
@@ -1353,7 +1353,6 @@ function ConvertTo-PodeOAParameter
         schema = @{
             type = $Property.type
             format = $Property.format
-            #enum = $Property.meta.enum
         }
     }
 

--- a/src/Public/OpenApi.ps1
+++ b/src/Public/OpenApi.ps1
@@ -1353,7 +1353,13 @@ function ConvertTo-PodeOAParameter
         schema = @{
             type = $Property.type
             format = $Property.format
-            enum = $Property.enum
+            #enum = $Property.meta.enum
+        }
+    }
+
+    if ($null -ne $Property.meta) {
+        foreach ($key in $Property.meta.Keys) {
+            $prop.schema[$key] = $Property.meta[$key]
         }
     }
 


### PR DESCRIPTION
### Description of the Change
Fix for some OpenAPI properties being dropped in `ConvertTo-PodeOAParameter` - such as enum.

### Related Issue
Resolves #957 