### PR TITLE
PlatyPS doesn't like HTML in Examples, so replace with a plain comment

### DIFF
--- a/pode.build.ps1
+++ b/pode.build.ps1
@@ -15,7 +15,7 @@ $Versions = @{
     DotNet = '7.0.1'
     Checksum = '0.2.0'
     MkDocsTheme = '9.0.2'
-    PlatyPS = '0.14.0'
+    PlatyPS = '0.14.2'
 }
 
 <#

--- a/src/Public/Responses.ps1
+++ b/src/Public/Responses.ps1
@@ -539,7 +539,7 @@ The path to a HTML file.
 The status code to set against the response.
 
 .EXAMPLE
-Write-PodeHtmlResponse -Value '<html><body>Hello!</body></html>'
+Write-PodeHtmlResponse -Value "Raw HTML can be placed here"
 
 .EXAMPLE
 Write-PodeHtmlResponse -Value @{ Message = 'Hello, all!' }


### PR DESCRIPTION
### Description of the Change
PlatyPS doesn't like HTML in Examples, so replace with a plain comment meaning you can use raw HTML.

### Related Issue
Resolves #1054 
