### PR TITLE
Fix missing 221 response on SMTP QUIT

### DIFF
--- a/src/Listener/PodeSmtpRequest.cs
+++ b/src/Listener/PodeSmtpRequest.cs
@@ -115,6 +115,7 @@ namespace Pode
             if (IsCommand(content, "QUIT"))
             {
                 Command = PodeSmtpCommand.Quit;
+                Context.Response.WriteLine("221 OK", true);
                 return true;
             }
 


### PR DESCRIPTION
### Description of the Change
When a `QUIT` is sent to a Pode SMTP server, Pode will now respond with `221 OK`.

### Related Issue
Resolves #1028 
