### PR TITLE
Fixed broken links in documentation

### DIFF
--- a/docs/Getting-Started/Migrating/0X-to-1X.md
+++ b/docs/Getting-Started/Migrating/0X-to-1X.md
@@ -186,7 +186,7 @@ There is a new [`New-PodeMiddleware`](../../../Functions/Middleware/New-PodeMidd
 
 ([Tutorial](../../../Tutorials/Middleware/Types/Sessions))
 
-The `session` function has now been replaced by the new [`Enable-PodeSessionMiddleware`](../../../Functions/Middleware/Enable-PodeSessionMiddleware) function. With the new function, not only will it automatically enabled session middleware for you, but the old `-Options` hashtable has now been converted into proper function parameters.
+The `session` function has now been replaced by the new [`Enable-PodeSessionMiddleware`](../../../Functions/Sessions/Enable-PodeSessionMiddleware) function. With the new function, not only will it automatically enabled session middleware for you, but the old `-Options` hashtable has now been converted into proper function parameters.
 
 ### CSRF
 

--- a/docs/Tutorials/Middleware/Types/Sessions.md
+++ b/docs/Tutorials/Middleware/Types/Sessions.md
@@ -12,7 +12,7 @@ The duration of the session cookie/header can be specified, as well as whether t
 
 ## Usage
 
-To initialise sessions in Pode you'll need to call [`Enable-PodeSessionMiddleware`](../../../../Functions/Middleware/Enable-PodeSessionMiddleware). This function will configure and automatically create the Middleware needed to enable sessions. By default sessions are set to use cookies, but support is also available for headers.
+To initialise sessions in Pode you'll need to call [`Enable-PodeSessionMiddleware`](../../../../Functions/Sessions/Enable-PodeSessionMiddleware). This function will configure and automatically create the Middleware needed to enable sessions. By default sessions are set to use cookies, but support is also available for headers.
 
 Sessions are automatically signed using a random GUID. For Pode running on a single server using the default in-memory storage this is OK, however if you're running Pode on multiple servers, or if you're defining a custom storage then a `-Secret` is required - this is so that sessions from different servers, or after a server restart, don't become corrupt and unusable.
 
@@ -46,7 +46,7 @@ The inbuilt SessionId generator used for sessions is a GUID, but you can supply 
 
 If supplied, the `-Generator` is a scriptblock that must return a valid string. The string itself should be a random unique value, that can be used as a unique session identifier.
 
-Within a route, or middleware, you can get the currently authenticated session'd ID using [`Get-PodeSessionId`](../../../../Functions/Middleware/Get-PodeSessionId). If there is no session, or the session is not authenticated, then `$null` is returned. This function can also returned the fully signed sessionId as well. If you want the sessionId even if it's not authenticated, then you can supply `-Force` to get the current SessionId back.
+Within a route, or middleware, you can get the currently authenticated session'd ID using [`Get-PodeSessionId`](../../../../Functions/Sessions/Get-PodeSessionId). If there is no session, or the session is not authenticated, then `$null` is returned. This function can also returned the fully signed sessionId as well. If you want the sessionId even if it's not authenticated, then you can supply `-Force` to get the current SessionId back.
 
 ### Strict
 

--- a/docs/Tutorials/Routes/Examples/LoginPage.md
+++ b/docs/Tutorials/Routes/Examples/LoginPage.md
@@ -35,7 +35,7 @@ Add-PodeEndpoint -Address * -Port 8080 -Protocol Http
 Set-PodeViewEngine -Type Pode
 ```
 
-To use sessions for our authentication (so we can stay logged in), we need to setup Session Middleware using the [`Enable-PodeSessionMiddleware`](../../../../Functions/Middleware/Enable-PodeSessionMiddleware) function. Here our sessions will last for 2 minutes, and will be extended on each request:
+To use sessions for our authentication (so we can stay logged in), we need to setup Session Middleware using the [`Enable-PodeSessionMiddleware`](../../../../Functions/Sessions/Enable-PodeSessionMiddleware) function. Here our sessions will last for 2 minutes, and will be extended on each request:
 
 ```powershell
 Enable-PodeSessionMiddleware -Duration 120 -Extend

--- a/docs/Tutorials/Routes/Examples/RestApiSessions.md
+++ b/docs/Tutorials/Routes/Examples/RestApiSessions.md
@@ -23,7 +23,7 @@ Add-PodeEndpoint -Address * -Port 8080 -Protocol Http
 
 ## Enabling Sessions
 
-To use sessions with headers for our authentication, we need to setup Session Middleware using the [`Enable-PodeSessionMiddleware`](../../../../Functions/Middleware/Enable-PodeSessionMiddleware) function. Here our sessions will last for 2 minutes, and will be extended on each request:
+To use sessions with headers for our authentication, we need to setup Session Middleware using the [`Enable-PodeSessionMiddleware`](../../../../Functions/Sessions/Enable-PodeSessionMiddleware/) function. Here our sessions will last for 2 minutes, and will be extended on each request:
 
 ```powershell
 Enable-PodeSessionMiddleware -Duration 120 -Extend -UseHeaders

--- a/docs/Tutorials/SharedState.md
+++ b/docs/Tutorials/SharedState.md
@@ -4,13 +4,13 @@ Most things in Pode run in isolated runspaces: routes, middleware, schedules - t
 
 You also have the option of saving the current state to a file, and then restoring the state back on server start. This way you won't lose state between server restarts.
 
-You can also use the State in combination with [`Lock-PodeObject`](../../Functions/Utilities/Lock-PodeObject) to ensure thread safety - if needed.
+You can also use the State in combination with [`Lock-PodeObject`](../../Functions/Threading/Lock-PodeObject) to ensure thread safety - if needed.
 
 !!! tip
-    It's wise to use the State in conjunction with [`Lock-PodeObject`](../../Functions/Utilities/Lock-PodeObject), to ensure thread safety between runspaces.
+    It's wise to use the State in conjunction with [`Lock-PodeObject`](../../Functions/Threading/Lock-PodeObject), to ensure thread safety between runspaces.
 
 !!! warning
-    If you omit the use of [`Lock-PodeObject`](../../Functions/Utilities/Lock-PodeObject), you might run into errors due to multi-threading. Only omit if you are *absolutely confident* you do not need locking. (ie: you set in state once and then only ever retrieve, never updating the variable).
+    If you omit the use of [`Lock-PodeObject`](../../Functions/Threading/Lock-PodeObject), you might run into errors due to multi-threading. Only omit if you are *absolutely confident* you do not need locking. (ie: you set in state once and then only ever retrieve, never updating the variable).
 
 ## Usage
 
@@ -98,7 +98,7 @@ Start-PodeServer {
 
 ### Save
 
-The [`Save-PodeState`](../../Functions/State/Save-PodeState) function will save the current state, as JSON, to the specified file. The file path can either be relative, or literal. When saving the state, it's recommended to wrap the function within [`Lock-PodeObject`](../../Functions/Utilities/Lock-PodeObject).
+The [`Save-PodeState`](../../Functions/State/Save-PodeState) function will save the current state, as JSON, to the specified file. The file path can either be relative, or literal. When saving the state, it's recommended to wrap the function within [`Lock-PodeObject`](../../Functions/Threading/Lock-PodeObject).
 
 An example of saving the current state every hour is as follows:
 
@@ -120,7 +120,7 @@ By default the JSON will be saved expanded, but you can saved the JSON as compre
 
 ### Restore
 
-The [`Restore-PodeState`](../../Functions/State/Restore-PodeState) function will restore the current state from the specified file. The file path can either be relative, or a literal path. if you're restoring the state immediately on server start, you don't need to use [`Lock-PodeObject`](../../Functions/Utilities/Lock-PodeObject).
+The [`Restore-PodeState`](../../Functions/State/Restore-PodeState) function will restore the current state from the specified file. The file path can either be relative, or a literal path. if you're restoring the state immediately on server start, you don't need to use [`Lock-PodeObject`](../../Functions/Threading/Lock-PodeObject).
 
 An example of restore the current state on server start is as follows:
 


### PR DESCRIPTION
### Description of the Change

- Updated broken links in *docs/Tutorials/SharedState.md* for `Lock-PodeObject`.
- Updated broken link in *docs/Tutorials/Routes/Examples/RestApiSessions.md* for `Enable-PodeSessionMiddleware`
- Updated broken links in *docs/Tutorials/Middleware/Types/Sessions.md* for `Enable-PodeSessionMiddleware` & `Get-PodeSessionId`
- Updated broken link in *docs/Getting-Started/Migrating/0X-to-1X.md* for `Enable-PodeSessionMiddleware`
- Updated broken link in *docs/Tutorials/Routes/Examples/LoginPage.md* for `Enable-PodeSessionMiddleware`
