### PR TITLE
Add * level for errors to enable everything

### DIFF
--- a/src/Public/Logging.ps1
+++ b/src/Public/Logging.ps1
@@ -322,7 +322,7 @@ function Enable-PodeErrorLogging
 
         [Parameter()]
         [ValidateNotNullOrEmpty()]
-        [ValidateSet('Error', 'Warning', 'Informational', 'Verbose', 'Debug')]
+        [ValidateSet('Error', 'Warning', 'Informational', 'Verbose', 'Debug', '*')]
         [string[]]
         $Levels = @('Error'),
 
@@ -340,6 +340,11 @@ function Enable-PodeErrorLogging
     # ensure the Method contains a scriptblock
     if (Test-PodeIsEmpty $Method.ScriptBlock) {
         throw "The supplied output Method for Error Logging requires a valid ScriptBlock"
+    }
+
+    # all errors?
+    if ($Levels -contains '*') {
+        $Levels = @('Error', 'Warning', 'Informational', 'Verbose', 'Debug')
     }
 
     # add the error logger


### PR DESCRIPTION
### Description of the Change
Add a new error level of `*` to `Enable-PodeErrorLogging` to show logs of every level: Error, Warning, Informational, Verbose, and Debug

### Examples
```powershell
New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging -Level *
```
