### PR TITLE
Add anonymous route access support, when authentication is enabled on a route

### DIFF
--- a/docs/Tutorials/Routes/Examples/AnonymousAccess.md
+++ b/docs/Tutorials/Routes/Examples/AnonymousAccess.md
@@ -1,0 +1,189 @@
+# Anonymous Access
+
+This example builds on top of the [Login Page](../LoginPage) example. This time instead of having a user navigate to the home page, and then be immediately redirected to the login page, this time we'll allow an unauthenticated user to access the home page.
+
+When this unauthenticated user accesses the home page, they'll be a switch in logic to show different content and a login button - rather than a greeting and a logout button.
+
+## Allow Anon
+
+The first thing we need to do is specify that the home page route should allow anonymous access. To achieve this we can use the `-AllowAnon` switch on [`Add-PodeRoute`](../../../../Functions/Routes/Add-PodeRoute). With this switch, if the user isn't authenticated - even if the `-Authentication` parameter supplied - then the home page will still load anyway.
+
+Below is the home page route from the [Login Page](../LoginPage) example, but now with anonymous access allowed:
+
+```powershell
+Add-PodeRoute -Method Get -Path '/' -Authentication 'Login' -AllowAnon -ScriptBlock {
+    $WebEvent.Session.Data.Views++
+
+    Write-PodeViewResponse -Path 'auth-home' -Data @{
+        Username = $WebEvent.Auth.User.Name;
+        Views = $WebEvent.Session.Data.Views;
+    }
+}
+```
+
+Now when a user navigates to `http://localhost:8080/` they won't be redirected to `http://localhost:8080/login`.
+
+## Is there a User?
+
+However, now we have an issue: if an authenticated or an unauthenticated user access the home page, they'll both be greeted with the same content! This is hardly desirable, so we need a way to test if whether we have an authenticated user or not.
+
+To achieve this we can use [`Test-PodeAuthUser`](../../../../Functions/Authentication/Test-PodeAuthUser). This function will return whether or not the current request (or `$WebEvent`) has an authenticated user, if it does then we can show the original content and if not we can show different content:
+
+```powershell
+Add-PodeRoute -Method Get -Path '/' -Authentication 'Login' -AllowAnon -ScriptBlock {
+    if (Test-PodeAuthUser) {
+        $session:Views++
+
+        Write-PodeViewResponse -Path 'auth-home' -Data @{
+            Username = $WebEvent.Auth.User.Name
+            Views = $session:Views
+        }
+    }
+    else {
+        Write-PodeViewResponse -Path 'auth-home-anon'
+    }
+}
+```
+
+Now, when an authenticated user hits the page, they're shown the original personal greeting page with view counter. However, when an unauthenticated user hits the page they are shown a generic greeting with a login button.
+
+## Example Code
+
+This is the full code for the server above:
+
+```powershell
+Start-PodeServer -Thread 2 {
+    Add-PodeEndpoint -Address * -Port 8080 -Protocol Http
+
+    # use pode template engine
+    Set-PodeViewEngine -Type Pode
+
+    # setup session middleware
+    Enable-PodeSessionMiddleware -Duration 120 -Extend
+
+    # setup form authentication
+    New-PodeAuthScheme -Form | Add-PodeAuth -Name 'Login' -FailureUrl '/login' -SuccessUrl '/' -ScriptBlock {
+        param($username, $password)
+
+        # here you'd check a real user storage, this is just for example
+        if ($username -eq 'morty' -and $password -eq 'pickle') {
+            return @{
+                User = @{
+                    ID ='M0R7Y302'
+                    Name = 'Morty'
+                    Type = 'Human'
+                }
+            }
+        }
+
+        # aww geez! no user was found
+        return @{ Message = 'Invalid details supplied' }
+    }
+
+    # the "GET /" endpoint for the homepage
+    Add-PodeRoute -Method Get -Path '/' -Authentication 'Login' -AllowAnon -ScriptBlock {
+        if (Test-PodeAuthUser) {
+            $session:Views++
+
+            Write-PodeViewResponse -Path 'auth-home' -Data @{
+                Username = $WebEvent.Auth.User.Name
+                Views = $session:Views
+            }
+        }
+        else {
+            Write-PodeViewResponse -Path 'auth-home-anon'
+        }
+    }
+
+    # the "GET /login" endpoint for the login page
+    Add-PodeRoute -Method Get -Path '/login' -Authentication 'Login' -Login -ScriptBlock {
+        Write-PodeViewResponse -Path 'auth-login' -FlashMessages
+    }
+
+    # the "POST /login" endpoint for user authentication
+    Add-PodeRoute -Method Post -Path '/login' -Authentication 'Login' -Login
+
+    # the "POST /logout" endpoint for ending the session
+    Add-PodeRoute -Method Post -Path '/logout' -Authentication 'Login' -Logout
+}
+```
+
+### Pages
+
+The following are the web pages used above, as well as the CSS style. The web pages have been created using [`.pode`](../../../Views/Pode) files, which allows you to embed PowerShell into the files.
+
+*auth-home.pode*
+```html
+<html>
+    <head>
+        <title>Auth Home</title>
+        <link rel="stylesheet" type="text/css" href="/styles/main.css">
+    </head>
+    <body>
+        Hello, $($data.Username)! You have view this page $($data.Views) times!
+
+        <form action="/logout" method="post">
+            <div>
+                <input type="submit" value="Logout"/>
+            </div>
+        </form>
+
+    </body>
+</html>
+```
+
+*auth-home-anon.pode*
+```html
+<html>
+    <head>
+        <title>Auth Home</title>
+        <link rel="stylesheet" type="text/css" href="/styles/simple.css">
+    </head>
+    <body>
+
+        Hello, there! Welcome to the home page, please login below.
+
+        <form action="/login" method="get">
+            <div>
+                <input type="submit" value="Login"/>
+            </div>
+        </form>
+
+    </body>
+</html>
+```
+
+*auth-login.pode*
+```html
+<html>
+    <head>
+        <title>Auth Login</title>
+        <link rel="stylesheet" type="text/css" href="/styles/main.css">
+    </head>
+    <body>
+        Please Login:
+
+        <form action="/login" method="post">
+            <div>
+                <label>Username:</label>
+                <input type="text" name="username"/>
+            </div>
+            <div>
+                <label>Password:</label>
+                <input type="password" name="password"/>
+            </div>
+            <div>
+                <input type="submit" value="Login"/>
+            </div>
+        </form>
+
+    </body>
+</html>
+```
+
+*styles/main.css*
+```css
+body {
+    background-color: rebeccapurple;
+}
+```

--- a/docs/Tutorials/Routes/Examples/LoginPage.md
+++ b/docs/Tutorials/Routes/Examples/LoginPage.md
@@ -98,7 +98,7 @@ Finally, we have the logout Route. Here we have another switch of `-Logout`, whi
 Add-PodeRoute -Method Post -Path '/logout' -Authentication 'Login' -Logout
 ```
 
-## Full Server
+## Example Code
 
 This is the full code for the server above:
 
@@ -154,7 +154,7 @@ Start-PodeServer -Thread 2 {
 }
 ```
 
-## Pages
+### Pages
 
 The following are the web pages used above, as well as the CSS style. The web pages have been created using [`.pode`](../../../Views/Pode) files, which allows you to embed PowerShell into the files.
 

--- a/docs/Tutorials/Routes/Examples/WebPages.md
+++ b/docs/Tutorials/Routes/Examples/WebPages.md
@@ -21,7 +21,7 @@ Start-PodeServer {
 !!! info
     If your web page references any CSS, JavaScript, etc. files, then Pode will automatically find them within the `/public` directory - or any relative static routes you may have defined. For example, if you reference `<link rel="stylesheet" type="text/css" href="/styles/simple.css">` in your HTML file, then Pode will look for `/public/styles/simple.css`.
 
-## Full Example
+## Example Code
 
 Here we'll have two simple HTML pages, with a CSS file and a simple server script. The directory structure is as follows:
 

--- a/examples/views/auth-home-anon.pode
+++ b/examples/views/auth-home-anon.pode
@@ -5,7 +5,7 @@
     </head>
     <body>
 
-        Hello, there! You have view this page $($data.Views) times, please login below.
+        Hello, there! Welcome to the home page, please login below.
 
         <form action="/login" method="get">
             <div>

--- a/examples/views/auth-home-anon.pode
+++ b/examples/views/auth-home-anon.pode
@@ -1,0 +1,17 @@
+<html>
+    <head>
+        <title>Auth Home</title>
+        <link rel="stylesheet" type="text/css" href="/styles/simple.css">
+    </head>
+    <body>
+
+        Hello, there! You have view this page $($data.Views) times, please login below.
+
+        <form action="/login" method="get">
+            <div>
+                <input type="submit" value="Login"/>
+            </div>
+        </form>
+
+    </body>
+</html>

--- a/examples/web-auth-basic-anon.ps1
+++ b/examples/web-auth-basic-anon.ps1
@@ -1,0 +1,74 @@
+$path = Split-Path -Parent -Path (Split-Path -Parent -Path $MyInvocation.MyCommand.Path)
+Import-Module "$($path)/src/Pode.psm1" -Force -ErrorAction Stop
+
+# or just:
+# Import-Module Pode
+
+<#
+This example shows how to use sessionless authentication, which will mostly be for
+REST APIs. The example used here is Basic authentication.
+
+Calling the '[POST] http://localhost:8085/users' endpoint, with an Authorization
+header of 'Basic bW9ydHk6cGlja2xl' will display the uesrs. Anything else and
+you'll get a 401 status code back.
+
+Success:
+Invoke-RestMethod -Uri http://localhost:8085/users -Headers @{ Authorization = 'Basic bW9ydHk6cGlja2xl' }
+
+Failure:
+Invoke-RestMethod -Uri http://localhost:8085/users -Headers @{ Authorization = 'Basic bW9ydHk6cmljaw==' }
+#>
+
+# create a server, and start listening on port 8085
+Start-PodeServer -Threads 2 {
+
+    # listen on localhost:8085
+    Add-PodeEndpoint -Address * -Port 8085 -Protocol Http
+
+    # setup basic auth (base64> username:password in header)
+    New-PodeAuthScheme -Basic -Realm 'Pode Example Page' | Add-PodeAuth -Name 'Validate' -Sessionless -ScriptBlock {
+        param($username, $password)
+
+        # here you'd check a real user storage, this is just for example
+        if ($username -eq 'morty' -and $password -eq 'pickle') {
+            return @{
+                User = @{
+                    ID ='M0R7Y302'
+                    Name = 'Morty'
+                    Type = 'Human'
+                }
+            }
+        }
+
+        return @{ Message = 'Invalid details supplied' }
+    }
+
+    # GET request to get list of users (since there's no session, authentication will always happen, but, we're allowing anon access)
+    Add-PodeRoute -Method Get -Path '/users' -Authentication 'Validate' -Anon -ScriptBlock {
+        if (Test-PodeAuthUser) {
+            Write-PodeJsonResponse -Value @{
+                Users = @(
+                    @{
+                        Name = 'Deep Thought'
+                        Age = 42
+                    },
+                    @{
+                        Name = 'Leeroy Jenkins'
+                        Age = 1337
+                    }
+                )
+            }
+        }
+        else {
+            Write-PodeJsonResponse -Value @{
+                Users = @(
+                    @{
+                        Name = 'John Smith'
+                        Age = 21
+                    }
+                )
+            }
+        }
+    }
+
+}

--- a/examples/web-auth-form-anon.ps1
+++ b/examples/web-auth-form-anon.ps1
@@ -1,0 +1,89 @@
+$path = Split-Path -Parent -Path (Split-Path -Parent -Path $MyInvocation.MyCommand.Path)
+Import-Module "$($path)/src/Pode.psm1" -Force -ErrorAction Stop
+
+# or just:
+# Import-Module Pode
+
+<#
+This examples shows how to use session persistant authentication, for things like logins on websites.
+The example used here is Form authentication, sent from the <form> in HTML.
+
+Navigating to the 'http://localhost:8085' endpoint in your browser will auto-rediect you to the '/login'
+page. Here, you can type the username (morty) and the password (pickle); clicking 'Login' will take you
+back to the home page with a greeting and a view counter. Clicking 'Logout' will purge the session and
+take you back to the login page.
+#>
+
+# create a server, and start listening on port 8085
+Start-PodeServer -Threads 2 {
+
+    # listen on localhost:8085
+    Add-PodeEndpoint -Address * -Port 8085 -Protocol Http
+
+    # set the view engine
+    Set-PodeViewEngine -Type Pode
+
+    # enable error logging
+    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+
+    # setup session details
+    Enable-PodeSessionMiddleware -Duration 120 -Extend
+
+    # setup form auth (<form> in HTML)
+    New-PodeAuthScheme -Form | Add-PodeAuth -Name 'Login' -FailureUrl '/login' -SuccessUrl '/' -ScriptBlock {
+        param($username, $password)
+
+        # here you'd check a real user storage, this is just for example
+        if ($username -eq 'morty' -and $password -eq 'pickle') {
+            return @{
+                User = @{
+                    ID ='M0R7Y302'
+                    Name = 'Morty'
+                    Type = 'Human'
+                }
+            }
+        }
+
+        return @{ Message = 'Invalid details supplied' }
+    }
+
+
+    # home page:
+    # redirects to login page if not authenticated
+    Add-PodeRoute -Method Get -Path '/' -Authentication Login -Anon -ScriptBlock {
+        $session:Views++
+
+        if (Test-PodeAuthUser) {
+            Write-PodeViewResponse -Path 'auth-home' -Data @{
+                Username = $WebEvent.Auth.User.Name
+                Views = $session:Views
+            }
+        }
+        else {
+            Write-PodeViewResponse -Path 'auth-home-anon' -Data @{
+                Views = $session:Views
+            }
+        }
+    }
+
+
+    # login page:
+    # the login flag set below checks if there is already an authenticated session cookie. If there is, then
+    # the user is redirected to the home page. If there is no session then the login page will load without
+    # checking user authetication (to prevent a 401 status)
+    Add-PodeRoute -Method Get -Path '/login' -Authentication Login -Login -ScriptBlock {
+        Write-PodeViewResponse -Path 'auth-login' -FlashMessages
+    }
+
+
+    # login check:
+    # this is the endpoint the <form>'s action will invoke. If the user validates then they are set against
+    # the session as authenticated, and redirect to the home page. If they fail, then the login page reloads
+    Add-PodeRoute -Method Post -Path '/login' -Authentication Login -Login
+
+
+    # logout check:
+    # when the logout button is click, this endpoint is invoked. The logout flag set below informs this call
+    # to purge the currently authenticated session, and then redirect back to the login page
+    Add-PodeRoute -Method Post -Path '/logout' -Authentication Login -Logout
+}

--- a/examples/web-auth-form-anon.ps1
+++ b/examples/web-auth-form-anon.ps1
@@ -51,9 +51,9 @@ Start-PodeServer -Threads 2 {
     # home page:
     # redirects to login page if not authenticated
     Add-PodeRoute -Method Get -Path '/' -Authentication Login -Anon -ScriptBlock {
-        $session:Views++
-
         if (Test-PodeAuthUser) {
+            $session:Views++
+
             Write-PodeViewResponse -Path 'auth-home' -Data @{
                 Username = $WebEvent.Auth.User.Name
                 Views = $session:Views

--- a/src/Pode.psd1
+++ b/src/Pode.psd1
@@ -209,6 +209,7 @@
         'ConvertFrom-PodeJwt',
         'Use-PodeAuth',
         'ConvertFrom-PodeOIDCDiscovery',
+        'Test-PodeAuthUser',
 
         # logging
         'New-PodeLoggingMethod',

--- a/src/Private/Endware.ps1
+++ b/src/Private/Endware.ps1
@@ -18,15 +18,7 @@ function Invoke-PodeEndware
         }
 
         try {
-            $_args = @($eware.Arguments)
-            if ($null -ne $eware.UsingVariables) {
-                $_vars = @()
-                foreach ($_var in $eware.UsingVariables) {
-                    $_vars += ,$_var.Value
-                }
-                $_args = $_vars + $_args
-            }
-
+            $_args = @(Get-PodeScriptblockArguments -ArgumentList $eware.Arguments -UsingVariables $eware.UsingVariables)
             $null = Invoke-PodeScriptBlock -ScriptBlock $eware.Logic -Arguments $_args -Scoped -Splat
         }
         catch {

--- a/src/Private/Events.ps1
+++ b/src/Private/Events.ps1
@@ -19,15 +19,7 @@ function Invoke-PodeEvent
         }
 
         try {
-            $_args = @($evt.Arguments)
-            if ($null -ne $evt.UsingVariables) {
-                $_vars = @()
-                foreach ($_var in $evt.UsingVariables) {
-                    $_vars += ,$_var.Value
-                }
-                $_args = $_vars + $_args
-            }
-
+            $_args = @(Get-PodeScriptblockArguments -ArgumentList $evt.Arguments -UsingVariables $evt.UsingVariables)
             $null = Invoke-PodeScriptBlock -ScriptBlock $evt.ScriptBlock -Arguments $_args -Scoped -Splat
         }
         catch {

--- a/src/Private/Logging.ps1
+++ b/src/Private/Logging.ps1
@@ -369,13 +369,7 @@ function Start-PodeLoggingRunspace
 
             # convert to log item into a writable format
             $_args = @($log.Item) + @($logger.Arguments)
-            if ($null -ne $logger.UsingVariables) {
-                $_vars = @()
-                foreach ($_var in $logger.UsingVariables) {
-                    $_vars += ,$_var.Value
-                }
-                $_args = $_vars + $_args
-            }
+            $_args = @(Get-PodeScriptblockArguments -ArgumentList $_args -UsingVariables $logger.UsingVariables)
 
             $rawItems = $log.Item
             $result = @(Invoke-PodeScriptBlock -ScriptBlock $logger.ScriptBlock -Arguments $_args -Return -Splat)
@@ -405,14 +399,7 @@ function Start-PodeLoggingRunspace
             # send the writable log item off to the log writer
             if ($null -ne $result) {
                 $_args = @(,$result) + @($logger.Method.Arguments) + @(,$rawItems)
-                if ($null -ne $logger.Method.UsingVariables) {
-                    $_vars = @()
-                    foreach ($_var in $logger.Method.UsingVariables) {
-                        $_vars += ,$_var.Value
-                    }
-                    $_args = $_vars + $_args
-                }
-
+                $_args = @(Get-PodeScriptblockArguments -ArgumentList $_args -UsingVariables $logger.Method.UsingVariables)
                 Invoke-PodeScriptBlock -ScriptBlock $logger.Method.ScriptBlock -Arguments $_args -Splat
             }
 
@@ -442,14 +429,7 @@ function Test-PodeLoggerBatches
             $batch.RawItems = @()
 
             $_args = @(,$result) + @($logger.Method.Arguments) + @(,$rawItems)
-            if ($null -ne $logger.Method.UsingVariables) {
-                $_vars = @()
-                foreach ($_var in $logger.Method.UsingVariables) {
-                    $_vars += ,$_var.Value
-                }
-                $_args = $_vars + $_args
-            }
-
+            $_args = @(Get-PodeScriptblockArguments -ArgumentList $_args -UsingVariables $logger.Method.UsingVariables)
             Invoke-PodeScriptBlock -ScriptBlock $logger.Method.ScriptBlock -Arguments $_args -Splat
         }
     }

--- a/src/Private/Middleware.ps1
+++ b/src/Private/Middleware.ps1
@@ -41,15 +41,7 @@ function Invoke-PodeMiddleware
         }
 
         try {
-            $_args = @($midware.Arguments)
-            if ($null -ne $midware.UsingVariables) {
-                $_vars = @()
-                foreach ($_var in $midware.UsingVariables) {
-                    $_vars += ,$_var.Value
-                }
-                $_args = $_vars + $_args
-            }
-
+            $_args = @(Get-PodeScriptblockArguments -ArgumentList $midware.Arguments -UsingVariables $midware.UsingVariables)
             $continue = Invoke-PodeScriptBlock -ScriptBlock $midware.Logic -Arguments $_args -Return -Scoped -Splat
             if ($null -eq $continue) {
                 $continue = $true

--- a/src/Private/PodeServer.ps1
+++ b/src/Private/PodeServer.ps1
@@ -200,15 +200,7 @@ function Start-PodeWebServer
                                         }
                                     }
                                     elseif ($null -ne $WebEvent.Route.Logic) {
-                                        $_args = @($WebEvent.Route.Arguments)
-                                        if ($null -ne $WebEvent.Route.UsingVariables) {
-                                            $_vars = @()
-                                            foreach ($_var in $WebEvent.Route.UsingVariables) {
-                                                $_vars += ,$_var.Value
-                                            }
-                                            $_args = $_vars + $_args
-                                        }
-
+                                        $_args = @(Get-PodeScriptblockArguments -ArgumentList $WebEvent.Route.Arguments -UsingVariables $WebEvent.Route.UsingVariables)
                                         Invoke-PodeScriptBlock -ScriptBlock $WebEvent.Route.Logic -Arguments $_args -Scoped -Splat
                                     }
                                 }
@@ -386,15 +378,7 @@ function Start-PodeWebServer
                         $SignalEvent.Route = Find-PodeSignalRoute -Path $SignalEvent.Path -EndpointName $SignalEvent.Endpoint.Name
 
                         if ($null -ne $SignalEvent.Route) {
-                            $_args = @($SignalEvent.Route.Arguments)
-                            if ($null -ne $SignalEvent.Route.UsingVariables) {
-                                $_vars = @()
-                                foreach ($_var in $SignalEvent.Route.UsingVariables) {
-                                    $_vars += ,$_var.Value
-                                }
-                                $_args = $_vars + $_args
-                            }
-
+                            $_args = @(Get-PodeScriptblockArguments -ArgumentList $SignalEvent.Route.Arguments -UsingVariables $SignalEvent.Route.UsingVariables)
                             Invoke-PodeScriptBlock -ScriptBlock $SignalEvent.Route.Logic -Arguments $_args -Scoped -Splat
                         }
                         else {

--- a/src/Private/Serverless.ps1
+++ b/src/Private/Serverless.ps1
@@ -95,15 +95,7 @@ function Start-PodeAzFuncServer
                         }
                     }
                     else {
-                        $_args = @($WebEvent.Route.Arguments)
-                        if ($null -ne $WebEvent.Route.UsingVariables) {
-                            $_vars = @()
-                            foreach ($_var in $WebEvent.Route.UsingVariables) {
-                                $_vars += ,$_var.Value
-                            }
-                            $_args = $_vars + $_args
-                        }
-
+                        $_args = @(Get-PodeScriptblockArguments -ArgumentList $WebEvent.Route.Arguments -UsingVariables $WebEvent.Route.UsingVariables)
                         Invoke-PodeScriptBlock -ScriptBlock $WebEvent.Route.Logic -Arguments $_args -Scoped -Splat
                     }
                 }
@@ -216,15 +208,7 @@ function Start-PodeAwsLambdaServer
                         }
                     }
                     else {
-                        $_args = @($WebEvent.Route.Arguments)
-                        if ($null -ne $WebEvent.Route.UsingVariables) {
-                            $_vars = @()
-                            foreach ($_var in $WebEvent.Route.UsingVariables) {
-                                $_vars += ,$_var.Value
-                            }
-                            $_args = $_vars + $_args
-                        }
-
+                        $_args = @(Get-PodeScriptblockArguments -ArgumentList $WebEvent.Route.Arguments -UsingVariables $WebEvent.Route.UsingVariables)
                         Invoke-PodeScriptBlock -ScriptBlock $WebEvent.Route.Logic -Arguments $_args -Scoped -Splat
                     }
                 }

--- a/src/Private/ServiceServer.ps1
+++ b/src/Private/ServiceServer.ps1
@@ -23,16 +23,7 @@ function Start-PodeServiceServer
                 $handlers = Get-PodeHandler -Type Service
                 foreach ($name in $handlers.Keys) {
                     $handler = $handlers[$name]
-
-                    $_args = @($handler.Arguments)
-                    if ($null -ne $handler.UsingVariables) {
-                        $_vars = @()
-                        foreach ($_var in $handler.UsingVariables) {
-                            $_vars += ,$_var.Value
-                        }
-                        $_args = $_vars + $_args
-                    }
-
+                    $_args = @(Get-PodeScriptblockArguments -ArgumentList $handler.Arguments -UsingVariables $handler.UsingVariables)
                     Invoke-PodeScriptBlock -ScriptBlock $handler.Logic -Arguments $_args -Scoped -Splat
                 }
 

--- a/src/Private/SmtpServer.ps1
+++ b/src/Private/SmtpServer.ps1
@@ -145,16 +145,7 @@ function Start-PodeSmtpServer
                             $handlers = Get-PodeHandler -Type Smtp
                             foreach ($name in $handlers.Keys) {
                                 $handler = $handlers[$name]
-
-                                $_args = @($handler.Arguments)
-                                if ($null -ne $handler.UsingVariables) {
-                                    $_vars = @()
-                                    foreach ($_var in $handler.UsingVariables) {
-                                        $_vars += ,$_var.Value
-                                    }
-                                    $_args = $_vars + $_args
-                                }
-
+                                $_args = @(Get-PodeScriptblockArguments -ArgumentList $handler.Arguments -UsingVariables $handler.UsingVariables)
                                 Invoke-PodeScriptBlock -ScriptBlock $handler.Logic -Arguments $_args -Scoped -Splat
                             }
                         }

--- a/src/Private/TcpServer.ps1
+++ b/src/Private/TcpServer.ps1
@@ -154,15 +154,7 @@ function Start-PodeTcpServer
 
                         # invoke it
                         if ($null -ne $verb.Logic) {
-                            $_args = @($verb.Arguments)
-                            if ($null -ne $verb.UsingVariables) {
-                                $_vars = @()
-                                foreach ($_var in $verb.UsingVariables) {
-                                    $_vars += ,$_var.Value
-                                }
-                                $_args = $_vars + $_args
-                            }
-
+                            $_args = @(Get-PodeScriptblockArguments -ArgumentList $verb.Arguments -UsingVariables $verb.UsingVariables)
                             Invoke-PodeScriptBlock -ScriptBlock $verb.Logic -Arguments $_args -Scoped -Splat
                         }
 

--- a/src/Private/Timers.ps1
+++ b/src/Private/Timers.ps1
@@ -94,13 +94,7 @@ function Invoke-PodeInternalTimer
         }
 
         # add timer $using args
-        if ($null -ne $Timer.UsingVariables) {
-            $_vars = @()
-            foreach ($_var in $Timer.UsingVariables) {
-                $_vars += ,$_var.Value
-            }
-            $_args = $_vars + $_args
-        }
+        $_args = @(Get-PodeScriptblockArguments -ArgumentList $_args -UsingVariables $Timer.UsingVariables)
 
         # invoke timer
         Invoke-PodeScriptBlock -ScriptBlock $Timer.Script -Arguments $_args -Scoped -Splat

--- a/src/Private/WebSockets.ps1
+++ b/src/Private/WebSockets.ps1
@@ -86,15 +86,7 @@ function Start-PodeWebSocketRunspace
                         $WsEvent.Files = $result.Files
 
                         # invoke websocket script
-                        $_args = @($websocket.Arguments)
-                        if ($null -ne $websocket.UsingVariables) {
-                            $_vars = @()
-                            foreach ($_var in $websocket.UsingVariables) {
-                                $_vars += ,$_var.Value
-                            }
-                            $_args = $_vars + $_args
-                        }
-
+                        $_args = @(Get-PodeScriptblockArguments -ArgumentList $websocket.Arguments -UsingVariables $websocket.UsingVariables)
                         Invoke-PodeScriptBlock -ScriptBlock $websocket.Logic -Arguments $_args -Scoped -Splat
                     }
                     catch [System.OperationCanceledException] {}

--- a/src/Public/Authentication.ps1
+++ b/src/Public/Authentication.ps1
@@ -1935,3 +1935,14 @@ function ConvertFrom-PodeOIDCDiscovery
         -CodeChallengeMethod $codeMethod `
         -UsePKCE:$UsePKCE)
 }
+
+function Test-PodeAuthUser
+{
+    [CmdletBinding()]
+    param()
+
+    return (
+        (($null -ne $WebEvent.Auth.User) -and $WebEvent.Auth.IsAuthenticated) -or
+        (($null -ne $WebEvent.Session.Data.Auth.User) -and $WebEvent.Session.Data.Auth.IsAuthenticated)
+    )
+}

--- a/src/Public/Routes.ps1
+++ b/src/Public/Routes.ps1
@@ -38,6 +38,9 @@ An array of arguments to supply to the Route's ScriptBlock.
 .PARAMETER Authentication
 The name of an Authentication method which should be used as middleware on this Route.
 
+.PARAMETER AllowAnon
+If supplied, the Route will allow anonymous access for non-authenticated users.
+
 .PARAMETER Login
 If supplied, the Route will be flagged to Authentication as being a Route that handles user logins.
 
@@ -117,6 +120,9 @@ function Add-PodeRoute
         $Authentication,
 
         [switch]
+        $AllowAnon,
+
+        [switch]
         $Login,
 
         [switch]
@@ -179,6 +185,7 @@ function Add-PodeRoute
             Name = $Authentication
             Login = $Login
             Logout = $Logout
+            Anon = $AllowAnon
         }
 
         $Middleware = (@(Get-PodeAuthMiddlewareScript | New-PodeMiddleware -ArgumentList $options) + $Middleware)
@@ -275,6 +282,9 @@ The content type of any error pages that may get returned.
 .PARAMETER Authentication
 The name of an Authentication method which should be used as middleware on this Route.
 
+.PARAMETER AllowAnon
+If supplied, the static route will allow anonymous access for non-authenticated users.
+
 .PARAMETER DownloadOnly
 When supplied, all static content on this Route will be attached as downloads - rather than rendered.
 
@@ -333,6 +343,9 @@ function Add-PodeStaticRoute
         $Authentication,
 
         [switch]
+        $AllowAnon,
+
+        [switch]
         $DownloadOnly,
 
         [switch]
@@ -388,7 +401,11 @@ function Add-PodeStaticRoute
             throw "Authentication method does not exist: $($Authentication)"
         }
 
-        $options = @{ Name = $Authentication }
+        $options = @{
+            Name = $Authentication
+            Anon = $AllowAnon
+        }
+
         $Middleware = (@(Get-PodeAuthMiddlewareScript | New-PodeMiddleware -ArgumentList $options) + $Middleware)
     }
 
@@ -824,6 +841,9 @@ Like normal Routes, an array of Middleware that will be applied to all generated
 .PARAMETER Authentication
 The name of an Authentication method which should be used as middleware on this Route.
 
+.PARAMETER AllowAnon
+If supplied, the Route will allow anonymous access for non-authenticated users.
+
 .PARAMETER NoVerb
 If supplied, the Command's Verb will not be included in the Route's path.
 
@@ -871,6 +891,9 @@ function ConvertTo-PodeRoute
         [Alias('Auth')]
         [string]
         $Authentication,
+
+        [switch]
+        $AllowAnon,
 
         [switch]
         $NoVerb,
@@ -940,7 +963,7 @@ function ConvertTo-PodeRoute
         $_path = ("$($Path)/$($Module)/$($name)" -replace '[/]+', '/')
 
         # create the route
-        $route = (Add-PodeRoute -Method $_method -Path $_path -Middleware $Middleware -Authentication $Authentication -ArgumentList $cmd -ScriptBlock {
+        $route = (Add-PodeRoute -Method $_method -Path $_path -Middleware $Middleware -Authentication $Authentication -AllowAnon:$AllowAnon -ArgumentList $cmd -ScriptBlock {
             param($cmd)
 
             # either get params from the QueryString or Payload
@@ -1022,6 +1045,9 @@ Like normal Routes, an array of Middleware that will be applied to all generated
 .PARAMETER Authentication
 The name of an Authentication method which should be used as middleware on this Route.
 
+.PARAMETER AllowAnon
+If supplied, the Page will allow anonymous access for non-authenticated users.
+
 .PARAMETER FlashMessages
 If supplied, Views will have any flash messages supplied to them for rendering.
 
@@ -1071,6 +1097,9 @@ function Add-PodePage
         [Alias('Auth')]
         [string]
         $Authentication,
+
+        [switch]
+        $AllowAnon,
 
         [Parameter(ParameterSetName='View')]
         [switch]
@@ -1143,6 +1172,7 @@ function Add-PodePage
         -Path $_path `
         -Middleware $Middleware `
         -Authentication $Authentication `
+        -AllowAnon:$AllowAnon `
         -ArgumentList $arg `
         -ScriptBlock $logic
 }


### PR DESCRIPTION
### Description of the Change
Add support for anonymous access on routes, plus a new helper function to test whether we have an authenticated user or not.

For the anonymous access, a new `-AllowAnon` switch has been added to `Add-PodeRoute`. If an unauthenticated user hits a Route with this switch then they can access the page - and not be redirected to the FailureUrl/Login page.

For testing if the user accessing the Route is authenticated or not, there's a new `Test-PodeAuthUser` function.

### Related Issue
Resolves #954

### Examples
```powershell
Add-PodeRoute -Method Get -Path '/' -Authentication 'Login' -AllowAnon -ScriptBlock {
    if (Test-PodeAuthUser) {
        $session:Views++
        Write-PodeViewResponse -Path 'auth-home' -Data @{
            Username = $WebEvent.Auth.User.Name
            Views = $session:Views
        }
    }
    else {
        Write-PodeViewResponse -Path 'auth-home-anon'
    }
}
```

Now, when an authenticated user hits the page, they're shown the original personal greeting page with view counter. However, when an unauthenticated user hits the page they are shown a generic greeting with a login button.
