### PR TITLE
Add support for the CONNECT http method

### DIFF
--- a/docs/Tutorials/Routes/Overview.md
+++ b/docs/Tutorials/Routes/Overview.md
@@ -8,7 +8,7 @@ Routes can also be bound against a specific protocol or endpoint. This allows yo
 
 !!! info
     The following HTTP methods are supported by routes in Pode:
-    DELETE, GET, HEAD, MERGE, OPTIONS, PATCH, POST, PUT, and TRACE.
+    CONNECT, DELETE, GET, HEAD, MERGE, OPTIONS, PATCH, POST, PUT, and TRACE.
 
 ## Usage
 

--- a/src/Listener/PodeHelpers.cs
+++ b/src/Listener/PodeHelpers.cs
@@ -10,7 +10,7 @@ namespace Pode
 {
     public class PodeHelpers
     {
-        public static readonly string[] HTTP_METHODS = new string[] { "DELETE", "GET", "HEAD", "MERGE", "OPTIONS", "PATCH", "POST", "PUT", "TRACE" };
+        public static readonly string[] HTTP_METHODS = new string[] { "CONNECT", "DELETE", "GET", "HEAD", "MERGE", "OPTIONS", "PATCH", "POST", "PUT", "TRACE" };
         public const string WEB_SOCKET_MAGIC_KEY = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
         public readonly static char[] NEW_LINE_ARRAY = new char[] { '\r', '\n' };
         public const string NEW_LINE = "\r\n";

--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -278,6 +278,7 @@ function New-PodeContext
 
     # routes for pages and api
     $ctx.Server.Routes = @{
+        'connect'   = [ordered]@{}
         'delete'    = [ordered]@{}
         'get'       = [ordered]@{}
         'head'      = [ordered]@{}

--- a/src/Private/Middleware.ps1
+++ b/src/Private/Middleware.ps1
@@ -218,7 +218,7 @@ function Get-PodeRouteValidateMiddleware
             # if there's no route defined, it's a 404 - or a 405 if a route exists for any other method
             if ($null -eq $route) {
                 # check if a route exists for another method
-                $methods = @('DELETE', 'GET', 'HEAD', 'MERGE', 'OPTIONS', 'PATCH', 'POST', 'PUT', 'TRACE')
+                $methods = @('CONNECT', 'DELETE', 'GET', 'HEAD', 'MERGE', 'OPTIONS', 'PATCH', 'POST', 'PUT', 'TRACE')
                 $diff_route = @(foreach ($method in $methods) {
                     $r = Find-PodeRoute -Method $method -Path $WebEvent.Path -EndpointName $WebEvent.Endpoint.Name
                     if ($null -ne $r) {

--- a/src/Private/Routes.ps1
+++ b/src/Private/Routes.ps1
@@ -2,7 +2,7 @@ function Test-PodeRouteFromRequest
 {
     param(
         [Parameter(Mandatory=$true)]
-        [ValidateSet('DELETE', 'GET', 'HEAD', 'MERGE', 'OPTIONS', 'PATCH', 'POST', 'PUT', 'TRACE', 'STATIC', 'SIGNAL', '*')]
+        [ValidateSet('CONNECT', 'DELETE', 'GET', 'HEAD', 'MERGE', 'OPTIONS', 'PATCH', 'POST', 'PUT', 'TRACE', 'STATIC', 'SIGNAL', '*')]
         [string]
         $Method,
 
@@ -27,7 +27,7 @@ function Find-PodeRoute
 {
     param(
         [Parameter(Mandatory=$true)]
-        [ValidateSet('DELETE', 'GET', 'HEAD', 'MERGE', 'OPTIONS', 'PATCH', 'POST', 'PUT', 'TRACE', 'STATIC', 'SIGNAL', '*')]
+        [ValidateSet('CONNECT', 'DELETE', 'GET', 'HEAD', 'MERGE', 'OPTIONS', 'PATCH', 'POST', 'PUT', 'TRACE', 'STATIC', 'SIGNAL', '*')]
         [string]
         $Method,
 

--- a/src/Public/Middleware.ps1
+++ b/src/Public/Middleware.ps1
@@ -228,7 +228,7 @@ function Initialize-PodeCsrf
     [CmdletBinding()]
     param (
         [Parameter()]
-        [ValidateSet('Delete', 'Get', 'Head', 'Merge', 'Options', 'Patch', 'Post', 'Put', 'Trace')]
+        [ValidateSet('Connect', 'Delete', 'Get', 'Head', 'Merge', 'Options', 'Patch', 'Post', 'Put', 'Trace')]
         [string[]]
         $IgnoreMethods = @('Get', 'Head', 'Options', 'Trace'),
 
@@ -295,7 +295,7 @@ function Enable-PodeCsrfMiddleware
     [CmdletBinding()]
     param (
         [Parameter()]
-        [ValidateSet('Delete', 'Get', 'Head', 'Merge', 'Options', 'Patch', 'Post', 'Put', 'Trace')]
+        [ValidateSet('Connect', 'Delete', 'Get', 'Head', 'Merge', 'Options', 'Patch', 'Post', 'Put', 'Trace')]
         [string[]]
         $IgnoreMethods = @('Get', 'Head', 'Options', 'Trace'),
 

--- a/src/Public/Routes.ps1
+++ b/src/Public/Routes.ps1
@@ -76,7 +76,7 @@ function Add-PodeRoute
     [CmdletBinding(DefaultParameterSetName='Script')]
     param(
         [Parameter(Mandatory=$true)]
-        [ValidateSet('Delete', 'Get', 'Head', 'Merge', 'Options', 'Patch', 'Post', 'Put', 'Trace', '*')]
+        [ValidateSet('Connect', 'Delete', 'Get', 'Head', 'Merge', 'Options', 'Patch', 'Post', 'Put', 'Trace', '*')]
         [string[]]
         $Method,
 
@@ -1214,7 +1214,7 @@ function Remove-PodeRoute
     [CmdletBinding()]
     param(
         [Parameter(Mandatory=$true)]
-        [ValidateSet('Delete', 'Get', 'Head', 'Merge', 'Options', 'Patch', 'Post', 'Put', 'Trace', '*')]
+        [ValidateSet('Connect', 'Delete', 'Get', 'Head', 'Merge', 'Options', 'Patch', 'Post', 'Put', 'Trace', '*')]
         [string]
         $Method,
 
@@ -1374,7 +1374,7 @@ function Clear-PodeRoutes
     [CmdletBinding()]
     param(
         [Parameter()]
-        [ValidateSet('', 'Delete', 'Get', 'Head', 'Merge', 'Options', 'Patch', 'Post', 'Put', 'Trace', '*')]
+        [ValidateSet('', 'Connect', 'Delete', 'Get', 'Head', 'Merge', 'Options', 'Patch', 'Post', 'Put', 'Trace', '*')]
         [string]
         $Method
     )
@@ -1484,7 +1484,7 @@ function ConvertTo-PodeRoute
         $Module,
 
         [Parameter()]
-        [ValidateSet('', 'Delete', 'Get', 'Head', 'Merge', 'Options', 'Patch', 'Post', 'Put', 'Trace')]
+        [ValidateSet('', 'Connect', 'Delete', 'Get', 'Head', 'Merge', 'Options', 'Patch', 'Post', 'Put', 'Trace')]
         [string]
         $Method,
 
@@ -1813,7 +1813,7 @@ function Get-PodeRoute
     [CmdletBinding()]
     param(
         [Parameter()]
-        [ValidateSet('', 'Delete', 'Get', 'Head', 'Merge', 'Options', 'Patch', 'Post', 'Put', 'Trace', '*')]
+        [ValidateSet('', 'Connect', 'Delete', 'Get', 'Head', 'Merge', 'Options', 'Patch', 'Post', 'Put', 'Trace', '*')]
         [string]
         $Method,
 
@@ -2104,7 +2104,7 @@ function Test-PodeRoute
     [CmdletBinding()]
     param(
         [Parameter(Mandatory=$true)]
-        [ValidateSet('Delete', 'Get', 'Head', 'Merge', 'Options', 'Patch', 'Post', 'Put', 'Trace', '*')]
+        [ValidateSet('Connect', 'Delete', 'Get', 'Head', 'Merge', 'Options', 'Patch', 'Post', 'Put', 'Trace', '*')]
         [string]
         $Method,
 

--- a/src/Public/Security.ps1
+++ b/src/Public/Security.ps1
@@ -1347,7 +1347,7 @@ function Set-PodeSecurityAccessControl
         $Origin,
 
         [Parameter()]
-        [ValidateSet('', 'Delete', 'Get', 'Head', 'Merge', 'Options', 'Patch', 'Post', 'Put', 'Trace', '*')]
+        [ValidateSet('', 'Connect', 'Delete', 'Get', 'Head', 'Merge', 'Options', 'Patch', 'Post', 'Put', 'Trace', '*')]
         [string[]]
         $Methods = '',
 


### PR DESCRIPTION
### Description of the Change
Add support for the CONNECT HTTP method on Routes.

### Related Issue
Resolves #1071 

### Examples
```powershell
Add-PodeRoute -Method Connect -Path '/connect' -ScriptBlock {
    # logic
}
```
