### PR TITLE
Fix verb cleardown on server restart

### DIFF
--- a/src/Private/Server.ps1
+++ b/src/Private/Server.ps1
@@ -176,8 +176,11 @@ function Restart-PodeInternalServer
         # clear up timers, schedules and loggers
         $PodeContext.Server.Routes | Clear-PodeHashtableInnerKeys
         $PodeContext.Server.Handlers | Clear-PodeHashtableInnerKeys
-        $PodeContext.Server.Verbs | Clear-PodeHashtableInnerKeys
         $PodeContext.Server.Events | Clear-PodeHashtableInnerKeys
+
+        if ($null -ne $PodeContext.Server.Verbs) {
+            $PodeContext.Server.Verbs.Clear()
+        }
 
         $PodeContext.Server.Views.Clear()
         $PodeContext.Timers.Items.Clear()


### PR DESCRIPTION
### Description of the Change
Fixes the cleardowns on TCP Verbs on server restart, so they are re-imported successful.

### Related Issue
Resolves #1125 
