### PR TITLE
Add helper security functions to hide/show the Server header

### DIFF
--- a/docs/Tutorials/Middleware/Types/Security.md
+++ b/docs/Tutorials/Middleware/Types/Security.md
@@ -19,6 +19,8 @@ The following headers are currently supported, but you can add custom header val
 * X-Content-Type-Options
 * Referrer-Policy
 
+You can also set the "Server" header to be hidden on responses if required.
+
 ## Types
 
 Pode has an inbuilt wrapper to easily toggle all headers with default values: [`Set-PodeSecurity`](../../../../Functions/Security/Set-PodeSecurity). This function lets you specify a `-Type` of either `Simple` or `Strict`. The specified value will setup the headers with the default values defined below. You can also force `X-XSS-Protection` to use blocking mode if you want to support older browsers, or enable `Strict-Transport-Security` via `-UseHsts`.
@@ -51,6 +53,8 @@ The following values are used for each header when the `Simple` type is supplied
 | X-Content-Type-Options | nosniff |
 | Referred-Policy | strict-origin |
 
+The Server header is also hidden.
+
 ### Strict
 
 The following values are used for each header when the `Strict` type is supplied:
@@ -71,6 +75,8 @@ The following values are used for each header when the `Strict` type is supplied
 | X-Frame-Options | DENY |
 | X-Content-Type-Options | nosniff |
 | Referred-Policy | no-referrer |
+
+The Server header is also hidden.
 
 ## Headers
 
@@ -204,6 +210,13 @@ The `Referrer-Policy` header tells the browser how much information to include i
 ```powershell
 Set-PodeSecurityReferrerPolicy -Type Strict-Origin
 ```
+
+### Server
+
+You can hide or show the Server header on responses using the following functions, by default the Server header is visible:
+
+* [`Hide-PodeSecurityServer`](../../../../Functions/Security/Hide-PodeSecurityServer)
+* [`Show-PodeSecurityServer`](../../../../Functions/Security/Show-PodeSecurityServer)
 
 ## Custom
 

--- a/src/Listener/PodeListener.cs
+++ b/src/Listener/PodeListener.cs
@@ -35,6 +35,16 @@ namespace Pode
             }
         }
 
+        private bool _showServerDetails = true;
+        public bool ShowServerDetails
+        {
+            get => _showServerDetails;
+            set
+            {
+                _showServerDetails = value;
+            }
+        }
+
         public PodeListener(CancellationToken cancellationToken = default(CancellationToken))
             : base(cancellationToken)
         {

--- a/src/Listener/PodeResponse.cs
+++ b/src/Listener/PodeResponse.cs
@@ -298,10 +298,20 @@ namespace Pode
 
             Headers.Add("Date", DateTime.UtcNow.ToString("r", CultureInfo.InvariantCulture));
 
-            // set the server
-            if (!Headers.ContainsKey("Server"))
+            // set the server if allowed
+            if (Context.Listener.ShowServerDetails)
             {
-                Headers.Add("Server", "Pode");
+                if (!Headers.ContainsKey("Server"))
+                {
+                    Headers.Add("Server", "Pode");
+                }
+            }
+            else
+            {
+                if (Headers.ContainsKey("Server"))
+                {
+                    Headers.Remove("Server");
+                }
             }
 
             // set context/socket ID

--- a/src/Pode.psd1
+++ b/src/Pode.psd1
@@ -312,6 +312,8 @@
         'Set-PodeSecurityPermissionsPolicy',
         'Set-PodeSecurityReferrerPolicy',
         'Set-PodeSecurityStrictTransportSecurity',
+        'Hide-PodeSecurityServer',
+        'Show-PodeSecurityServer',
 
         # Verbs
         'Add-PodeVerb',

--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -415,6 +415,7 @@ function New-PodeContext
 
     # setup security
     $ctx.Server.Security = @{
+        ServerDetails = $true
         Headers = @{}
         Cache = @{
             ContentSecurity  = @{}

--- a/src/Private/PodeServer.ps1
+++ b/src/Private/PodeServer.ps1
@@ -66,6 +66,7 @@ function Start-PodeWebServer
     $listener.ErrorLoggingLevels = @(Get-PodeErrorLoggingLevels)
     $listener.RequestTimeout = $PodeContext.Server.Request.Timeout
     $listener.RequestBodySize = $PodeContext.Server.Request.BodySize
+    $listener.ShowServerDetails = [bool]$PodeContext.Server.Security.ServerDetails
 
     try
     {

--- a/src/Public/Security.ps1
+++ b/src/Public/Security.ps1
@@ -75,6 +75,9 @@ function Set-PodeSecurity
             Set-PodeSecurityReferrerPolicy -Type No-Referrer
         }
     }
+
+    # hide server info
+    Hide-PodeSecurityServer
 }
 
 <#
@@ -93,6 +96,7 @@ function Remove-PodeSecurity
     param()
 
     $PodeContext.Server.Security.Headers.Clear()
+    Show-PodeSecurityServer
 }
 
 <#
@@ -152,6 +156,42 @@ function Remove-PodeSecurityHeader
     )
 
     $PodeContext.Server.Security.Headers.Remove($Name)
+}
+
+<#
+.SYNOPSIS
+Hide the Server HTTP Header from Responses
+
+.DESCRIPTION
+Hide the Server HTTP Header from Responses
+
+.EXAMPLE
+Hide-PodeSecurityServer
+#>
+function Hide-PodeSecurityServer
+{
+    [CmdletBinding()]
+    param()
+
+    $PodeContext.Server.Security.ServerDetails = $false
+}
+
+<#
+.SYNOPSIS
+Show the Server HTTP Header on Responses
+
+.DESCRIPTION
+Show the Server HTTP Header on Responses
+
+.EXAMPLE
+Show-PodeSecurityServer
+#>
+function Show-PodeSecurityServer
+{
+    [CmdletBinding()]
+    param()
+
+    $PodeContext.Server.Security.ServerDetails = $true
 }
 
 <#


### PR DESCRIPTION
### Description of the Change
Adds two new functions to allow the hiding or showing of the "Server" header in responses, by default the header is visible.

* `Hide-PodeSecurityServer`
* `Show-PodeSecurityServer`

### Related Issue
Resolves #1106 
