### PR TITLE
Add Position=0 to most response write functions

### DIFF
--- a/src/Public/Responses.ps1
+++ b/src/Public/Responses.ps1
@@ -162,7 +162,7 @@ function Write-PodeTextResponse
 {
     [CmdletBinding(DefaultParameterSetName='String')]
     param (
-        [Parameter(ParameterSetName='String', ValueFromPipeline=$true)]
+        [Parameter(ParameterSetName='String', ValueFromPipeline=$true, Position=0)]
         [string]
         $Value,
 
@@ -478,7 +478,7 @@ function Write-PodeCsvResponse
 {
     [CmdletBinding(DefaultParameterSetName='Value')]
     param (
-        [Parameter(Mandatory=$true, ParameterSetName='Value', ValueFromPipeline=$true)]
+        [Parameter(Mandatory=$true, ParameterSetName='Value', ValueFromPipeline=$true, Position=0)]
         $Value,
 
         [Parameter(Mandatory=$true, ParameterSetName='File')]
@@ -551,7 +551,7 @@ function Write-PodeHtmlResponse
 {
     [CmdletBinding(DefaultParameterSetName='Value')]
     param (
-        [Parameter(Mandatory=$true, ParameterSetName='Value', ValueFromPipeline=$true)]
+        [Parameter(Mandatory=$true, ParameterSetName='Value', ValueFromPipeline=$true, Position=0)]
         $Value,
 
         [Parameter(Mandatory=$true, ParameterSetName='File')]
@@ -614,7 +614,7 @@ function Write-PodeMarkdownResponse
 {
     [CmdletBinding(DefaultParameterSetName='Value')]
     param (
-        [Parameter(Mandatory=$true, ParameterSetName='Value', ValueFromPipeline=$true)]
+        [Parameter(Mandatory=$true, ParameterSetName='Value', ValueFromPipeline=$true, Position=0)]
         $Value,
 
         [Parameter(Mandatory=$true, ParameterSetName='File')]
@@ -685,7 +685,7 @@ function Write-PodeJsonResponse
 {
     [CmdletBinding(DefaultParameterSetName='Value')]
     param (
-        [Parameter(Mandatory=$true, ParameterSetName='Value', ValueFromPipeline=$true)]
+        [Parameter(Mandatory=$true, ParameterSetName='Value', ValueFromPipeline=$true, Position=0)]
         $Value,
 
         [Parameter(Mandatory=$true, ParameterSetName='File')]
@@ -756,7 +756,7 @@ function Write-PodeXmlResponse
 {
     [CmdletBinding(DefaultParameterSetName='Value')]
     param (
-        [Parameter(Mandatory=$true, ParameterSetName='Value', ValueFromPipeline=$true)]
+        [Parameter(Mandatory=$true, ParameterSetName='Value', ValueFromPipeline=$true, Position=0)]
         $Value,
 
         [Parameter(Mandatory=$true, ParameterSetName='File')]


### PR DESCRIPTION
### Description of the Change
Add `Position = 0` to the `-Value` parameter of most Response Write functions, so supplying a simple value with no parameter name works.

### Related Issue
Resolves #974 

### Examples
```powershell
Write-PodeJsonResponse @{ Name = 'John' }

# as a short hand for:
Write-PodeJsonResponse -Value @{ Name = 'John' }
```
