### PR TITLE
Overhauls the TCP server, and documents it as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 > 💝 A lot of my free time, evenings, and weekends goes into making Pode happen; please do consider sponsoring as it will really help! 😊
 
-Pode is a Cross-Platform framework for creating web servers to host [REST APIs](https://badgerati.github.io/Pode/Tutorials/Routes/Overview/), [Web Pages](https://badgerati.github.io/Pode/Tutorials/Routes/Examples/WebPages/), and [SMTP/TCP](https://badgerati.github.io/Pode/Hosting/) Servers. Pode also allows you to render dynamic files using [`.pode`](https://badgerati.github.io/Pode/Tutorials/Views/Pode/) files, which are just embedded PowerShell, or other [Third-Party](https://badgerati.github.io/Pode/Tutorials/Views/ThirdParty/) template engines. Plus many more features, including [Azure Functions](https://badgerati.github.io/Pode/Hosting/AzureFunctions/) and [AWS Lambda](https://badgerati.github.io/Pode/Hosting/AwsLambda/) support!
+Pode is a Cross-Platform framework for creating web servers to host [REST APIs](https://badgerati.github.io/Pode/Tutorials/Routes/Overview/), [Web Pages](https://badgerati.github.io/Pode/Tutorials/Routes/Examples/WebPages/), and [SMTP/TCP](https://badgerati.github.io/Pode/Servers/) Servers. Pode also allows you to render dynamic files using [`.pode`](https://badgerati.github.io/Pode/Tutorials/Views/Pode/) files, which are just embedded PowerShell, or other [Third-Party](https://badgerati.github.io/Pode/Tutorials/Views/ThirdParty/) template engines. Plus many more features, including [Azure Functions](https://badgerati.github.io/Pode/Hosting/AzureFunctions/) and [AWS Lambda](https://badgerati.github.io/Pode/Hosting/AwsLambda/) support!
 
 <p align="center">
     <img src="https://github.com/Badgerati/Pode/blob/develop/images/example_code_2.png?raw=true" />

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 > 💝 A lot of my free time, evenings, and weekends goes into making Pode happen; please do consider sponsoring as it will really help! 😊
 
-Pode is a Cross-Platform framework for creating web servers to host [REST APIs](https://badgerati.github.io/Pode/Tutorials/Routes/Overview/), [Web Pages](https://badgerati.github.io/Pode/Tutorials/Routes/Examples/WebPages/), and [SMTP/TCP](https://badgerati.github.io/Pode/Hosting/SmtpServer/) Servers. Pode also allows you to render dynamic files using [`.pode`](https://badgerati.github.io/Pode/Tutorials/Views/Pode/) files, which are just embedded PowerShell, or other [Third-Party](https://badgerati.github.io/Pode/Tutorials/Views/ThirdParty/) template engines. Plus many more features, including [Azure Functions](https://badgerati.github.io/Pode/Hosting/AzureFunctions/) and [AWS Lambda](https://badgerati.github.io/Pode/Hosting/AwsLambda/) support!
+Pode is a Cross-Platform framework for creating web servers to host [REST APIs](https://badgerati.github.io/Pode/Tutorials/Routes/Overview/), [Web Pages](https://badgerati.github.io/Pode/Tutorials/Routes/Examples/WebPages/), and [SMTP/TCP](https://badgerati.github.io/Pode/Hosting/) Servers. Pode also allows you to render dynamic files using [`.pode`](https://badgerati.github.io/Pode/Tutorials/Views/Pode/) files, which are just embedded PowerShell, or other [Third-Party](https://badgerati.github.io/Pode/Tutorials/Views/ThirdParty/) template engines. Plus many more features, including [Azure Functions](https://badgerati.github.io/Pode/Hosting/AzureFunctions/) and [AWS Lambda](https://badgerati.github.io/Pode/Hosting/AwsLambda/) support!
 
 <p align="center">
     <img src="https://github.com/Badgerati/Pode/blob/develop/images/example_code_2.png?raw=true" />

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Then navigate to `http://127.0.0.1:8000` in your browser.
 * Azure Functions, AWS Lambda, and IIS support
 * OpenAPI, Swagger, and ReDoc support
 * Listen on a single or multiple IP address/hostnames
-* Cross-platform support for HTTP, HTTPS, TCP and SMTP
+* Cross-platform support for HTTP(S), SMTP(S), and TCP(S)
 * Cross-platform support for WebSockets, including secure WebSockets
 * Host REST APIs, Web Pages, and Static Content (with caching)
 * Support for custom error pages

--- a/docs/Getting-Started/Migrating/0X-to-1X.md
+++ b/docs/Getting-Started/Migrating/0X-to-1X.md
@@ -109,7 +109,7 @@ The `gui` function use to take a Name with a hashtable of options. This function
 
 ## Handlers
 
-([Tutorial](../../../Hosting/SmtpServer))
+([Tutorial](../../../Servers/SMTP))
 
 The biggest change the Handlers is that you can now create multiple handlers for each of SMTP, TCP and Service - rather than just one. With this, the new [`Add-PodeHandler`](../../../Functions/Handlers/Add-PodeHandler) requires a `-Name` to be supplied.
 

--- a/docs/Servers/SMTP.md
+++ b/docs/Servers/SMTP.md
@@ -1,4 +1,4 @@
-# SMTP Server
+# SMTP
 
 Pode has an inbuilt SMTP server for receiving emails, with support for non-TLS as well as implicit and explicit TLS. Unlike with web servers that use the Route functions, an SMTP server use the Handler functions, which let you specify logic for handling responses from TCP streams.
 
@@ -82,6 +82,8 @@ The SMTP Handler will be passed the `$SmtpEvent` object, that contains the Reque
 | Response | object | The raw Response object |
 | Lockable | hashtable | A synchronized hashtable that can be used with `Lock-PodeObject` |
 | Email | hashtable | An object containing data from the email, as seen below |
+| Endpoint | hashtable | Contains the Address and Protocol of the endpoint being hit - such as "pode.example.com" or "127.0.0.2", or HTTP or HTTPS for the Protocol |
+| Timestamp | datetime | The current date and time of the Request |
 
 ### Email
 

--- a/docs/Servers/TCP.md
+++ b/docs/Servers/TCP.md
@@ -1,0 +1,209 @@
+# TCP
+
+Pode has a generic TCP server type inbuilt. Unlike the other server types, the TCP server lets you build pretty much anything over TCP. The TCP server supports non-TLS, as well as implicit and explicit TLS endpoints.
+
+Where a web server using Routes, a TCP server uses Verbs - think of them like "commands" or "phrases". Requests sent will be matched to a Verb, and that Verb's logic invoked (more info below).
+
+## Usage
+
+To create a TCP server you need to create an appropriate [Endpoint](../../Tutorials/Endpoints/Basics) with the TCP protocol, plus some [Verbs](#verbs).
+
+The following example will create a TCP endpoint listening on `localhost:9000`, and creates a simple Verb to respond back to a connected client:
+
+```powershell
+Start-PodeServer {
+    Add-PodeEndpoint -Address localhost -Port 9000 -Protocol Tcp -CRLFMessageEnd
+
+    Add-PodeVerb -Verb 'HELLO' -ScriptBlock {
+        Write-PodeTcpClient -Message 'HI'
+    }
+}
+```
+
+!!! note
+    If you use telnet to test/send data to a TCP server, ensure that the Endpoint has the `-CRLFMessageEnd` switch. If missed, the server will receive data in single characters.
+
+Start the above server, and then in a different terminal start telnet and send "HELLO" - pressing Enter to send:
+
+```powershell
+$> telnet localhost 9000
+C> HELLO
+S> HI
+```
+
+When you send "HELLO", the server will respond with "HI". If you can't use telnet, then there's a quick [test script](#test-send) below to use.
+
+### Acknowledge
+
+If you'd like to send an initial message to clients as soon as they connect, you can set an `-Acknowledge` message on the Endpoint:
+
+```powershell
+Add-PodeEndpoint -Address localhost -Port 9000 -Protocol Tcp -CRLFMessageEnd -Acknowledge 'Welcome!'
+```
+
+If you connect via telnet now:
+
+```powershell
+$> telnet localhost 9000
+S> Welcome!
+```
+
+## Verbs
+
+Verbs work like Routes, whereby you can setup many of them and Pode will invoke the Verb's logic that best matches the data sent. Data sent usually should be in a structured format, such as `<COMMAND> <PARAMETERS>` - akin to SMTP and FTP. However, data can be unstructured, and this is where the wildcard Verb comes in handy.
+
+To create a Verb you use [`Add-PodeVerb`](../../Functions/Verbs/Add-PodeVerb):
+
+```powershell
+Add-PodeVerb -Verb 'HELLO' -ScriptBlock {
+    Write-PodeTcpClient -Message 'HI'
+}
+```
+
+### Parameters
+
+Also similar to Routes, Verbs support parameters in the format `:<name>`. These parameters will be available in `$TcpEvent.Parameters`:
+
+```powershell
+Add-PodeVerb -Verb 'HELLO :username' -ScriptBlock {
+    Write-PodeTcpClient -Message "HI, $($TcpEvent.Parameters.username)"
+}
+```
+
+### Wildcard
+
+The wildcard Verb, denoted via `-Verb *`, is a catch-all for any data that doesn't match other defined Verbs. You could use this Verb to write back to the client that they sent invalid data:
+
+```powershell
+Add-PodeVerb -Verb * -ScriptBlock {
+    Write-PodeTcpClient -Message 'Unrecognised verb sent'
+}
+```
+
+Or, you can access the data sent by the client via either `$TcpEvent.Request.RawBody` or `$TcpEvent.Request.Body`. RawBody is a byte array of the data, where as Body is a UTF8 decoded string of the RawBody. This should allow you to then parse any freestyle data as you see fit, such as a simple web server:
+
+```powershell
+Start-PodeServer {
+    Add-PodeEndpoint -Address localhost -Port 9000 -Protocol Tcp
+
+    Add-PodeVerb -Verb * -Close -ScriptBlock {
+        $TcpEvent.Request.Body | Out-Default
+        Write-PodeTcpClient -Message "HTTP/1.1 200 `r`nConnection: close`r`n`r`n<b>Hello, there</b>"
+    }
+}
+```
+
+Running the above server and navigating to http://localhost:9000 will greet you with a message. The raw data sent by the browser will be display on the terminal; this could be parsed to do different things.
+
+### SSL Upgrade
+
+If you're using explicit TLS on your TCP server, then at some point you'll want to upgrade the connection to using SSL.
+There are two ways of achieving this; one is to use a simple command verb, and the `-UpgradeToSsl` switch:
+
+```powershell
+Add-PodeVerb -Verb 'STARTTLS' -UpgradeToSsl
+```
+
+The second way is to call the upgrade method directly:
+
+```powershell
+Add-PodeVerb -Verb 'STARTTLS' -ScriptBlock {
+    Write-PodeTcpClient -Message 'TLS GO AHEAD'
+    $TcpEvent.Request.UpgradeToSSL()
+}
+```
+
+### Close
+
+At some point you'll likely need to close the connection from the server side. There are two ways of achieving this; one is to use a simple command verb, and the `-Close` switch:
+
+```powershell
+Add-PodeVerb -Verb 'QUIT' -Close
+```
+
+The second way is to call [`Close-PodeTcpClient`](../../Functions/Responses/Close-PodeTcpClient) directly:
+
+```powershell
+Add-PodeVerb -Verb 'QUIT' -ScriptBlock {
+    Write-PodeTcpClient -Message 'Bye!'
+    Close-PodeTcpClient
+}
+```
+
+## Read Data
+
+In the above examples you've seen [`Write-PodeTcpClient`](../../Functions/Responses/Write-PodeTcpClient) being used. This function simply sends data back to a connected client, but what if we want to read data? Sometimes, instead of ending a Verb's logic and letting Pode wait for the next data, you might want to receive this data yourself in a Verb. For this there is [`Read-PodeTcpClient`](../../Functions/Responses/Read-PodeTcpClient):
+
+```powershell
+Add-PodeVerb -Verb 'HELLO' -ScriptBlock {
+    Write-PodeTcpClient -Message "Hi! What's your name?"
+    $name = Read-PodeTcpClient
+    Write-PodeTcpClient -Message "Hi, $($name)!"
+}
+```
+
+## TLS
+
+You can enable TLS for your endpoints by supplying the normal relevant certificates parameters on [`Add-PodeEndpoint`](../../Functions/Core/Add-PodeEndpoint), and setting the `-Protocol` to `Tcps`. You can also toggle between implicit and explicit TLS by using the `-TlsMode` parameter.
+
+By default the TLS mode is implicit, and the default port for implicit TLS is 9002; for explicit TLS it's 9003. These can of course be customised using `-Port`.
+
+```powershell
+Start-PodeServer {
+    Add-PodeEndpoint -Address * -Protocol Tcps -SelfSigned -TlsMode Explicit
+    Add-PodeEndpoint -Address * -Protocol Tcps -SelfSigned -TlsMode Implicit
+
+    Add-PodeVerb -Verb 'HELLO' -ScriptBlock {
+        Write-PodeTcpClient -Message 'HI'
+    }
+}
+```
+
+## Objects
+
+### TcpEvent
+
+Verbs will be passed the `$TcpEvent` object, that contains the Request, Response, and other properties:
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| Request | object | The raw Request object |
+| Response | object | The raw Response object |
+| Lockable | hashtable | A synchronized hashtable that can be used with `Lock-PodeObject` |
+| Endpoint | hashtable | Contains the Address and Protocol of the endpoint being hit - such as "pode.example.com" or "127.0.0.2", or HTTP or HTTPS for the Protocol |
+| Parameters | hashtable | Contains the parsed parameter values from the Verb's path |
+| Timestamp | datetime | The current date and time of the Request |
+
+## Test Send
+
+The following function can be used to test sending messages to a TCP server. This is a modified version of the function [found here](https://riptutorial.com/powershell/example/18118/tcp-sender).
+
+```powershell
+function Send-TCPMessage($Endpoint, $Port, $Message) {
+    # Setup connection
+    $Address = [System.Net.IPAddress]::Parse([System.Net.Dns]::GetHostAddresses($EndPoint))
+    $Socket = New-Object System.Net.Sockets.TCPClient($Address,$Port)
+
+    # Setup stream wrtier
+    $Stream = $Socket.GetStream()
+    $Writer = New-Object System.IO.StreamWriter($Stream)
+
+    # Write message to stream
+    $Writer.WriteLine($Message)
+    $Writer.Flush()
+
+    # Close connection and stream
+    Start-Sleep -Seconds 1
+    $Stream.Close()
+    $Socket.Close()
+}
+```
+
+ie:
+
+```powershell
+Send-TCPMessage -Port 9000 -EndPoint 127.0.0.1 -Message "HELLO"
+```
+
+!!! note
+    If you have the `-CRLFMessageEnd` switch specified, you'll need to add ``` `r`n``` to the end of the `-Message`

--- a/docs/Servers/TCP.md
+++ b/docs/Servers/TCP.md
@@ -4,6 +4,9 @@ Pode has a generic TCP server type inbuilt. Unlike the other server types, the T
 
 Where a web server using Routes, a TCP server uses Verbs - think of them like "commands" or "phrases". Requests sent will be matched to a Verb, and that Verb's logic invoked (more info below).
 
+!!! important
+    This server type is still in the early days, so if you find any bugs or have any suggestions, please feel free to raise them over on [GitHub](https://github.com/badgerati/pode) or [Discord](https://discord.gg/fRqeGcbF6h)! 😄
+
 ## Usage
 
 To create a TCP server you need to create an appropriate [Endpoint](../../Tutorials/Endpoints/Basics) with the TCP protocol, plus some [Verbs](#verbs).
@@ -12,7 +15,7 @@ The following example will create a TCP endpoint listening on `localhost:9000`, 
 
 ```powershell
 Start-PodeServer {
-    Add-PodeEndpoint -Address localhost -Port 9000 -Protocol Tcp -CRLFMessageEnd
+    Add-PodeEndpoint -Address localhost -Port 9000 -Protocol Tcp -CRLFMessageEnd -Acknowledge 'Welcome!'
 
     Add-PodeVerb -Verb 'HELLO' -ScriptBlock {
         Write-PodeTcpClient -Message 'HI'
@@ -27,11 +30,15 @@ Start the above server, and then in a different terminal start telnet and send "
 
 ```powershell
 $> telnet localhost 9000
+S> Welcome!
 C> HELLO
 S> HI
 ```
 
 When you send "HELLO", the server will respond with "HI". If you can't use telnet, then there's a quick [test script](#test-send) below to use.
+
+!!! important
+    If you're using telnet to send data, backspaces will be recorded as sent data.
 
 ### Acknowledge
 
@@ -93,7 +100,7 @@ Start-PodeServer {
 }
 ```
 
-Running the above server and navigating to http://localhost:9000 will greet you with a message. The raw data sent by the browser will be display on the terminal; this could be parsed to do different things.
+Running the above server and navigating to `http://localhost:9000` will greet you with a message. The raw data sent by the browser will be display on the terminal; this could be parsed to do different things.
 
 ### SSL Upgrade
 
@@ -137,7 +144,7 @@ In the above examples you've seen [`Write-PodeTcpClient`](../../Functions/Respon
 ```powershell
 Add-PodeVerb -Verb 'HELLO' -ScriptBlock {
     Write-PodeTcpClient -Message "Hi! What's your name?"
-    $name = Read-PodeTcpClient
+    $name = Read-PodeTcpClient -CRLFMessageEnd
     Write-PodeTcpClient -Message "Hi, $($name)!"
 }
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,7 @@ Pode is a Cross-Platform framework to create web servers that host REST APIs, We
 * Azure Functions, AWS Lambda, and IIS support
 * OpenAPI, Swagger, and ReDoc support
 * Listen on a single or multiple IP address/hostnames
-* Cross-platform support for HTTP, HTTPS, TCP and SMTP
+* Cross-platform support for HTTP(S), SMTP(S), and TCP(S)
 * Cross-platform support for WebSockets, including secure WebSockets
 * Host REST APIs, Web Pages, and Static Content (with caching)
 * Support for custom error pages

--- a/examples/tcp-server-http.ps1
+++ b/examples/tcp-server-http.ps1
@@ -1,0 +1,24 @@
+$path = Split-Path -Parent -Path (Split-Path -Parent -Path $MyInvocation.MyCommand.Path)
+Import-Module "$($path)/src/Pode.psm1" -Force -ErrorAction Stop
+
+# or just:
+# Import-Module Pode
+
+# create a server, and start listening on port 8999
+Start-PodeServer -Threads 2 {
+
+    # add two endpoints
+    Add-PodeEndpoint -Address * -Port 8999 -Protocol Tcp
+
+    # enable logging
+    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+
+    # catch-all for http
+    Add-PodeVerb -Verb '*' -ScriptBlock {
+        $TcpEvent.Request.Body | Out-Default
+        Write-PodeTcpClient -Message "HTTP/1.1 200 `r`nConnection: close`r`n`r`n<b>Hello, there</b>"
+        Close-PodeTcpClient
+        # navigate to "http://localhost:8999"
+    }
+
+}

--- a/examples/tcp-server-http.ps1
+++ b/examples/tcp-server-http.ps1
@@ -4,21 +4,20 @@ Import-Module "$($path)/src/Pode.psm1" -Force -ErrorAction Stop
 # or just:
 # Import-Module Pode
 
-# create a server, and start listening on port 8999
+# create a server, and start listening on port 9000
 Start-PodeServer -Threads 2 {
 
     # add two endpoints
-    Add-PodeEndpoint -Address * -Port 8999 -Protocol Tcp
+    Add-PodeEndpoint -Address * -Port 9000 -Protocol Tcp
 
     # enable logging
     New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
 
     # catch-all for http
-    Add-PodeVerb -Verb '*' -ScriptBlock {
+    Add-PodeVerb -Verb '*' -Close -ScriptBlock {
         $TcpEvent.Request.Body | Out-Default
         Write-PodeTcpClient -Message "HTTP/1.1 200 `r`nConnection: close`r`n`r`n<b>Hello, there</b>"
-        Close-PodeTcpClient
-        # navigate to "http://localhost:8999"
+        # navigate to "http://localhost:9000"
     }
 
 }

--- a/examples/tcp-server-multi-endpoint.ps1
+++ b/examples/tcp-server-multi-endpoint.ps1
@@ -1,0 +1,37 @@
+$path = Split-Path -Parent -Path (Split-Path -Parent -Path $MyInvocation.MyCommand.Path)
+Import-Module "$($path)/src/Pode.psm1" -Force -ErrorAction Stop
+
+# or just:
+# Import-Module Pode
+
+# create a server, and start listening on port 9000
+Start-PodeServer -Threads 2 {
+
+    # add two endpoints
+    Add-PodeEndpoint -Address * -Port 9000 -Protocol Tcp -Name 'EP1' -Acknowledge 'Hello there!' -CRLFMessageEnd
+    Add-PodeEndpoint -Address '127.0.0.2' -Hostname 'foo.pode.com' -Port 9000 -Protocol Tcp -Name 'EP2' -Acknowledge 'Hello there!' -CRLFMessageEnd
+
+    # enable logging
+    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+
+    # hello verb for endpoint1
+    Add-PodeVerb -Verb 'HELLO :forename :surname' -EndpointName EP1 -ScriptBlock {
+        Write-PodeTcpClient -Message "HI 1, $($TcpEvent.Parameters.forename) $($TcpEvent.Parameters.surname)"
+        "HI 1, $($TcpEvent.Parameters.forename) $($TcpEvent.Parameters.surname)" | Out-Default
+    }
+
+    # hello verb for endpoint2
+    Add-PodeVerb -Verb 'HELLO :forename :surname' -EndpointName EP2 -ScriptBlock {
+        Write-PodeTcpClient -Message "HI 2, $($TcpEvent.Parameters.forename) $($TcpEvent.Parameters.surname)"
+        "HI 2, $($TcpEvent.Parameters.forename) $($TcpEvent.Parameters.surname)" | Out-Default
+    }
+
+    # catch-all verb for both endpoints
+    Add-PodeVerb -Verb '*' -ScriptBlock {
+        Write-PodeTcpClient -Message "Unrecognised verb sent"
+    }
+
+    # quit verb for both endpoints
+    Add-PodeVerb -Verb 'Quit' -Close
+
+}

--- a/examples/tcp-server.ps1
+++ b/examples/tcp-server.ps1
@@ -7,16 +7,31 @@ Import-Module "$($path)/src/Pode.psm1" -Force -ErrorAction Stop
 # create a server, and start listening on port 8999
 Start-PodeServer -Threads 2 {
 
-    Add-PodeEndpoint -Address * -Port 8999 -Protocol TCP
+    # add two endpoints
+    Add-PodeEndpoint -Address * -Port 8999 -Protocol Tcp -Name 'EP1' -Acknowledge 'Hello there!' -CRLFMessageEnd
+    Add-PodeEndpoint -Address '127.0.0.2' -Hostname 'foo.pode.com' -Port 8999 -Protocol Tcp -Name 'EP2' -Acknowledge 'Hello there!' -CRLFMessageEnd
 
-    # allow the local ip
-    Add-PodeAccessRule -Access Allow -Type IP -Values 127.0.0.1
+    # enable logging
+    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
 
-    # setup a tcp handler
-    Add-PodeHandler -Type Tcp -Name 'Main' -ScriptBlock {
-        Write-PodeTcpClient -Message 'gief data'
-        $msg = (Read-PodeTcpClient)
-        Write-Host $msg
+    # hello verb for endpoint1
+    Add-PodeVerb -Verb 'HELLO :forename :surname' -EndpointName EP1 -ScriptBlock {
+        Write-PodeTcpClient -Message "HI 1, $($TcpEvent.Parameters.forename) $($TcpEvent.Parameters.surname)"
+        "HI 1, $($TcpEvent.Parameters.forename) $($TcpEvent.Parameters.surname)" | Out-Default
     }
+
+    # hello verb for endpoint2
+    Add-PodeVerb -Verb 'HELLO :forename :surname' -EndpointName EP2 -ScriptBlock {
+        Write-PodeTcpClient -Message "HI 2, $($TcpEvent.Parameters.forename) $($TcpEvent.Parameters.surname)"
+        "HI 2, $($TcpEvent.Parameters.forename) $($TcpEvent.Parameters.surname)" | Out-Default
+    }
+
+    # catch-all verb for both endpoints
+    Add-PodeVerb -Verb '*' -ScriptBlock {
+        Write-PodeTcpClient -Message "Unrecognised verb sent"
+    }
+
+    # quit verb for both endpoints
+    Add-PodeVerb -Verb 'Quit' -Close
 
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,7 +38,9 @@ repo_url: https://github.com/Badgerati/Pode
 
 extra:
   social:
-    - icon: fontawesome/brands/github-alt
-      link: https://github.com/badgerati
+    - icon: fontawesome/brands/discord
+      link: https://discord.gg/fRqeGcbF6h
+    - icon: fontawesome/brands/github
+      link: https://github.com/badgerati/pode
     - icon: fontawesome/brands/twitter
       link: https://twitter.com/badgerati

--- a/src/Listener/PodeRequest.cs
+++ b/src/Listener/PodeRequest.cs
@@ -192,7 +192,7 @@ namespace Pode
                     cancellationToken.ThrowIfCancellationRequested();
                     bufferStream.Write(buffer, 0, read);
 
-                    if (Socket.Available > 0 || !ValidateInputInternal(BufferStream.ToArray(), checkBytes))
+                    if (Socket.Available > 0 || !ValidateInputInternal(bufferStream.ToArray(), checkBytes))
                     {
                         continue;
                     }
@@ -201,7 +201,7 @@ namespace Pode
                 }
 
                 cancellationToken.ThrowIfCancellationRequested();
-                return Encoding.GetString(bufferStream.ToArray());
+                return Encoding.GetString(bufferStream.ToArray()).Trim();
             }
             finally
             {

--- a/src/Listener/PodeRequest.cs
+++ b/src/Listener/PodeRequest.cs
@@ -32,6 +32,18 @@ namespace Pode
         public bool IsAborted => (Error != default(HttpRequestException));
         public bool IsDisposed { get; private set; }
 
+        public virtual string Address
+        {
+            get => (Context.PodeSocket.HasHostnames
+                ? $"{Context.PodeSocket.Hostname}:{((IPEndPoint)LocalEndPoint).Port}"
+                : $"{((IPEndPoint)LocalEndPoint).Address}:{((IPEndPoint)LocalEndPoint).Port}");
+        }
+
+        public virtual string Scheme
+        {
+            get => (SslUpgraded ? $"{Context.PodeSocket.Type}s" : $"{Context.PodeSocket.Type}");
+        }
+
         private Socket Socket;
         protected PodeContext Context;
         protected static UTF8Encoding Encoding = new UTF8Encoding();
@@ -106,10 +118,10 @@ namespace Pode
             return true;
         }
 
-        protected async Task<int> BeginRead(CancellationToken cancellationToken)
+        protected async Task<int> BeginRead(byte[] buffer, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            return await Task<int>.Factory.FromAsync(InputStream.BeginRead, InputStream.EndRead, Buffer, 0, BufferSize, null);
+            return await Task<int>.Factory.FromAsync(InputStream.BeginRead, InputStream.EndRead, buffer, 0, BufferSize, null);
         }
 
         public async Task<bool> Receive(CancellationToken cancellationToken)
@@ -124,7 +136,7 @@ namespace Pode
                 var read = 0;
                 var close = true;
 
-                while ((read = await BeginRead(cancellationToken)) > 0)
+                while ((read = await BeginRead(Buffer, cancellationToken)) > 0)
                 {
                     cancellationToken.ThrowIfCancellationRequested();
                     BufferStream.Write(Buffer, 0, read);
@@ -134,16 +146,13 @@ namespace Pode
                         continue;
                     }
 
-                    var bytes = BufferStream.ToArray();
-                    if (!Parse(bytes))
+                    if (!Parse(BufferStream.ToArray()))
                     {
-                        bytes = default(byte[]);
                         BufferStream.Dispose();
                         BufferStream = new MemoryStream();
                         continue;
                     }
 
-                    bytes = default(byte[]);
                     close = false;
                     break;
                 }
@@ -168,6 +177,37 @@ namespace Pode
             }
 
             return false;
+        }
+
+        public async Task<string> Read(CancellationToken cancellationToken)
+        {
+            var buffer = new byte[BufferSize];
+            var bufferStream = new MemoryStream();
+
+            try
+            {
+                var read = 0;
+                while ((read = await BeginRead(buffer, cancellationToken)) > 0)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    bufferStream.Write(buffer, 0, read);
+
+                    if (Socket.Available > 0)
+                    {
+                        continue;
+                    }
+
+                    break;
+                }
+
+                cancellationToken.ThrowIfCancellationRequested();
+                return Encoding.GetString(bufferStream.ToArray());
+            }
+            finally
+            {
+                bufferStream.Dispose();
+                buffer = default(byte[]);
+            }
         }
 
         protected virtual bool Parse(byte[] bytes)

--- a/src/Listener/PodeSmtpRequest.cs
+++ b/src/Listener/PodeSmtpRequest.cs
@@ -55,7 +55,11 @@ namespace Pode
 
         public void SendAck()
         {
-            Context.Response.WriteLine($"220 {Context.PodeSocket.Hostname} -- Pode Proxy Server", true);
+            var ack = string.IsNullOrWhiteSpace(Context.PodeSocket.AcknowledgeMessage)
+                ? $"{Context.PodeSocket.Hostname} -- Pode Proxy Server"
+                : Context.PodeSocket.AcknowledgeMessage;
+
+            Context.Response.WriteLine($"220 {ack}", true);
         }
 
         protected override bool ValidateInput(byte[] bytes)

--- a/src/Listener/PodeSocket.cs
+++ b/src/Listener/PodeSocket.cs
@@ -22,6 +22,8 @@ namespace Pode
         public SslProtocols Protocols { get; private set; }
         public PodeTlsMode TlsMode { get; private set; }
         public Socket Socket { get; private set; }
+        public string AcknowledgeMessage { get; set; }
+        public bool CRLFMessageEnd { get; set; }
 
         private ConcurrentQueue<SocketAsyncEventArgs> AcceptConnections;
         private ConcurrentQueue<SocketAsyncEventArgs> ReceiveConnections;

--- a/src/Listener/PodeTcpRequest.cs
+++ b/src/Listener/PodeTcpRequest.cs
@@ -1,0 +1,85 @@
+using System.Net.Sockets;
+
+namespace Pode
+{
+    public class PodeTcpRequest : PodeRequest
+    {
+        public byte[] RawBody { get; private set; }
+
+        private string _body = string.Empty;
+        public string Body
+        {
+            get
+            {
+                if (RawBody != default(byte[]) && RawBody.Length > 0)
+                {
+                    _body = Encoding.GetString(RawBody).Trim();
+                }
+
+                return _body;
+            }
+        }
+
+        public override bool CloseImmediately
+        {
+            get => (IsDisposed || RawBody == default(byte[]) || RawBody.Length == 0);
+        }
+
+        public PodeTcpRequest(Socket socket, PodeSocket podeSocket)
+            : base(socket, podeSocket)
+        {
+            IsKeepAlive = true;
+            Type = PodeProtocolType.Tcp;
+        }
+
+        protected override bool ValidateInput(byte[] bytes)
+        {
+            // we need more bytes!
+            if (bytes.Length < (Context.PodeSocket.CRLFMessageEnd ? 2 : 1))
+            {
+                return false;
+            }
+
+            // expect to end with <CR><LF>?
+            if (Context.PodeSocket.CRLFMessageEnd)
+            {
+                return (bytes[bytes.Length - 2] == (byte)13
+                    && bytes[bytes.Length - 1] == (byte)10);
+            }
+
+            return true;
+        }
+
+        protected override bool Parse(byte[] bytes)
+        {
+            RawBody = bytes;
+
+            // if there are no bytes, return (0 bytes read means we can close the socket)
+            if (bytes.Length == 0)
+            {
+                return true;
+            }
+
+            return true;
+        }
+
+        public void Reset()
+        {
+            PodeHelpers.WriteErrorMessage($"Request reset", Context.Listener, PodeLoggingLevel.Verbose, Context);
+            _body = string.Empty;
+            RawBody = default(byte[]);
+        }
+
+        public void Close()
+        {
+            Context.Dispose(true);
+        }
+
+        public override void Dispose()
+        {
+            RawBody = default(byte[]);
+            _body = string.Empty;
+            base.Dispose();
+        }
+    }
+}

--- a/src/Pode.psd1
+++ b/src/Pode.psd1
@@ -81,6 +81,7 @@
         'Move-PodeResponseUrl',
         'Write-PodeTcpClient',
         'Read-PodeTcpClient',
+        'Close-PodeTcpClient',
         'Save-PodeRequestFile',
         'Set-PodeViewEngine',
         'Use-PodePartialView',
@@ -297,7 +298,14 @@
         'Set-PodeSecurityFrameOptions',
         'Set-PodeSecurityPermissionsPolicy',
         'Set-PodeSecurityReferrerPolicy',
-        'Set-PodeSecurityStrictTransportSecurity'
+        'Set-PodeSecurityStrictTransportSecurity',
+
+        # Verbs
+        'Add-PodeVerb',
+        'Remove-PodeVerb',
+        'Clear-PodeVerbs',
+        'Get-PodeVerb',
+        'Use-PodeVerbs'
     )
 
     # Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.

--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -289,7 +289,6 @@ function New-PodeContext
 
     # handlers for tcp
     $ctx.Server.Handlers = @{
-        tcp     = @{}
         smtp    = @{}
         service = @{}
     }

--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -232,7 +232,11 @@ function New-PodeContext
     # set the IP address details
     $ctx.Server.Endpoints = @{}
     $ctx.Server.EndpointsMap = @{}
-    $ctx.Server.FindRouteEndpoint = $false
+    $ctx.Server.FindEndpoints = @{
+        Route = $false
+        Smtp  = $false
+        Tcp   = $false
+    }
 
     # general encoding for the server
     $ctx.Server.Encoding = New-Object System.Text.UTF8Encoding
@@ -276,6 +280,9 @@ function New-PodeContext
         'signal'    = [ordered]@{}
         '*'         = [ordered]@{}
     }
+
+    # verbs for tcp
+    $ctx.Server.Verbs = @{}
 
     # custom view paths
     $ctx.Server.Views = @{}

--- a/src/Private/Endpoints.ps1
+++ b/src/Private/Endpoints.ps1
@@ -77,7 +77,7 @@ function Get-PodeEndpoints
             }
 
             'tcp' {
-                $endpoints += @($PodeContext.Server.Endpoints.Values | Where-Object { @('tcp') -icontains $_.Protocol })
+                $endpoints += @($PodeContext.Server.Endpoints.Values | Where-Object { @('tcp', 'tcps') -icontains $_.Protocol })
             }
         }
     }
@@ -89,7 +89,7 @@ function Test-PodeEndpointProtocol
 {
     param(
         [Parameter(Mandatory=$true)]
-        [ValidateSet('Http', 'Https', 'Ws', 'Wss', 'Smtp', 'Smtps', 'Tcp')]
+        [ValidateSet('Http', 'Https', 'Ws', 'Wss', 'Smtp', 'Smtps', 'Tcp', 'Tcps')]
         [string]
         $Protocol
     )
@@ -102,7 +102,7 @@ function Get-PodeEndpointType
 {
     param(
         [Parameter()]
-        [ValidateSet('Http', 'Https', 'Smtp', 'Smtps', 'Tcp', 'Ws', 'Wss')]
+        [ValidateSet('Http', 'Https', 'Smtp', 'Smtps', 'Tcp', 'Tcps', 'Ws', 'Wss')]
         [string]
         $Protocol
     )
@@ -111,6 +111,7 @@ function Get-PodeEndpointType
         { $_ -iin @('http', 'https') } { 'Http' }
         { $_ -iin @('ws', 'wss') } { 'Ws' }
         { $_ -iin @('smtp', 'smtps') } { 'Smtp' }
+        { $_ -iin @('tcp', 'tcps') } { 'Tcp' }
         default { $Protocol }
     }
 }
@@ -119,7 +120,7 @@ function Get-PodeEndpointRunspacePoolName
 {
     param(
         [Parameter()]
-        [ValidateSet('Http', 'Https', 'Smtp', 'Smtps', 'Tcp', 'Ws', 'Wss')]
+        [ValidateSet('Http', 'Https', 'Smtp', 'Smtps', 'Tcp', 'Tcps', 'Ws', 'Wss')]
         [string]
         $Protocol
     )
@@ -128,6 +129,7 @@ function Get-PodeEndpointRunspacePoolName
         { $_ -iin @('http', 'https') } { 'Web' }
         { $_ -iin @('ws', 'wss') } { 'Signals' }
         { $_ -iin @('smtp', 'smtps') } { 'Smtp' }
+        { $_ -iin @('tcp', 'tcps') } { 'Tcp' }
         default { $Protocol }
     }
 }
@@ -165,10 +167,13 @@ function Find-PodeEndpointName
         $Force,
 
         [switch]
-        $ThrowError
+        $ThrowError,
+
+        [switch]
+        $Enabled
     )
 
-    if (!$PodeContext.Server.FindRouteEndpoint -and !$Force) {
+    if (!$Enabled -and !$Force) {
         return $null
     }
 

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -2287,7 +2287,7 @@ function Get-PodeHandler
 {
     param (
         [Parameter(Mandatory=$true)]
-        [ValidateSet('Service', 'Smtp', 'Tcp')]
+        [ValidateSet('Service', 'Smtp')]
         [string]
         $Type,
 

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -2214,7 +2214,7 @@ function Get-PodeDefaultPort
 {
     param(
         [Parameter()]
-        [ValidateSet('Http', 'Https', 'Smtp', 'Smtps', 'Tcp', 'Ws', 'Wss')]
+        [ValidateSet('Http', 'Https', 'Smtp', 'Smtps', 'Tcp', 'Tcps', 'Ws', 'Wss')]
         [string]
         $Protocol,
 
@@ -2235,6 +2235,7 @@ function Get-PodeDefaultPort
             Smtp    = @{ Implicit = 25 }
             Smtps   = @{ Implicit = 465; Explicit = 587 }
             Tcp     = @{ Implicit = 9001 }
+            Tcps    = @{ Implicit = 9002; Explicit = 9003 }
             Ws      = @{ Implicit = 80 }
             Wss     = @{ Implicit = 443 }
         })[$Protocol.ToLowerInvariant()][$TlsMode.ToLowerInvariant()]
@@ -2257,6 +2258,7 @@ function Get-PodeDefaultPort
         Smtp    = @{ Implicit = 25 }
         Smtps   = @{ Implicit = 465; Explicit = 587 }
         Tcp     = @{ Implicit = 9001 }
+        Tcps    = @{ Implicit = 9002; Explicit = 9003 }
         Ws      = @{ Implicit = 9080 }
         Wss     = @{ Implicit = 9443 }
     })[$Protocol.ToLowerInvariant()][$TlsMode.ToLowerInvariant()]

--- a/src/Private/PodeServer.ps1
+++ b/src/Private/PodeServer.ps1
@@ -164,7 +164,7 @@ function Start-PodeWebServer
                             $WebEvent.Ranges = (Get-PodeRanges -Range (Get-PodeHeader -Name 'Range') -ThrowError)
 
                             # endpoint name
-                            $WebEvent.Endpoint.Name = (Find-PodeEndpointName -Protocol $WebEvent.Endpoint.Protocol -Address $WebEvent.Endpoint.Address -LocalAddress $WebEvent.Request.LocalEndPoint)
+                            $WebEvent.Endpoint.Name = (Find-PodeEndpointName -Protocol $WebEvent.Endpoint.Protocol -Address $WebEvent.Endpoint.Address -LocalAddress $WebEvent.Request.LocalEndPoint -Enabled:($PodeContext.Server.FindEndpoints.Route))
 
                             # add logging endware for post-request
                             Add-PodeRequestLogEndware -WebEvent $WebEvent
@@ -379,7 +379,7 @@ function Start-PodeWebServer
                         }
 
                         # endpoint name
-                        $SignalEvent.Endpoint.Name = (Find-PodeEndpointName -Protocol $SignalEvent.Endpoint.Protocol -Address $SignalEvent.Endpoint.Address -LocalAddress $SignalEvent.Request.LocalEndPoint)
+                        $SignalEvent.Endpoint.Name = (Find-PodeEndpointName -Protocol $SignalEvent.Endpoint.Protocol -Address $SignalEvent.Endpoint.Address -LocalAddress $SignalEvent.Request.LocalEndPoint -Enabled:($PodeContext.Server.FindEndpoints.Route))
 
                         # see if we have a route and invoke it, otherwise auto-send
                         $SignalEvent.Route = Find-PodeSignalRoute -Path $SignalEvent.Path -EndpointName $SignalEvent.Endpoint.Name

--- a/src/Private/Responses.ps1
+++ b/src/Private/Responses.ps1
@@ -50,35 +50,3 @@ function Show-PodeErrorPage
     # write the error page to the stream
     Write-PodeFileResponse -Path $errorPage.Path -Data $data -ContentType $errorPage.ContentType
 }
-
-function Close-PodeTcpConnection
-{
-    param (
-        [Parameter()]
-        $Client,
-
-        [Parameter(ParameterSetName='Quit')]
-        [string]
-        $Message,
-
-        [Parameter(ParameterSetName='Quit')]
-        [switch]
-        $Quit
-    )
-
-    if ($null -eq $Client) {
-        $Client = $TcpEvent.Client
-    }
-
-    if ($null -ne $Client) {
-        if ($Quit -and $Client.Connected) {
-            if ([string]::IsNullOrWhiteSpace($Message)) {
-                $Message = '221 Bye'
-            }
-
-            Write-PodeTcpClient -Message $Message
-        }
-
-        Close-PodeDisposable -Disposable $Client -Close
-    }
-}

--- a/src/Private/Routes.ps1
+++ b/src/Private/Routes.ps1
@@ -25,7 +25,7 @@ function Test-PodeRoute
 
 function Find-PodeRoute
 {
-    param (
+    param(
         [Parameter(Mandatory=$true)]
         [ValidateSet('DELETE', 'GET', 'HEAD', 'MERGE', 'OPTIONS', 'PATCH', 'POST', 'PUT', 'TRACE', 'STATIC', 'SIGNAL', '*')]
         [string]
@@ -67,28 +67,25 @@ function Find-PodeRoute
         return $found
     }
 
-    # otherwise, attempt to match on regex parameters
-    else {
-        # match the path to routes on regex (first match only)
-        $valid = @(foreach ($key in $_method.Keys) {
-            if ($Path -imatch "^$($key)$") {
-                $key
-                break
-            }
-        })[0]
-
-        if ($null -eq $valid) {
-            return $null
+    # otherwise, match the path to routes on regex (first match only)
+    $valid = @(foreach ($key in $_method.Keys) {
+        if ($Path -imatch "^$($key)$") {
+            $key
+            break
         }
+    })[0]
 
-        # is the route valid for any protocols/endpoints?
-        $found = Get-PodeRouteByUrl -Routes $_method[$valid] -EndpointName $EndpointName
-        if ($null -eq $found) {
-            return $null
-        }
-
-        return $found
+    if ($null -eq $valid) {
+        return $null
     }
+
+    # is the route valid for any protocols/endpoints?
+    $found = Get-PodeRouteByUrl -Routes $_method[$valid] -EndpointName $EndpointName
+    if ($null -eq $found) {
+        return $null
+    }
+
+    return $found
 }
 
 function Find-PodePublicRoute
@@ -233,7 +230,7 @@ function Test-PodeRouteValidForCaching
 
 function Get-PodeRouteByUrl
 {
-    param (
+    param(
         [Parameter()]
         [hashtable[]]
         $Routes,
@@ -254,7 +251,7 @@ function Get-PodeRouteByUrl
 
 function Get-PodeRoutesByUrl
 {
-    param (
+    param(
         [Parameter()]
         [hashtable[]]
         $Routes,
@@ -285,7 +282,7 @@ function Get-PodeRoutesByUrl
 
 function Update-PodeRoutePlaceholders
 {
-    param (
+    param(
         [Parameter(Mandatory=$true)]
         [string]
         $Path

--- a/src/Private/Security.ps1
+++ b/src/Private/Security.ps1
@@ -465,7 +465,7 @@ function Add-PodeRouteLimit
 
 function Add-PodeEndpointLimit
 {
-    param (
+    param(
         [Parameter(Mandatory=$true)]
         [ValidateNotNull()]
         [string]
@@ -486,6 +486,12 @@ function Add-PodeEndpointLimit
     # current limit type
     $type = 'Endpoint'
 
+    # does the endpoint exist?
+    $endpoint = Get-PodeEndpointByName -Name $EndpointName
+    if ($null -eq $endpoint) {
+        throw "Endpoint not found: $($EndpointName)"
+    }
+
     # ensure limit and seconds are non-zero and negative
     if ($Limit -le 0) {
         throw "Limit value cannot be 0 or less for $($IP)"
@@ -496,7 +502,23 @@ function Add-PodeEndpointLimit
     }
 
     # we need to check endpoints on requests
-    $PodeContext.Server.FindRouteEndpoint = $true
+    switch ($endpoint.Type.ToLowerInvariant()) {
+        'http' {
+            $PodeContext.Server.FindEndpoints.Route = $true
+        }
+
+        'ws' {
+            $PodeContext.Server.FindEndpoints.Route = $true
+        }
+
+        'smtp' {
+            $PodeContext.Server.FindEndpoints.Smtp = $true
+        }
+
+        'tcp' {
+            $PodeContext.Server.FindEndpoints.Tcp = $true
+        }
+    }
 
     # get current rules
     $rules = $PodeContext.Server.Limits.Rules[$type]

--- a/src/Private/Server.ps1
+++ b/src/Private/Server.ps1
@@ -170,6 +170,10 @@ function Restart-PodeInternalServer
             $PodeContext.Server.Handlers[$_].Clear()
         }
 
+        $PodeContext.Server.Verbs.Keys.Clone() | ForEach-Object {
+            $PodeContext.Server.Verbs[$_].Clear()
+        }
+
         $PodeContext.Server.Events.Keys.Clone() | ForEach-Object {
             $PodeContext.Server.Events[$_].Clear()
         }
@@ -208,7 +212,11 @@ function Restart-PodeInternalServer
         # clear endpoints
         $PodeContext.Server.Endpoints.Clear()
         $PodeContext.Server.EndpointsMap.Clear()
-        $PodeContext.Server.FindRouteEndpoint = $false
+        $PodeContext.Server.FindEndpoints = @{
+            Route = $false
+            Smtp  = $false
+            Tcp   = $false
+        }
 
         # clear openapi
         $PodeContext.Server.OpenAPI = Get-PodeOABaseObject

--- a/src/Private/Verbs.ps1
+++ b/src/Private/Verbs.ps1
@@ -1,0 +1,129 @@
+function Find-PodeVerb
+{
+    param(
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $Verb,
+
+        [Parameter()]
+        [string]
+        $EndpointName
+    )
+
+    # if we have a perfect match for the verb, return it
+    $found = Get-PodeVerbByLiteral -Verbs $PodeContext.Server.Verbs[$Verb] -EndpointName $EndpointName
+    if ($null -ne $found) {
+        return $found
+    }
+
+    # otherwise, match regex on the verbs (first match only)
+    $valid = @(foreach ($key in $PodeContext.Server.Verbs.Keys) {
+        if (($key -ine '*') -and ($Verb -imatch "^$($key)$")) {
+            $key
+            break
+        }
+    })[0]
+
+    if ($null -eq $valid) {
+        return $null
+    }
+
+    # is the verb valid for any protocols/endpoints?
+    $found = Get-PodeVerbByLiteral -Verbs $PodeContext.Server.Verbs[$valid] -EndpointName $EndpointName
+    if ($null -eq $found) {
+        return $null
+    }
+
+    return $found
+}
+
+function Get-PodeVerbByLiteral
+{
+    param(
+        [Parameter()]
+        [hashtable[]]
+        $Verbs,
+
+        [Parameter()]
+        [string]
+        $EndpointName
+    )
+
+    # if verbs is already null/empty just return
+    if (($null -eq $Verbs) -or ($Verbs.Length -eq 0)) {
+        return $null
+    }
+
+    # get the verb
+    return (Get-PodeVerbsByLiteral -Verbs $Verbs -EndpointName $EndpointName)
+}
+
+function Get-PodeVerbsByLiteral
+{
+    param(
+        [Parameter()]
+        [hashtable[]]
+        $Verbs,
+
+        [Parameter()]
+        [string]
+        $EndpointName
+    )
+
+    # see if a verb has the endpoint name
+    if (![string]::IsNullOrWhiteSpace($EndpointName)) {
+        foreach ($verb in $Verbs) {
+            if ($verb.Endpoint.Name -ieq $EndpointName) {
+                return $verb
+            }
+        }
+    }
+
+    # else find first default verb
+    foreach ($verb in $Verbs) {
+        if ([string]::IsNullOrWhiteSpace($verb.Endpoint.Name)) {
+            return $verb
+        }
+    }
+
+    return $null
+}
+
+function Test-PodeVerbAndError
+{
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Verb,
+
+        [Parameter()]
+        [string]
+        $Protocol,
+
+        [Parameter()]
+        [string]
+        $Address
+    )
+
+    $found = @($PodeContext.Server.Verbs[$Verb])
+
+    if (($found | Where-Object { ($_.Endpoint.Protocol -ieq $Protocol) -and ($_.Endpoint.Address -ieq $Address) } | Measure-Object).Count -eq 0) {
+        return
+    }
+
+    $_url = $Protocol
+    if (![string]::IsNullOrEmpty($_url) -and ![string]::IsNullOrWhiteSpace($Address)) {
+        $_url = "$($_url)://$($Address)"
+    }
+    elseif (![string]::IsNullOrWhiteSpace($Address)) {
+        $_url = $Address
+    }
+
+    if ([string]::IsNullOrEmpty($_url)) {
+        throw "[Verb] $($Verb): Already defined"
+    }
+    else {
+        throw "[Verb] $($Verb): Already defined for $($_url)"
+    }
+}

--- a/src/Public/Core.ps1
+++ b/src/Public/Core.ps1
@@ -762,7 +762,7 @@ function Add-PodeEndpoint
         $Hostname,
 
         [Parameter()]
-        [ValidateSet('Http', 'Https', 'Smtp', 'Smtps', 'Tcp', 'Ws', 'Wss')]
+        [ValidateSet('Http', 'Https', 'Smtp', 'Smtps', 'Tcp', 'Tcps', 'Ws', 'Wss')]
         [string]
         $Protocol,
 
@@ -820,6 +820,13 @@ function Add-PodeEndpoint
         [Parameter()]
         [string]
         $Description,
+
+        [Parameter()]
+        [string]
+        $Acknowledge,
+
+        [switch]
+        $CRLFMessageEnd,
 
         [switch]
         $Force,
@@ -900,9 +907,19 @@ function Add-PodeEndpoint
         throw "Client certificates are only supported on HTTPS endpoints"
     }
 
-    # explicit tls is only supported for smtp
-    if (($type -ine 'smtp') -and ($TlsMode -ieq 'explicit')) {
-        throw "The Explicit TLS mode is only supported on SMTPS endpoints"
+    # explicit tls is only supported for smtp/tcp
+    if (($type -inotin @('smtp', 'tcp')) -and ($TlsMode -ieq 'explicit')) {
+        throw "The Explicit TLS mode is only supported on SMTPS and TCPS endpoints"
+    }
+
+    # ack message is only for smtp/tcp
+    if (($type -inotin @('smtp', 'tcp')) -and ![string]::IsNullOrEmpty($Acknowledge)) {
+        throw "The Acknowledge message is only supported on SMTP and TCP endpoints"
+    }
+
+    # crlf message end is only for tcp
+    if (($type -ine 'tcp') -and $CRLFMessageEnd) {
+        throw "The CRLF message end check is only supported on TCP endpoints"
     }
 
     # new endpoint object
@@ -916,7 +933,7 @@ function Add-PodeEndpoint
         HostName = $Hostname
         FriendlyName = $Hostname
         Url = $null
-        Ssl = (@('https', 'wss', 'smtps') -icontains $Protocol)
+        Ssl = (@('https', 'wss', 'smtps', 'tcps') -icontains $Protocol)
         Protocol = $Protocol.ToLowerInvariant()
         Type = $type.ToLowerInvariant()
         Runspace = @{
@@ -928,6 +945,10 @@ function Add-PodeEndpoint
             SelfSigned = $SelfSigned
             AllowClientCertificate = $AllowClientCertificate
             TlsMode = $TlsMode
+        }
+        Tcp = @{
+            Acknowledge = $Acknowledge
+            CRLFMessageEnd = $CRLFMessageEnd
         }
     }
 
@@ -971,7 +992,7 @@ function Add-PodeEndpoint
     # if we're dealing with a certificate, attempt to import it
     if (!(Test-PodeIsHosted) -and ($PSCmdlet.ParameterSetName -ilike 'cert*')) {
         # fail if protocol is not https
-        if (@('https', 'wss', 'smtps') -inotcontains $Protocol) {
+        if (@('https', 'wss', 'smtps', 'tcps') -inotcontains $Protocol) {
             throw "Certificate supplied for non-HTTPS/WSS endpoint"
         }
 
@@ -1001,11 +1022,6 @@ function Add-PodeEndpoint
     }
 
     if (!$exists) {
-        # has an endpoint already been defined for smtp/tcp?
-        if ((@('tcp') -icontains $type) -and ($PodeContext.Server.Types -icontains $type)) {
-            throw "An endpoint for $($type.ToUpperInvariant()) has already been defined"
-        }
-
         # set server type
         $_type = $type
         if ($_type -iin @('http', 'ws')) {
@@ -1091,7 +1107,7 @@ function Get-PodeEndpoint
         $Hostname,
 
         [Parameter()]
-        [ValidateSet('', 'Http', 'Https', 'Smtp', 'Smtps', 'Tcp', 'Ws', 'Wss')]
+        [ValidateSet('', 'Http', 'Https', 'Smtp', 'Smtps', 'Tcp', 'Tcps', 'Ws', 'Wss')]
         [string]
         $Protocol,
 

--- a/src/Public/Core.ps1
+++ b/src/Public/Core.ps1
@@ -712,6 +712,12 @@ The Name of another Endpoint to automatically generate a redirect route for all 
 .PARAMETER Description
 A quick description of the Endpoint - normally used in OpenAPI.
 
+.PARAMETER Acknowledge
+An optional Acknowledge message to send to clients when they first connect, for TCP and SMTP endpoints only.
+
+.PARAMETER CRLFMessageEnd
+If supplied, TCP endpoints will expect incoming data to end with CRLF.
+
 .PARAMETER Force
 Ignore Adminstrator checks for non-localhost endpoints.
 

--- a/src/Public/Handlers.ps1
+++ b/src/Public/Handlers.ps1
@@ -65,17 +65,7 @@ function Add-PodeHandler
 
     # if we have a file path supplied, load that path as a scriptblock
     if ($PSCmdlet.ParameterSetName -ieq 'file') {
-        # if file doesn't exist, error
-        if (!(Test-PodePath -Path $FilePath -NoStatus)) {
-            throw "[$($Type)] $($Name): The FilePath does not exist: $($FilePath)"
-        }
-
-        # if the path is a wildcard or directory, error
-        if (!(Test-PodePathIsFile -Path $FilePath -FailOnWildcard)) {
-            throw "[$($Type)] $($Name): The FilePath cannot be a wildcard or directory: $($FilePath)"
-        }
-
-        $ScriptBlock = [scriptblock](Use-PodeScript -Path $FilePath)
+        $ScriptBlock = Convert-PodeFileToScriptBlock -FilePath $FilePath
     }
 
     # check if the scriptblock has any using vars
@@ -86,6 +76,7 @@ function Add-PodeHandler
     $ScriptBlock = Invoke-PodeSessionScriptConversion -ScriptBlock $ScriptBlock
 
     # add the handler
+    Write-Verbose "Adding Handler: [$($Type)] $($Name)"
     $PodeContext.Server.Handlers[$Type][$Name] += @(@{
         Logic = $ScriptBlock
         UsingVariables = $usingVars

--- a/src/Public/Handlers.ps1
+++ b/src/Public/Handlers.ps1
@@ -34,7 +34,7 @@ function Add-PodeHandler
     [CmdletBinding(DefaultParameterSetName='Script')]
     param (
         [Parameter(Mandatory=$true)]
-        [ValidateSet('Service', 'Smtp', 'Tcp')]
+        [ValidateSet('Service', 'Smtp')]
         [string]
         $Type,
 
@@ -105,7 +105,7 @@ function Remove-PodeHandler
     [CmdletBinding()]
     param (
         [Parameter(Mandatory=$true)]
-        [ValidateSet('Service', 'Smtp', 'Tcp')]
+        [ValidateSet('Service', 'Smtp')]
         [string]
         $Type,
 
@@ -141,7 +141,7 @@ function Clear-PodeHandlers
     [CmdletBinding()]
     param (
         [Parameter()]
-        [ValidateSet('', 'Service', 'Smtp', 'Tcp')]
+        [ValidateSet('', 'Service', 'Smtp')]
         [string]
         $Type
     )

--- a/src/Public/Routes.ps1
+++ b/src/Public/Routes.ps1
@@ -138,8 +138,8 @@ function Add-PodeRoute
     $Path = Update-PodeRoutePlaceholders -Path $Path
 
     # get endpoints from name
-    if (!$PodeContext.Server.FindRouteEndpoint) {
-        $PodeContext.Server.FindRouteEndpoint = !(Test-PodeIsEmpty $EndpointName)
+    if (!$PodeContext.Server.FindEndpoints.Route) {
+        $PodeContext.Server.FindEndpoints.Route = !(Test-PodeIsEmpty $EndpointName)
     }
 
     $endpoints = Find-PodeEndpoints -EndpointName $EndpointName
@@ -354,8 +354,8 @@ function Add-PodeStaticRoute
     $Path = Update-PodeRoutePlaceholders -Path $Path
 
     # get endpoints from name
-    if (!$PodeContext.Server.FindRouteEndpoint) {
-        $PodeContext.Server.FindRouteEndpoint = !(Test-PodeIsEmpty $EndpointName)
+    if (!$PodeContext.Server.FindEndpoints.Route) {
+        $PodeContext.Server.FindEndpoints.Route = !(Test-PodeIsEmpty $EndpointName)
     }
 
     $endpoints = Find-PodeEndpoints -EndpointName $EndpointName
@@ -507,8 +507,8 @@ function Add-PodeSignalRoute
     $Path = Update-PodeRouteSlashes -Path $Path
 
     # get endpoints from name
-    if (!$PodeContext.Server.FindRouteEndpoint) {
-        $PodeContext.Server.FindRouteEndpoint = !(Test-PodeIsEmpty $EndpointName)
+    if (!$PodeContext.Server.FindEndpoints.Route) {
+        $PodeContext.Server.FindEndpoints.Route = !(Test-PodeIsEmpty $EndpointName)
     }
 
     $endpoints = Find-PodeEndpoints -EndpointName $EndpointName
@@ -586,7 +586,7 @@ Remove-PodeRoute -Method Post -Route '/users/:userId' -EndpointName User
 function Remove-PodeRoute
 {
     [CmdletBinding()]
-    param (
+    param(
         [Parameter(Mandatory=$true)]
         [ValidateSet('Delete', 'Get', 'Head', 'Merge', 'Options', 'Patch', 'Post', 'Put', 'Trace', '*')]
         [string]
@@ -746,7 +746,7 @@ Clear-PodeRoutes -Method Get
 function Clear-PodeRoutes
 {
     [CmdletBinding()]
-    param (
+    param(
         [Parameter()]
         [ValidateSet('', 'Delete', 'Get', 'Head', 'Merge', 'Options', 'Patch', 'Post', 'Put', 'Trace', '*')]
         [string]
@@ -1172,7 +1172,7 @@ Get-PodeRoute -Method Post -Path '/users/:userId' -EndpointName User
 function Get-PodeRoute
 {
     [CmdletBinding()]
-    param (
+    param(
         [Parameter()]
         [ValidateSet('', 'Delete', 'Get', 'Head', 'Merge', 'Options', 'Patch', 'Post', 'Put', 'Trace', '*')]
         [string]

--- a/src/Public/Verbs.ps1
+++ b/src/Public/Verbs.ps1
@@ -1,0 +1,180 @@
+function Add-PodeVerb
+{
+    [CmdletBinding(DefaultParameterSetName='Script')]
+    param(
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $Verb,
+
+        [Parameter(ParameterSetName='Script')]
+        [scriptblock]
+        $ScriptBlock,
+
+        [Parameter(Mandatory=$true, ParameterSetName='File')]
+        [string]
+        $FilePath,
+
+        [Parameter()]
+        [object[]]
+        $ArgumentList,
+
+        [Parameter()]
+        [string[]]
+        $EndpointName,
+
+        [switch]
+        $UpgradeToSsl,
+
+        [switch]
+        $Close
+    )
+
+    # find placeholder parameters in verb (ie: COMMAND :parameter)
+    $Verb = Update-PodeRoutePlaceholders -Path $Verb
+
+    # get endpoints from name
+    if (!$PodeContext.Server.FindEndpoints.Tcp) {
+        $PodeContext.Server.FindEndpoints.Tcp = !(Test-PodeIsEmpty $EndpointName)
+    }
+
+    $endpoints = Find-PodeEndpoints -EndpointName $EndpointName
+
+    # ensure the verb doesn't already exist for each endpoint
+    foreach ($_endpoint in $endpoints) {
+        Test-PodeVerbAndError -Verb $Verb -Protocol $_endpoint.Protocol -Address $_endpoint.Address
+    }
+
+    # if scriptblock and file path are all null/empty, error
+    if ((Test-PodeIsEmpty $ScriptBlock) -and (Test-PodeIsEmpty $FilePath) -and !$Close -and !$UpgradeToSsl) {
+        throw "[Verb] $($Verb): No logic passed"
+    }
+
+    # if we have a file path supplied, load that path as a scriptblock
+    if ($PSCmdlet.ParameterSetName -ieq 'file') {
+        $ScriptBlock = Convert-PodeFileToScriptBlock -FilePath $FilePath
+    }
+
+    # check if the scriptblock has any using vars
+    $ScriptBlock, $usingVars = Invoke-PodeUsingScriptConversion -ScriptBlock $ScriptBlock -PSSession $PSCmdlet.SessionState
+
+    # check for state/session vars
+    $ScriptBlock = Invoke-PodeStateScriptConversion -ScriptBlock $ScriptBlock
+    $ScriptBlock = Invoke-PodeSessionScriptConversion -ScriptBlock $ScriptBlock
+
+    # add the verb(s)
+    Write-Verbose "Adding Verb: $($Verb)"
+    $PodeContext.Server.Verbs[$Verb] += @(foreach ($_endpoint in $endpoints) {
+        @{
+            Logic = $ScriptBlock
+            UsingVariables = $usingVars
+            Endpoint = @{
+                Protocol = $_endpoint.Protocol
+                Address = $_endpoint.Address.Trim()
+                Name = $_endpoint.Name
+            }
+            Arguments = $ArgumentList
+            Verb = $Verb
+            Connection = @{
+                UpgradeToSsl = $UpgradeToSsl
+                Close = $Close
+            }
+        }
+    })
+}
+
+function Remove-PodeVerb
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Verb,
+
+        [Parameter()]
+        [string]
+        $EndpointName
+    )
+
+    # ensure the verb placeholders are replaced
+    $Verb = Update-PodeRoutePlaceholders -Path $Verb
+
+    # ensure verb does exist
+    if (!$PodeContext.Server.Verbs.Contains($Verb)) {
+        return
+    }
+
+    # remove the verb's logic
+    $PodeContext.Server.Verbs[$Verb] = @($PodeContext.Server.Verbs[$Verb] | Where-Object {
+        $_.Endpoint.Name -ine $EndpointName
+    })
+
+    # if the verb has no more logic, just remove it
+    if ((Get-PodeCount $PodeContext.Server.Verbs[$Verb]) -eq 0) {
+        $null = $PodeContext.Server.Verbs.Remove($Verb)
+    }
+}
+
+function Clear-PodeVerbs
+{
+    [CmdletBinding()]
+    param()
+
+    $PodeContext.Server.Verbs.Clear()
+}
+
+function Get-PodeVerb
+{
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [string]
+        $Verb,
+
+        [Parameter()]
+        [string[]]
+        $EndpointName
+    )
+
+    # start off with every verb
+    $verbs = @()
+
+    # if we have a verb, filter
+    if (![string]::IsNullOrWhiteSpace($Verb)) {
+        $Verb = Update-PodeRoutePlaceholders -Path $Verb
+        $verbs = $PodeContext.Server.Verbs[$Verb]
+    }
+    else {
+        foreach ($v in $PodeContext.Server.Verbs.Values) {
+            $verbs += $v
+        }
+    }
+
+    # further filter by endpoint names
+    if (($null -ne $EndpointName) -and ($EndpointName.Length -gt 0)) {
+        $verbs = @(foreach ($name in $EndpointName) {
+            foreach ($v in $verbs) {
+                if ($v.Endpoint.Name -ine $name) {
+                    continue
+                }
+
+                $v
+            }
+        })
+    }
+
+    # return
+    return $verbs
+}
+
+function Use-PodeVerb
+{
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [string]
+        $Path
+    )
+
+    Use-PodeFolder -Path $Path -DefaultPath 'verbs'
+}

--- a/src/Public/Verbs.ps1
+++ b/src/Public/Verbs.ps1
@@ -1,3 +1,43 @@
+<#
+.SYNOPSIS
+Adds a Verb for a TCP data.
+
+.DESCRIPTION
+Adds a Verb for a TCP data.
+
+.PARAMETER Verb
+The Verb for the Verb.
+
+.PARAMETER ScriptBlock
+A ScriptBlock for the Verb's main logic.
+
+.PARAMETER EndpointName
+The EndpointName of an Endpoint(s) this Verb should be bound against.
+
+.PARAMETER FilePath
+A literal, or relative, path to a file containing a ScriptBlock for the Verb's main logic.
+
+.PARAMETER ArgumentList
+An array of arguments to supply to the Verb's ScriptBlock.
+
+.PARAMETER UpgradeToSsl
+If supplied, the Verb will auto-upgrade the connection to use SSL.
+
+.PARAMETER Close
+If supplied, the Verb will auto-close the connection.
+
+.EXAMPLE
+Add-PodeVerb -Verb 'Hello' -ScriptBlock { /* logic */ }
+
+.EXAMPLE
+Add-PodeVerb -Verb 'Hello' -ScriptBlock { /* logic */ } -ArgumentList 'arg1', 'arg2'
+
+.EXAMPLE
+Add-PodeVerb -Verb 'Quit' -Close
+
+.EXAMPLE
+Add-PodeVerb -Verb 'StartTls' -UpgradeToSsl
+#>
 function Add-PodeVerb
 {
     [CmdletBinding(DefaultParameterSetName='Script')]
@@ -83,6 +123,25 @@ function Add-PodeVerb
     })
 }
 
+<#
+.SYNOPSIS
+Remove a specific Verb.
+
+.DESCRIPTION
+Remove a specific Verb.
+
+.PARAMETER Verb
+The Verb of the Verb to remove.
+
+.PARAMETER EndpointName
+The EndpointName of an Endpoint(s) bound to the Verb to be removed.
+
+.EXAMPLE
+Remove-PodeVerb -Verb 'Hello'
+
+.EXAMPLE
+Remove-PodeVerb -Verb 'Hello :username' -EndpointName User
+#>
 function Remove-PodeVerb
 {
     [CmdletBinding()]
@@ -115,6 +174,16 @@ function Remove-PodeVerb
     }
 }
 
+<#
+.SYNOPSIS
+Removes all added Verbs.
+
+.DESCRIPTION
+Removes all added Verbs.
+
+.EXAMPLE
+Clear-PodeVerbs
+#>
 function Clear-PodeVerbs
 {
     [CmdletBinding()]
@@ -123,6 +192,25 @@ function Clear-PodeVerbs
     $PodeContext.Server.Verbs.Clear()
 }
 
+<#
+.SYNOPSIS
+Get a Verb(s).
+
+.DESCRIPTION
+Get a Verb(s).
+
+.PARAMETER Verb
+A Verb to filter the verbs.
+
+.PARAMETER EndpointName
+The name of an endpoint to filter verbs.
+
+.EXAMPLE
+Get-PodeVerb -Verb 'Hello'
+
+.EXAMPLE
+Get-PodeVerb -Verb 'Hello :username' -EndpointName User
+#>
 function Get-PodeVerb
 {
     [CmdletBinding()]
@@ -167,6 +255,22 @@ function Get-PodeVerb
     return $verbs
 }
 
+<#
+.SYNOPSIS
+Automatically loads verb ps1 files
+
+.DESCRIPTION
+Automatically loads verb ps1 files from either a /verbs folder, or a custom folder. Saves space dot-sourcing them all one-by-one.
+
+.PARAMETER Path
+Optional Path to a folder containing ps1 files, can be relative or literal.
+
+.EXAMPLE
+Use-PodeVerbs
+
+.EXAMPLE
+Use-PodeVerbs -Path './my-verbs'
+#>
 function Use-PodeVerbs
 {
     [CmdletBinding()]

--- a/src/Public/Verbs.ps1
+++ b/src/Public/Verbs.ps1
@@ -167,7 +167,7 @@ function Get-PodeVerb
     return $verbs
 }
 
-function Use-PodeVerb
+function Use-PodeVerbs
 {
     [CmdletBinding()]
     param(

--- a/tests/unit/Context.Tests.ps1
+++ b/tests/unit/Context.Tests.ps1
@@ -344,10 +344,24 @@ Describe 'Add-PodeEndpoint' {
             $endpoint.Address.ToString() | Should Be '127.0.0.1'
         }
 
-        It 'Throws error when adding two TCP endpoints' {
+        It 'Add two endpoints to listen on, one of TCP and one of TCPS' {
             $PodeContext.Server = @{ Endpoints = @{}; EndpointsMap = @{}; 'Type' = $null }
-            Add-PodeEndpoint -Address '127.0.0.1' -Port 80 -Protocol 'TCP'
-            { Add-PodeEndpoint -Address 'pode.foo.com' -Port 80 -Protocol 'TCP' } | Should Throw 'already been defined'
+            Add-PodeEndpoint -Address '127.0.0.1' -Port 80 -Protocol 'TCP' -Name 'Tcp'
+            Add-PodeEndpoint -Address 'pode.foo.com' -Port 443 -Protocol 'TCPS' -Name 'Tcps'
+
+            $PodeContext.Server.Types | Should Be 'TCP'
+            $PodeContext.Server.Endpoints | Should Not Be $null
+            $PodeContext.Server.Endpoints.Count | Should Be 2
+
+            $endpoint = $PodeContext.Server.Endpoints['Tcp']
+            $endpoint.Port | Should Be 80
+            $endpoint.HostName | Should Be ''
+            $endpoint.Address.ToString() | Should Be '127.0.0.1'
+
+            $endpoint = $PodeContext.Server.Endpoints['Tcps']
+            $endpoint.Port | Should Be 443
+            $endpoint.HostName | Should Be 'pode.foo.com'
+            $endpoint.Address.ToString() | Should Be '127.0.0.1'
         }
 
         It 'Throws an error for not running as admin' {

--- a/tests/unit/Handlers.Tests.ps1
+++ b/tests/unit/Handlers.Tests.ps1
@@ -14,17 +14,17 @@ Describe 'Get-PodeHandler' {
     Context 'Valid parameters' {
         It 'Return null as type does not exist' {
             $PodeContext.Server = @{ 'Handlers' = @{}; }
-            Get-PodeHandler -Type Tcp | Should Be $null
+            Get-PodeHandler -Type Smtp | Should Be $null
         }
 
         It 'Returns handlers for type' {
-            $PodeContext.Server = @{ 'Handlers' = @{ 'TCP' = @{
+            $PodeContext.Server = @{ 'Handlers' = @{ 'Smtp' = @{
                 'Main' = @{
                     'Logic' = { Write-Host 'hello' };
                 };
              }; }; }
 
-            $result = (Get-PodeHandler -Type Tcp)
+            $result = (Get-PodeHandler -Type Smtp)
 
             $result | Should Not Be $null
             $result.Count | Should Be 1
@@ -32,26 +32,26 @@ Describe 'Get-PodeHandler' {
         }
 
         It 'Returns handler for type by name' {
-            $PodeContext.Server = @{ 'Handlers' = @{ 'TCP' = @{
+            $PodeContext.Server = @{ 'Handlers' = @{ 'Smtp' = @{
                 'Main' = @{
                     'Logic' = { Write-Host 'hello' };
                 };
              }; }; }
 
-            $result = (Get-PodeHandler -Type Tcp -Name 'Main')
+            $result = (Get-PodeHandler -Type Smtp -Name 'Main')
 
             $result | Should Not Be $null
             $result.Logic.ToString() | Should Be ({ Write-Host 'hello' }).ToString()
         }
 
         It 'Returns no handler for type by name' {
-            $PodeContext.Server = @{ 'Handlers' = @{ 'TCP' = @{
+            $PodeContext.Server = @{ 'Handlers' = @{ 'Smtp' = @{
                 'Main' = @{
                     'Logic' = { Write-Host 'hello' };
                 };
              }; }; }
 
-            $result = (Get-PodeHandler -Type Tcp -Name 'Fail')
+            $result = (Get-PodeHandler -Type Smtp -Name 'Fail')
             $result | Should Be $null
         }
     }
@@ -59,17 +59,8 @@ Describe 'Get-PodeHandler' {
 
 Describe 'Add-PodeHandler' {
     It 'Throws error because type already exists' {
-        $PodeContext.Server = @{ 'Handlers' = @{ 'TCP' = @{ 'Main' = @{}; }; }; }
-        { Add-PodeHandler -Type Tcp -Name 'Main' -ScriptBlock {} } | Should Throw 'already defined'
-    }
-
-    It 'Adds tcp handler' {
-        $PodeContext.Server = @{ 'Handlers' = @{ 'TCP' = @{}; }; }
-        Add-PodeHandler -Type Tcp -Name 'Main' -ScriptBlock { Write-Host 'hello' }
-
-        $handler = $PodeContext.Server.Handlers['tcp']
-        $handler.Count | Should Be 1
-        $handler['Main'].Logic.ToString() | Should Be ({ Write-Host 'hello' }).ToString()
+        $PodeContext.Server = @{ 'Handlers' = @{ 'Smtp' = @{ 'Main' = @{}; }; }; }
+        { Add-PodeHandler -Type Smtp -Name 'Main' -ScriptBlock {} } | Should Throw 'already defined'
     }
 
     It 'Adds smtp handler' {
@@ -93,19 +84,19 @@ Describe 'Add-PodeHandler' {
 
 Describe 'Remove-PodeHandler' {
     It 'Adds two handlers, and removes one by name' {
-        $PodeContext.Server = @{ 'Handlers' = @{ 'TCP' = @{}; }; }
+        $PodeContext.Server = @{ 'Handlers' = @{ 'Smtp' = @{}; }; }
 
-        Add-PodeHandler -Type Tcp -Name 'Main1' -ScriptBlock { Write-Host 'hello1' }
-        Add-PodeHandler -Type Tcp -Name 'Main2' -ScriptBlock { Write-Host 'hello2' }
+        Add-PodeHandler -Type Smtp -Name 'Main1' -ScriptBlock { Write-Host 'hello1' }
+        Add-PodeHandler -Type Smtp -Name 'Main2' -ScriptBlock { Write-Host 'hello2' }
 
-        $handler = $PodeContext.Server.Handlers['tcp']
+        $handler = $PodeContext.Server.Handlers['Smtp']
         $handler.Count | Should Be 2
         $handler['Main1'].Logic.ToString() | Should Be ({ Write-Host 'hello1' }).ToString()
         $handler['Main2'].Logic.ToString() | Should Be ({ Write-Host 'hello2' }).ToString()
 
-        Remove-PodeHandler -Type Tcp -Name 'Main1'
+        Remove-PodeHandler -Type Smtp -Name 'Main1'
 
-        $handler = $PodeContext.Server.Handlers['tcp']
+        $handler = $PodeContext.Server.Handlers['Smtp']
         $handler.Count | Should Be 1
         $handler['Main2'].Logic.ToString() | Should Be ({ Write-Host 'hello2' }).ToString()
     }
@@ -114,17 +105,12 @@ Describe 'Remove-PodeHandler' {
 Describe 'Clear-PodeHandlers' {
     It 'Adds handlers, and removes them all for one type' {
         $PodeContext.Server = @{ 'Handlers' = @{
-            'TCP' = @{};
             'SMTP' = @{};
             'Service' = @{};
         }; }
 
-        Add-PodeHandler -Type Tcp -Name 'Main' -ScriptBlock { Write-Host 'hello' }
         Add-PodeHandler -Type Smtp -Name 'Main' -ScriptBlock { Write-Host 'hello' }
         Add-PodeHandler -Type Service -Name 'Main' -ScriptBlock { Write-Host 'hello' }
-
-        $handler = $PodeContext.Server.Handlers['tcp']
-        $handler.Count | Should Be 1
 
         $handler = $PodeContext.Server.Handlers['smtp']
         $handler.Count | Should Be 1
@@ -132,13 +118,10 @@ Describe 'Clear-PodeHandlers' {
         $handler = $PodeContext.Server.Handlers['service']
         $handler.Count | Should Be 1
 
-        Clear-PodeHandlers -Type Tcp
-
-        $handler = $PodeContext.Server.Handlers['tcp']
-        $handler.Count | Should Be 0
+        Clear-PodeHandlers -Type Smtp
 
         $handler = $PodeContext.Server.Handlers['smtp']
-        $handler.Count | Should Be 1
+        $handler.Count | Should Be 0
 
         $handler = $PodeContext.Server.Handlers['service']
         $handler.Count | Should Be 1
@@ -146,17 +129,12 @@ Describe 'Clear-PodeHandlers' {
 
     It 'Adds handlers, and removes them all' {
         $PodeContext.Server = @{ 'Handlers' = @{
-            'TCP' = @{};
             'SMTP' = @{};
             'Service' = @{};
         }; }
 
-        Add-PodeHandler -Type Tcp -Name 'Main' -ScriptBlock { Write-Host 'hello' }
         Add-PodeHandler -Type Smtp -Name 'Main' -ScriptBlock { Write-Host 'hello' }
         Add-PodeHandler -Type Service -Name 'Main' -ScriptBlock { Write-Host 'hello' }
-
-        $handler = $PodeContext.Server.Handlers['tcp']
-        $handler.Count | Should Be 1
 
         $handler = $PodeContext.Server.Handlers['smtp']
         $handler.Count | Should Be 1
@@ -165,9 +143,6 @@ Describe 'Clear-PodeHandlers' {
         $handler.Count | Should Be 1
 
         Clear-PodeHandlers
-
-        $handler = $PodeContext.Server.Handlers['tcp']
-        $handler.Count | Should Be 0
 
         $handler = $PodeContext.Server.Handlers['smtp']
         $handler.Count | Should Be 0

--- a/tests/unit/Responses.Tests.ps1
+++ b/tests/unit/Responses.Tests.ps1
@@ -386,50 +386,11 @@ Describe 'Use-PodePartialView' {
     }
 }
 
-Describe 'Close-PodeTcpConnection' {
-    It 'Disposes a passes client' {
-        Mock Close-PodeDisposable { }
-
-        try {
-            $_client = New-Object System.IO.MemoryStream
-            Close-PodeTcpConnection -Client $_client
-        }
-        finally {
-            $_client.Dispose()
-        }
-
-        Assert-MockCalled Close-PodeDisposable -Times 1 -Scope It
-    }
-
-    It 'Disposes and Quits a passes client' {
-        Mock Close-PodeDisposable { }
-        Mock Write-PodeTcpClient { }
-
-        try {
-            $_client = New-Object System.IO.MemoryStream
-            $_client | Add-Member -MemberType NoteProperty -Name Connected -Value $true -Force
-            Close-PodeTcpConnection -Client $_client -Quit
-        }
-        finally {
-            $_client.Dispose()
-        }
-
-        Assert-MockCalled Write-PodeTcpClient -Times 1 -Scope It
-        Assert-MockCalled Close-PodeDisposable -Times 1 -Scope It
-    }
-
+Describe 'Close-PodeTcpClient' {
     It 'Disposes a stored client' {
-        Mock Close-PodeDisposable { }
-
-        try {
-            $TcpEvent = @{ 'Client' = New-Object System.IO.MemoryStream }
-            Close-PodeTcpConnection
-        }
-        finally {
-            $TcpEvent.Client.Dispose()
-        }
-
-        Assert-MockCalled Close-PodeDisposable -Times 1 -Scope It
+        $TcpEvent = @{ 'Request' = @{} }
+        $TcpEvent.Request | Add-Member -MemberType ScriptMethod -Name Close -Value { return $true } -Force
+        Close-PodeTcpClient
     }
 }
 

--- a/tests/unit/Routes.Tests.ps1
+++ b/tests/unit/Routes.Tests.ps1
@@ -83,7 +83,7 @@ Describe 'Add-PodeStaticRoute' {
         Mock Test-PodePath { return $true }
         Mock New-PodePSDrive { return './assets' }
 
-        $PodeContext.Server = @{ 'Routes' = @{ 'STATIC' = @{}; }; 'Root' = $pwd }
+        $PodeContext.Server = @{ 'Routes' = @{ 'STATIC' = @{}; }; 'Root' = $pwd; FindEndpoints = @{} }
         Add-PodeStaticRoute -Path '/assets' -Source './assets'
 
         $route = $PodeContext.Server.Routes['static']
@@ -94,14 +94,14 @@ Describe 'Add-PodeStaticRoute' {
 
     It 'Throws error when adding static route for non-existing folder' {
         Mock Test-PodePath { return $false }
-        $PodeContext.Server = @{ 'Routes' = @{ 'STATIC' = @{}; }; 'Root' = $pwd }
+        $PodeContext.Server = @{ 'Routes' = @{ 'STATIC' = @{}; }; 'Root' = $pwd; FindEndpoints = @{} }
         { Add-PodeStaticRoute -Path '/assets' -Source './assets' } | Should Throw 'does not exist'
     }
 }
 
 Describe 'Remove-PodeRoute' {
     It 'Adds route with simple url, and then removes it' {
-        $PodeContext.Server = @{ 'Routes' = @{ 'GET' = @{}; }; }
+        $PodeContext.Server = @{ 'Routes' = @{ 'GET' = @{}; }; 'FindEndpoints' = @{} }
 
         Add-PodeRoute -Method Get -Path '/users' -ScriptBlock { Write-Host 'hello' }
 
@@ -118,7 +118,7 @@ Describe 'Remove-PodeRoute' {
     }
 
     It 'Adds two routes with simple url, and then removes one' {
-        $PodeContext.Server = @{ Routes = @{ GET = @{}; }; Endpoints = @{}; EndpointsMap = @{}; Type = $null }
+        $PodeContext.Server = @{ Routes = @{ GET = @{}; }; Endpoints = @{}; EndpointsMap = @{}; FindEndpoints = @{}; Type = $null }
 
         Add-PodeEndpoint -Address '127.0.0.1' -Port 8080 -Protocol Http -Name user
 
@@ -144,7 +144,7 @@ Describe 'Remove-PodeStaticRoute' {
         Mock Test-PodePath { return $true }
         Mock New-PodePSDrive { return './assets' }
 
-        $PodeContext.Server = @{ 'Routes' = @{ 'STATIC' = @{}; }; 'Root' = $pwd }
+        $PodeContext.Server = @{ 'Routes' = @{ 'STATIC' = @{}; }; 'Root' = $pwd; FindEndpoints = @{} }
         Add-PodeStaticRoute -Path '/assets' -Source './assets'
 
         $routes = $PodeContext.Server.Routes['static']
@@ -162,7 +162,7 @@ Describe 'Remove-PodeStaticRoute' {
 
 Describe 'Clear-PodeRoutes' {
     It 'Adds routes for methods, and clears everything' {
-        $PodeContext.Server = @{ 'Routes' = @{ 'GET' = @{}; 'POST' = @{}; }; }
+        $PodeContext.Server = @{ 'Routes' = @{ 'GET' = @{}; 'POST' = @{}; }; 'FindEndpoints' = @{} }
         Add-PodeRoute -Method GET -Path '/users' -ScriptBlock { Write-Host 'hello1' }
         Add-PodeRoute -Method POST -Path '/messages' -ScriptBlock { Write-Host 'hello2' }
 
@@ -182,7 +182,7 @@ Describe 'Clear-PodeRoutes' {
     }
 
     It 'Adds routes for methods, and clears one method' {
-        $PodeContext.Server = @{ 'Routes' = @{ 'GET' = @{}; 'POST' = @{}; }; }
+        $PodeContext.Server = @{ 'Routes' = @{ 'GET' = @{}; 'POST' = @{}; }; 'FindEndpoints' = @{} }
         Add-PodeRoute -Method GET -Path '/users' -ScriptBlock { Write-Host 'hello1' }
         Add-PodeRoute -Method POST -Path '/messages' -ScriptBlock { Write-Host 'hello2' }
 
@@ -207,7 +207,7 @@ Describe 'Clear-PodeStaticRoutes' {
         Mock Test-PodePath { return $true }
         Mock New-PodePSDrive { return './assets' }
 
-        $PodeContext.Server = @{ 'Routes' = @{ 'STATIC' = @{}; }; 'Root' = $pwd }
+        $PodeContext.Server = @{ 'Routes' = @{ 'STATIC' = @{}; }; 'Root' = $pwd; FindEndpoints = @{} }
 
         Add-PodeStaticRoute -Path '/assets' -Source './assets'
         Add-PodeStaticRoute -Path '/images' -Source './images'
@@ -244,14 +244,14 @@ Describe 'Add-PodeRoute' {
     It 'Throws error when file path is a directory' {
         Mock Get-PodeRelativePath { return $Path }
         Mock Test-PodePath { return $true }
-        $PodeContext.Server = @{ 'Routes' = @{ 'GET' = @{} } }
+        $PodeContext.Server = @{ 'Routes' = @{ 'GET' = @{} }; 'FindEndpoints' = @{} }
         { Add-PodeRoute -Method GET -Path '/' -FilePath './path' } | Should Throw 'cannot be a wildcard or a directory'
     }
 
     It 'Throws error when file path is a wildcard' {
         Mock Get-PodeRelativePath { return $Path }
         Mock Test-PodePath { return $true }
-        $PodeContext.Server = @{ 'Routes' = @{ 'GET' = @{} } }
+        $PodeContext.Server = @{ 'Routes' = @{ 'GET' = @{} }; 'FindEndpoints' = @{} }
         { Add-PodeRoute -Method GET -Path '/' -FilePath './path/*' } | Should Throw 'cannot be a wildcard or a directory'
     }
 
@@ -266,18 +266,18 @@ Describe 'Add-PodeRoute' {
     It 'Throws error because route already exists' {
         $PodeContext.Server = @{ 'Routes' = @{ 'GET' = @{ '/' = @(
             @{ 'Endpoint' = @{'Protocol' = ''; 'Address' = ''} }
-        ); }; }; }
+        ); }; }; 'FindEndpoints' = @{} }
 
         { Add-PodeRoute -Method GET -Path '/' -ScriptBlock { write-host 'hi' } } | Should Throw 'already defined'
     }
 
     It 'Throws error on GET route for endpoint name not existing' {
-        $PodeContext.Server = @{ 'Endpoints' = @{}; 'Routes' = @{ 'GET' = @{}; }; }
+        $PodeContext.Server = @{ 'Endpoints' = @{}; 'Routes' = @{ 'GET' = @{}; }; 'FindEndpoints' = @{} }
         { Add-PodeRoute -Method GET -Path '/users' -ScriptBlock { Write-Host 'hello' } -EndpointName 'test' } | Should Throw 'does not exist'
     }
 
     It 'Adds route with simple url' {
-        $PodeContext.Server = @{ 'Routes' = @{ 'GET' = @{}; }; }
+        $PodeContext.Server = @{ 'Routes' = @{ 'GET' = @{}; }; 'FindEndpoints' = @{} }
         Add-PodeRoute -Method GET -Path '/users' -ScriptBlock { Write-Host 'hello' }
 
         $routes = $PodeContext.Server.Routes['get']
@@ -295,7 +295,7 @@ Describe 'Add-PodeRoute' {
         Mock Test-PodePath { return $true }
         Mock Use-PodeScript { return { Write-Host 'bye' } }
 
-        $PodeContext.Server = @{ 'Routes' = @{ 'GET' = @{}; }; }
+        $PodeContext.Server = @{ 'Routes' = @{ 'GET' = @{}; }; 'FindEndpoints' = @{} }
         Add-PodeRoute -Method GET -Path '/users' -FilePath './path/route.ps1'
 
         $routes = $PodeContext.Server.Routes['get']
@@ -311,7 +311,7 @@ Describe 'Add-PodeRoute' {
     Mock Test-PodePath { return $false }
 
     It 'Adds route with simple url with content type' {
-        $PodeContext.Server = @{ 'Routes' = @{ 'GET' = @{}; }; }
+        $PodeContext.Server = @{ 'Routes' = @{ 'GET' = @{}; }; 'FindEndpoints' = @{} }
         Add-PodeRoute -Method GET -Path '/users' -ContentType 'application/json' -ScriptBlock { Write-Host 'hello' }
 
         $routes = $PodeContext.Server.Routes['get']
@@ -331,6 +331,7 @@ Describe 'Add-PodeRoute' {
                 'Default' = 'text/xml';
                 'Routes' = @{};
             } };
+            'FindEndpoints' = @{}
         }
 
         Add-PodeRoute -Method GET -Path '/users' -ScriptBlock { Write-Host 'hello' }
@@ -352,6 +353,7 @@ Describe 'Add-PodeRoute' {
                 'Default' = 'text/xml';
                 'Routes' = @{ '/users' = 'text/plain' };
             } };
+            'FindEndpoints' = @{}
         }
 
         Add-PodeRoute -Method GET -Path '/users' -ScriptBlock { Write-Host 'hello' }
@@ -367,7 +369,7 @@ Describe 'Add-PodeRoute' {
     }
 
     It 'Adds route with middleware supplied as scriptblock and no logic' {
-        $PodeContext.Server = @{ 'Routes' = @{ 'GET' = @{}; }; }
+        $PodeContext.Server = @{ 'Routes' = @{ 'GET' = @{}; }; 'FindEndpoints' = @{} }
         Add-PodeRoute -Method GET -Path '/users' -Middleware ({ Write-Host 'middle' }) -ScriptBlock {}
 
         $route = $PodeContext.Server.Routes['get']
@@ -381,22 +383,22 @@ Describe 'Add-PodeRoute' {
     }
 
     It 'Adds route with middleware supplied as hashtable with null logic' {
-        $PodeContext.Server = @{ 'Routes' = @{ 'GET' = @{}; }; }
+        $PodeContext.Server = @{ 'Routes' = @{ 'GET' = @{}; }; 'FindEndpoints' = @{} }
         { Add-PodeRoute -Method GET -Path '/users' -Middleware (@{ 'Logic' = $null }) -ScriptBlock {} } | Should Throw 'no logic defined'
     }
 
     It 'Adds route with middleware supplied as hashtable with invalid type logic' {
-        $PodeContext.Server = @{ 'Routes' = @{ 'GET' = @{}; }; }
+        $PodeContext.Server = @{ 'Routes' = @{ 'GET' = @{}; }; 'FindEndpoints' = @{} }
         { Add-PodeRoute -Method GET -Path '/users' -Middleware (@{ 'Logic' = 74 }) -ScriptBlock {} } | Should Throw 'invalid logic type'
     }
 
     It 'Adds route with invalid middleware type' {
-        $PodeContext.Server = @{ 'Routes' = @{ 'GET' = @{}; }; }
+        $PodeContext.Server = @{ 'Routes' = @{ 'GET' = @{}; }; 'FindEndpoints' = @{} }
         { Add-PodeRoute -Method GET -Path '/users' -Middleware 74 -ScriptBlock {} } | Should Throw 'invalid type'
     }
 
     It 'Adds route with middleware supplied as hashtable and empty logic' {
-        $PodeContext.Server = @{ 'Routes' = @{ 'GET' = @{}; }; }
+        $PodeContext.Server = @{ 'Routes' = @{ 'GET' = @{}; };  'FindEndpoints' = @{}}
         Add-PodeRoute -Method GET -Path '/users' -Middleware (@{ 'Logic' = { Write-Host 'middle' }; 'Arguments' = 'test' }) -ScriptBlock {}
 
         $routes = $PodeContext.Server.Routes['get']
@@ -416,7 +418,7 @@ Describe 'Add-PodeRoute' {
     }
 
     It 'Adds route with middleware supplied as hashtable and no logic' {
-        $PodeContext.Server = @{ 'Routes' = @{ 'GET' = @{}; }; }
+        $PodeContext.Server = @{ 'Routes' = @{ 'GET' = @{}; }; 'FindEndpoints' = @{} }
         Add-PodeRoute -Method GET -Path '/users' -Middleware (@{ 'Logic' = { Write-Host 'middle' }; 'Arguments' = 'test' }) -ScriptBlock {}
 
         $routes = $PodeContext.Server.Routes['get']
@@ -436,7 +438,7 @@ Describe 'Add-PodeRoute' {
     }
 
     It 'Adds route with middleware and logic supplied' {
-        $PodeContext.Server = @{ 'Routes' = @{ 'GET' = @{}; }; }
+        $PodeContext.Server = @{ 'Routes' = @{ 'GET' = @{}; }; 'FindEndpoints' = @{} }
         Add-PodeRoute -Method GET -Path '/users' -Middleware { Write-Host 'middle' } -ScriptBlock { Write-Host 'logic' }
 
         $routes = $PodeContext.Server.Routes['get']
@@ -455,7 +457,7 @@ Describe 'Add-PodeRoute' {
     }
 
     It 'Adds route with array of middleware and no logic supplied' {
-        $PodeContext.Server = @{ 'Routes' = @{ 'GET' = @{}; }; }
+        $PodeContext.Server = @{ 'Routes' = @{ 'GET' = @{}; }; 'FindEndpoints' = @{} }
 
         Add-PodeRoute -Method GET -Path '/users' -Middleware @(
             { Write-Host 'middle1' },
@@ -477,7 +479,7 @@ Describe 'Add-PodeRoute' {
     }
 
     It 'Adds route with array of middleware and logic supplied' {
-        $PodeContext.Server = @{ 'Routes' = @{ 'GET' = @{}; }; }
+        $PodeContext.Server = @{ 'Routes' = @{ 'GET' = @{}; }; 'FindEndpoints' = @{} }
         Add-PodeRoute -Method GET -Path '/users' -Middleware @(
             { Write-Host 'middle1' },
             { Write-Host 'middle2' }
@@ -496,7 +498,7 @@ Describe 'Add-PodeRoute' {
     }
 
     It 'Adds route with simple url and querystring' {
-        $PodeContext.Server = @{ 'Routes' = @{ 'GET' = @{}; }; }
+        $PodeContext.Server = @{ 'Routes' = @{ 'GET' = @{}; }; 'FindEndpoints' = @{} }
         Add-PodeRoute -Method GET -Path '/users?k=v' -ScriptBlock { Write-Host 'hello' }
 
         $route = $PodeContext.Server.Routes['get']
@@ -508,7 +510,7 @@ Describe 'Add-PodeRoute' {
     }
 
     It 'Adds route with url parameters' {
-        $PodeContext.Server = @{ 'Routes' = @{ 'GET' = @{}; }; }
+        $PodeContext.Server = @{ 'Routes' = @{ 'GET' = @{}; }; 'FindEndpoints' = @{} }
         Add-PodeRoute -Method GET -Path '/users/:userId' -ScriptBlock { Write-Host 'hello' }
 
         $route = $PodeContext.Server.Routes['get']
@@ -520,7 +522,7 @@ Describe 'Add-PodeRoute' {
     }
 
     It 'Adds route with url parameters and querystring' {
-        $PodeContext.Server = @{ 'Routes' = @{ 'GET' = @{}; }; }
+        $PodeContext.Server = @{ 'Routes' = @{ 'GET' = @{}; }; 'FindEndpoints' = @{} }
         Add-PodeRoute -Method GET -Path '/users/:userId?k=v' -ScriptBlock { Write-Host 'hello' }
 
         $route = $PodeContext.Server.Routes['get']
@@ -811,7 +813,7 @@ Describe 'Get-PodeRoute' {
     Mock Test-PodeIsAdminUser { return $true }
 
     It 'Returns both routes whe nothing supplied' {
-        $PodeContext.Server = @{ Routes = @{ GET = @{}; POST = @{}; }; }
+        $PodeContext.Server = @{ Routes = @{ GET = @{}; POST = @{}; }; FindEndpoints = @{} }
         Add-PodeRoute -Method Get -Path '/users' -ScriptBlock { Write-Host 'hello' }
         Add-PodeRoute -Method Get -Path '/about' -ScriptBlock { Write-Host 'hello' }
         Add-PodeRoute -Method Post -Path '/users' -ScriptBlock { Write-Host 'hello' }
@@ -821,7 +823,7 @@ Describe 'Get-PodeRoute' {
     }
 
     It 'Returns both routes for GET method' {
-        $PodeContext.Server = @{ Routes = @{ GET = @{}; POST = @{}; }; }
+        $PodeContext.Server = @{ Routes = @{ GET = @{}; POST = @{}; }; FindEndpoints = @{} }
         Add-PodeRoute -Method Get -Path '/users' -ScriptBlock { Write-Host 'hello' }
         Add-PodeRoute -Method Get -Path '/about' -ScriptBlock { Write-Host 'hello' }
         Add-PodeRoute -Method Post -Path '/users' -ScriptBlock { Write-Host 'hello' }
@@ -831,7 +833,7 @@ Describe 'Get-PodeRoute' {
     }
 
     It 'Returns one route for POST method' {
-        $PodeContext.Server = @{ Routes = @{ GET = @{}; POST = @{}; }; }
+        $PodeContext.Server = @{ Routes = @{ GET = @{}; POST = @{}; }; FindEndpoints = @{} }
         Add-PodeRoute -Method Get -Path '/users' -ScriptBlock { Write-Host 'hello' }
         Add-PodeRoute -Method Get -Path '/about' -ScriptBlock { Write-Host 'hello' }
         Add-PodeRoute -Method Post -Path '/users' -ScriptBlock { Write-Host 'hello' }
@@ -841,7 +843,7 @@ Describe 'Get-PodeRoute' {
     }
 
     It 'Returns both routes for users path' {
-        $PodeContext.Server = @{ Routes = @{ GET = @{}; POST = @{}; }; }
+        $PodeContext.Server = @{ Routes = @{ GET = @{}; POST = @{}; }; FindEndpoints = @{} }
         Add-PodeRoute -Method Get -Path '/users' -ScriptBlock { Write-Host 'hello' }
         Add-PodeRoute -Method Get -Path '/about' -ScriptBlock { Write-Host 'hello' }
         Add-PodeRoute -Method Post -Path '/users' -ScriptBlock { Write-Host 'hello' }
@@ -851,7 +853,7 @@ Describe 'Get-PodeRoute' {
     }
 
     It 'Returns one route for users path and GET method' {
-        $PodeContext.Server = @{ Routes = @{ GET = @{}; POST = @{}; }; }
+        $PodeContext.Server = @{ Routes = @{ GET = @{}; POST = @{}; }; FindEndpoints = @{} }
         Add-PodeRoute -Method Get -Path '/users' -ScriptBlock { Write-Host 'hello' }
         Add-PodeRoute -Method Get -Path '/about' -ScriptBlock { Write-Host 'hello' }
         Add-PodeRoute -Method Post -Path '/users' -ScriptBlock { Write-Host 'hello' }
@@ -861,7 +863,7 @@ Describe 'Get-PodeRoute' {
     }
 
     It 'Returns one route for users path and endpoint name user' {
-        $PodeContext.Server = @{ Routes = @{ GET = @{}; POST = @{}; }; Endpoints = @{}; EndpointsMap = @{}; Type = $null }
+        $PodeContext.Server = @{ Routes = @{ GET = @{}; POST = @{}; }; Endpoints = @{}; EndpointsMap = @{}; FindEndpoints = @{}; Type = $null }
 
         Add-PodeEndpoint -Address '127.0.0.1' -Port 8080 -Protocol Http -Name user
         Add-PodeEndpoint -Address '127.0.0.1' -Port 8081 -Protocol Http -Name admin
@@ -876,7 +878,7 @@ Describe 'Get-PodeRoute' {
     }
 
     It 'Returns both routes for users path and endpoint names' {
-        $PodeContext.Server = @{ Routes = @{ GET = @{}; POST = @{}; }; Endpoints = @{}; EndpointsMap = @{}; Type = $null }
+        $PodeContext.Server = @{ Routes = @{ GET = @{}; POST = @{}; }; Endpoints = @{}; EndpointsMap = @{}; FindEndpoints = @{}; Type = $null }
 
         Add-PodeEndpoint -Address '127.0.0.1' -Port 8080 -Protocol Http -Name user
         Add-PodeEndpoint -Address '127.0.0.1' -Port 8081 -Protocol Http -Name admin
@@ -889,7 +891,7 @@ Describe 'Get-PodeRoute' {
     }
 
     It 'Returns both routes for user endpoint name' {
-        $PodeContext.Server = @{ Routes = @{ GET = @{}; POST = @{}; }; Endpoints = @{}; EndpointsMap = @{}; Type = $null }
+        $PodeContext.Server = @{ Routes = @{ GET = @{}; POST = @{}; }; Endpoints = @{}; EndpointsMap = @{}; FindEndpoints = @{}; Type = $null }
 
         Add-PodeEndpoint -Address '127.0.0.1' -Port 8080 -Protocol Http -Name user
         Add-PodeEndpoint -Address '127.0.0.1' -Port 8081 -Protocol Http -Name admin
@@ -907,7 +909,7 @@ Describe 'Get-PodeStaticRoute' {
     Mock New-PodePSDrive { return './assets' }
 
     It 'Returns all static routes' {
-        $PodeContext.Server = @{ Routes = @{ STATIC = @{}; }; Root = $pwd }
+        $PodeContext.Server = @{ Routes = @{ STATIC = @{}; }; FindEndpoints = @{}; Root = $pwd }
         Add-PodeStaticRoute -Path '/assets' -Source './assets'
         Add-PodeStaticRoute -Path '/images' -Source './images'
 
@@ -916,7 +918,7 @@ Describe 'Get-PodeStaticRoute' {
     }
 
     It 'Returns one static route' {
-        $PodeContext.Server = @{ Routes = @{ STATIC = @{}; }; Root = $pwd }
+        $PodeContext.Server = @{ Routes = @{ STATIC = @{}; }; FindEndpoints = @{}; Root = $pwd }
         Add-PodeStaticRoute -Path '/assets' -Source './assets'
         Add-PodeStaticRoute -Path '/images' -Source './images'
 
@@ -925,7 +927,7 @@ Describe 'Get-PodeStaticRoute' {
     }
 
     It 'Returns one static route for endpoint name user' {
-        $PodeContext.Server = @{ Routes = @{ STATIC = @{}; }; Root = $pwd; Endpoints = @{}; EndpointsMap = @{}; Type = $null }
+        $PodeContext.Server = @{ Routes = @{ STATIC = @{}; }; Root = $pwd; Endpoints = @{}; EndpointsMap = @{}; FindEndpoints = @{}; Type = $null }
 
         Add-PodeEndpoint -Address '127.0.0.1' -Port 8080 -Protocol Http -Name user
         Add-PodeEndpoint -Address '127.0.0.1' -Port 8081 -Protocol Http -Name admin
@@ -940,7 +942,7 @@ Describe 'Get-PodeStaticRoute' {
     }
 
     It 'Returns both routes for users path and endpoint names' {
-        $PodeContext.Server = @{ Routes = @{ STATIC = @{}; }; Root = $pwd; Endpoints = @{}; EndpointsMap = @{}; Type = $null }
+        $PodeContext.Server = @{ Routes = @{ STATIC = @{}; }; Root = $pwd; Endpoints = @{}; EndpointsMap = @{}; FindEndpoints = @{}; Type = $null }
 
         Add-PodeEndpoint -Address '127.0.0.1' -Port 8080 -Protocol Http -Name user
         Add-PodeEndpoint -Address '127.0.0.1' -Port 8081 -Protocol Http -Name admin
@@ -953,7 +955,7 @@ Describe 'Get-PodeStaticRoute' {
     }
 
     It 'Returns both routes for user endpoint' {
-        $PodeContext.Server = @{ Routes = @{ STATIC = @{}; }; Root = $pwd; Endpoints = @{}; EndpointsMap = @{}; Type = $null }
+        $PodeContext.Server = @{ Routes = @{ STATIC = @{}; }; Root = $pwd; Endpoints = @{}; EndpointsMap = @{}; FindEndpoints = @{}; Type = $null }
 
         Add-PodeEndpoint -Address '127.0.0.1' -Port 8080 -Protocol Http -Name user
         Add-PodeEndpoint -Address '127.0.0.1' -Port 8081 -Protocol Http -Name admin

--- a/tests/unit/Server.Tests.ps1
+++ b/tests/unit/Server.Tests.ps1
@@ -108,7 +108,10 @@ Describe 'Restart-PodeInternalServer' {
                     POST = @{ 'key' = 'value' }
                 }
                 Handlers = @{
-                    TCP = @{ }
+                    SMTP = @{}
+                }
+                Verbs = @{
+                    key = @{}
                 }
                 Logging = @{
                     Types = @{ 'key' = 'value' }


### PR DESCRIPTION
### Description of the Change
Overhauls the TCP server type, and documents it. The TCP server type now uses the PodeListener, enabling it to listen on multiple endpoints and have SSL support.

Like how the web server part of Pode uses Routes for request logic, the TCP server will use Verbs. Verbs work in a similar fashion to Routes, and any Verb that best matches the sent data is the Verb's logic which is invoked. Verbs also support parameters (`:<name>) for more dynamic data matching.

The following functions have also been updated, and the Close function made public:
* `Write-PodeTcpClient`
* `Read-PodeTcpClient`
* `Close-PodeTcpClient`

### Related Issue
Resolves #902 

### Examples
```powershell
Start-PodeServer {
    Add-PodeEndpoint -Address localhost -Port 9000 -Protocol Tcp -CRLFMessageEnd -Acknowledge 'Welcome!'

    Add-PodeVerb -Verb 'HELLO' -ScriptBlock {
        Write-PodeTcpClient -Message 'HI'
    }
}
```

Start the above server, and then in a different terminal start telnet and send "HELLO" - pressing Enter to send:

```powershell
$> telnet localhost 9000
S> Welcome!
C> HELLO
S> HI
```
