### PR TITLE
Add support for grouping Routes

### DIFF
--- a/docs/Tutorials/Routes/Overview.md
+++ b/docs/Tutorials/Routes/Overview.md
@@ -166,6 +166,32 @@ Get-PodeRoute -EndpointName Admin
 
 The [`Get-PodeStaticRoute`](../../../Functions/Routes/Get-PodeStaticRoute) function works in the same way as above - but with no `-Method` parameter.
 
+## Grouping
+
+If you have a number of Routes that all share the same base path, middleware, authentication, or other parameters, then you can add these Routes within a Route Group (via [`Add-PodeRouteGroup`](../../../Functions/Routes/Add-PodeRouteGroup)) to share the parameter values:
+
+```powershell
+Add-PodeRouteGroup -Path '/api' -Authentication Basic -Routes {
+    Add-PodeRoute -Method Get -Path '/route1' -ScriptBlock {
+        Write-PodeJsonResponse -Value @{ ID = 1 }
+    }
+
+    Add-PodeRoute -Method Get -Path '/route2' -ScriptBlock {
+        Write-PodeJsonResponse -Value @{ ID = 2 }
+    }
+
+    Add-PodeRoute -Method Get -Path '/route3' -ScriptBlock {
+        Write-PodeJsonResponse -Value @{ ID = 3 }
+    }
+}
+```
+
+In the above example, this will create 3 Routes: `/api/route1`, `/api/route2`, and `/api/route3`. Each of the Routes will also all require some Basic authentication.
+
+You can also do the same with Static and Signal Routes via [`Add-PodeStaticRouteGroup`](../../../Functions/Routes/Add-PodeStaticRouteGroup) and [`Add-PodeSignalRouteGroup`](../../../Functions/Routes/Add-PodeSignalRouteGroup).
+
+More information on Route grouping can be [found here](../Utilities/RouteGrouping).
+
 ## Route Object
 
 !!! warning

--- a/docs/Tutorials/Routes/Utilities/RouteGrouping.md
+++ b/docs/Tutorials/Routes/Utilities/RouteGrouping.md
@@ -1,0 +1,90 @@
+# Route Grouping
+
+Instead of adding multiple Routes all with the same path, middleware, authentication and other values; you can instead create these Routes in a Route Group. This will let you specify a shared base path, middleware, authentication, etc. for multiple Routes.
+
+There are Route groupings for normal Routes, Static Routes, and Signal Routes.
+
+## Routes
+
+You can add a new Route Group using [`Add-PodeRouteGroup`](../../../../Functions/Routes/Add-PodeRouteGroup), and passing a any shared details, plus a `-Routes` scriptblock for the routes to be created within the grouping's scope.
+
+For example, the below will add 3 Routes which all share a `/api` base path; some Basic authentication, and some other middleware:
+
+```powershell
+$mid = New-PodeMiddleware -ScriptBlock {
+    'some middleware being run' | Out-Default
+}
+
+Add-PodeRouteGroup -Path '/api' -Authentication Basic -Middleware $mid -Routes {
+    Add-PodeRoute -Method Get -Path '/route1' -ScriptBlock {
+        Write-PodeJsonResponse -Value @{ ID = 1 }
+    }
+
+    Add-PodeRoute -Method Get -Path '/route2' -ScriptBlock {
+        Write-PodeJsonResponse -Value @{ ID = 2 }
+    }
+
+    Add-PodeRoute -Method Get -Path '/route3' -ScriptBlock {
+        Write-PodeJsonResponse -Value @{ ID = 3 }
+    }
+}
+```
+
+When run, you'll have 3 Routes that all need some Basic authentication at `/api/route1`, `/api/route2`, and `/api/route3`.
+
+You can still add custom `-Middleware` on the Routes, and they'll be appended to the shared Middleware from the Group. Other parameters, such as `-ContentType` and `-EndpointName`, if supplied, will override the values passed into the Group.
+
+You can also embed groups within groups. The following is the same as the above, except this time the last 2 Routes will be at `/api/inner/route2`, and `/api/inner/route3`:
+
+```powershell
+$mid = New-PodeMiddleware -ScriptBlock {
+    'some middleware being run' | Out-Default
+}
+
+Add-PodeRouteGroup -Path '/api' -Authentication Basic -Middleware $mid -Routes {
+    Add-PodeRoute -Method Get -Path '/route1' -ScriptBlock {
+        Write-PodeJsonResponse -Value @{ ID = 1 }
+    }
+
+    Add-PodeRouteGroup -Path '/inner' -Routes {
+        Add-PodeRoute -Method Get -Path '/route2' -ScriptBlock {
+            Write-PodeJsonResponse -Value @{ ID = 2 }
+        }
+
+        Add-PodeRoute -Method Get -Path '/route3' -ScriptBlock {
+            Write-PodeJsonResponse -Value @{ ID = 3 }
+        }
+    }
+}
+```
+
+## Static Routes
+
+The Groups for Static Routes work in the same manor as normal Routes, but you'll need to use [`Add-PodeStaticRouteGroup`](../../../../Functions/Routes/Add-PodeStaticRouteGroup) instead:
+
+```powershell
+Add-PodeStaticRouteGroup -Path '/assets' -Source './content/assets' -Routes {
+    Add-PodeStaticRoute -Path '/images' -Source '/images'
+    Add-PodeStaticRoute -Path '/videos' -Source '/videos'
+}
+```
+
+This will create 2 Static Routes at `/assets/images` and `/assets/videos`, referencing files from the directories `./content/assets/images` and `./content/assets/videos` respectively.
+
+## Signal Routes
+
+Groupings for Signal Routes also work in the same manor as normal Routes, but you'll need to use [`Add-PodeSignalRouteGroup`](../../../../Functions/Routes/Add-PodeSignalRouteGroup) instead:
+
+```powershell
+Add-PodeSignalRoute -Path '/ws' -Routes {
+    Add-PodeSignalRoute -Path '/messages1' -ScriptBlock {
+        Send-PodeSignal -Value $SignalEvent.Data.Message
+    }
+
+    Add-PodeSignalRoute -Path '/messages2' -ScriptBlock {
+        Send-PodeSignal -Value $SignalEvent.Data.Message
+    }
+}
+```
+
+This will create 2 Signal Routes at `/ws/messages1` and `/ws/messages2`.

--- a/examples/web-route-group.ps1
+++ b/examples/web-route-group.ps1
@@ -1,0 +1,65 @@
+$path = Split-Path -Parent -Path (Split-Path -Parent -Path $MyInvocation.MyCommand.Path)
+Import-Module "$($path)/src/Pode.psm1" -Force -ErrorAction Stop
+
+$message = 'Kenobi'
+
+# create a server, and start listening on port 8090
+Start-PodeServer -Threads 2 {
+
+    # listen on localhost:8090
+    Add-PodeEndpoint -Address localhost -Port 8090 -Protocol Http
+    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+
+    $mid1 = New-PodeMiddleware -ScriptBlock {
+        'here1' | Out-Default
+    }
+
+    $mid2 = New-PodeMiddleware -ScriptBlock {
+        'here2' | Out-Default
+    }
+
+    Add-PodeRouteGroup -Path '/api' -Middleware $mid1 -Routes {
+        Add-PodeRoute -Method Get -Path '/route1' -ScriptBlock {
+            Write-PodeJsonResponse -Value @{ ID = 1 }
+        }
+
+        Add-PodeRoute -Method Get -Path '/route2' -Middleware $using:mid2 -ScriptBlock {
+            Write-PodeJsonResponse -Value @{ ID = 2 }
+        }
+
+        Add-PodeRoute -Method Get -Path '/route3' -ScriptBlock {
+            "Hello there, $($using:message)" | Out-Default
+            Write-PodeJsonResponse -Value @{ ID = 3 }
+        }
+    }
+
+
+    # Invoke-RestMethod -Uri http://localhost:8090/auth/route1 -Method Post -Headers @{ Authorization = 'Basic bW9ydHk6cGlja2xl' }
+    New-PodeAuthScheme -Basic | Add-PodeAuth -Name 'Basic' -Sessionless -ScriptBlock {
+        param($username, $password)
+
+        # here you'd check a real user storage, this is just for example
+        if ($username -eq 'morty' -and $password -eq 'pickle') {
+            return @{
+                User = @{ ID ='M0R7Y302' }
+            }
+        }
+
+        return @{ Message = 'Invalid details supplied' }
+    }
+
+    Add-PodeRouteGroup -Path '/auth' -Authentication Basic -Routes {
+        Add-PodeRoute -Method Post -Path '/route1' -ScriptBlock {
+            Write-PodeJsonResponse -Value @{ ID = 1 }
+        }
+
+        Add-PodeRoute -Method Post -Path '/route2' -ScriptBlock {
+            Write-PodeJsonResponse -Value @{ ID = 2 }
+        }
+
+        Add-PodeRoute -Method Post -Path '/route3' -ScriptBlock {
+            Write-PodeJsonResponse -Value @{ ID = 3 }
+        }
+    }
+
+}

--- a/examples/web-route-group.ps1
+++ b/examples/web-route-group.ps1
@@ -23,13 +23,15 @@ Start-PodeServer -Threads 2 {
             Write-PodeJsonResponse -Value @{ ID = 1 }
         }
 
-        Add-PodeRoute -Method Get -Path '/route2' -Middleware $using:mid2 -ScriptBlock {
-            Write-PodeJsonResponse -Value @{ ID = 2 }
-        }
+        Add-PodeRouteGroup -Path '/inner' -Routes {
+            Add-PodeRoute -Method Get -Path '/route2' -Middleware $using:mid2 -ScriptBlock {
+                Write-PodeJsonResponse -Value @{ ID = 2 }
+            }
 
-        Add-PodeRoute -Method Get -Path '/route3' -ScriptBlock {
-            "Hello there, $($using:message)" | Out-Default
-            Write-PodeJsonResponse -Value @{ ID = 3 }
+            Add-PodeRoute -Method Get -Path '/route3' -ScriptBlock {
+                "Hello there, $($using:message)" | Out-Default
+                Write-PodeJsonResponse -Value @{ ID = 3 }
+            }
         }
     }
 

--- a/src/Pode.psd1
+++ b/src/Pode.psd1
@@ -136,6 +136,9 @@
         'Get-PodeStaticRoute',
         'Get-PodeSignalRoute',
         'Use-PodeRoutes',
+        'Add-PodeRouteGroup',
+        'Add-PodeStaticRouteGroup',
+        'Add-PodeSignalRouteGroup',
 
         # handlers
         'Add-PodeHandler',

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -2910,6 +2910,10 @@ function Get-PodeScriptblockArguments
         $UsingVariables
     )
 
+    if ($null -eq $ArgumentList) {
+        $ArgumentList = @()
+    }
+
     if (($null -eq $UsingVariables) -or ($UsingVariables.Length -le 0)) {
         return $ArgumentList
     }

--- a/src/Public/Routes.ps1
+++ b/src/Public/Routes.ps1
@@ -393,6 +393,10 @@ function Add-PodeStaticRoute
             $Path = "$($RouteGroup.Path)$($Path)"
         }
 
+        if (![string]::IsNullOrWhiteSpace($RouteGroup.Source)) {
+            $Source = [System.IO.Path]::Combine($Source, $RouteGroup.Source.TrimStart('\/'))
+        }
+
         if ($null -ne $RouteGroup.Middleware) {
             $Middleware = $RouteGroup.Middleware + $Middleware
         }
@@ -675,7 +679,7 @@ Add a Route Group for multiple Routes.
 Add a Route Group for sharing values between multiple Routes.
 
 .PARAMETER Path
-The URI path to use as a base for the Routes.
+The URI path to use as a base for the Routes, that should be prepended.
 
 .PARAMETER Routes
 A ScriptBlock for adding Routes.
@@ -708,7 +712,7 @@ function Add-PodeRouteGroup
 {
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
+        [Parameter()]
         [string]
         $Path,
 
@@ -750,6 +754,10 @@ function Add-PodeRouteGroup
         throw "No scriptblock for -Routes passed"
     }
 
+    if ($Path -eq '/') {
+        $Path = $null
+    }
+
     # check if the scriptblock has any using vars
     $Routes, $usingVars = Invoke-PodeUsingScriptConversion -ScriptBlock $Routes -PSSession $PSCmdlet.SessionState
 
@@ -758,6 +766,40 @@ function Add-PodeRouteGroup
     $Routes = Invoke-PodeSessionScriptConversion -ScriptBlock $Routes
 
     # group details
+    if ($null -ne $RouteGroup) {
+        if (![string]::IsNullOrWhiteSpace($RouteGroup.Path)) {
+            $Path = "$($RouteGroup.Path)$($Path)"
+        }
+
+        if ($null -ne $RouteGroup.Middleware) {
+            $Middleware = $RouteGroup.Middleware + $Middleware
+        }
+
+        if ([string]::IsNullOrWhiteSpace($EndpointName)) {
+            $EndpointName = $RouteGroup.EndpointName
+        }
+
+        if ([string]::IsNullOrWhiteSpace($ContentType)) {
+            $ContentType = $RouteGroup.ContentType
+        }
+
+        if ([string]::IsNullOrWhiteSpace($TransferEncoding)) {
+            $TransferEncoding = $RouteGroup.TransferEncoding
+        }
+
+        if ([string]::IsNullOrWhiteSpace($ErrorContentType)) {
+            $ErrorContentType = $RouteGroup.ErrorContentType
+        }
+
+        if ([string]::IsNullOrWhiteSpace($Authentication)) {
+            $Authentication = $RouteGroup.Authentication
+        }
+
+        if ($RouteGroup.AllowAnon) {
+            $AllowAnon = $RouteGroup.AllowAnon
+        }
+    }
+
     $RouteGroup = @{
         Path = $Path
         Middleware = $Middleware
@@ -783,6 +825,9 @@ Add a Static Route Group for sharing values between multiple Static Routes.
 
 .PARAMETER Path
 The URI path to use as a base for the Static Routes.
+
+.PARAMETER Source
+A literal, or relative, base path to the directory that contains the static content, that should be prepended.
 
 .PARAMETER Routes
 A ScriptBlock for adding Static Routes.
@@ -821,9 +866,13 @@ function Add-PodeStaticRouteGroup
 {
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
+        [Parameter()]
         [string]
         $Path,
+
+        [Parameter()]
+        [string]
+        $Source,
 
         [Parameter(Mandatory=$true)]
         [scriptblock]
@@ -870,6 +919,10 @@ function Add-PodeStaticRouteGroup
         throw "No scriptblock for -Routes passed"
     }
 
+    if ($Path -eq '/') {
+        $Path = $null
+    }
+
     # check if the scriptblock has any using vars
     $Routes, $usingVars = Invoke-PodeUsingScriptConversion -ScriptBlock $Routes -PSSession $PSCmdlet.SessionState
 
@@ -878,8 +931,55 @@ function Add-PodeStaticRouteGroup
     $Routes = Invoke-PodeSessionScriptConversion -ScriptBlock $Routes
 
     # group details
+    if ($null -ne $RouteGroup) {
+        if (![string]::IsNullOrWhiteSpace($RouteGroup.Path)) {
+            $Path = "$($RouteGroup.Path)$($Path)"
+        }
+
+        if (![string]::IsNullOrWhiteSpace($RouteGroup.Source)) {
+            $Source = [System.IO.Path]::Combine($Source, $RouteGroup.Source.TrimStart('\/'))
+        }
+
+        if ($null -ne $RouteGroup.Middleware) {
+            $Middleware = $RouteGroup.Middleware + $Middleware
+        }
+
+        if ([string]::IsNullOrWhiteSpace($EndpointName)) {
+            $EndpointName = $RouteGroup.EndpointName
+        }
+
+        if ([string]::IsNullOrWhiteSpace($ContentType)) {
+            $ContentType = $RouteGroup.ContentType
+        }
+
+        if ([string]::IsNullOrWhiteSpace($TransferEncoding)) {
+            $TransferEncoding = $RouteGroup.TransferEncoding
+        }
+
+        if ([string]::IsNullOrWhiteSpace($ErrorContentType)) {
+            $ErrorContentType = $RouteGroup.ErrorContentType
+        }
+
+        if ([string]::IsNullOrWhiteSpace($Authentication)) {
+            $Authentication = $RouteGroup.Authentication
+        }
+
+        if (Test-PodeIsEmpty $Defaults) {
+            $Defaults = $RouteGroup.Defaults
+        }
+
+        if ($RouteGroup.AllowAnon) {
+            $AllowAnon = $RouteGroup.AllowAnon
+        }
+
+        if ($RouteGroup.DownloadOnly) {
+            $DownloadOnly = $RouteGroup.DownloadOnly
+        }
+    }
+
     $RouteGroup = @{
         Path = $Path
+        Source = $Source
         Middleware = $Middleware
         EndpointName = $EndpointName
         ContentType = $ContentType
@@ -905,7 +1005,7 @@ Adds a Signal Route Group for multiple WebSockets.
 Adds a Signal Route Group for sharing values between multiple WebSockets.
 
 .PARAMETER Path
-The URI path to use as a base for the Signal Routes.
+The URI path to use as a base for the Signal Routes, that should be prepended.
 
 .PARAMETER Routes
 A ScriptBlock for adding Signal Routes.
@@ -920,7 +1020,7 @@ function Add-PodeSignalRouteGroup
 {
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
+        [Parameter()]
         [string]
         $Path,
 
@@ -937,6 +1037,10 @@ function Add-PodeSignalRouteGroup
         throw "No scriptblock for -Routes passed"
     }
 
+    if ($Path -eq '/') {
+        $Path = $null
+    }
+
     # check if the scriptblock has any using vars
     $Routes, $usingVars = Invoke-PodeUsingScriptConversion -ScriptBlock $Routes -PSSession $PSCmdlet.SessionState
 
@@ -945,6 +1049,16 @@ function Add-PodeSignalRouteGroup
     $Routes = Invoke-PodeSessionScriptConversion -ScriptBlock $Routes
 
     # group details
+    if ($null -ne $RouteGroup) {
+        if (![string]::IsNullOrWhiteSpace($RouteGroup.Path)) {
+            $Path = "$($RouteGroup.Path)$($Path)"
+        }
+
+        if ([string]::IsNullOrWhiteSpace($EndpointName)) {
+            $EndpointName = $RouteGroup.EndpointName
+        }
+    }
+
     $RouteGroup = @{
         Path = $Path
         EndpointName = $EndpointName

--- a/src/Public/Routes.ps1
+++ b/src/Public/Routes.ps1
@@ -667,6 +667,43 @@ function Add-PodeSignalRoute
     $PodeContext.Server.Routes[$Method][$Path] += @($newRoutes)
 }
 
+<#
+.SYNOPSIS
+Add a Route Group for multiple Routes.
+
+.DESCRIPTION
+Add a Route Group for sharing values between multiple Routes.
+
+.PARAMETER Path
+The URI path to use as a base for the Routes.
+
+.PARAMETER Routes
+A ScriptBlock for adding Routes.
+
+.PARAMETER Middleware
+An array of ScriptBlocks for optional Middleware to give each Route.
+
+.PARAMETER EndpointName
+The EndpointName of an Endpoint(s) to use for the Routes.
+
+.PARAMETER ContentType
+The content type to use for the Routes, when parsing any payloads.
+
+.PARAMETER TransferEncoding
+The transfer encoding to use for the Routes, when parsing any payloads.
+
+.PARAMETER ErrorContentType
+The content type of any error pages that may get returned.
+
+.PARAMETER Authentication
+The name of an Authentication method which should be used as middleware on the Routes.
+
+.PARAMETER AllowAnon
+If supplied, the Routes will allow anonymous access for non-authenticated users.
+
+.EXAMPLE
+Add-PodeRouteGroup -Path '/api' -Routes { Add-PodeRoute -Path '/route1' -Etc }
+#>
 function Add-PodeRouteGroup
 {
     [CmdletBinding()]
@@ -737,6 +774,49 @@ function Add-PodeRouteGroup
     $null = Invoke-PodeScriptBlock -ScriptBlock $Routes -Arguments $_args -Splat
 }
 
+<#
+.SYNOPSIS
+Add a Static Route Group for multiple Static Routes.
+
+.DESCRIPTION
+Add a Static Route Group for sharing values between multiple Static Routes.
+
+.PARAMETER Path
+The URI path to use as a base for the Static Routes.
+
+.PARAMETER Routes
+A ScriptBlock for adding Static Routes.
+
+.PARAMETER Middleware
+An array of ScriptBlocks for optional Middleware to give each Static Route.
+
+.PARAMETER EndpointName
+The EndpointName of an Endpoint(s) to use for the Static Routes.
+
+.PARAMETER ContentType
+The content type to use for the Static Routes, when parsing any payloads.
+
+.PARAMETER TransferEncoding
+The transfer encoding to use for the Static Routes, when parsing any payloads.
+
+.PARAMETER Defaults
+An array of default pages to display, such as 'index.html', for each Static Route.
+
+.PARAMETER ErrorContentType
+The content type of any error pages that may get returned.
+
+.PARAMETER Authentication
+The name of an Authentication method which should be used as middleware on the Static Routes.
+
+.PARAMETER AllowAnon
+If supplied, the Static Routes will allow anonymous access for non-authenticated users.
+
+.PARAMETER DownloadOnly
+When supplied, all static content on the Routes will be attached as downloads - rather than rendered.
+
+.EXAMPLE
+Add-PodeStaticRouteGroup -Path '/static' -Routes { Add-PodeStaticRoute -Path '/images' -Etc }
+#>
 function Add-PodeStaticRouteGroup
 {
     [CmdletBinding()]


### PR DESCRIPTION
### Description of the Change
Adds support for grouping Routes, to make it easier to give multiple routes shared data - such as middleware, auth, base paths, etc.

This has been added for Routes, Static Routes, and Signal Routes:

* `Add-PodeRouteGroup`
* `Add-PodeStaticRouteGroup`
* `Add-PodeSignalRouteGroup`

### Examples
For example, the below will add 3 Routes which all share a `/api` base path; some Basic authentication, and some other middleware:

```powershell
$mid = New-PodeMiddleware -ScriptBlock {
    'some middleware being run' | Out-Default
}
Add-PodeRouteGroup -Path '/api' -Authentication Basic -Middleware $mid -Routes {
    Add-PodeRoute -Method Get -Path '/route1' -ScriptBlock {
        Write-PodeJsonResponse -Value @{ ID = 1 }
    }
    Add-PodeRoute -Method Get -Path '/route2' -ScriptBlock {
        Write-PodeJsonResponse -Value @{ ID = 2 }
    }
    Add-PodeRoute -Method Get -Path '/route3' -ScriptBlock {
        Write-PodeJsonResponse -Value @{ ID = 3 }
    }
}
```

When run, you'll have 3 Routes that all need some Basic authentication at `/api/route1`, `/api/route2`, and `/api/route3`.
