### PR TITLE
Adds missing ListenerType parameter description

### DIFF
--- a/src/Public/Core.ps1
+++ b/src/Public/Core.ps1
@@ -34,6 +34,10 @@ Optional, this is the serverless type, to define how Pode should run and deal wi
 An optional value of Show/Hide to control where Stacktraces are shown in the Status Pages.
 If supplied this value will override the ShowExceptions setting in the server.psd1 file.
 
+.PARAMETER ListenerType
+An optional value to use a custom Socket Listener. The default is Pode's inbuilt listener.
+There's the Pode.Kestrel module, so the value here should be "Kestrel" if using that.
+
 .PARAMETER DisableTermination
 Disables the ability to terminate the Server.
 

--- a/tests/unit/_.Tests.ps1
+++ b/tests/unit/_.Tests.ps1
@@ -1,0 +1,21 @@
+$path = $MyInvocation.MyCommand.Path
+$src = (Split-Path -Parent -Path $path) -ireplace '[\\/]tests[\\/]unit', '/src/'
+Import-Module "$($src)/Pode.psm1" -Force
+
+Describe 'Exported Functions' {
+    It 'Have Parameter Descriptions' {
+        $funcs = (Get-Module Pode).ExportedFunctions.Values.Name
+        $found = @()
+
+        foreach ($func in $funcs) {
+            $params = (Get-Help -Name $func -Detailed).parameters.parameter
+            foreach ($param in $params) {
+                if (!$param.Description) {
+                    $found += "$($func): $($param.Name)"
+                }
+            }
+        }
+
+        $found | Should Be @()
+    }
+}


### PR DESCRIPTION
### Description of the Change
Adds missing `-ListenerType` parameter description for `Start-PodeServer`. Also adds a unit test which checks that all exported function parameters have descriptions.

### Related Issue
Resolves #988 
