### PR TITLE
Fix supplying mutliple files when the multiple property is used on input

### DIFF
--- a/docs/Tutorials/Misc/UploadFiles.md
+++ b/docs/Tutorials/Misc/UploadFiles.md
@@ -3,7 +3,7 @@
 Pode's inbuilt middleware supports parsing a request's body/payload and query string, and this also extends to uploading files via a `<form>`. Like how POST data can be accessed in a Route via the [web event](../../WebEvent) as `$WebEvent.Data[<name>]`, uploaded files can be accessed via `$WebEvent.Files[<filename>]`.
 
 !!! important
-    In order for uploaded files to work, your `<form>` must contain `enctype="multipart/form-data"`
+    In order for uploaded files to work, your `<form>` must contain the `enctype="multipart/form-data"` property.
 
 ## Web Form
 
@@ -36,8 +36,6 @@ The following HTML is an example of a `<form>` for a simple sign-up flow. Here t
 </html>
 ```
 
-> You can upload multiple files from one `<form>`
-
 The inputs will be POSTed to the server, and accessible via the [web event](../../WebEvent)'s `.Data` and `.Files`.
 
 For the `.Data`:
@@ -52,7 +50,13 @@ For the `.Files`:
 $WebEvent.Files['image.png']   # the bytes of the uploaded file
 ```
 
-## Script
+## Multiple Files
+
+You can upload multiple files from one `<form>` by either supplying multiple file `<input>` fields, or by using the `multiple` property in a file `<input>`.
+
+If you use the `multiple` property then all the file names will be available under the same `$WebEvent.Data` key. When you use [`Save-PodeRequestFile`](../../../Functions/Responses/Save-PodeRequestFile) on this key, all of the files will be saved at once.
+
+## Examples
 
 ### Inbuilt Save
 

--- a/examples/views/web-upload-multi.html
+++ b/examples/views/web-upload-multi.html
@@ -1,0 +1,23 @@
+<html>
+    <head>
+        <title>Upload Multiple Files</title>
+        <link rel="stylesheet" type="text/css" href="/styles/simple.css">
+    </head>
+    <body>
+
+        <form action="/upload-multi" method="post" enctype="multipart/form-data">
+            <div>
+                <label>Comment:</label>
+                <input type="text" name="comment"/>
+            </div>
+            <div>
+                <label>Files:</label>
+                <input type="file" name="avatar" multiple="multiple"/>
+            </div>
+            <div>
+                <input type="submit" value="Submit"/>
+            </div>
+        </form>
+
+    </body>
+</html>

--- a/examples/web-upload.ps1
+++ b/examples/web-upload.ps1
@@ -16,6 +16,7 @@ Start-PodeServer -Threads 2 {
     Add-PodeEndpoint -Address * -Port $port -Protocol Http
 
     Set-PodeViewEngine -Type HTML
+    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
 
     # GET request for web page on "localhost:8085/"
     Add-PodeRoute -Method Get -Path '/' -ScriptBlock {
@@ -26,6 +27,19 @@ Start-PodeServer -Threads 2 {
     Add-PodeRoute -Method Post -Path '/upload' -ScriptBlock {
         Save-PodeRequestFile -Key 'avatar'
         Move-PodeResponseUrl -Url '/'
+    }
+
+    # GET request for web page on "localhost:8085/multi"
+    Add-PodeRoute -Method Get -Path '/multi' -ScriptBlock {
+        Write-PodeViewResponse -Path 'web-upload-multi'
+    }
+
+    # POST request to upload multiple files
+    Add-PodeRoute -Method Post -Path '/upload-multi' -ScriptBlock {
+        # $WebEvent.Data | Out-Default
+        # $WebEvent.Files | Out-Default
+        Save-PodeRequestFile -Key 'avatar' -Path 'C:/temp' -FileName 'Ruler.png'
+        Move-PodeResponseUrl -Url '/multi'
     }
 
 }

--- a/examples/web-upload.ps1
+++ b/examples/web-upload.ps1
@@ -36,8 +36,6 @@ Start-PodeServer -Threads 2 {
 
     # POST request to upload multiple files
     Add-PodeRoute -Method Post -Path '/upload-multi' -ScriptBlock {
-        # $WebEvent.Data | Out-Default
-        # $WebEvent.Files | Out-Default
         Save-PodeRequestFile -Key 'avatar' -Path 'C:/temp' -FileName 'Ruler.png'
         Move-PodeResponseUrl -Url '/multi'
     }

--- a/src/Listener/PodeFormData.cs
+++ b/src/Listener/PodeFormData.cs
@@ -1,4 +1,4 @@
-using System;
+using System.Linq;
 using System.Collections.Generic;
 
 namespace Pode
@@ -6,12 +6,25 @@ namespace Pode
     public class PodeFormData
     {
         public string Key { get; private set; }
-        public string Value { get; private set; }
+
+        private IList<string> _values;
+        public string[] Values => _values.ToArray();
+
+        public int Count => _values.Count;
+        public bool IsSingular => (_values.Count == 1);
+        public bool IsEmpty => (_values.Count == 0);
 
         public PodeFormData(string key, string value)
         {
             Key = key;
-            Value = value;
+
+            _values = new List<string>();
+            _values.Add(value);
+        }
+
+        public void AddValue(string value)
+        {
+            _values.Add(value);
         }
     }
 }

--- a/src/Pode.psd1
+++ b/src/Pode.psd1
@@ -83,6 +83,7 @@
         'Read-PodeTcpClient',
         'Close-PodeTcpClient',
         'Save-PodeRequestFile',
+        'Test-PodeRequestFile',
         'Set-PodeViewEngine',
         'Use-PodePartialView',
         'Send-PodeSignal',

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -1576,7 +1576,12 @@ function ConvertFrom-PodeRequestContent
             }
 
             foreach ($item in $form.Data) {
-                $Result.Data.Add($item.Key, $item.Value)
+                if ($item.IsSingular) {
+                    $Result.Data.Add($item.Key, $item.Values[0])
+                }
+                else {
+                    $Result.Data.Add($item.Key, $item.Values)
+                }
             }
 
             $form = $null

--- a/src/Public/Responses.ps1
+++ b/src/Public/Responses.ps1
@@ -1192,57 +1192,134 @@ function Close-PodeTcpClient
 
 <#
 .SYNOPSIS
-Saves an uploaded file on the Request to the File System.
+Saves any uploaded files on the Request to the File System.
 
 .DESCRIPTION
-Saves an uploaded file on the Request to the File System.
+Saves any uploaded files on the Request to the File System.
 
 .PARAMETER Key
-The name of the key within the web event's Data HashTable that stores the file's name.
+The name of the key within the $WebEvent's Data HashTable that stores the file names.
 
 .PARAMETER Path
-The path to save files.
+The path to save files. If this is a directory then the file name of the uploaded file will be used, but if this is a file path then that name is used instead.
+If the Request has multiple files in, and you specify a file path, then all files will be saved to that one file path - overwriting each other.
+
+.PARAMETER FileName
+An optional FileName to save a specific files if multiple files were supplied in the Request. By default, every file is saved.
 
 .EXAMPLE
 Save-PodeRequestFile -Key 'avatar'
 
 .EXAMPLE
 Save-PodeRequestFile -Key 'avatar' -Path 'F:/Images'
+
+.EXAMPLE
+Save-PodeRequestFile -Key 'avatar' -Path 'F:/Images' -FileName 'icon.png'
 #>
 function Save-PodeRequestFile
 {
     [CmdletBinding()]
-    param (
+    param(
         [Parameter(Mandatory=$true)]
         [string]
         $Key,
 
         [Parameter()]
         [string]
-        $Path = '.'
+        $Path = '.',
+
+        [Parameter()]
+        [string[]]
+        $FileName
     )
 
     # if path is '.', replace with server root
     $Path = Get-PodeRelativePath -Path $Path -JoinRoot
 
     # ensure the parameter name exists in data
-    $fileName = $WebEvent.Data[$Key]
-    if ([string]::IsNullOrWhiteSpace($fileName)) {
-        throw "A parameter called '$($Key)' was not supplied in the request"
+    if (!(Test-PodeRequestFile -Key $Key)) {
+        throw "A parameter called '$($Key)' was not supplied in the request, or has no data available"
+    }
+
+    # get the file names
+    $files = @($WebEvent.Data[$Key])
+    if (($null -ne $FileName) -and ($FileName.Length -gt 0)) {
+        $files = @(foreach ($file in $files) {
+            if ($FileName -icontains $file) {
+                $file
+            }
+        })
     }
 
     # ensure the file data exists
-    if (!$WebEvent.Files.ContainsKey($fileName)) {
-        throw "No data for file '$($fileName)' was uploaded in the request"
+    foreach ($file in $files) {
+        if (!$WebEvent.Files.ContainsKey($file)) {
+            throw "No data for file '$($file)' was uploaded in the request"
+        }
     }
 
-    # if the path is a directory, add the filename
-    if (Test-PodePathIsDirectory -Path $Path) {
-        $Path = [System.IO.Path]::Combine($Path, $fileName)
+    # save the files
+    foreach ($file in $files) {
+        # if the path is a directory, add the filename
+        $filePath = $Path
+        if (Test-PodePathIsDirectory -Path $filePath) {
+            $filePath = [System.IO.Path]::Combine($filePath, $file)
+        }
+
+        # save the file
+        $WebEvent.Files[$file].Save($filePath)
+    }
+}
+
+<#
+.SYNOPSIS
+Test to see if the Request contains the key for any uploaded files.
+
+.DESCRIPTION
+Test to see if the Request contains the key for any uploaded files.
+
+.PARAMETER Key
+The name of the key within the $WebEvent's Data HashTable that stores the file names.
+
+.PARAMETER FileName
+An optional FileName to test for a specific file within the list of uploaded files.
+
+.EXAMPLE
+Test-PodeRequestFile -Key 'avatar'
+
+.EXAMPLE
+Test-PodeRequestFile -Key 'avatar' -FileName 'icon.png'
+#>
+function Test-PodeRequestFile
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Key,
+
+        [Parameter()]
+        [string]
+        $FileName
+    )
+
+    # ensure the parameter name exists in data
+    if (!$WebEvent.Data.ContainsKey($Key)) {
+        return $false
     }
 
-    # save the file
-    $WebEvent.Files[$fileName].Save($Path)
+    # ensure it has filenames
+    if ([string]::IsNullOrEmpty($WebEvent.Data[$Key])) {
+        return $false
+    }
+
+    # do we have any specific files?
+    if (![string]::IsNullOrEmpty($FileName)) {
+        return (@($WebEvent.Data[$Key]) -icontains $FileName)
+    }
+
+    # we have files
+    return $true
 }
 
 <#


### PR DESCRIPTION
### Description of the Change
Fixes supplying multiple files via a single `<input>` when the `multiple` property is used.

Also updates `Save-PodeRequestFile` so that is saves all files under a single data key when called.

### Related Issue
Resolves #1044 
