### PR TITLE
Fix restarting when no Verbs

### DIFF
--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -2925,3 +2925,20 @@ function Get-PodeScriptblockArguments
 
     return ($_vars + $ArgumentList)
 }
+
+function Clear-PodeHashtableInnerKeys
+{
+    param(
+        [Parameter(ValueFromPipeline=$true)]
+        [hashtable]
+        $InputObject
+    )
+
+    if (Test-PodeIsEmpty $InputObject) {
+        return
+    }
+
+    $InputObject.Keys.Clone() | ForEach-Object {
+        $InputObject[$_].Clear()
+    }
+}

--- a/src/Private/Server.ps1
+++ b/src/Private/Server.ps1
@@ -165,21 +165,10 @@ function Restart-PodeInternalServer
         $PodeContext.Server.Modules.Clear()
 
         # clear up timers, schedules and loggers
-        $PodeContext.Server.Routes.Keys.Clone() | ForEach-Object {
-            $PodeContext.Server.Routes[$_].Clear()
-        }
-
-        $PodeContext.Server.Handlers.Keys.Clone() | ForEach-Object {
-            $PodeContext.Server.Handlers[$_].Clear()
-        }
-
-        $PodeContext.Server.Verbs.Keys.Clone() | ForEach-Object {
-            $PodeContext.Server.Verbs[$_].Clear()
-        }
-
-        $PodeContext.Server.Events.Keys.Clone() | ForEach-Object {
-            $PodeContext.Server.Events[$_].Clear()
-        }
+        $PodeContext.Server.Routes | Clear-PodeHashtableInnerKeys
+        $PodeContext.Server.Handlers | Clear-PodeHashtableInnerKeys
+        $PodeContext.Server.Verbs | Clear-PodeHashtableInnerKeys
+        $PodeContext.Server.Events | Clear-PodeHashtableInnerKeys
 
         $PodeContext.Server.Views.Clear()
         $PodeContext.Timers.Items.Clear()
@@ -207,10 +196,7 @@ function Restart-PodeInternalServer
 
         # clear security headers
         $PodeContext.Server.Security.Headers.Clear()
-
-        $PodeContext.Server.Security.Cache.Keys.Clone() | ForEach-Object {
-            $PodeContext.Server.Security.Cache[$_].Clear()
-        }
+        $PodeContext.Server.Security.Cache | Clear-PodeHashtableInnerKeys
 
         # clear endpoints
         $PodeContext.Server.Endpoints.Clear()


### PR DESCRIPTION
### Description of the Change
When no Verbs were created, restarting a Pode server crashed because the Verbs hashtable has no entries. This PR fixes this issue, by not attempting to clear empty hashtables.

### Related Issue
Resolves #1001 
