### PR TITLE
Don't parse Query String if there is no Query String

### DIFF
--- a/src/Listener/PodeHttpRequest.cs
+++ b/src/Listener/PodeHttpRequest.cs
@@ -205,15 +205,11 @@ namespace Pode
 
             // query string
             var reqQuery = reqMeta[1].Trim();
-            if (!string.IsNullOrWhiteSpace(reqQuery))
-            {
-                var qmIndex = reqQuery.IndexOf("?");
-                QueryString = HttpUtility.ParseQueryString(qmIndex > 0 ? reqQuery.Substring(qmIndex) : reqQuery);
-            }
-            else
-            {
-                QueryString = default(NameValueCollection);
-            }
+            var qmIndex = string.IsNullOrEmpty(reqQuery) ? 0 : reqQuery.IndexOf("?");
+
+            QueryString = qmIndex > 0
+                ? HttpUtility.ParseQueryString(reqQuery.Substring(qmIndex))
+                : default(NameValueCollection);
 
             // http protocol version
             Protocol = (reqMeta[2] ?? "HTTP/1.1").Trim();


### PR DESCRIPTION
### Description of the Change
If there's no query string supplied on the request, don't attempt to parse it - otherwise there's a redundant empty key which isn't apart of the query string stored.

### Related Issue
Resolves #1081 