### PR TITLE
Add IfExists parameter for Routes to define if a second Route should Error, Overwrite or be Skipped

### DIFF
--- a/src/Pode.psd1
+++ b/src/Pode.psd1
@@ -139,6 +139,10 @@
         'Add-PodeRouteGroup',
         'Add-PodeStaticRouteGroup',
         'Add-PodeSignalRouteGroup',
+        'Set-PodeRouteIfExistsPreference',
+        'Test-PodeRoute',
+        'Test-PodeStaticRoute',
+        'Test-PodeSignalRoute',
 
         # handlers
         'Add-PodeHandler',

--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -276,6 +276,13 @@ function New-PodeContext
         IsDynamic = $false
     }
 
+    # pode default preferences
+    $ctx.Server.Preferences = @{
+        Routes = @{
+            IfExists = $null
+        }
+    }
+
     # routes for pages and api
     $ctx.Server.Routes = @{
         'delete'    = [ordered]@{}

--- a/src/Private/Routes.ps1
+++ b/src/Private/Routes.ps1
@@ -609,16 +609,23 @@ function ConvertTo-PodeMiddleware
 
 function Get-PodeRouteIfExistsPreference
 {
-    $interalPref = $RouteIfExists
+    # from route groups
+    $groupPref = $RouteGroup.IfExists
+    if (![string]::IsNullOrWhiteSpace($groupPref) -and ($groupPref -ine 'default')) {
+        return $groupPref
+    }
+
+    # from Use-PodeRoute
+    if (![string]::IsNullOrWhiteSpace($RouteIfExists) -and ($RouteIfExists -ine 'default')) {
+        return $RouteIfExists
+    }
+
+    # global preference
     $globalPref = $PodeContext.Server.Preferences.Routes.IfExists
-
-    if ([string]::IsNullOrWhiteSpace($interalPref) -or ($interalPref -ieq 'default')) {
-        if ([string]::IsNullOrWhiteSpace($globalPref) -or ($globalPref -ieq 'default')) {
-            return 'Error'
-        }
-
+    if (![string]::IsNullOrWhiteSpace($globalPref) -and ($globalPref -ine 'default')) {
         return $globalPref
     }
 
-    return $interalPref
+    # final global default
+    return 'Error'
 }

--- a/src/Private/Routes.ps1
+++ b/src/Private/Routes.ps1
@@ -1,4 +1,4 @@
-function Test-PodeRoute
+function Test-PodeRouteFromRequest
 {
     param (
         [Parameter(Mandatory=$true)]
@@ -395,9 +395,9 @@ function Get-PodeStaticRouteDefaults
     )
 }
 
-function Test-PodeRouteAndError
+function Test-PodeRouteInternal
 {
-    param (
+    param(
         [Parameter(Mandatory=$true)]
         [string]
         $Method,
@@ -412,15 +412,34 @@ function Test-PodeRouteAndError
 
         [Parameter()]
         [string]
-        $Address
+        $Address,
+
+        [switch]
+        $ThrowError
     )
 
-    $found = @($PodeContext.Server.Routes[$Method][$Path])
+    # check the routes
+    $found = $false
+    $routes = @($PodeContext.Server.Routes[$Method][$Path])
 
-    if (($found | Where-Object { ($_.Endpoint.Protocol -ieq $Protocol) -and ($_.Endpoint.Address -ieq $Address) } | Measure-Object).Count -eq 0) {
-        return
+    foreach ($route in $routes) {
+        if (($route.Endpoint.Protocol -ieq $Protocol) -and ($route.Endpoint.Address -ieq $Address)) {
+            $found = $true
+            break
+        }
     }
 
+    # skip if not found
+    if (!$found) {
+        return $false
+    }
+
+    # do we want to throw an error if found, or skip?
+    if (!$ThrowError) {
+        return $true
+    }
+
+    # throw error
     $_url = $Protocol
     if (![string]::IsNullOrEmpty($_url) -and ![string]::IsNullOrWhiteSpace($Address)) {
         $_url = "$($_url)://$($Address)"
@@ -432,9 +451,8 @@ function Test-PodeRouteAndError
     if ([string]::IsNullOrEmpty($_url)) {
         throw "[$($Method)] $($Path): Already defined"
     }
-    else {
-        throw "[$($Method)] $($Path): Already defined for $($_url)"
-    }
+
+    throw "[$($Method)] $($Path): Already defined for $($_url)"
 }
 
 function Convert-PodeFunctionVerbToHttpMethod
@@ -587,4 +605,20 @@ function ConvertTo-PodeMiddleware
     })
 
     return $converted
+}
+
+function Get-PodeRouteIfExistsPreference
+{
+    $interalPref = $RouteIfExists
+    $globalPref = $PodeContext.Server.Preferences.Routes.IfExists
+
+    if ([string]::IsNullOrWhiteSpace($interalPref) -or ($interalPref -ieq 'default')) {
+        if ([string]::IsNullOrWhiteSpace($globalPref) -or ($globalPref -ieq 'default')) {
+            return 'Error'
+        }
+
+        return $globalPref
+    }
+
+    return $interalPref
 }

--- a/src/Public/Routes.ps1
+++ b/src/Public/Routes.ps1
@@ -50,6 +50,9 @@ If supplied, the Route will be flagged to Authentication as being a Route that h
 .PARAMETER PassThru
 If supplied, the route created will be returned so it can be passed through a pipe.
 
+.PARAMETER IfExists
+Specifies what action to take when a Route already exists. (Default: Default)
+
 .EXAMPLE
 Add-PodeRoute -Method Get -Path '/' -ScriptBlock { /* logic */ }
 
@@ -119,6 +122,10 @@ function Add-PodeRoute
         [string]
         $Authentication,
 
+        [Parameter()]
+        [ValidateSet('Default', 'Error', 'Overwrite', 'Skip')]
+        $IfExists = 'Default',
+
         [switch]
         $AllowAnon,
 
@@ -167,6 +174,9 @@ function Add-PodeRoute
         }
     }
 
+    # store the original path
+    $origPath = $Path
+
     # split route on '?' for query
     $Path = Split-PodeRouteQuery -Path $Path
     if ([string]::IsNullOrWhiteSpace($Path)) {
@@ -185,9 +195,30 @@ function Add-PodeRoute
 
     $endpoints = Find-PodeEndpoints -EndpointName $EndpointName
 
+    # get default route IfExists state
+    if ($IfExists -ieq 'Default') {
+        $IfExists = Get-PodeRouteIfExistsPreference
+    }
+
     # ensure the route doesn't already exist for each endpoint
-    foreach ($_endpoint in $endpoints) {
-        Test-PodeRouteAndError -Method $Method -Path $Path -Protocol $_endpoint.Protocol -Address $_endpoint.Address
+    $endpoints = @(foreach ($_endpoint in $endpoints) {
+        $found = Test-PodeRouteInternal -Method $Method -Path $Path -Protocol $_endpoint.Protocol -Address $_endpoint.Address -ThrowError:($IfExists -ieq 'Error')
+
+        if ($found) {
+            if ($IfExists -ieq 'Overwrite') {
+                Remove-PodeRoute -Method $Method -Path $origPath -EndpointName $_endpoint.Name
+            }
+
+            if ($IfExists -ieq 'Skip') {
+                continue
+            }
+        }
+
+        $_endpoint
+    })
+
+    if (($null -eq $endpoints) -or ($endpoints.Length -eq 0)) {
+        return
     }
 
     # if middleware, scriptblock and file path are all null/empty, error
@@ -326,6 +357,9 @@ When supplied, all static content on this Route will be attached as downloads - 
 .PARAMETER PassThru
 If supplied, the static route created will be returned so it can be passed through a pipe.
 
+.PARAMETER IfExists
+Specifies what action to take when a Static Route already exists. (Default: Default)
+
 .EXAMPLE
 Add-PodeStaticRoute -Path '/assets' -Source './assets'
 
@@ -338,7 +372,7 @@ Add-PodeStaticRoute -Path '/installers' -Source './exes' -DownloadOnly
 function Add-PodeStaticRoute
 {
     [CmdletBinding()]
-    param (
+    param(
         [Parameter(Mandatory=$true)]
         [string]
         $Path,
@@ -376,6 +410,10 @@ function Add-PodeStaticRoute
         [Alias('Auth')]
         [string]
         $Authentication,
+
+        [Parameter()]
+        [ValidateSet('Default', 'Error', 'Overwrite', 'Skip')]
+        $IfExists = 'Default',
 
         [switch]
         $AllowAnon,
@@ -437,6 +475,9 @@ function Add-PodeStaticRoute
     # store the route method
     $Method = 'Static'
 
+    # store the original path
+    $origPath = $Path
+
     # split route on '?' for query
     $Path = Split-PodeRouteQuery -Path $Path
     if ([string]::IsNullOrWhiteSpace($Path)) {
@@ -455,9 +496,30 @@ function Add-PodeStaticRoute
 
     $endpoints = Find-PodeEndpoints -EndpointName $EndpointName
 
+    # get default route IfExists state
+    if ($IfExists -ieq 'Default') {
+        $IfExists = Get-PodeRouteIfExistsPreference
+    }
+
     # ensure the route doesn't already exist for each endpoint
-    foreach ($_endpoint in $endpoints) {
-        Test-PodeRouteAndError -Method $Method -Path $Path -Protocol $_endpoint.Protocol -Address $_endpoint.Address
+    $endpoints = @(foreach ($_endpoint in $endpoints) {
+        $found = Test-PodeRouteInternal -Method $Method -Path $Path -Protocol $_endpoint.Protocol -Address $_endpoint.Address -ThrowError:($IfExists -ieq 'Error')
+
+        if ($found) {
+            if ($IfExists -ieq 'Overwrite') {
+                Remove-PodeStaticRoute -Path $origPath -EndpointName $_endpoint.Name
+            }
+
+            if ($IfExists -ieq 'Skip') {
+                continue
+            }
+        }
+
+        $_endpoint
+    })
+
+    if (($null -eq $endpoints) -or ($endpoints.Length -eq 0)) {
+        return
     }
 
     # if static, ensure the path exists at server root
@@ -569,6 +631,9 @@ A literal, or relative, path to a file containing a ScriptBlock for the Signal R
 .PARAMETER ArgumentList
 An array of arguments to supply to the Signal Route's ScriptBlock.
 
+.PARAMETER IfExists
+Specifies what action to take when a Signal Route already exists. (Default: Default)
+
 .EXAMPLE
 Add-PodeSignalRoute -Path '/message' -ScriptBlock { /* logic */ }
 
@@ -597,7 +662,11 @@ function Add-PodeSignalRoute
 
         [Parameter()]
         [object[]]
-        $ArgumentList
+        $ArgumentList,
+
+        [Parameter()]
+        [ValidateSet('Default', 'Error', 'Overwrite', 'Skip')]
+        $IfExists = 'Default'
     )
 
     # check if we have any route group info defined
@@ -613,6 +682,9 @@ function Add-PodeSignalRoute
 
     $Method = 'Signal'
 
+    # store the original path
+    $origPath = $Path
+
     # ensure the route has appropriate slashes
     $Path = Update-PodeRouteSlashes -Path $Path
 
@@ -623,9 +695,30 @@ function Add-PodeSignalRoute
 
     $endpoints = Find-PodeEndpoints -EndpointName $EndpointName
 
+    # get default route IfExists state
+    if ($IfExists -ieq 'Default') {
+        $IfExists = Get-PodeRouteIfExistsPreference
+    }
+
     # ensure the route doesn't already exist for each endpoint
-    foreach ($_endpoint in $endpoints) {
-        Test-PodeRouteAndError -Method $Method -Path $Path -Protocol $_endpoint.Protocol -Address $_endpoint.Address
+    $endpoints = @(foreach ($_endpoint in $endpoints) {
+        $found = Test-PodeRouteInternal -Method $Method -Path $Path -Protocol $_endpoint.Protocol -Address $_endpoint.Address -ThrowError:($IfExists -ieq 'Error')
+
+        if ($found) {
+            if ($IfExists -ieq 'Overwrite') {
+                Remove-PodeSignalRoute -Path $origPath -EndpointName $_endpoint.Name
+            }
+
+            if ($IfExists -ieq 'Skip') {
+                continue
+            }
+        }
+
+        $_endpoint
+    })
+
+    if (($null -eq $endpoints) -or ($endpoints.Length -eq 0)) {
+        return
     }
 
     # if scriptblock and file path are all null/empty, error
@@ -1154,7 +1247,7 @@ Remove-PodeStaticRoute -Path '/assets'
 function Remove-PodeStaticRoute
 {
     [CmdletBinding()]
-    param (
+    param(
         [Parameter(Mandatory=$true)]
         [string]
         $Path,
@@ -1356,7 +1449,7 @@ ConvertTo-PodeRoute -Commands @('Invoke-Pester') -Module Pester
 function ConvertTo-PodeRoute
 {
     [CmdletBinding()]
-    param (
+    param(
         [Parameter(ValueFromPipeline=$true)]
         [string[]]
         $Commands,
@@ -1554,7 +1647,7 @@ Add-PodePage -Name About -FilePath '.\views\about.pode' -Data @{ Date = [DateTim
 function Add-PodePage
 {
     [CmdletBinding(DefaultParameterSetName='ScriptBlock')]
-    param (
+    param(
         [Parameter(Mandatory=$true)]
         [ValidateNotNullOrEmpty()]
         [string]
@@ -1779,7 +1872,7 @@ Get-PodeStaticRoute -Path '/assets' -EndpointName User
 function Get-PodeStaticRoute
 {
     [CmdletBinding()]
-    param (
+    param(
         [Parameter()]
         [string]
         $Path,
@@ -1898,11 +1991,14 @@ Automatically loads route ps1 files from either a /routes folder, or a custom fo
 .PARAMETER Path
 Optional Path to a folder containing ps1 files, can be relative or literal.
 
+.PARAMETER IfExists
+Specifies what action to take when a Route already exists. (Default: Default)
+
 .EXAMPLE
 Use-PodeRoutes
 
 .EXAMPLE
-Use-PodeRoutes -Path './my-routes'
+Use-PodeRoutes -Path './my-routes' -IfExists Skip
 #>
 function Use-PodeRoutes
 {
@@ -1910,8 +2006,203 @@ function Use-PodeRoutes
     param(
         [Parameter()]
         [string]
-        $Path
+        $Path,
+
+        [Parameter()]
+        [ValidateSet('Default', 'Error', 'Overwrite', 'Skip')]
+        $IfExists = 'Default'
     )
 
+    if ($IfExists -ieq 'Default') {
+        $IfExists = Get-PodeRouteIfExistsPreference
+    }
+
+    $RouteIfExists = $IfExists
     Use-PodeFolder -Path $Path -DefaultPath 'routes'
+}
+
+<#
+.SYNOPSIS
+Set the default IfExists preference for Routes.
+
+.DESCRIPTION
+Set the default IfExists preference for Routes.
+
+.PARAMETER Value
+Specifies what action to take when a Route already exists. (Default: Default)
+
+.EXAMPLE
+Set-PodeRouteIfExistsPreference -Value Overwrite
+#>
+function Set-PodeRouteIfExistsPreference
+{
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [ValidateSet('Default', 'Error', 'Overwrite', 'Skip')]
+        $Value = 'Default'
+    )
+
+    $PodeContext.Server.Preferences.Routes.IfExists = $Value
+}
+
+<#
+.SYNOPSIS
+Test if a Route already exists.
+
+.DESCRIPTION
+Test if a Route already exists for a given Method and Path.
+
+.PARAMETER Method
+The HTTP Method of the Route.
+
+.PARAMETER Path
+The URI path of the Route.
+
+.PARAMETER EndpointName
+The EndpointName of an Endpoint the Route is bound against.
+
+.PARAMETER CheckWildcard
+If supplied, Pode will check for the Route on the Method first, and then check for the Route on the '*' Method.
+
+.EXAMPLE
+Test-PodeRoute -Method Post -Path '/example'
+
+.EXAMPLE
+Test-PodeRoute -Method Post -Path '/example' -CheckWildcard
+
+.EXAMPLE
+Test-PodeRoute -Method Get -Path '/example/:exampleId' -CheckWildcard
+#>
+function Test-PodeRoute
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [ValidateSet('Delete', 'Get', 'Head', 'Merge', 'Options', 'Patch', 'Post', 'Put', 'Trace', '*')]
+        [string]
+        $Method,
+
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Path,
+
+        [Parameter()]
+        [string]
+        $EndpointName,
+
+        [switch]
+        $CheckWildcard
+    )
+
+    # split route on '?' for query
+    $Path = Split-PodeRouteQuery -Path $Path
+    if ([string]::IsNullOrWhiteSpace($Path)) {
+        throw "No Path supplied for testing Route"
+    }
+
+    # ensure the route has appropriate slashes
+    $Path = Update-PodeRouteSlashes -Path $Path
+    $Path = Update-PodeRoutePlaceholders -Path $Path
+
+    # get endpoint from name
+    $endpoint = @(Find-PodeEndpoints -EndpointName $EndpointName)[0]
+
+    # check for routes
+    $found = (Test-PodeRouteInternal -Method $Method -Path $Path -Protocol $endpoint.Protocol -Address $endpoint.Address)
+    if (!$found -and $CheckWildcard) {
+        $found = (Test-PodeRouteInternal -Method '*' -Path $Path -Protocol $endpoint.Protocol -Address $endpoint.Address)
+    }
+
+    return $found
+}
+
+<#
+.SYNOPSIS
+Test if a Static Route already exists.
+
+.DESCRIPTION
+Test if a Static Route already exists for a given Path.
+
+.PARAMETER Path
+The URI path of the Static Route.
+
+.PARAMETER EndpointName
+The EndpointName of an Endpoint the Static Route is bound against.
+
+.EXAMPLE
+Test-PodeStaticRoute -Path '/assets'
+#>
+function Test-PodeStaticRoute
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Path,
+
+        [Parameter()]
+        [string]
+        $EndpointName
+    )
+
+    # store the route method
+    $Method = 'Static'
+
+    # split route on '?' for query
+    $Path = Split-PodeRouteQuery -Path $Path
+    if ([string]::IsNullOrWhiteSpace($Path)) {
+        throw "No Path supplied for testing Static Route"
+    }
+
+    # ensure the route has appropriate slashes
+    $Path = Update-PodeRouteSlashes -Path $Path -Static
+    $Path = Update-PodeRoutePlaceholders -Path $Path
+
+    # get endpoint from name
+    $endpoint = @(Find-PodeEndpoints -EndpointName $EndpointName)[0]
+
+    # check for routes
+    return (Test-PodeRouteInternal -Method $Method -Path $Path -Protocol $endpoint.Protocol -Address $endpoint.Address)
+}
+
+<#
+.SYNOPSIS
+Test if a Signal Route already exists.
+
+.DESCRIPTION
+Test if a Signal Route already exists for a given Path.
+
+.PARAMETER Path
+The URI path of the Signal Route.
+
+.PARAMETER EndpointName
+The EndpointName of an Endpoint the Signal Route is bound against.
+
+.EXAMPLE
+Test-PodeSignalRoute -Path '/message'
+#>
+function Test-PodeSignalRoute
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Path,
+
+        [Parameter()]
+        [string]
+        $EndpointName
+    )
+
+    $Method = 'Signal'
+
+    # ensure the route has appropriate slashes
+    $Path = Update-PodeRouteSlashes -Path $Path
+
+    # get endpoint from name
+    $endpoint = @(Find-PodeEndpoints -EndpointName $EndpointName)[0]
+
+    # check for routes
+    return (Test-PodeRouteInternal -Method $Method -Path $Path -Protocol $endpoint.Protocol -Address $endpoint.Address)
 }

--- a/src/Public/Routes.ps1
+++ b/src/Public/Routes.ps1
@@ -795,6 +795,9 @@ The content type of any error pages that may get returned.
 .PARAMETER Authentication
 The name of an Authentication method which should be used as middleware on the Routes.
 
+.PARAMETER IfExists
+Specifies what action to take when a Route already exists. (Default: Default)
+
 .PARAMETER AllowAnon
 If supplied, the Routes will allow anonymous access for non-authenticated users.
 
@@ -838,6 +841,10 @@ function Add-PodeRouteGroup
         [Alias('Auth')]
         [string]
         $Authentication,
+
+        [Parameter()]
+        [ValidateSet('Default', 'Error', 'Overwrite', 'Skip')]
+        $IfExists = 'Default',
 
         [switch]
         $AllowAnon
@@ -891,6 +898,10 @@ function Add-PodeRouteGroup
         if ($RouteGroup.AllowAnon) {
             $AllowAnon = $RouteGroup.AllowAnon
         }
+
+        if ($IfExists -ieq 'default') {
+            $IfExists = Get-PodeRouteIfExistsPreference
+        }
     }
 
     $RouteGroup = @{
@@ -902,6 +913,7 @@ function Add-PodeRouteGroup
         ErrorContentType = $ErrorContentType
         Authentication = $Authentication
         AllowAnon = $AllowAnon
+        IfExists = $IfExists
     }
 
     # add routes
@@ -945,6 +957,9 @@ The content type of any error pages that may get returned.
 
 .PARAMETER Authentication
 The name of an Authentication method which should be used as middleware on the Static Routes.
+
+.PARAMETER IfExists
+Specifies what action to take when a Static Route already exists. (Default: Default)
 
 .PARAMETER AllowAnon
 If supplied, the Static Routes will allow anonymous access for non-authenticated users.
@@ -1000,6 +1015,10 @@ function Add-PodeStaticRouteGroup
         [Alias('Auth')]
         [string]
         $Authentication,
+
+        [Parameter()]
+        [ValidateSet('Default', 'Error', 'Overwrite', 'Skip')]
+        $IfExists = 'Default',
 
         [switch]
         $AllowAnon,
@@ -1068,6 +1087,10 @@ function Add-PodeStaticRouteGroup
         if ($RouteGroup.DownloadOnly) {
             $DownloadOnly = $RouteGroup.DownloadOnly
         }
+
+        if ($IfExists -ieq 'default') {
+            $IfExists = Get-PodeRouteIfExistsPreference
+        }
     }
 
     $RouteGroup = @{
@@ -1082,6 +1105,7 @@ function Add-PodeStaticRouteGroup
         Authentication = $Authentication
         AllowAnon = $AllowAnon
         DownloadOnly = $DownloadOnly
+        IfExists = $IfExists
     }
 
     # add routes
@@ -1106,6 +1130,9 @@ A ScriptBlock for adding Signal Routes.
 .PARAMETER EndpointName
 The EndpointName of an Endpoint(s) to use for the Signal Routes.
 
+.PARAMETER IfExists
+Specifies what action to take when a Signal Route already exists. (Default: Default)
+
 .EXAMPLE
 Add-PodeSignalRouteGroup -Path '/signals' -Routes { Add-PodeSignalRoute -Path '/signal1' -Etc }
 #>
@@ -1123,7 +1150,11 @@ function Add-PodeSignalRouteGroup
 
         [Parameter()]
         [string[]]
-        $EndpointName
+        $EndpointName,
+
+        [Parameter()]
+        [ValidateSet('Default', 'Error', 'Overwrite', 'Skip')]
+        $IfExists = 'Default'
     )
 
     if (Test-PodeIsEmpty $Routes) {
@@ -1150,11 +1181,16 @@ function Add-PodeSignalRouteGroup
         if ([string]::IsNullOrWhiteSpace($EndpointName)) {
             $EndpointName = $RouteGroup.EndpointName
         }
+
+        if ($IfExists -ieq 'default') {
+            $IfExists = Get-PodeRouteIfExistsPreference
+        }
     }
 
     $RouteGroup = @{
         Path = $Path
         EndpointName = $EndpointName
+        IfExists = $IfExists
     }
 
     # add routes


### PR DESCRIPTION
### Description of the Change
Adds a new `-IfExists` parameter to `Add-PodeRoute`, `Add-PodeStaticRoute`, and `Add-PodeSignalRoute` - including the relevant Group functions like `Add-PodeRouteGroup`. This parameter takes the values Default, Error, Overwrite, and Skip. (the default behaviour is Error, as it currently is)

The same parameter has also been added onto `Use-PodeRoutes`, meaning you can apply `Skip` to all Routes on mass:
```powershell
Use-PodeRoutes -IfExists Skip
```

Furthermore, there's also a new `Set-PodeRouteIfExistsPreference` function which let's you overwrite the global default behaviour of Error:
```powershell
Set-PodeRouteIfExistsPreference -Value Overwrite
```

In the case of the options:
* **Default**: will use the IfExists value from higher up the hierarchy (see below) - if none defined, Error is the final default
* **Error**: if the Route already exists, throw an error
* **Overwrite**: if the Route already exists, delete the existing Route and recreate with the new definition
* **Skip**: if the Route already exists, skip over the Route and do nothing

The default value that is used is defined by the following hierarchy:
* IfExists value of the current Route (like `Add-PodeRoute`)
* IfExists value of the Route Group (like `Add-PodeRouteGroup`)
* IfExists value from `Use-PodeRoute`
* IfExists value from `Set-PodeRouteIfExistsPreference`
* Throw an Error

This also adds 3 new Test functions:
* `Test-PodeRoute`
* `Test-PodeStaticRoute`
* `Test-PodeSignalRoute`

### Related Issue
Resolves #964 

### Examples
To Skip over creating a Route that already exists:
```powershell
Start-PodeServer -Thread 2 -Verbose {
    Add-PodeEndpoint -Address * -Port 8090 -Protocol Http

    Add-PodeRoute -Method Get -Path '/' -ScriptBlock {
        Write-PodeJsonResponse -Value @{ Result = 1 }
    }

    Add-PodeRoute -Method Get -Path '/' -IfExists Skip -ScriptBlock {
        Write-PodeJsonResponse -Value @{ Result = 2 }
    }
}
```

Running the above, and calling `http://localhost:8090/` will return the result of `1` not `2` 😄. If you swap `Skip` to `Overwrite` and re-run, you'll get the result of `2` instead!