### PR TITLE
Issue #1096 - Add Save-PodeRequestFile functionality - disable overwrite and return filepaths

### DIFF
--- a/src/Public/Responses.ps1
+++ b/src/Public/Responses.ps1
@@ -1277,7 +1277,7 @@ function Save-PodeRequestFile
     }
 
     # set up filepath list
-    if($Return){
+    if ($Return) {
         $filePathsList = New-Object System.Collections.Generic.List[string]
     }
 
@@ -1290,13 +1290,13 @@ function Save-PodeRequestFile
         }
 		
         # add numeric suffix to file name if overwrites are not permitted
-        if($NoOverwrite -and [System.IO.File]::Exists($filePath)){
+        if ($NoOverwrite -and [System.IO.File]::Exists($filePath)) {
             # set up necessary variables for looping
             $splitPathArray = $filePath -split '\.(?=[^\\\/]+$)'
             $i = 0
 
             # loop until suggested filepath doesn't already exist
-            while([System.IO.File]::Exists($filePath)){
+            while ([System.IO.File]::Exists($filePath)) {
                 $i++
                 $tempSplitPathArray = $splitPathArray.Clone()
                 $tempSplitPathArray[0] = -join ($splitPathArray[0], " ($i)")
@@ -1305,7 +1305,7 @@ function Save-PodeRequestFile
         }
 		
         # add filepath to filepath list
-        if($Return){
+        if ($Return) {
             $filePathsList.Add($filePath)
         }
 
@@ -1315,7 +1315,7 @@ function Save-PodeRequestFile
     }
 	
     # return filepath list
-    if($Return){
+    if ($Return) {
         return ,$filePathsList
     }
 	

--- a/src/Public/Responses.ps1
+++ b/src/Public/Responses.ps1
@@ -1224,7 +1224,7 @@ Save-PodeRequestFile -Key 'avatar' -Path 'F:/Images'
 Save-PodeRequestFile -Key 'avatar' -Path 'F:/Images' -FileName 'icon.png'
 
 .EXAMPLE
-Save-PodeRequestFile -Key 'avatar' -Path 'F:/Images' -NoOverwrite -Return
+$filePaths = Save-PodeRequestFile -Key 'avatar' -Path 'F:/Images' -NoOverwrite -Return
 #>
 function Save-PodeRequestFile
 {

--- a/src/Public/Responses.ps1
+++ b/src/Public/Responses.ps1
@@ -1207,6 +1207,13 @@ If the Request has multiple files in, and you specify a file path, then all file
 .PARAMETER FileName
 An optional FileName to save a specific files if multiple files were supplied in the Request. By default, every file is saved.
 
+.PARAMETER NoOverwrite
+If supplied, disables overwriting already existing files, and adds a numerical suffix to the filename if necessary.
+F.x. if C:\pode\test.txt already exists and test.txt is uploaded again, it will be saved as C:\pode\test (1).txt
+
+.PARAMETER Return
+If supplied, filepaths of all saved files will be returned as a list.
+
 .EXAMPLE
 Save-PodeRequestFile -Key 'avatar'
 
@@ -1215,6 +1222,9 @@ Save-PodeRequestFile -Key 'avatar' -Path 'F:/Images'
 
 .EXAMPLE
 Save-PodeRequestFile -Key 'avatar' -Path 'F:/Images' -FileName 'icon.png'
+
+.EXAMPLE
+Save-PodeRequestFile -Key 'avatar' -Path 'F:/Images' -NoOverwrite -Return
 #>
 function Save-PodeRequestFile
 {
@@ -1232,13 +1242,13 @@ function Save-PodeRequestFile
         [string[]]
         $FileName,
 		
-		[Parameter()]
-		[switch]
-		$NoOverwrite,
+        [Parameter()]
+        [switch]
+        $NoOverwrite,
 		
-		[Parameter()]
-		[switch]
-		$Return
+        [Parameter()]
+        [switch]
+        $Return
     )
 
     # if path is '.', replace with server root
@@ -1265,11 +1275,11 @@ function Save-PodeRequestFile
             throw "No data for file '$($file)' was uploaded in the request"
         }
     }
-    
-	# set up filepath list
-	if($Return){
-		$filePathsList = New-Object System.Collections.Generic.List[string]
-	}
+
+    # set up filepath list
+    if($Return){
+        $filePathsList = New-Object System.Collections.Generic.List[string]
+    }
 
     # save the files
     foreach ($file in $files) {
@@ -1279,35 +1289,35 @@ function Save-PodeRequestFile
             $filePath = [System.IO.Path]::Combine($filePath, $file)
         }
 		
-		# add numeric suffix to file name if overwrites are not permitted
-		if($NoOverwrite -and [System.IO.File]::Exists($filePath)){
-			# set up necessary variables for looping
-			$splitPathArray = $filePath -split '\.(?=[^\\]+$)'
-			$i = 0
-			
-			# loop until suggested filepath doesn't exist
-			while([System.IO.File]::Exists($filePath)){
-				$i++
-				$tempSplitPathArray = $splitPathArray.Clone()
-				$tempSplitPathArray[0] = -join ($splitPathArray[0], " ($i)")
-				$filePath = $tempSplitPathArray -join '.'
-			}
-		}
+        # add numeric suffix to file name if overwrites are not permitted
+        if($NoOverwrite -and [System.IO.File]::Exists($filePath)){
+            # set up necessary variables for looping
+            $splitPathArray = $filePath -split '\.(?=[^\\]+$)'
+            $i = 0
+
+            # loop until suggested filepath doesn't already exist
+            while([System.IO.File]::Exists($filePath)){
+                $i++
+                $tempSplitPathArray = $splitPathArray.Clone()
+                $tempSplitPathArray[0] = -join ($splitPathArray[0], " ($i)")
+                $filePath = $tempSplitPathArray -join '.'
+            }
+        }
 		
-		# add filepath to filepath list
-		if($Return){
-			$filePathsList.Add($filePath)
-		}
+        # add filepath to filepath list
+        if($Return){
+            $filePathsList.Add($filePath)
+        }
 
         # save the file
         $WebEvent.Files[$file].Save($filePath)
 		
     }
 	
-	# return filepath list
-	if($Return){
-		return ,$filePathsList
-	}
+    # return filepath list
+    if($Return){
+        return ,$filePathsList
+    }
 	
 }
 

--- a/src/Public/Responses.ps1
+++ b/src/Public/Responses.ps1
@@ -1292,7 +1292,7 @@ function Save-PodeRequestFile
         # add numeric suffix to file name if overwrites are not permitted
         if($NoOverwrite -and [System.IO.File]::Exists($filePath)){
             # set up necessary variables for looping
-            $splitPathArray = $filePath -split '\.(?=[^\\]+$)'
+            $splitPathArray = $filePath -split '\.(?=[^\\\/]+$)'
             $i = 0
 
             # loop until suggested filepath doesn't already exist


### PR DESCRIPTION
### Description of the Change
Added functionality to make it possible to disable overwriting files, and instead add a numerical suffix to the filename if it already exists in the directory. Enabled via Switch parameter.

Added functionality to make it possible to return a list of filepaths of the uploaded files. Enabled via Switch parameter.

Help comment updated to include parameters and an example.

### Related Issue
Resolves #1096 

### Examples
Parameter **NoOverwrite**
If supplied, disables overwriting already existing files, and adds a numerical suffix to the filename if necessary.
F.x. if C:\pode\test.txt already exists and test.txt is uploaded again, it will be saved as C:\pode\test (1).txt

Parameter **Return**
If supplied, filepaths of all saved files will be returned as a list.

**Usage**
$filePaths = Save-PodeRequestFile -Key 'avatar' -Path 'F:/Images' -NoOverwrite -Return

**Result**
In the above example, if _F:/Images_ already contains _test.jpg_ and you're uploading the files _test.jpg_ and _asdf.jpg_. _test.jpg_ will be saved as _test (1).jpg_ and _asdf.jpg_ as _asdf.jpg_, the function will then return a list containing the following filepaths:

F:/Images\test (1).jpg
F:/Images\asdf.jpg