### PR TITLE
Allow -Method on Add-PodeRoute to support handling multiple methods

### DIFF
--- a/docs/Tutorials/Routes/Overview.md
+++ b/docs/Tutorials/Routes/Overview.md
@@ -32,6 +32,9 @@ Here, anyone who calls `http://localhost:8080/ping` will receive the following r
 }
 ```
 
+!!! tip
+    You can supply more than 1 `-Method` if required, such as: `-Method Get, Post`
+
 The scriptblock for the route will have access to the `$WebEvent` variable which contains information about the current [web event](../../WebEvent). This argument will contain the `Request` and `Response` objects, `Data` (from POST), and the `Query` (from the query string of the URL), as well as any `Parameters` from the route itself (eg: `/:accountId`).
 
 You can add your routes straight into the [`Start-PodeServer`](../../../Functions/Core/Start-PodeServer) scriptblock, or separate them into different files. These files can then be dot-sourced, or you can use [`Use-PodeRoutes`](../../../Functions/Routes/Use-PodeRoutes) to automatically load all ps1 files within a `/routes` directory at the root of your server.

--- a/examples/web-pages.ps1
+++ b/examples/web-pages.ps1
@@ -86,8 +86,8 @@ Start-PodeServer -Threads 2 -Verbose {
         Set-PodeResponseAttachment -Path 'Anger.jpg'
     }
 
-    # GET request with parameters
-    Add-PodeRoute -Method Get -Path '/:userId/details' -ScriptBlock {
+    # GET and POST request with parameters
+    Add-PodeRoute -Method Get, Post -Path '/:userId/details' -ScriptBlock {
         Write-PodeJsonResponse -Value @{ 'userId' = $WebEvent.Parameters['userId'] }
     }
 


### PR DESCRIPTION
### Description of the Change
Add support for `-Method` on `Add-PodeRoute` to be able to handle multiple methods being supplied.

### Related Issue
Resolves #996 

### Examples
```powershell
Add-PodeRoute -Method Get, Post -Path '/route' -ScriptBlock {
    # logic
}
```
