### PR TITLE
Add support for connecting to external websocket servers

### DIFF
--- a/docs/Tutorials/WebSockets/Endpoints.md
+++ b/docs/Tutorials/WebSockets/Endpoints.md
@@ -1,8 +1,6 @@
-# Web Sockets
+# Endpoints
 
-Pode has support for using WebSockets, including secure WebSockets, for either server-to-client or vice-versa.
-
-WebSockets allow you to broadcast messages directly from your server to connected clients. This allows you to get real-time continuous updates on the frontend without having to constantly refresh the page, or by using async javascript.
+Pode has support for creating WebSocket endpoints, for server-to-client and/or client-to-server communications. WebSockets allow you to broadcast messages directly from your server to connected clients. This allows you to get real-time continuous updates on the frontend without having to constantly refresh the page, or by using async javascript.
 
 ## Server Side
 

--- a/docs/Tutorials/WebSockets/External.md
+++ b/docs/Tutorials/WebSockets/External.md
@@ -1,10 +1,10 @@
 # External
 
-Pode has support to connect to external WebSocket servers, and be able to receive messages from then as well as send messages to them as well. This is useful if you want to connect to external metrics servers to update dashboards; send messages to external WebSockets; or even create a bot.
+Pode has support to connect to external WebSocket servers, and has the ability to receive and send messages to/from them. This is useful if you want to connect to external metrics servers to update dashboards; send messages to external WebSockets; or even create a bot.
 
 ## Connecting
 
-You can connect to an external WebSocket either in the main [`Start-PodeServer`] script, or adhoc in Routes, Timers, etc. If you opt to connect adhoc, then you'll need to pass `WebSockets` to `-EnablePool`:
+You can connect to an external WebSocket either in the main [`Start-PodeServer`](../../../Functions/Core/Start-PodeServer) script, or adhoc in Routes, Timers, etc. If you opt to connect adhoc, then you'll need to pass `WebSockets` to `-EnablePool`:
 
 ```powershell
 Start-PodeServer -EnablePool WebSockets {
@@ -12,7 +12,7 @@ Start-PodeServer -EnablePool WebSockets {
 }
 ```
 
-The function to use to connect to external WebSockets is [`Connect-PodeWebSocket`], this expects a `-Name`; `-Url`, and a `-ScriptBlock`. The scriptblock is what will be invoked when a message is recieved from the WebSocket server.
+The function to use to connect to external WebSockets is [`Connect-PodeWebSocket`](../../../Functions/WebSockets/Connect-PodeWebSocket), this expects a `-Name`, `-Url`, and a `-ScriptBlock`. The scriptblock is what will be invoked when a message is received from the WebSocket server.
 
 !!! important
     The `-Url` should begin with either `ws://` or `wss://`
@@ -25,21 +25,58 @@ Connect-PodeWebSocket -Name 'Example' -Url 'ws://localhost:8091' -ScriptBlock {
 }
 ```
 
-This will simply output the message recieved from the WebSocket to the terminal. You'll notice the `$WsEvent` variable; this works like `$WebEvent` and others, and will contain details about the current event - mostly just the Request object with available Body.
+This will simply output the message received from the WebSocket to the terminal. You'll notice the `$WsEvent` variable; this works like `$WebEvent` and others, and will contain details about the current event - mostly just the Request object and the Data received. By default the data received will be parsed from JSON, but you can customise this using the `-ContentType` parameter on [`Connect-PodeWebSocket`](../../../Functions/WebSockets/Connect-PodeWebSocket).
 
-When you're done with a WebSocket, you can optionally call [`Disconnect-PodeWebSocket`]. Or if at any point you need to reset a WebSocket connection, because the connection has/will expire then you can call [`Reset-PodeWebSocket`] - optionally with a new `-Url`.
+### Pre-Call
+
+Sometimes you might need to make a call to a REST API first to retrieve the WebSocket URL to connect. The best way to achieve this is to just make an `Invoke-RestMethod` call first, then pass the URL into [`Connect-PodeWebSocket`](../../../Functions/WebSockets/Connect-PodeWebSocket):
+
+```powershell
+$response = Invoke-RestMethod -Url 'https://example.com/websocket/get_url'
+
+Connect-PodeWebSocket -Name 'Example' -Url $response.url -ScriptBlock {
+    $WsEvent.Request | Out-Default
+}
+```
+
+### Disconnect
+
+When you're done with a WebSocket, you can optionally call [`Disconnect-PodeWebSocket`](../../../Functions/WebSockets/Disconnect-PodeWebSocket) to close the connection. This can be called from within the scriptblock of [`Connect-PodeWebSocket`](../../../Functions/WebSockets/Connect-PodeWebSocket), or by passing the `-Name` of the WebSocket to close directly.
+
+### Reconnect
+
+If at any point you need to reset a WebSocket connection, because the connection has/will expire and you have a new URL, then you can call [`Reset-PodeWebSocket`](../../../Functions/WebSockets/Reset-PodeWebSocket). If called without `-Url` then it will attempt to reconnect using the existing connection details, or it will attempt to reconnect but use the new URL instead.
+
+An example of this could be how Slack's Real Time Messaging works, where a new URL to connect to will be sent as a WebSocket message. You'll need to called [`Reset-PodeWebSocket`](../../../Functions/WebSockets/Reset-PodeWebSocket) using this new URL for the Slack connection to continue.
+
+Or, you might have to reset an existing connection on the same details because the connection dropped.
 
 ## Send Message
 
-You can also send messages back to a connected WebSocket by using [`Send-PodeWebSocket`]. This will need the `-Name` of the WebSocket to send the message, and naturally the `-Message` itself.
+You can also send messages back to a connected WebSocket by using [`Send-PodeWebSocket`](../../../Functions/WebSockets/Send-PodeWebSocket). This will need the `-Name` of the WebSocket to send the message, and naturally the `-Message` itself.
 
 For example, using the connect example above, we can extend this to send back a response instead of outputting to the terminal:
 
 ```powershell
 Connect-PodeWebSocket -Name 'Example' -Url 'ws://localhost:8091' -ScriptBlock {
-    Send-PodeWebSocket -Message (@{ message = $WsEvent.Request.Body } | ConvertTo-Json -Compress)
+    Send-PodeWebSocket -Message @{ message = $WsEvent.Request.Body }
 }
 ```
 
+If the `-Message` is a hashtable or a psobject then Pode will auto-convert these to JSON (unless a different `-ContentType` was supplied on [`Connect-PodeWebSocket`](../../../Functions/WebSockets/Connect-PodeWebSocket)). Or, you can supply a raw string message that will be used instead, with no auto-conversion.
+
 !!! tip
-    In the scope of `Connect-PodeWebSocket` you don't need to supply the `-Name` on `Send-PodeWebSocket`.
+    In the scope of [`Connect-PodeWebSocket`](../../../Functions/WebSockets/Connect-PodeWebSocket) you don't need to supply the `-Name` on [`Send-PodeWebSocket`](../../../Functions/WebSockets/Send-PodeWebSocket).
+
+## WebSocket Event
+
+When connecting to external WebSocket servers, the `$WsEvent` is a HashTable that is available for you to use - much like the `$WebEvent` object for normal routes.
+
+This `$WsEvent` object has the following properties:
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| Data | hashtable | Contains the message data received from the WebSocket |
+| Lockable | hashtable | A synchronized hashtable that can be used with `Lock-PodeObject` |
+| Request | object | The raw Request object |
+| Timestamp | datetime | The current date and time of the received data |

--- a/docs/Tutorials/WebSockets/External.md
+++ b/docs/Tutorials/WebSockets/External.md
@@ -1,0 +1,45 @@
+# External
+
+Pode has support to connect to external WebSocket servers, and be able to receive messages from then as well as send messages to them as well. This is useful if you want to connect to external metrics servers to update dashboards; send messages to external WebSockets; or even create a bot.
+
+## Connecting
+
+You can connect to an external WebSocket either in the main [`Start-PodeServer`] script, or adhoc in Routes, Timers, etc. If you opt to connect adhoc, then you'll need to pass `WebSockets` to `-EnablePool`:
+
+```powershell
+Start-PodeServer -EnablePool WebSockets {
+    # ...
+}
+```
+
+The function to use to connect to external WebSockets is [`Connect-PodeWebSocket`], this expects a `-Name`; `-Url`, and a `-ScriptBlock`. The scriptblock is what will be invoked when a message is recieved from the WebSocket server.
+
+!!! important
+    The `-Url` should begin with either `ws://` or `wss://`
+
+For example, if you have a WebSocket server running at `ws://localhost:8091` (like the [web-signal.ps1](https://github.com/Badgerati/Pode/blob/develop/examples/web-signal.ps1) example) then you can connect to it like below:
+
+```powershell
+Connect-PodeWebSocket -Name 'Example' -Url 'ws://localhost:8091' -ScriptBlock {
+    $WsEvent.Request | Out-Default
+}
+```
+
+This will simply output the message recieved from the WebSocket to the terminal. You'll notice the `$WsEvent` variable; this works like `$WebEvent` and others, and will contain details about the current event - mostly just the Request object with available Body.
+
+When you're done with a WebSocket, you can optionally call [`Disconnect-PodeWebSocket`]. Or if at any point you need to reset a WebSocket connection, because the connection has/will expire then you can call [`Reset-PodeWebSocket`] - optionally with a new `-Url`.
+
+## Send Message
+
+You can also send messages back to a connected WebSocket by using [`Send-PodeWebSocket`]. This will need the `-Name` of the WebSocket to send the message, and naturally the `-Message` itself.
+
+For example, using the connect example above, we can extend this to send back a response instead of outputting to the terminal:
+
+```powershell
+Connect-PodeWebSocket -Name 'Example' -Url 'ws://localhost:8091' -ScriptBlock {
+    Send-PodeWebSocket -Message (@{ message = $WsEvent.Request.Body } | ConvertTo-Json -Compress)
+}
+```
+
+!!! tip
+    In the scope of `Connect-PodeWebSocket` you don't need to supply the `-Name` on `Send-PodeWebSocket`.

--- a/examples/public/scripts/websockets.js
+++ b/examples/public/scripts/websockets.js
@@ -4,14 +4,15 @@ $(document).ready(() => {
 
     // event for inbound messages to append them
     ws.onmessage = function(evt) {
-        //var data = JSON.parse(evt.data)
-        console.log(evt.data);
-        $('#messages').append(`<p>${evt.data}</p>`);
+        var data = JSON.parse(evt.data)
+        console.log(data);
+        $('#messages').append(`<p>${data.message}</p>`);
     }
 
     // send message on the socket, to all clients
     $('#bc-form').submit(function(e) {
         e.preventDefault();
+        console.log(`send: ${$('#bc-message').val()}`);
         ws.send(JSON.stringify({ message: $('#bc-message').val() }));
         $('input[name=message]').val('');
     })

--- a/examples/web-signal-connection.ps1
+++ b/examples/web-signal-connection.ps1
@@ -15,10 +15,10 @@ Start-PodeServer -EnablePool WebSockets {
 
     # connect to web socket from web-signal.ps1
     Connect-PodeWebSocket -Name 'Example' -Url 'ws://localhost:8091' -ScriptBlock {
-        $WsEvent.Request | out-default
-        # if ($WsEvent.Request.Body -inotlike '*Ex:*') {
-        #     Send-PodeWebSocket -Message (@{ message = "Ex: $($WsEvent.Request.Body)" } | ConvertTo-Json -Compress)
-        # }
+        $WsEvent.Data | Out-Default
+        if ($WsEvent.Data.message -inotlike '*Ex:*') {
+            Send-PodeWebSocket -Message @{ message = "Ex: $($WsEvent.Data.message)" }
+        }
     }
 
     # Add-PodeRoute -Method Get -Path '/connect' -ScriptBlock {

--- a/examples/web-signal-connection.ps1
+++ b/examples/web-signal-connection.ps1
@@ -1,0 +1,49 @@
+param($token)
+
+$path = Split-Path -Parent -Path (Split-Path -Parent -Path $MyInvocation.MyCommand.Path)
+Import-Module "$($path)/src/Pode.psm1" -Force -ErrorAction Stop
+
+# or just:
+# Import-Module Pode
+
+# create a server, and start listening
+Start-PodeServer {
+
+    # listen
+    Add-PodeEndpoint -Address * -Port 8092 -Protocol Http
+
+    # log requests to the terminal
+    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging -Level Error, Debug, Verbose
+
+    # connect to web socket from web-signal.ps1
+    # Connect-PodeWebSocket -Name 'Example' -Url 'ws://localhost:8091' -ScriptBlock {
+    #     $WsEvent.Request | out-default
+    #     if ($WsEvent.Request.Body -inotlike '*Ex:*') {
+    #         Send-PodeWebSocket -Message (@{ message = "Ex: $($WsEvent.Request.Body)" } | ConvertTo-Json -Compress)
+    #     }
+    # }
+
+    $slack = Invoke-RestMethod -Method Post -Uri 'https://slack.com/api/apps.connections.open' -Headers @{ Authorization = "Bearer $token" }
+    Connect-PodeWebSocket -Name 'Slack' -Url $slack.url -ScriptBlock {
+        # $WsEvent.Request.Body | out-default
+
+        $msg = $WsEvent.Request.Body | ConvertFrom-Json -AsHashtable
+        $msg | out-default
+        switch ($msg.type) {
+            'disconnect' {
+                Disconnect-PodeWebSocket
+            }
+
+            'events_api' {
+                Send-PodeWebSocket -Message (@{
+                    envelope_id = $msg.envelope_id
+                } | ConvertTo-Json -Compress) # acknowledge
+
+            }
+        }
+    }
+
+    # Add-PodeRoute -Method Get -Path '/reset' -ScriptBlock {
+    #     Reset-PodeWebSocket -Name 'Example'
+    # }
+}

--- a/examples/web-signal-connection.ps1
+++ b/examples/web-signal-connection.ps1
@@ -14,23 +14,23 @@ Start-PodeServer -EnablePool WebSockets {
     New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging -Level Error, Debug, Verbose
 
     # connect to web socket from web-signal.ps1
-    # Connect-PodeWebSocket -Name 'Example' -Url 'ws://localhost:8091' -ScriptBlock {
-    #     $WsEvent.Request | out-default
-    #     if ($WsEvent.Request.Body -inotlike '*Ex:*') {
-    #         Send-PodeWebSocket -Message (@{ message = "Ex: $($WsEvent.Request.Body)" } | ConvertTo-Json -Compress)
+    Connect-PodeWebSocket -Name 'Example' -Url 'ws://localhost:8091' -ScriptBlock {
+        $WsEvent.Request | out-default
+        # if ($WsEvent.Request.Body -inotlike '*Ex:*') {
+        #     Send-PodeWebSocket -Message (@{ message = "Ex: $($WsEvent.Request.Body)" } | ConvertTo-Json -Compress)
+        # }
+    }
+
+    # Add-PodeRoute -Method Get -Path '/connect' -ScriptBlock {
+    #     Connect-PodeWebSocket -Name 'Test' -Url 'wss://ws.ifelse.io/' -ScriptBlock {
+    #         $WsEvent.Request | out-default
     #     }
     # }
 
-    Add-PodeRoute -Method Get -Path '/connect' -ScriptBlock {
-        Connect-PodeWebSocket -Name 'Test' -Url 'wss://ws.ifelse.io/' -ScriptBlock {
-            $WsEvent.Request | out-default
-        }
-    }
-
-    Add-PodeTimer -Name 'Test' -Interval 10 -ScriptBlock {
-        $rand = Get-Random -Minimum 10 -Maximum 1000
-        Send-PodeWebSocket -Name 'Test' -Message "hello $rand"
-    }
+    # Add-PodeTimer -Name 'Test' -Interval 10 -ScriptBlock {
+    #     $rand = Get-Random -Minimum 10 -Maximum 1000
+    #     Send-PodeWebSocket -Name 'Test' -Message "hello $rand"
+    # }
 
     # Add-PodeRoute -Method Get -Path '/reset' -ScriptBlock {
     #     Reset-PodeWebSocket -Name 'Example'

--- a/examples/web-signal.ps1
+++ b/examples/web-signal.ps1
@@ -32,6 +32,6 @@ Start-PodeServer -Threads 3 {
             $msg = [datetime]::Now.ToString()
         }
 
-        Send-PodeSignal -Value $msg
+        Send-PodeSignal -Value @{ message = $msg }
     }
 }

--- a/pode.build.ps1
+++ b/pode.build.ps1
@@ -193,10 +193,24 @@ task Build BuildDeps, {
 
     try {
         dotnet build --configuration Release --self-contained --framework netstandard2.0
+        if (!$?) {
+            throw "dotnet build failed for netstandard2"
+        }
+
         dotnet publish --configuration Release --self-contained --framework netstandard2.0 --output ../Libs/netstandard2.0
+        if (!$?) {
+            throw "dotnet publish failed for netstandard2"
+        }
 
         dotnet build --configuration Release --self-contained --framework net6.0
+        if (!$?) {
+            throw "dotnet build failed for net6"
+        }
+
         dotnet publish --configuration Release --self-contained --framework net6.0 --output ../Libs/net6.0
+        if (!$?) {
+            throw "dotnet publish failed for net6"
+        }
     }
     finally {
         Pop-Location

--- a/src/Listener/PodeClientSignal.cs
+++ b/src/Listener/PodeClientSignal.cs
@@ -4,14 +4,14 @@ namespace Pode
 {
     public class PodeClientSignal : IDisposable
     {
-        public PodeWebSocket WebSocket { get; private set; }
+        public PodeSignal Signal { get; private set; }
         public string Message { get; private set; }
         public DateTime Timestamp { get; private set; }
         public PodeListener Listener { get; private set; }
 
-        public PodeClientSignal(PodeWebSocket webSocket, string message, PodeListener listener)
+        public PodeClientSignal(PodeSignal signal, string message, PodeListener listener)
         {
-            WebSocket = webSocket;
+            Signal = signal;
             Message = message;
             Timestamp = DateTime.UtcNow;
             Listener = listener;

--- a/src/Listener/PodeConnector.cs
+++ b/src/Listener/PodeConnector.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Linq;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Pode
+{
+    public class PodeConnector : IDisposable
+    {
+        public bool IsConnected { get; private set; }
+        public bool IsDisposed { get; private set; }
+        public bool ErrorLoggingEnabled { get; set; }
+        public string[] ErrorLoggingLevels { get; set; }
+        public CancellationToken CancellationToken { get; private set; }
+
+        public PodeConnector(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            CancellationToken = cancellationToken == default(CancellationToken)
+                ? cancellationToken
+                : (new CancellationTokenSource()).Token;
+
+            // IsConnected = true;
+            IsDisposed = false;
+        }
+
+        public virtual void Start()
+        {
+            IsConnected = true;
+        }
+
+        protected virtual void Close()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Dispose()
+        {
+            // stop connecting
+            IsConnected = false;
+
+            // close
+            Close();
+
+            // disposed
+            IsDisposed = true;
+        }
+    }
+}

--- a/src/Listener/PodeContext.cs
+++ b/src/Listener/PodeContext.cs
@@ -49,7 +49,7 @@ namespace Pode
 
         public bool IsWebSocketUpgraded
         {
-            get => (IsWebSocket && Request is PodeWsRequest);
+            get => (IsWebSocket && Request is PodeSignalRequest);
         }
 
         public new bool IsSmtp
@@ -72,9 +72,9 @@ namespace Pode
             get => (PodeHttpRequest)Request;
         }
 
-        public PodeWsRequest WsRequest
+        public PodeSignalRequest SignalRequest
         {
-            get => (PodeWsRequest)Request;
+            get => (PodeSignalRequest)Request;
         }
 
         public bool IsKeepAlive
@@ -302,7 +302,7 @@ namespace Pode
 
         public void UpgradeWebSocket(string clientId = null)
         {
-            PodeHelpers.WriteErrorMessage($"Uprading Websocket", Listener, PodeLoggingLevel.Verbose, this);
+            PodeHelpers.WriteErrorMessage($"Upgrading Websocket", Listener, PodeLoggingLevel.Verbose, this);
 
             // websocket
             if (!IsWebSocket)
@@ -342,12 +342,9 @@ namespace Pode
             Response.Send();
 
             // add open web socket to listener
-            var webSocket = new PodeWebSocket(this, HttpRequest.Url.AbsolutePath, clientId);
-
-            var wsRequest = new PodeWsRequest(HttpRequest, webSocket);
-            Request = wsRequest;
-
-            Listener.AddWebSocket(WsRequest.WebSocket);
+            var signal = new PodeSignal(this, HttpRequest.Url.AbsolutePath, clientId);
+            Request = new PodeSignalRequest(HttpRequest, signal);
+            Listener.AddSignal(SignalRequest.Signal);
             PodeHelpers.WriteErrorMessage($"Websocket upgraded", Listener, PodeLoggingLevel.Verbose, this);
         }
 

--- a/src/Listener/PodeContext.cs
+++ b/src/Listener/PodeContext.cs
@@ -403,7 +403,7 @@ namespace Pode
                     }
 
                     // if it was smtp, and it was processable, RESET!
-                    if (IsSmtp && SmtpRequest.CanProcess)
+                    if (IsSmtp && Request.IsProcessable)
                     {
                         SmtpRequest.Reset();
                     }

--- a/src/Listener/PodeHelpers.cs
+++ b/src/Listener/PodeHelpers.cs
@@ -3,12 +3,13 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
+using System.Reflection;
+using System.Runtime.Versioning;
 
 namespace Pode
 {
     public class PodeHelpers
     {
-
         public static readonly string[] HTTP_METHODS = new string[] { "DELETE", "GET", "HEAD", "MERGE", "OPTIONS", "PATCH", "POST", "PUT", "TRACE" };
         public const string WEB_SOCKET_MAGIC_KEY = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
         public readonly static char[] NEW_LINE_ARRAY = new char[] { '\r', '\n' };
@@ -19,7 +20,23 @@ namespace Pode
         public const byte CARRIAGE_RETURN_BYTE = 13;
         public const byte DASH_BYTE = 45;
 
-        public static void WriteException(Exception ex, PodeListener listener = default(PodeListener), PodeLoggingLevel level = PodeLoggingLevel.Error)
+        private static string _dotnet_version = string.Empty;
+        private static bool _is_net_framework = false;
+        public static bool IsNetFramework
+        {
+            get
+            {
+                if (String.IsNullOrWhiteSpace(_dotnet_version))
+                {
+                    _dotnet_version = Assembly.GetEntryAssembly()?.GetCustomAttribute<TargetFrameworkAttribute>()?.FrameworkName ?? "Framework";
+                    _is_net_framework = _dotnet_version.Equals("Framework", StringComparison.InvariantCultureIgnoreCase);
+                }
+
+                return _is_net_framework;
+            }
+        }
+
+        public static void WriteException(Exception ex, PodeConnector connector = default(PodeConnector), PodeLoggingLevel level = PodeLoggingLevel.Error)
         {
             if (ex == default(Exception))
             {
@@ -27,7 +44,7 @@ namespace Pode
             }
 
             // return if logging disabled, or if level isn't being logged
-            if (listener != default(PodeListener) && (!listener.ErrorLoggingEnabled || !listener.ErrorLoggingLevels.Contains(level.ToString(), StringComparer.InvariantCultureIgnoreCase)))
+            if (connector != default(PodeConnector) && (!connector.ErrorLoggingEnabled || !connector.ErrorLoggingLevels.Contains(level.ToString(), StringComparer.InvariantCultureIgnoreCase)))
             {
                 return;
             }
@@ -43,7 +60,7 @@ namespace Pode
             }
         }
 
-        public static void HandleAggregateException(AggregateException aex, PodeListener listener = default(PodeListener), PodeLoggingLevel level = PodeLoggingLevel.Error, bool handled = false)
+        public static void HandleAggregateException(AggregateException aex, PodeConnector connector = default(PodeConnector), PodeLoggingLevel level = PodeLoggingLevel.Error, bool handled = false)
         {
             try
             {
@@ -54,7 +71,7 @@ namespace Pode
                         return true;
                     }
 
-                    PodeHelpers.WriteException(ex, listener, level);
+                    PodeHelpers.WriteException(ex, connector, level);
                     return false;
                 });
             }
@@ -67,7 +84,7 @@ namespace Pode
             }
         }
 
-        public static void WriteErrorMessage(string message, PodeListener listener = default(PodeListener), PodeLoggingLevel level = PodeLoggingLevel.Error, PodeContext context = default(PodeContext))
+        public static void WriteErrorMessage(string message, PodeConnector connector = default(PodeConnector), PodeLoggingLevel level = PodeLoggingLevel.Error, PodeContext context = default(PodeContext))
         {
             // do nothing if no message
             if (string.IsNullOrWhiteSpace(message))
@@ -76,7 +93,7 @@ namespace Pode
             }
 
             // return if logging disabled, or if level isn't being logged
-            if (listener != default(PodeListener) && (!listener.ErrorLoggingEnabled || !listener.ErrorLoggingLevels.Contains(level.ToString(), StringComparer.InvariantCultureIgnoreCase)))
+            if (connector != default(PodeConnector) && (!connector.ErrorLoggingEnabled || !connector.ErrorLoggingLevels.Contains(level.ToString(), StringComparer.InvariantCultureIgnoreCase)))
             {
                 return;
             }

--- a/src/Listener/PodeHttpRequest.cs
+++ b/src/Listener/PodeHttpRequest.cs
@@ -54,6 +54,11 @@ namespace Pode
                 || (IsWebSocket && !HttpMethod.Equals("GET", StringComparison.InvariantCultureIgnoreCase)));
         }
 
+        public override bool IsProcessable
+        {
+            get => (!CloseImmediately && !AwaitingBody);
+        }
+
         public PodeHttpRequest(Socket socket, PodeSocket podeSocket)
             : base(socket, podeSocket)
         {

--- a/src/Listener/PodeItemQueue.cs
+++ b/src/Listener/PodeItemQueue.cs
@@ -1,0 +1,71 @@
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Pode
+{
+    public class PodeItemQueue<T>
+    {
+        private BlockingCollection<T> Items;
+        private List<T> ProcessingItems;
+
+        public int Count { get => Items.Count + ProcessingItems.Count; }
+        public int QueuedCount { get => Items.Count; }
+        public int ProcessingCount { get => ProcessingItems.Count; }
+
+        public PodeItemQueue()
+        {
+            Items = new BlockingCollection<T>();
+            ProcessingItems = new List<T>();
+        }
+
+        public T Get(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var item = (cancellationToken == default(CancellationToken)
+                ? Items.Take()
+                : Items.Take(cancellationToken));
+
+            lock (ProcessingItems)
+            {
+                ProcessingItems.Add(item);
+            }
+
+            return item;
+        }
+
+        public Task<T> GetAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return (cancellationToken == default(CancellationToken)
+                ? Task.Factory.StartNew(() => Get())
+                : Task.Factory.StartNew(() => Get(cancellationToken), cancellationToken));
+        }
+
+        public void Add(T item)
+        {
+            lock (Items)
+            {
+                Items.Add(item);
+            }
+        }
+
+        public void RemoveProcessing(T item)
+        {
+            lock (ProcessingItems)
+            {
+                ProcessingItems.Remove(item);
+            }
+        }
+
+        public T[] ToArray()
+        {
+            return Items.ToArray();
+        }
+
+        public void Clear()
+        {
+            Items = new BlockingCollection<T>();
+            ProcessingItems = new List<T>();
+        }
+    }
+}

--- a/src/Listener/PodeListener.cs
+++ b/src/Listener/PodeListener.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Linq;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -9,7 +8,7 @@ namespace Pode
 {
     public class PodeListener : IDisposable
     {
-        public IDictionary<string, PodeWebSocket> WebSockets { get; private set; }
+        public IDictionary<string, PodeSignal> Signals { get; private set; }
         public bool IsListening { get; private set; }
         public bool IsDisposed { get; private set; }
         public bool ErrorLoggingEnabled { get; set; }
@@ -18,9 +17,9 @@ namespace Pode
 
         private IList<PodeSocket> Sockets;
 
-        public PodeListenerQueue<PodeContext> Contexts { get; private set; }
-        public PodeListenerQueue<PodeServerSignal> ServerSignals { get; private set; }
-        public PodeListenerQueue<PodeClientSignal> ClientSignals { get; private set; }
+        public PodeItemQueue<PodeContext> Contexts { get; private set; }
+        public PodeItemQueue<PodeServerSignal> ServerSignals { get; private set; }
+        public PodeItemQueue<PodeClientSignal> ClientSignals { get; private set; }
 
         private int _requestTimeout = 30;
         public int RequestTimeout
@@ -51,11 +50,11 @@ namespace Pode
             IsDisposed = false;
 
             Sockets = new List<PodeSocket>();
-            WebSockets = new Dictionary<string, PodeWebSocket>();
+            Signals = new Dictionary<string, PodeSignal>();
 
-            Contexts = new PodeListenerQueue<PodeContext>();
-            ServerSignals = new PodeListenerQueue<PodeServerSignal>();
-            ClientSignals = new PodeListenerQueue<PodeClientSignal>();
+            Contexts = new PodeItemQueue<PodeContext>();
+            ServerSignals = new PodeItemQueue<PodeServerSignal>();
+            ClientSignals = new PodeItemQueue<PodeClientSignal>();
         }
 
         public void Add(PodeSocket socket)
@@ -97,17 +96,17 @@ namespace Pode
             Contexts.RemoveProcessing(context);
         }
 
-        public void AddWebSocket(PodeWebSocket webSocket)
+        public void AddSignal(PodeSignal signal)
         {
-            lock (WebSockets)
+            lock (Signals)
             {
-                if (WebSockets.ContainsKey(webSocket.ClientId))
+                if (Signals.ContainsKey(signal.ClientId))
                 {
-                    WebSockets[webSocket.ClientId] = webSocket;
+                    Signals[signal.ClientId] = signal;
                 }
                 else
                 {
-                    WebSockets.Add(webSocket.ClientId, webSocket);
+                    Signals.Add(signal.ClientId, signal);
                 }
             }
         }
@@ -182,72 +181,18 @@ namespace Pode
                 _context.Dispose(true);
             }
 
-            // close connected web sockets
-            foreach (var _socket in WebSockets.Values)
+            Contexts.Clear();
+
+            // close connected signals
+            foreach (var _signal in Signals.Values)
             {
-                _socket.Context.Dispose(true);
+                _signal.Context.Dispose(true);
             }
+
+            Signals.Clear();
 
             // disposed
             IsDisposed = true;
-        }
-    }
-
-    public class PodeListenerQueue<T>
-    {
-        private BlockingCollection<T> Items;
-        private List<T> ProcessingItems;
-
-        public int Count { get => Items.Count + ProcessingItems.Count; }
-        public int QueuedCount { get => Items.Count; }
-        public int ProcessingCount { get => ProcessingItems.Count; }
-
-        public PodeListenerQueue()
-        {
-            Items = new BlockingCollection<T>();
-            ProcessingItems = new List<T>();
-        }
-
-        public T Get(CancellationToken cancellationToken = default(CancellationToken))
-        {
-            var item = (cancellationToken == default(CancellationToken)
-                ? Items.Take()
-                : Items.Take(cancellationToken));
-
-            lock (ProcessingItems)
-            {
-                ProcessingItems.Add(item);
-            }
-
-            return item;
-        }
-
-        public Task<T> GetAsync(CancellationToken cancellationToken = default(CancellationToken))
-        {
-            return (cancellationToken == default(CancellationToken)
-                ? Task.Factory.StartNew(() => Get())
-                : Task.Factory.StartNew(() => Get(cancellationToken), cancellationToken));
-        }
-
-        public void Add(T item)
-        {
-            lock (Items)
-            {
-                Items.Add(item);
-            }
-        }
-
-        public void RemoveProcessing(T item)
-        {
-            lock (ProcessingItems)
-            {
-                ProcessingItems.Remove(item);
-            }
-        }
-
-        public T[] ToArray()
-        {
-            return Items.ToArray();
         }
     }
 }

--- a/src/Listener/PodeReceiver.cs
+++ b/src/Listener/PodeReceiver.cs
@@ -63,6 +63,19 @@ namespace Pode
                 }
 
                 WebSockets[name].Dispose();
+            }
+        }
+
+        public void RemoveWebSocket(string name)
+        {
+            lock (WebSockets)
+            {
+                if (!WebSockets.ContainsKey(name))
+                {
+                    return;
+                }
+
+                WebSockets[name].Dispose();
                 WebSockets.Remove(name);
             }
         }

--- a/src/Listener/PodeReceiver.cs
+++ b/src/Listener/PodeReceiver.cs
@@ -27,8 +27,6 @@ namespace Pode
 
             WebSockets = new Dictionary<string, PodeWebSocket>();
             Requests = new PodeItemQueue<PodeWebSocketRequest>();
-            //TODO: change to PodeReceiverRequest? or PodeReceiverContext?
-            //TODO: rename PodeContext to PodeListenerContext?
 
             IsReceiving = true;
             IsDisposed = false;

--- a/src/Listener/PodeReceiver.cs
+++ b/src/Listener/PodeReceiver.cs
@@ -52,7 +52,7 @@ namespace Pode
 
         public PodeWebSocket GetWebSocket(string name)
         {
-            return WebSockets[name];
+            return (WebSockets.ContainsKey(name) ? WebSockets[name] : default(PodeWebSocket));
         }
 
         public void DisconnectWebSocket(string name)

--- a/src/Listener/PodeReceiver.cs
+++ b/src/Listener/PodeReceiver.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Linq;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Pode
+{
+    public class PodeReceiver : IDisposable
+    {
+        public bool IsReceiving { get; private set; }
+        public bool IsDisposed { get; private set; }
+        public bool ErrorLoggingEnabled { get; set; }
+        public string[] ErrorLoggingLevels { get; set; }
+        public CancellationToken CancellationToken { get; private set; }
+
+        private IDictionary<string, PodeWebSocket> WebSockets;
+
+        public PodeItemQueue<PodeWebSocketRequest> Requests { get; private set; }
+
+        public PodeReceiver(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            CancellationToken = cancellationToken == default(CancellationToken)
+                ? cancellationToken
+                : (new CancellationTokenSource()).Token;
+
+            WebSockets = new Dictionary<string, PodeWebSocket>();
+            Requests = new PodeItemQueue<PodeWebSocketRequest>();
+            //TODO: change to PodeReceiverRequest? or PodeReceiverContext?
+            //TODO: rename PodeContext to PodeListenerContext?
+
+            IsReceiving = true;
+            IsDisposed = false;
+        }
+
+        public void ConnectWebSocket(string name, string url)
+        {
+            lock (WebSockets)
+            {
+                if (WebSockets.ContainsKey(name))
+                {
+                    throw new Exception($"WebSocket connection with name {name} already defined");
+                }
+
+                var socket = new PodeWebSocket(name, url);
+                socket.BindReceiver(this);
+                socket.Connect();
+                WebSockets.Add(name, socket);
+            }
+        }
+
+        public PodeWebSocket GetWebSocket(string name)
+        {
+            return WebSockets[name];
+        }
+
+        public void DisconnectWebSocket(string name)
+        {
+            lock (WebSockets)
+            {
+                if (!WebSockets.ContainsKey(name))
+                {
+                    return;
+                }
+
+                WebSockets[name].Dispose();
+                WebSockets.Remove(name);
+            }
+        }
+
+        public void AddWebSocketRequest(PodeWebSocketRequest request)
+        {
+            Requests.Add(request);
+        }
+
+        public PodeWebSocketRequest GetWebSocketRequest(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return Requests.Get(cancellationToken);
+        }
+
+        public Task<PodeWebSocketRequest> GetWebSocketRequestAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return Requests.GetAsync(cancellationToken);
+        }
+
+        public void Dispose()
+        {
+            // stop receiving
+            IsReceiving = false;
+
+            // disconnect websockets
+            foreach (var _webSocket in WebSockets.Values)
+            {
+                _webSocket.Dispose();
+            }
+
+            WebSockets.Clear();
+
+            // close existing websocket requests
+            foreach (var _req in Requests.ToArray())
+            {
+                _req.Dispose();
+            }
+
+            Requests.Clear();
+
+            // disposed
+            IsDisposed = true;
+        }
+    }
+}

--- a/src/Listener/PodeReceiver.cs
+++ b/src/Listener/PodeReceiver.cs
@@ -21,7 +21,7 @@ namespace Pode
             Start();
         }
 
-        public void ConnectWebSocket(string name, string url)
+        public void ConnectWebSocket(string name, string url, string contentType)
         {
             lock (WebSockets)
             {
@@ -30,7 +30,7 @@ namespace Pode
                     throw new Exception($"WebSocket connection with name {name} already defined");
                 }
 
-                var socket = new PodeWebSocket(name, url);
+                var socket = new PodeWebSocket(name, url, contentType);
                 socket.BindReceiver(this);
                 socket.Connect();
                 WebSockets.Add(name, socket);

--- a/src/Listener/PodeRequest.cs
+++ b/src/Listener/PodeRequest.cs
@@ -173,6 +173,7 @@ namespace Pode
             finally
             {
                 BufferStream.Dispose();
+                BufferStream = default(MemoryStream);
                 Buffer = default(byte[]);
             }
 
@@ -206,6 +207,7 @@ namespace Pode
             finally
             {
                 bufferStream.Dispose();
+                bufferStream = default(MemoryStream);
                 buffer = default(byte[]);
             }
         }
@@ -274,11 +276,13 @@ namespace Pode
             if (InputStream != default(Stream))
             {
                 InputStream.Dispose();
+                InputStream = default(Stream);
             }
 
             if (BufferStream != default(MemoryStream))
             {
                 BufferStream.Dispose();
+                BufferStream = default(MemoryStream);
             }
 
             PodeHelpers.WriteErrorMessage($"Request disposed", Context.Listener, PodeLoggingLevel.Verbose, Context);

--- a/src/Listener/PodeRequest.cs
+++ b/src/Listener/PodeRequest.cs
@@ -20,6 +20,7 @@ namespace Pode
         public bool SslUpgraded { get; private set; }
         public bool IsKeepAlive { get; protected set; }
         public virtual bool CloseImmediately { get => false; }
+        public virtual bool IsProcessable { get => true; }
 
         public Stream InputStream { get; private set; }
         public X509Certificate Certificate { get; private set; }

--- a/src/Listener/PodeResponse.cs
+++ b/src/Listener/PodeResponse.cs
@@ -182,7 +182,10 @@ namespace Pode
 
         public void SendSignal(PodeServerSignal signal)
         {
-            Write(signal.Value);
+            if (!string.IsNullOrEmpty(signal.Value))
+            {
+                Write(signal.Value);
+            }
         }
 
         public void Write(string message, bool flush = false)
@@ -274,10 +277,17 @@ namespace Pode
 
         private void SetDefaultHeaders()
         {
-            // ensure content length
-            if (ContentLength64 == 0)
+            // ensure content length (remove for 1xx responses, ensure added otherwise)
+            if (StatusCode < 200)
             {
-                ContentLength64 = (OutputStream.Length > 0 ? OutputStream.Length : 0);
+                Headers.Remove("Content-Length");
+            }
+            else
+            {
+                if (ContentLength64 == 0)
+                {
+                    ContentLength64 = (OutputStream.Length > 0 ? OutputStream.Length : 0);
+                }
             }
 
             // set the date

--- a/src/Listener/PodeResponse.cs
+++ b/src/Listener/PodeResponse.cs
@@ -353,6 +353,7 @@ namespace Pode
             if (OutputStream != default(MemoryStream))
             {
                 OutputStream.Dispose();
+                OutputStream = default(MemoryStream);
             }
 
             PodeHelpers.WriteErrorMessage($"Response disposed", Context.Listener, PodeLoggingLevel.Verbose, Context);

--- a/src/Listener/PodeSignal.cs
+++ b/src/Listener/PodeSignal.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace Pode
+{
+    public class PodeSignal
+    {
+        public PodeContext Context { get; private set; }
+        public string Path { get; private set; }
+        public string ClientId { get; private set; }
+        public DateTime Timestamp { get; private set; }
+
+        public PodeSignal(PodeContext context, string path, string clientId)
+        {
+            Context = context;
+            Path = path;
+            ClientId = clientId;
+            Timestamp = DateTime.UtcNow;
+        }
+    }
+}

--- a/src/Listener/PodeSignalRequest.cs
+++ b/src/Listener/PodeSignalRequest.cs
@@ -3,12 +3,12 @@ using System.Net.WebSockets;
 
 namespace Pode
 {
-    public class PodeWsRequest : PodeRequest
+    public class PodeSignalRequest : PodeRequest
     {
         public PodeWsOpCode OpCode { get; private set; }
         public string Body { get; private set; }
         public byte[] RawBody { get; private set; }
-        public PodeWebSocket WebSocket { get; private set; }
+        public PodeSignal Signal { get; private set; }
         public Uri Url { get; private set; }
         public string Host { get; private set; }
         public int ContentLength { get; private set; }
@@ -30,10 +30,10 @@ namespace Pode
             get => (OpCode == PodeWsOpCode.Close);
         }
 
-        public PodeWsRequest(PodeHttpRequest request, PodeWebSocket webSocket)
+        public PodeSignalRequest(PodeHttpRequest request, PodeSignal signal)
             : base(request)
         {
-            WebSocket = webSocket;
+            Signal = signal;
             IsKeepAlive = true;
             Type = PodeProtocolType.Ws;
 
@@ -44,7 +44,7 @@ namespace Pode
 
         public PodeClientSignal NewClientSignal()
         {
-            return new PodeClientSignal(WebSocket, Body, Context.Listener);
+            return new PodeClientSignal(Signal, Body, Context.Listener);
         }
 
         protected override bool Parse(byte[] bytes)
@@ -128,7 +128,7 @@ namespace Pode
             }
 
             // remove client, and dispose
-            Context.Listener.WebSockets.Remove(WebSocket.ClientId);
+            Context.Listener.Signals.Remove(Signal.ClientId);
             base.Dispose();
         }
 

--- a/src/Listener/PodeSocket.cs
+++ b/src/Listener/PodeSocket.cs
@@ -165,7 +165,7 @@ namespace Pode
             socket.Start();
 
             // close socket if not successful, or if listener is stopped - close now!
-            if ((accepted == default(Socket)) || (error != SocketError.Success) || (!Listener.IsListening))
+            if ((accepted == default(Socket)) || (error != SocketError.Success) || (!Listener.IsConnected))
             {
                 if (error != SocketError.Success)
                 {
@@ -202,7 +202,7 @@ namespace Pode
             RemovePendingSocket(received);
 
             // close socket if not successful, or if listener is stopped - close now!
-            if ((received == default(Socket)) || (error != SocketError.Success) || (!Listener.IsListening))
+            if ((received == default(Socket)) || (error != SocketError.Success) || (!Listener.IsConnected))
             {
                 if (error != SocketError.Success)
                 {

--- a/src/Listener/PodeSocket.cs
+++ b/src/Listener/PodeSocket.cs
@@ -261,17 +261,25 @@ namespace Pode
                 }
 
                 // if it's a websocket, upgrade it, then add context back for re-receiving
-                else if (context.IsWebSocket && !context.IsWebSocketUpgraded)
+                else if (context.IsWebSocket)
                 {
-                    context.UpgradeWebSocket();
-                    process = false;
-                    context.Dispose();
+                    if (!context.IsWebSocketUpgraded)
+                    {
+                        context.UpgradeWebSocket();
+                        process = false;
+                        context.Dispose();
+                    }
+                    else if (!context.Request.IsProcessable)
+                    {
+                        process = false;
+                        context.Dispose();
+                    }
                 }
 
                 // if it's an email, re-receive unless processable
                 else if (context.IsSmtp)
                 {
-                    if (!context.SmtpRequest.CanProcess)
+                    if (!context.Request.IsProcessable)
                     {
                         process = false;
                         context.Dispose();

--- a/src/Listener/PodeSocket.cs
+++ b/src/Listener/PodeSocket.cs
@@ -294,7 +294,7 @@ namespace Pode
                     if (context.IsWebSocket)
                     {
                         PodeHelpers.WriteErrorMessage($"Received client signal", Listener, PodeLoggingLevel.Verbose, context);
-                        Listener.AddClientSignal(context.WsRequest.NewClientSignal());
+                        Listener.AddClientSignal(context.SignalRequest.NewClientSignal());
                         context.Dispose();
                     }
                     else
@@ -428,6 +428,7 @@ namespace Pode
             // dispose
             socket.Close();
             socket.Dispose();
+            socket = default(Socket);
         }
 
         private void ClearSocketAsyncEvent(SocketAsyncEventArgs e)

--- a/src/Listener/PodeWebSocket.cs
+++ b/src/Listener/PodeWebSocket.cs
@@ -106,7 +106,7 @@ namespace Pode
 
         public void Send(string message, WebSocketMessageType type = WebSocketMessageType.Text)
         {
-            if (WebSocket.State != WebSocketState.Open)
+            if (!IsConnected)
             {
                 return;
             }

--- a/src/Listener/PodeWebSocket.cs
+++ b/src/Listener/PodeWebSocket.cs
@@ -108,7 +108,7 @@ namespace Pode
             catch (TaskCanceledException) {}
             catch (WebSocketException ex)
             {
-                PodeHelpers.WriteException(ex, Receiver, PodeLoggingLevel.Error);
+                PodeHelpers.WriteException(ex, Receiver, PodeLoggingLevel.Debug);
                 Dispose();
             }
             finally

--- a/src/Listener/PodeWebSocket.cs
+++ b/src/Listener/PodeWebSocket.cs
@@ -104,14 +104,14 @@ namespace Pode
             }
         }
 
-        public void Send(string message)
+        public void Send(string message, WebSocketMessageType type = WebSocketMessageType.Text)
         {
             if (WebSocket.State != WebSocketState.Open)
             {
                 return;
             }
 
-            WebSocket.SendAsync(new ArraySegment<byte>(Encoding.UTF8.GetBytes(message)), WebSocketMessageType.Binary, true, Receiver.CancellationToken).Wait();
+            WebSocket.SendAsync(new ArraySegment<byte>(Encoding.UTF8.GetBytes(message)), type, true, Receiver.CancellationToken).Wait();
         }
 
         public void Disconnect()

--- a/src/Listener/PodeWebSocket.cs
+++ b/src/Listener/PodeWebSocket.cs
@@ -1,20 +1,139 @@
 using System;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Net.WebSockets;
+using _WebSocket = System.Net.WebSockets.WebSocket;
+using System.IO;
+using System.Threading;
 
 namespace Pode
 {
-    public class PodeWebSocket
+    public class PodeWebSocket : IDisposable
     {
-        public PodeContext Context { get; private set; }
-        public string Path { get; private set; }
-        public string ClientId { get; private set; }
-        public DateTime Timestamp { get; private set; }
-
-        public PodeWebSocket(PodeContext context, string path, string clientId)
+        public string Name { get; private set; }
+        public Uri URL { get; private set; }
+        public bool IsConnected
         {
-            Context = context;
-            Path = path;
-            ClientId = clientId;
-            Timestamp = DateTime.UtcNow;
+            get => (WebSocket != default(ClientWebSocket) && WebSocket.State == WebSocketState.Open);
+        }
+
+        private ClientWebSocket WebSocket;
+        private PodeReceiver Receiver;
+
+        public PodeWebSocket(string name, string url)
+        {
+            Name = name;
+            URL = new Uri(url);
+        }
+
+        public void BindReceiver(PodeReceiver receiver)
+        {
+            Receiver = receiver;
+        }
+
+        public async void Connect()
+        {
+            if (IsConnected)
+            {
+                return;
+            }
+
+            if (WebSocket != default(ClientWebSocket))
+            {
+                WebSocket.Dispose();
+            }
+
+            WebSocket = new ClientWebSocket();
+            await WebSocket.ConnectAsync(URL, Receiver.CancellationToken);
+            await Task.Factory.StartNew(Receive, Receiver.CancellationToken, TaskCreationOptions.LongRunning, TaskScheduler.Default);
+        }
+
+        public void Reconnect(string url)
+        {
+            if (!string.IsNullOrWhiteSpace(url))
+            {
+                URL = new Uri(url);
+            }
+
+            Disconnect();
+            Connect();
+        }
+
+        public async void Receive()
+        {
+            var result = default(WebSocketReceiveResult);
+            var buffer = _WebSocket.CreateClientBuffer(1024, 1024);
+            var bufferStream = new MemoryStream();
+
+            try
+            {
+                while (!Receiver.CancellationToken.IsCancellationRequested && IsConnected)
+                {
+                    do
+                    {
+                        result = await WebSocket.ReceiveAsync(buffer, Receiver.CancellationToken);
+                        if (result.MessageType != WebSocketMessageType.Close)
+                        {
+                            bufferStream.Write(buffer.ToArray(), 0, result.Count);
+                        }
+                    }
+                    while (!result.EndOfMessage && IsConnected);
+
+                    if (result.MessageType == WebSocketMessageType.Close)
+                    {
+                        break;
+                    }
+
+                    bufferStream.Position = 0;
+                    Receiver.AddWebSocketRequest(new PodeWebSocketRequest(this, bufferStream));
+                    bufferStream.Dispose();
+                    bufferStream = new MemoryStream();
+                }
+            }
+            catch (TaskCanceledException) {}
+            catch (WebSocketException)
+            {
+                Dispose();
+            }
+            finally
+            {
+                bufferStream.Dispose();
+                bufferStream = default(MemoryStream);
+                buffer = default(ArraySegment<byte>);
+            }
+        }
+
+        public void Send(string message)
+        {
+            if (WebSocket.State != WebSocketState.Open)
+            {
+                return;
+            }
+
+            WebSocket.SendAsync(new ArraySegment<byte>(Encoding.UTF8.GetBytes(message)), WebSocketMessageType.Binary, true, Receiver.CancellationToken).Wait();
+        }
+
+        public void Disconnect()
+        {
+            if (WebSocket == default(ClientWebSocket))
+            {
+                return;
+            }
+
+            if (IsConnected)
+            {
+                WebSocket.CloseOutputAsync(WebSocketCloseStatus.Empty, string.Empty, CancellationToken.None).Wait();
+                WebSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, CancellationToken.None).Wait();
+            }
+
+            WebSocket.Dispose();
+            WebSocket = default(ClientWebSocket);
+        }
+
+        public void Dispose()
+        {
+            Disconnect();
         }
     }
 }

--- a/src/Listener/PodeWebSocketCloseFrom.cs
+++ b/src/Listener/PodeWebSocketCloseFrom.cs
@@ -1,0 +1,8 @@
+namespace Pode
+{
+    public enum PodeWebSocketCloseFrom
+    {
+        Client,
+        Server
+    }
+}

--- a/src/Listener/PodeWebSocketRequest.cs
+++ b/src/Listener/PodeWebSocketRequest.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Text;
+using System.IO;
+
+namespace Pode
+{
+    public class PodeWebSocketRequest : IDisposable
+    {
+
+        public PodeWebSocket WebSocket {get; private set; }
+        public byte[] RawBody { get; private set; }
+
+        private string _body = string.Empty;
+        public string Body
+        {
+            get
+            {
+                if (RawBody != default(byte[]) && RawBody.Length > 0)
+                {
+                    _body = Encoding.UTF8.GetString(RawBody);
+                }
+
+                return _body;
+            }
+        }
+
+        public PodeWebSocketRequest(PodeWebSocket webSocket, MemoryStream bytes)
+        {
+            WebSocket = webSocket;
+            RawBody = bytes.ToArray();
+        }
+
+        public void Dispose()
+        {
+            RawBody = default(byte[]);
+            _body = string.Empty;
+        }
+
+    }
+}

--- a/src/Listener/PodeWebSocketRequest.cs
+++ b/src/Listener/PodeWebSocketRequest.cs
@@ -7,8 +7,14 @@ namespace Pode
     public class PodeWebSocketRequest : IDisposable
     {
 
-        public PodeWebSocket WebSocket {get; private set; }
+        public PodeWebSocket WebSocket { get; private set; }
         public byte[] RawBody { get; private set; }
+        public Encoding ContentEncoding = new UTF8Encoding();
+
+        public int ContentLength
+        {
+            get => (RawBody == default(byte[]) ? 0 : RawBody.Length);
+        }
 
         private string _body = string.Empty;
         public string Body

--- a/src/Pode.psd1
+++ b/src/Pode.psd1
@@ -305,7 +305,15 @@
         'Remove-PodeVerb',
         'Clear-PodeVerbs',
         'Get-PodeVerb',
-        'Use-PodeVerbs'
+        'Use-PodeVerbs',
+
+        # WebSockets
+        'Set-PodeWebSocketConcurrency',
+        'Connect-PodeWebSocket',
+        'Disconnect-PodeWebSocket',
+        'Send-PodeWebSocket',
+        'Reset-PodeWebSocket',
+        'Test-PodeWebSocket'
     )
 
     # Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.

--- a/src/Pode.psd1
+++ b/src/Pode.psd1
@@ -311,6 +311,7 @@
         'Set-PodeWebSocketConcurrency',
         'Connect-PodeWebSocket',
         'Disconnect-PodeWebSocket',
+        'Remove-PodeWebSocket',
         'Send-PodeWebSocket',
         'Reset-PodeWebSocket',
         'Test-PodeWebSocket'

--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -629,6 +629,8 @@ function New-PodeRunspacePools
             Pool = [runspacefactory]::CreateRunspacePool(1, $PodeContext.Threads.WebSockets + 1, $PodeContext.RunspaceState, $Host)
             State = 'Waiting'
         }
+
+        New-PodeWebSocketReceiver
     }
 
     # setup schedule runspace pool -if we have any schedules

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -514,7 +514,7 @@ function Add-PodeRunspace
 {
     param (
         [Parameter(Mandatory=$true)]
-        [ValidateSet('Main', 'Signals', 'Schedules', 'Gui', 'Web', 'Smtp', 'Tcp', 'Tasks')]
+        [ValidateSet('Main', 'Signals', 'Schedules', 'Gui', 'Web', 'Smtp', 'Tcp', 'Tasks', 'WebSockets')]
         [string]
         $Type,
 
@@ -646,6 +646,13 @@ function Close-PodeRunspaces
                 $continue = $false
                 foreach ($listener in $PodeContext.Listeners) {
                     if (!$listener.IsDisposed) {
+                        $continue = $true
+                        break
+                    }
+                }
+
+                foreach ($receiver in $PodeContext.Receivers) {
+                    if (!$receiver.IsDisposed) {
                         $continue = $true
                         break
                     }

--- a/src/Private/PodeServer.ps1
+++ b/src/Private/PodeServer.ps1
@@ -108,7 +108,7 @@ function Start-PodeWebServer
 
             try
             {
-                while ($Listener.IsListening -and !$PodeContext.Tokens.Cancellation.IsCancellationRequested)
+                while ($Listener.IsConnected -and !$PodeContext.Tokens.Cancellation.IsCancellationRequested)
                 {
                     # get request and response
                     $context = (Wait-PodeTask -Task $Listener.GetContextAsync($PodeContext.Tokens.Cancellation.Token))
@@ -270,7 +270,7 @@ function Start-PodeWebServer
             )
 
             try {
-                while ($Listener.IsListening -and !$PodeContext.Tokens.Cancellation.IsCancellationRequested)
+                while ($Listener.IsConnected -and !$PodeContext.Tokens.Cancellation.IsCancellationRequested)
                 {
                     $message = (Wait-PodeTask -Task $Listener.GetServerSignalAsync($PodeContext.Tokens.Cancellation.Token))
 
@@ -347,7 +347,7 @@ function Start-PodeWebServer
             )
 
             try {
-                while ($Listener.IsListening -and !$PodeContext.Tokens.Cancellation.IsCancellationRequested)
+                while ($Listener.IsConnected -and !$PodeContext.Tokens.Cancellation.IsCancellationRequested)
                 {
                     $context = (Wait-PodeTask -Task $Listener.GetClientSignalAsync($PodeContext.Tokens.Cancellation.Token))
 
@@ -435,7 +435,7 @@ function Start-PodeWebServer
         )
 
         try {
-            while ($Listener.IsListening -and !$PodeContext.Tokens.Cancellation.IsCancellationRequested) {
+            while ($Listener.IsConnected -and !$PodeContext.Tokens.Cancellation.IsCancellationRequested) {
                 Start-Sleep -Seconds 1
             }
         }

--- a/src/Private/PodeServer.ps1
+++ b/src/Private/PodeServer.ps1
@@ -83,7 +83,8 @@ function Start-PodeWebServer
 
         $listener.Start()
         $PodeContext.Listeners += $listener
-        $PodeContext.Server.WebSockets.Listener = $listener
+        $PodeContext.Server.Signals.Enabled = $true
+        $PodeContext.Server.Signals.Listener = $listener
     }
     catch {
         $_ | Write-PodeErrorLog
@@ -280,10 +281,10 @@ function Start-PodeWebServer
 
                         # by clientId
                         if (![string]::IsNullOrWhiteSpace($message.ClientId)) {
-                            $sockets = @($Listener.WebSockets[$message.ClientId])
+                            $sockets = @($Listener.Signals[$message.ClientId])
                         }
                         else {
-                            $sockets = @($Listener.WebSockets.Values)
+                            $sockets = @($Listener.Signals.Values)
 
                             # by path
                             if (![string]::IsNullOrWhiteSpace($message.Path)) {
@@ -307,7 +308,7 @@ function Start-PodeWebServer
                                 $socket.Context.Response.SendSignal($message)
                             }
                             catch {
-                                $null = $Listener.WebSockets.Remove($socket.ClientId)
+                                $null = $Listener.Signals.Remove($socket.ClientId)
                             }
                         }
                     }
@@ -353,8 +354,8 @@ function Start-PodeWebServer
                     try
                     {
                         $payload = ($context.Message | ConvertFrom-Json)
-                        $Request = $context.WebSocket.Context.Request
-                        $Response = $context.WebSocket.Context.Response
+                        $Request = $context.Signal.Context.Request
+                        $Response = $context.Signal.Context.Response
 
                         $SignalEvent = @{
                             Response = $Response
@@ -373,7 +374,7 @@ function Start-PodeWebServer
                                 Name = $null
                             }
                             Route = $null
-                            ClientId = $context.WebSocket.ClientId
+                            ClientId = $context.Signal.ClientId
                             Timestamp = $context.Timestamp
                             Streamed = $true
                         }

--- a/src/Private/Server.ps1
+++ b/src/Private/Server.ps1
@@ -60,6 +60,9 @@ function Start-PodeInternalServer
 
             # start runspace for gui
             Start-PodeGuiRunspace
+
+            # start runspace for websockets
+            Start-PodeWebSocketRunspace
         }
 
         # start the appropriate server
@@ -222,8 +225,10 @@ function Restart-PodeInternalServer
         $PodeContext.Server.OpenAPI = Get-PodeOABaseObject
 
         # clear the sockets
-        $PodeContext.Server.WebSockets.Listener = $null
+        $PodeContext.Server.Signals.Enabled = $false
+        $PodeContext.Server.Signals.Listener = $null
         $PodeContext.Listeners = @()
+        $PodeContext.Receivers = @()
 
         # set view engine back to default
         $PodeContext.Server.ViewEngine = @{

--- a/src/Private/SmtpServer.ps1
+++ b/src/Private/SmtpServer.ps1
@@ -83,7 +83,7 @@ function Start-PodeSmtpServer
 
         try
         {
-            while ($Listener.IsListening -and !$PodeContext.Tokens.Cancellation.IsCancellationRequested)
+            while ($Listener.IsConnected -and !$PodeContext.Tokens.Cancellation.IsCancellationRequested)
             {
                 # get email
                 $context = (Wait-PodeTask -Task $Listener.GetContextAsync($PodeContext.Tokens.Cancellation.Token))
@@ -193,7 +193,7 @@ function Start-PodeSmtpServer
         )
 
         try {
-            while ($Listener.IsListening -and !$PodeContext.Tokens.Cancellation.IsCancellationRequested) {
+            while ($Listener.IsConnected -and !$PodeContext.Tokens.Cancellation.IsCancellationRequested) {
                 Start-Sleep -Seconds 1
             }
         }

--- a/src/Private/TcpServer.ps1
+++ b/src/Private/TcpServer.ps1
@@ -80,7 +80,7 @@ function Start-PodeTcpServer
 
         try
         {
-            while ($Listener.IsListening -and !$PodeContext.Tokens.Cancellation.IsCancellationRequested)
+            while ($Listener.IsConnected -and !$PodeContext.Tokens.Cancellation.IsCancellationRequested)
             {
                 # get email
                 $context = (Wait-PodeTask -Task $Listener.GetContextAsync($PodeContext.Tokens.Cancellation.Token))
@@ -211,7 +211,7 @@ function Start-PodeTcpServer
         )
 
         try {
-            while ($Listener.IsListening -and !$PodeContext.Tokens.Cancellation.IsCancellationRequested) {
+            while ($Listener.IsConnected -and !$PodeContext.Tokens.Cancellation.IsCancellationRequested) {
                 Start-Sleep -Seconds 1
             }
         }

--- a/src/Private/WebSockets.ps1
+++ b/src/Private/WebSockets.ps1
@@ -1,0 +1,132 @@
+using namespace Pode
+
+function Test-PodeWebSocketsExist
+{
+    return (($null -ne $PodeContext.Server.WebSockets) -and (($PodeContext.Server.WebSockets.Enabled) -or ($PodeContext.Server.WebSockets.Connections.Count -gt 0)))
+}
+
+function Find-PodeWebSocket
+{
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Name
+    )
+
+    return $PodeContext.Server.WebSockets.Connections[$Name]
+}
+
+function New-PodeWebSocketReceiver
+{
+    if ($null -ne $PodeContext.Server.WebSockets.Receiver) {
+        return
+    }
+
+    try {
+        $receiver = [PodeReceiver]::new($PodeContext.Tokens.Cancellation.Token)
+        $receiver.ErrorLoggingEnabled = (Test-PodeErrorLoggingEnabled)
+        $receiver.ErrorLoggingLevels = @(Get-PodeErrorLoggingLevels)
+        $PodeContext.Server.WebSockets.Receiver = $receiver
+        $PodeContext.Receivers += $receiver
+    }
+    catch {
+        $_ | Write-PodeErrorLog
+        $_.Exception | Write-PodeErrorLog -CheckInnerException
+        Close-PodeDisposable -Disposable $receiver
+        throw $_.Exception
+    }
+}
+
+function Start-PodeWebSocketRunspace
+{
+    if (!(Test-PodeWebSocketsExist)) {
+        return
+    }
+
+    # script for listening out of for incoming requests
+    $receiveScript = {
+        param(
+            [Parameter(Mandatory=$true)]
+            [ValidateNotNull()]
+            $Receiver,
+
+            [Parameter(Mandatory=$true)]
+            [int]
+            $ThreadId
+        )
+
+        try
+        {
+            while ($Receiver.IsReceiving -and !$PodeContext.Tokens.Cancellation.IsCancellationRequested)
+            {
+                # get request
+                $request = (Wait-PodeTask -Task $Receiver.GetWebSocketRequestAsync($PodeContext.Tokens.Cancellation.Token))
+
+                try
+                {
+                    try
+                    {
+                        $WsEvent = @{
+                            Request = $request
+                            Lockable = $PodeContext.Lockables.Global
+                            Timestamp = [datetime]::UtcNow
+                        }
+
+                        # invoke websocket script
+                        $websocket = Find-PodeWebSocket -Name $request.WebSocket.Name
+                        if ($null -ne $websocket.Logic) {
+                            #TODO: args and using vars
+                            Invoke-PodeScriptBlock -ScriptBlock $websocket.Logic -Arguments @{} -Scoped -Splat
+                        }
+                    }
+                    catch [System.OperationCanceledException] {}
+                    catch {
+                        $_ | Write-PodeErrorLog
+                        $_.Exception | Write-PodeErrorLog -CheckInnerException
+                    }
+                }
+                finally {
+                    $WsEvent = $null
+                    Close-PodeDisposable -Disposable $request
+                }
+            }
+        }
+        catch [System.OperationCanceledException] {}
+        catch {
+            $_ | Write-PodeErrorLog
+            $_.Exception | Write-PodeErrorLog -CheckInnerException
+            throw $_.Exception
+        }
+    }
+
+    # start the runspace for listening on x-number of threads
+    1..$PodeContext.Threads.WebSockets | ForEach-Object {
+        Add-PodeRunspace -Type WebSockets -ScriptBlock $receiveScript -Parameters @{ 'Receiver' = $PodeContext.Server.WebSockets.Receiver; 'ThreadId' = $_ }
+    }
+
+    # script to keep websocket server receiving until cancelled
+    $waitScript = {
+        param(
+            [Parameter(Mandatory=$true)]
+            [ValidateNotNull()]
+            $Receiver
+        )
+
+        try {
+            while ($Receiver.IsReceiving -and !$PodeContext.Tokens.Cancellation.IsCancellationRequested) {
+                Start-Sleep -Seconds 1
+            }
+        }
+        catch [System.OperationCanceledException] {}
+        catch {
+            $_ | Write-PodeErrorLog
+            $_.Exception | Write-PodeErrorLog -CheckInnerException
+            throw $_.Exception
+        }
+        finally {
+            Close-PodeDisposable -Disposable $Receiver
+        }
+    }
+
+    Add-PodeRunspace -Type WebSockets -ScriptBlock $waitScript -Parameters @{ 'Receiver' = $PodeContext.Server.WebSockets.Receiver } -NoProfile
+}

--- a/src/Private/WebSockets.ps1
+++ b/src/Private/WebSockets.ps1
@@ -57,7 +57,7 @@ function Start-PodeWebSocketRunspace
 
         try
         {
-            while ($Receiver.IsReceiving -and !$PodeContext.Tokens.Cancellation.IsCancellationRequested)
+            while ($Receiver.IsConnected -and !$PodeContext.Tokens.Cancellation.IsCancellationRequested)
             {
                 # get request
                 $request = (Wait-PodeTask -Task $Receiver.GetWebSocketRequestAsync($PodeContext.Tokens.Cancellation.Token))
@@ -121,7 +121,7 @@ function Start-PodeWebSocketRunspace
         )
 
         try {
-            while ($Receiver.IsReceiving -and !$PodeContext.Tokens.Cancellation.IsCancellationRequested) {
+            while ($Receiver.IsConnected -and !$PodeContext.Tokens.Cancellation.IsCancellationRequested) {
                 Start-Sleep -Seconds 1
             }
         }

--- a/src/Private/WebSockets.ps1
+++ b/src/Private/WebSockets.ps1
@@ -75,8 +75,16 @@ function Start-PodeWebSocketRunspace
                         # invoke websocket script
                         $websocket = Find-PodeWebSocket -Name $request.WebSocket.Name
                         if ($null -ne $websocket.Logic) {
-                            #TODO: args and using vars
-                            Invoke-PodeScriptBlock -ScriptBlock $websocket.Logic -Arguments @{} -Scoped -Splat
+                            $_args = @($websocket.Arguments)
+                            if ($null -ne $websocket.UsingVariables) {
+                                $_vars = @()
+                                foreach ($_var in $websocket.UsingVariables) {
+                                    $_vars += ,$_var.Value
+                                }
+                                $_args = $_vars + $_args
+                            }
+
+                            Invoke-PodeScriptBlock -ScriptBlock $websocket.Logic -Arguments $_args -Scoped -Splat
                         }
                     }
                     catch [System.OperationCanceledException] {}

--- a/src/Public/Core.ps1
+++ b/src/Public/Core.ps1
@@ -104,7 +104,7 @@ function Start-PodeServer
         $ListenerType = [string]::Empty,
 
         [Parameter()]
-        [ValidateSet('Timers', 'Schedules', 'Tasks')]
+        [ValidateSet('Timers', 'Schedules', 'Tasks', 'WebSockets')]
         [string[]]
         $EnablePool,
 

--- a/src/Public/Metrics.ps1
+++ b/src/Public/Metrics.ps1
@@ -145,15 +145,15 @@ function Get-PodeServerActiveRequestMetric
 
     switch ($CountType.ToLowerInvariant()) {
         'total' {
-            return $PodeContext.Server.WebSockets.Listener.Contexts.Count
+            return $PodeContext.Server.Signals.Listener.Contexts.Count
         }
 
         'queued' {
-            return $PodeContext.Server.WebSockets.Listener.Contexts.QueuedCount
+            return $PodeContext.Server.Signals.Listener.Contexts.QueuedCount
         }
 
         'processing' {
-            return $PodeContext.Server.WebSockets.Listener.Contexts.ProcessingCount
+            return $PodeContext.Server.Signals.Listener.Contexts.ProcessingCount
         }
     }
 }
@@ -196,15 +196,15 @@ function Get-PodeServerActiveSignalMetric
         'total' {
             switch ($CountType.ToLowerInvariant()) {
                 'total' {
-                    return $PodeContext.Server.WebSockets.Listener.ServerSignals.Count + $PodeContext.Server.WebSockets.Listener.ClientSignals.Count
+                    return $PodeContext.Server.Signals.Listener.ServerSignals.Count + $PodeContext.Server.Signals.Listener.ClientSignals.Count
                 }
 
                 'queued' {
-                    return $PodeContext.Server.WebSockets.Listener.ServerSignals.QueuedCount + $PodeContext.Server.WebSockets.Listener.ClientSignals.QueuedCount
+                    return $PodeContext.Server.Signals.Listener.ServerSignals.QueuedCount + $PodeContext.Server.Signals.Listener.ClientSignals.QueuedCount
                 }
 
                 'processing' {
-                    return $PodeContext.Server.WebSockets.Listener.ServerSignals.ProcessingCount + $PodeContext.Server.WebSockets.Listener.ClientSignals.ProcessingCount
+                    return $PodeContext.Server.Signals.Listener.ServerSignals.ProcessingCount + $PodeContext.Server.Signals.Listener.ClientSignals.ProcessingCount
                 }
             }
         }
@@ -212,15 +212,15 @@ function Get-PodeServerActiveSignalMetric
         'server' {
             switch ($CountType.ToLowerInvariant()) {
                 'total' {
-                    return $PodeContext.Server.WebSockets.Listener.ServerSignals.Count
+                    return $PodeContext.Server.Signals.Listener.ServerSignals.Count
                 }
 
                 'queued' {
-                    return $PodeContext.Server.WebSockets.Listener.ServerSignals.QueuedCount
+                    return $PodeContext.Server.Signals.Listener.ServerSignals.QueuedCount
                 }
 
                 'processing' {
-                    return $PodeContext.Server.WebSockets.Listener.ServerSignals.ProcessingCount
+                    return $PodeContext.Server.Signals.Listener.ServerSignals.ProcessingCount
                 }
             }
         }
@@ -228,15 +228,15 @@ function Get-PodeServerActiveSignalMetric
         'client' {
             switch ($CountType.ToLowerInvariant()) {
                 'total' {
-                    return $PodeContext.Server.WebSockets.Listener.ClientSignals.Count
+                    return $PodeContext.Server.Signals.Listener.ClientSignals.Count
                 }
 
                 'queued' {
-                    return $PodeContext.Server.WebSockets.Listener.ClientSignals.QueuedCount
+                    return $PodeContext.Server.Signals.Listener.ClientSignals.QueuedCount
                 }
 
                 'processing' {
-                    return $PodeContext.Server.WebSockets.Listener.ClientSignals.ProcessingCount
+                    return $PodeContext.Server.Signals.Listener.ClientSignals.ProcessingCount
                 }
             }
         }

--- a/src/Public/Responses.ps1
+++ b/src/Public/Responses.ps1
@@ -1411,7 +1411,7 @@ function Send-PodeSignal
 {
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
+        [Parameter(ValueFromPipeline=$true)]
         $Value,
 
         [Parameter()]
@@ -1436,8 +1436,13 @@ function Send-PodeSignal
     )
 
     # error if not configured
-    if ($null -eq $PodeContext.Server.WebSockets.Listener) {
+    if (!$PodeContext.Server.Signals.Enabled) {
         throw "WebSockets have not been configured to send signal messages"
+    }
+
+    # do nothing if no value
+    if (($null -eq $Value) -or ([string]::IsNullOrEmpty($Value))) {
+        return
     }
 
     # jsonify the value
@@ -1467,7 +1472,7 @@ function Send-PodeSignal
 
     # broadcast or direct?
     if ($Mode -iin @('Auto', 'Broadcast')) {
-        $PodeContext.Server.WebSockets.Listener.AddServerSignal($Value, $Path, $ClientId)
+        $PodeContext.Server.Signals.Listener.AddServerSignal($Value, $Path, $ClientId)
     }
     else {
         $SignalEvent.Response.Write($Value)

--- a/src/Public/WebSockets.ps1
+++ b/src/Public/WebSockets.ps1
@@ -1,0 +1,139 @@
+using namespace Pode
+
+function Set-PodeWebSocketConcurrency
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [int]
+        $Maximum
+    )
+
+    # error if <=0
+    if ($Maximum -le 0) {
+        throw "Maximum concurrent WebSocket threads must be >=1 but got: $($Maximum)"
+    }
+
+    # add 1, for the waiting script
+    $Maximum++
+
+    # ensure max > min
+    $_min = 1
+    if ($null -ne $PodeContext.RunspacePools.WebSockets) {
+        $_min = $PodeContext.RunspacePools.WebSockets.Pool.GetMinRunspaces()
+    }
+
+    if ($_min -gt $Maximum) {
+        throw "Maximum concurrent WebSocket threads cannot be less than the minimum of $($_min) but got: $($Maximum)"
+    }
+
+    # set the max tasks
+    $PodeContext.Threads.WebSockets = $Maximum
+    if ($null -ne $PodeContext.RunspacePools.WebSockets) {
+        $PodeContext.RunspacePools.WebSockets.Pool.SetMaxRunspaces($Maximum)
+    }
+}
+
+function Connect-PodeWebSocket
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Name,
+
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Url,
+
+        [Parameter(Mandatory=$true)]
+        [scriptblock]
+        $ScriptBlock
+    )
+
+    # ensure we have a receiver
+    New-PodeWebSocketReceiver
+
+    # connect
+    $PodeContext.Server.WebSockets.Receiver.ConnectWebSocket($Name, $Url)
+    $PodeContext.Server.WebSockets.Connections[$Name] = @{
+        Name = $Name
+        Url = $Url
+        Logic = $ScriptBlock
+        #TODO: using-vars
+        UsingVariables = $null
+        #TODO: args list
+        Arguments = $null
+    }
+}
+
+function Disconnect-PodeWebSocket
+{
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [string]
+        $Name
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Name) -and ($null -ne $WsEvent)) {
+        $Name = $WsEvent.Request.WebSocket.Name
+    }
+
+    if ([string]::IsNullOrWhiteSpace($Name)) {
+        throw "No Name for a WebSocket to disconnect from supplied"
+    }
+
+    $PodeContext.Server.WebSockets.Receiver.DisconnectWebSocket($Name)
+    $PodeContext.Server.WebSockets.Connections.Remove($Name)
+}
+
+function Send-PodeWebSocket
+{
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [string]
+        $Name,
+
+        [Parameter()]
+        [string]
+        $Message
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Name) -and ($null -ne $WsEvent)) {
+        $WsEvent.Request.WebSocket.Send($Message)
+        return
+    }
+
+    if ([string]::IsNullOrWhiteSpace($Name)) {
+        throw "No Name for a WebSocket to send message to supplied"
+    }
+
+    $PodeContext.Server.WebSockets.Receiver.GetWebSocket($Name).Send($Message)
+}
+
+function Reset-PodeWebSocket
+{
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [string]
+        $Name,
+
+        [Parameter()]
+        [string]
+        $Url
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Name) -and ($null -ne $WsEvent)) {
+        $WsEvent.Request.WebSocket.Reconnect($Url)
+        return
+    }
+
+    if ([string]::IsNullOrWhiteSpace($Name)) {
+        throw "No Name for a WebSocket to reset supplied"
+    }
+
+    $PodeContext.Server.WebSockets.Receiver.GetWebSocket($Name).Reconnect($Url)
+}

--- a/tests/unit/Server.Tests.ps1
+++ b/tests/unit/Server.Tests.ps1
@@ -140,7 +140,7 @@ Describe 'Restart-PodeInternalServer' {
                         Connections = [System.Collections.Concurrent.ConcurrentQueue[System.Net.Sockets.SocketAsyncEventArgs]]::new()
                     }
                 }
-                WebSockets = @{
+                Signals = @{
                     Listeners = @()
                     Queues = @{
                         Sockets = @{}


### PR DESCRIPTION
### Description of the Change
Adds support for connecting to external websocket servers, for the receiving and sending of messages from your Pode server.

New functions added:
* `Set-PodeWebSocketConcurrency`
* `Connect-PodeWebSocket`
* `Disconnect-PodeWebSocket`
* `Remove-PodeWebSocket`
* `Send-PodeWebSocket`
* `Reset-PodeWebSocket`
* `Test-PodeWebSocket`

### Related Issue
Resolves #895 

### Examples
```powershell
Start-PodeServer -EnablePool WebSockets {

    # listen
    Add-PodeEndpoint -Address * -Port 8092 -Protocol Http

    # connect to web socket
    Connect-PodeWebSocket -Name 'Example' -Url 'ws://localhost:8091' -ScriptBlock {
        Send-PodeWebSocket -Message (@{ message = $WsEvent.Request.Body } | ConvertTo-Json -Compress)
    }

    # connect to web socket via route
    Add-PodeRoute -Method Get -Path '/connect' -ScriptBlock {
        Connect-PodeWebSocket -Name 'Test' -Url 'wss://ws.ifelse.io/' -ScriptBlock {
            $WsEvent.Request | out-default
        }
    }
}
```
