### PR TITLE
Fix for importing ps1 files

### DIFF
--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -518,7 +518,7 @@ function Import-PodeModulesIntoRunspaceState
         # import the module
         $path = Find-PodeModuleFile -Name $module.Name
 
-        if ($module.ModuleType -ieq 'Manifest') {
+        if (($module.ModuleType -ieq 'Manifest') -or ($path.EndsWith('.ps1'))) {
             $PodeContext.RunspaceState.ImportPSModule($path)
         }
         else {


### PR DESCRIPTION
### Description of the Change
If the "module" being imported is a ps1 file instead of a psm1 file, then use the Runspace importer so it's imported into the global scope.

### Related Issue
Resolves #965 
