### PR TITLE
Add support for merging Authentication and Access methods

### DIFF
--- a/docs/Tutorials/Authentication/Inbuilt/AzureAD.md
+++ b/docs/Tutorials/Authentication/Inbuilt/AzureAD.md
@@ -41,6 +41,8 @@ To setup and start using Azure AD authentication in Pode you use `New-PodeAuthAz
 
 ```powershell
 Start-PodeServer {
+    Enable-PodeSessionMiddleware -Duration 120 -Extend
+
     $scheme = New-PodeAuthAzureADScheme -ClientID '<clientId>' -ClientSecret '<clientSecret>' -Tenant '<tenant>'
 
     $scheme | Add-PodeAuth -Name 'Login' -FailureUrl '/login' -SuccessUrl '/' -ScriptBlock {
@@ -63,6 +65,8 @@ To setup Azure AD authentcation, but using your own Form login, then you can use
 
 ```powershell
 Start-PodeServer {
+    Enable-PodeSessionMiddleware -Duration 120 -Extend
+
     $form  = New-PodeAuthScheme -Form
 
     $scheme = New-PodeAuthAzureADScheme -ClientID '<clientId>' -ClientSecret '<clientSecret>' -Tenant '<tenant>' -InnerScheme $form
@@ -97,7 +101,7 @@ The Pode side needs to be configured to allow basic authentication as well. This
 $form  = New-PodeAuthScheme -Form
 $schemeForm = New-PodeAuthAzureADScheme -ClientID '<clientId>' -ClientSecret '<clientSecret>' -Tenant '<tenant>' -InnerScheme $form
 
-$basic = New-PodeAuthSceme -Basic
+$basic = New-PodeAuthScheme -Basic
 $schemeBasic = New-PodeAuthAzureADScheme -ClientID '<clientId>' -ClientSecret '<clientSecret>' -Tenant '<tenant>' -InnerScheme $basic
 
 $authLogin = {

--- a/docs/Tutorials/Authentication/Methods/Bearer.md
+++ b/docs/Tutorials/Authentication/Methods/Bearer.md
@@ -12,7 +12,7 @@ To start using Bearer authentication in Pode you can use `New-PodeAuthScheme -Be
 
 ```powershell
 Start-PodeServer {
-    New-PodeAuthScheme -Bearer | Add-PodeAuth -Name 'Authenticate' -ScriptBlock {
+    New-PodeAuthScheme -Bearer | Add-PodeAuth -Name 'Authenticate' -Sessionless -ScriptBlock {
         param($token)
 
         # check if the token is valid, and get user

--- a/docs/Tutorials/Routes/Examples/AnonymousAccess.md
+++ b/docs/Tutorials/Routes/Examples/AnonymousAccess.md
@@ -47,6 +47,10 @@ Add-PodeRoute -Method Get -Path '/' -Authentication 'Login' -AllowAnon -ScriptBl
 
 Now, when an authenticated user hits the page, they're shown the original personal greeting page with view counter. However, when an unauthenticated user hits the page they are shown a generic greeting with a login button.
 
+The [`Test-PodeAuthUser`] will check both the `$WebEvent.Auth` and `$WebEvent.Session` objects for an authenticated user. You can force the function to only check the former by supplying `-IgnoreSession`.
+
+You can also retrieve the user object using [`Get-PodeAuthUser`]. Under most circumstances you'll be able to access the authenticated user at `$WebEvent.Auth.User`, however if you're relying on Sessions and a Route without Authentication configured then you'll ave to use this function. Similar to above, you can supply `-IgnoreSession` here as well.
+
 ## Example Code
 
 This is the full code for the server above:

--- a/docs/Tutorials/Routes/Examples/AnonymousAccess.md
+++ b/docs/Tutorials/Routes/Examples/AnonymousAccess.md
@@ -47,9 +47,9 @@ Add-PodeRoute -Method Get -Path '/' -Authentication 'Login' -AllowAnon -ScriptBl
 
 Now, when an authenticated user hits the page, they're shown the original personal greeting page with view counter. However, when an unauthenticated user hits the page they are shown a generic greeting with a login button.
 
-The [`Test-PodeAuthUser`] will check both the `$WebEvent.Auth` and `$WebEvent.Session` objects for an authenticated user. You can force the function to only check the former by supplying `-IgnoreSession`.
+The [`Test-PodeAuthUser`](../../../../Functions/Authentication/Test-PodeAuthUser) will check both the `$WebEvent.Auth` and `$WebEvent.Session` objects for an authenticated user. You can force the function to only check the former by supplying `-IgnoreSession`.
 
-You can also retrieve the user object using [`Get-PodeAuthUser`]. Under most circumstances you'll be able to access the authenticated user at `$WebEvent.Auth.User`, however if you're relying on Sessions and a Route without Authentication configured then you'll ave to use this function. Similar to above, you can supply `-IgnoreSession` here as well.
+You can also retrieve the user object using [`Get-PodeAuthUser`](../../../../Functions/Authentication/Get-PodeAuthUser). Under most circumstances you'll be able to access the authenticated user at `$WebEvent.Auth.User`, however if you're relying on Sessions and a Route without Authentication configured then you'll ave to use this function. Similar to above, you can supply `-IgnoreSession` here as well.
 
 ## Example Code
 

--- a/examples/web-auth-apikey.ps1
+++ b/examples/web-auth-apikey.ps1
@@ -11,6 +11,8 @@ Import-Module "$($path)/src/Pode.psm1" -Force -ErrorAction Stop
 # or just:
 # Import-Module Pode
 
+# Invoke-RestMethod -Method Get -Uri 'http://localhost:8085/users' -Headers @{ 'X-API-KEY' = 'test-api-key' }
+
 # create a server, and start listening on port 8085
 Start-PodeServer -Threads 2 {
 

--- a/examples/web-auth-basic-access.ps1
+++ b/examples/web-auth-basic-access.ps1
@@ -8,15 +8,15 @@ Import-Module "$($path)/src/Pode.psm1" -Force -ErrorAction Stop
 This example shows how to use sessionless authentication, which will mostly be for
 REST APIs. The example used here is Basic authentication.
 
-Calling the '[POST] http://localhost:8085/users' endpoint, with an Authorization
+Calling the '[POST] http://localhost:8085/users-all' endpoint, with an Authorization
 header of 'Basic bW9ydHk6cGlja2xl' will display the uesrs. Anything else and
 you'll get a 401 status code back.
 
 Success:
-Invoke-RestMethod -Uri http://localhost:8085/users -Method Post -Headers @{ Authorization = 'Basic bW9ydHk6cGlja2xl' }
+Invoke-RestMethod -Uri http://localhost:8085/users-all -Method Post -Headers @{ Authorization = 'Basic bW9ydHk6cGlja2xl' }
 
 Failure:
-Invoke-RestMethod -Uri http://localhost:8085/users -Method Post -Headers @{ Authorization = 'Basic bW9ydHk6cmljaw==' }
+Invoke-RestMethod -Uri http://localhost:8085/users-all -Method Post -Headers @{ Authorization = 'Basic bW9ydHk6cmljaw==' }
 #>
 
 # create a server, and start listening on port 8085
@@ -33,8 +33,10 @@ Start-PodeServer -Threads 2 {
     #     return $userRoles.Example -iin $customValues.Example
     # }
 
+    Merge-PodeAuthAccess -Name 'TestMerged' -Access 'TestRbac', 'TestGbac' -Valid All
+
     # setup basic auth (base64> username:password in header)
-    New-PodeAuthScheme -Basic -Realm 'Pode Example Page' | Add-PodeAuth -Name 'Validate' -Access 'TestRbac', 'TestGbac' -Sessionless -ScriptBlock {
+    New-PodeAuthScheme -Basic -Realm 'Pode Example Page' | Add-PodeAuth -Name 'Validate' -Access 'TestMerged' -Sessionless -ScriptBlock {
         param($username, $password)
 
         # here you'd check a real user storage, this is just for example

--- a/examples/web-auth-basic-adhoc.ps1
+++ b/examples/web-auth-basic-adhoc.ps1
@@ -6,10 +6,10 @@ Import-Module "$($path)/src/Pode.psm1" -Force -ErrorAction Stop
 
 <#
 This example shows how to use sessionless authentication, which will mostly be for
-REST APIs. The example used here is Basic authentication.
+REST APIs. The example used here is adhoc Basic authentication.
 
 Calling the '[POST] http://localhost:8085/users' endpoint, with an Authorization
-header of 'Basic bW9ydHk6cGlja2xl' will display the uesrs. Anything else and
+header of 'Basic bW9ydHk6cGlja2xl' will display the users. Anything else and
 you'll get a 401 status code back.
 
 Success:
@@ -43,10 +43,24 @@ Start-PodeServer -Threads 2 {
         return @{ Message = 'Invalid details supplied' }
     }
 
-    # POST request to get current user (since there's no session, authentication will always happen)
-    Add-PodeRoute -Method Post -Path '/users' -Authentication 'Validate' -ScriptBlock {
+    # POST request to get list of users (authentication is done adhoc, and not directly using -Authentication on the Route)
+    Add-PodeRoute -Method Post -Path '/users' -ScriptBlock {
+        if (!(Test-PodeAuth -Name Validate)) {
+            Set-PodeResponseStatus -Code 401
+            return
+        }
+
         Write-PodeJsonResponse -Value @{
-            User = (Get-PodeAuthUser)
+            User = @(
+                @{
+                    Name = 'Deep Thought'
+                    Age = 42
+                },
+                @{
+                    Name = 'Leeroy Jenkins'
+                    Age = 1337
+                }
+            )
         }
     }
 

--- a/examples/web-auth-basic-anon.ps1
+++ b/examples/web-auth-basic-anon.ps1
@@ -44,7 +44,7 @@ Start-PodeServer -Threads 2 {
     }
 
     # GET request to get list of users (since there's no session, authentication will always happen, but, we're allowing anon access)
-    Add-PodeRoute -Method Get -Path '/users' -Authentication 'Validate' -Anon -ScriptBlock {
+    Add-PodeRoute -Method Get -Path '/users' -Authentication 'Validate' -AllowAnon -ScriptBlock {
         if (Test-PodeAuthUser) {
             Write-PodeJsonResponse -Value @{
                 Users = @(

--- a/examples/web-auth-bearer.ps1
+++ b/examples/web-auth-bearer.ps1
@@ -4,6 +4,8 @@ Import-Module "$($path)/src/Pode.psm1" -Force -ErrorAction Stop
 # or just:
 # Import-Module Pode
 
+# Invoke-RestMethod -Method Get -Uri 'http://localhost:8085/users' -Headers @{ Authorization = 'Bearer test-token' }
+
 # create a server, and start listening on port 8085
 Start-PodeServer -Threads 2 {
 

--- a/examples/web-auth-form-anon.ps1
+++ b/examples/web-auth-form-anon.ps1
@@ -50,7 +50,7 @@ Start-PodeServer -Threads 2 {
 
     # home page:
     # redirects to login page if not authenticated
-    Add-PodeRoute -Method Get -Path '/' -Authentication Login -Anon -ScriptBlock {
+    Add-PodeRoute -Method Get -Path '/' -Authentication Login -AllowAnon -ScriptBlock {
         if (Test-PodeAuthUser) {
             $session:Views++
 

--- a/examples/web-auth-form-merged.ps1
+++ b/examples/web-auth-form-merged.ps1
@@ -1,0 +1,102 @@
+$path = Split-Path -Parent -Path (Split-Path -Parent -Path $MyInvocation.MyCommand.Path)
+Import-Module "$($path)/src/Pode.psm1" -Force -ErrorAction Stop
+
+# or just:
+# Import-Module Pode
+
+<#
+This examples shows how to use session persistant authentication, for things like logins on websites.
+The example used here is Form authentication, sent from the <form> in HTML.
+
+Navigating to the 'http://localhost:8085' endpoint in your browser will auto-rediect you to the '/login'
+page. Here, you can type the username (morty) and the password (pickle); clicking 'Login' will take you
+back to the home page with a greeting and a view counter. Clicking 'Logout' will purge the session and
+take you back to the login page.
+#>
+
+# create a server, and start listening on port 8085
+Start-PodeServer -Threads 2 {
+
+    # listen on localhost:8085
+    Add-PodeEndpoint -Address * -Port 8085 -Protocol Http
+
+    # set the view engine
+    Set-PodeViewEngine -Type Pode
+
+    # enable error logging
+    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+
+    # setup session details
+    Enable-PodeSessionMiddleware -Duration 120 -Extend
+
+    # setup form auth (<form> in HTML)
+    New-PodeAuthScheme -Form | Add-PodeAuth -Name 'Login1' -FailureUrl '/login' -SuccessUrl '/' -ScriptBlock {
+        param($username, $password)
+
+        # here you'd check a real user storage, this is just for example
+        if ($username -eq 'morty' -and $password -eq 'pickle') {
+            return @{
+                User = @{
+                    ID ='M0R7Y302'
+                    Name = 'Morty'
+                    Type = 'Human'
+                }
+            }
+        }
+
+        return @{ Message = 'Invalid details supplied' }
+    }
+
+    New-PodeAuthScheme -Form | Add-PodeAuth -Name 'Login2' -FailureUrl '/login' -SuccessUrl '/' -ScriptBlock {
+        param($username, $password)
+
+        # here you'd check a real user storage, this is just for example
+        if ($username -eq 'morty' -and $password -eq 'bob') {
+            return @{
+                User = @{
+                    ID ='M0R7Y302'
+                    Name = 'Morty'
+                    Type = 'Human'
+                }
+            }
+        }
+
+        return @{ Message = 'Invalid details supplied' }
+    }
+
+    Merge-PodeAuth -Name 'Login' -Authentication Login1, Login2
+
+
+    # home page:
+    # redirects to login page if not authenticated
+    Add-PodeRoute -Method Get -Path '/' -Authentication Login -ScriptBlock {
+        $session:Views++
+
+        Write-PodeViewResponse -Path 'auth-home' -Data @{
+            Username = $WebEvent.Auth.User.Name
+            Views = $session:Views
+            Expiry = Get-PodeSessionExpiry
+        }
+    }
+
+
+    # login page:
+    # the login flag set below checks if there is already an authenticated session cookie. If there is, then
+    # the user is redirected to the home page. If there is no session then the login page will load without
+    # checking user authetication (to prevent a 401 status)
+    Add-PodeRoute -Method Get -Path '/login' -Authentication Login -Login -ScriptBlock {
+        Write-PodeViewResponse -Path 'auth-login' -FlashMessages
+    }
+
+
+    # login check:
+    # this is the endpoint the <form>'s action will invoke. If the user validates then they are set against
+    # the session as authenticated, and redirect to the home page. If they fail, then the login page reloads
+    Add-PodeRoute -Method Post -Path '/login' -Authentication Login -Login
+
+
+    # logout check:
+    # when the logout button is click, this endpoint is invoked. The logout flag set below informs this call
+    # to purge the currently authenticated session, and then redirect back to the login page
+    Add-PodeRoute -Method Post -Path '/logout' -Authentication Login -Logout
+}

--- a/examples/web-auth-merged.ps1
+++ b/examples/web-auth-merged.ps1
@@ -1,0 +1,76 @@
+$path = Split-Path -Parent -Path (Split-Path -Parent -Path $MyInvocation.MyCommand.Path)
+Import-Module "$($path)/src/Pode.psm1" -Force -ErrorAction Stop
+
+# or just:
+# Import-Module Pode
+
+# Success
+# Invoke-RestMethod -Method Get -Uri 'http://localhost:8085/users' -Headers @{ 'X-API-KEY' = 'test-api-key'; Authorization = 'Basic bW9ydHk6cGlja2xl' }
+
+# Failure
+# Invoke-RestMethod -Method Get -Uri 'http://localhost:8085/users' -Headers @{ 'X-API-KEY' = 'test-api-key'; Authorization = 'Basic bW9ydHk6cmljaw==' }
+
+# create a server, and start listening on port 8085
+Start-PodeServer -Threads 2 {
+
+    # listen on localhost:8085
+    Add-PodeEndpoint -Address * -Port 8085 -Protocol Http
+    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+
+    # setup access
+    Add-PodeAuthAccess -Type Role -Name 'Rbac'
+    Add-PodeAuthAccess -Type Group -Name 'Gbac'
+
+    # setup a merged access
+    Merge-PodeAuthAccess -Name 'MergedAccess' -Access 'Rbac', 'Gbac' -Valid All
+
+    # setup apikey auth
+    New-PodeAuthScheme -ApiKey -Location Header | Add-PodeAuth -Name 'ApiKey' -Access 'Gbac' -Sessionless -ScriptBlock {
+        param($key)
+
+        # here you'd check a real user storage, this is just for example
+        if ($key -ieq 'test-api-key') {
+            return @{
+                User = @{
+                    ID ='M0R7Y302'
+                    Name = 'Morty'
+                    Type = 'Human'
+                    Groups = @('Software')
+                }
+            }
+        }
+
+        return $null
+    }
+
+    # setup basic auth (base64> username:password in header)
+    New-PodeAuthScheme -Basic | Add-PodeAuth -Name 'Basic' -Access 'MergedAccess' -Sessionless -ScriptBlock {
+        param($username, $password)
+
+        # here you'd check a real user storage, this is just for example
+        if ($username -eq 'morty' -and $password -eq 'pickle') {
+            return @{
+                User = @{
+                    ID ='M0R7Y302'
+                    Name = 'Morty'
+                    Type = 'Human'
+                    Roles = @('Developer')
+                    Groups = @('Software')
+                }
+            }
+        }
+
+        return @{ Message = 'Invalid details supplied' }
+    }
+
+    # merge the auths together
+    Merge-PodeAuth -Name 'MergedAuth' -Authentication 'ApiKey', 'Basic' -Valid All
+
+    # GET request to get list of users (since there's no session, authentication will always happen)
+    Add-PodeRoute -Method Get -Path '/users' -Authentication 'MergedAuth' -Role Developer -Group Software -ScriptBlock {
+        Write-PodeJsonResponse -Value @{
+            Users = $WebEvent.Auth.User
+        }
+    }
+
+}

--- a/src/Pode.psd1
+++ b/src/Pode.psd1
@@ -116,6 +116,7 @@
         'Out-PodeVariable',
         'Test-PodeIsHosted',
         'New-PodeCron',
+        'Test-PodeInRunspace',
 
         # routes
         'Add-PodeRoute',
@@ -229,6 +230,10 @@
         'Test-PodeAuthAccessUser',
         'Test-PodeAuthAccessRoute',
         'Merge-PodeAuth',
+        'Test-PodeAuth',
+        'Test-PodeAuthExists',
+        'Merge-PodeAuthAccess',
+        'Get-PodeAuthUser',
 
         # logging
         'New-PodeLoggingMethod',

--- a/src/Pode.psd1
+++ b/src/Pode.psd1
@@ -228,6 +228,7 @@
         'Test-PodeAuthAccess',
         'Test-PodeAuthAccessUser',
         'Test-PodeAuthAccessRoute',
+        'Merge-PodeAuth',
 
         # logging
         'New-PodeLoggingMethod',

--- a/src/Private/Authentication.ps1
+++ b/src/Private/Authentication.ps1
@@ -1313,7 +1313,7 @@ function Test-PodeAuthValidationAccess
     }
 
     # check access
-    return ([string]::IsNullOrEmpty($access) -or (Invoke-PodeAuthValidationAccess -Name $access))
+    return ([string]::IsNullOrEmpty($access) -or (Invoke-PodeAuthValidationAccess -Name $access -Authentication $BaseName))
 }
 
 function Invoke-PodeAuthValidationAccess
@@ -1321,7 +1321,11 @@ function Invoke-PodeAuthValidationAccess
     param(
         [Parameter(Mandatory=$true)]
         [string]
-        $Name
+        $Name,
+
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Authentication
     )
 
     # get the access method
@@ -1330,7 +1334,7 @@ function Invoke-PodeAuthValidationAccess
     # if it's a merged access, re-call this function and check against "succeed" value
     if ($access.Merged) {
         foreach ($accName in $access.Access) {
-            $result = Invoke-PodeAuthValidationAccess -Name $accName
+            $result = Invoke-PodeAuthValidationAccess -Name $accName -Authentication $Authentication
 
             # if the access passed, and we only need one access to pass, return true
             if ($result -and $access.PassOne) {
@@ -1358,7 +1362,7 @@ function Invoke-PodeAuthValidationAccess
     }
 
     # main access validation logic
-    return (Test-PodeAuthAccessRoute -Name $Name)
+    return (Test-PodeAuthAccessRoute -Name $Name -Authentication $Authentication)
 }
 
 function Get-PodeAuthMiddlewareScript

--- a/src/Private/OpenApi.ps1
+++ b/src/Private/OpenApi.ps1
@@ -453,7 +453,7 @@ function Set-PodeOAAuth
     )
 
     foreach ($n in @($Name)) {
-        if (!(Test-PodeAuth -Name $n)) {
+        if (!(Test-PodeAuthExists -Name $n)) {
             throw "Authentication method does not exist: $($n)"
         }
     }
@@ -479,7 +479,7 @@ function Set-PodeOAGlobalAuth
         $Route
     )
 
-    if (!(Test-PodeAuth -Name $Name)) {
+    if (!(Test-PodeAuthExists -Name $Name)) {
         throw "Authentication method does not exist: $($Name)"
     }
 

--- a/src/Public/Authentication.ps1
+++ b/src/Public/Authentication.ps1
@@ -1088,8 +1088,8 @@ function Test-PodeAuth
     )
 
     # if the session already has a user/isAuth'd, then skip auth - or allow anon
-    if (!$IgnoreSession -and (Test-PodeSessionsInUse)) {
-        return (Test-PodeAuthUser)
+    if (!$IgnoreSession -and (Test-PodeSessionsInUse) -and (Test-PodeAuthUser)) {
+        return $true
     }
 
     try {

--- a/src/Public/Routes.ps1
+++ b/src/Public/Routes.ps1
@@ -277,7 +277,7 @@ function Add-PodeRoute
 
     # if an auth name was supplied, setup the auth as the first middleware
     if (![string]::IsNullOrWhiteSpace($Authentication)) {
-        if (!(Test-PodeAuth -Name $Authentication)) {
+        if (!(Test-PodeAuthExists -Name $Authentication)) {
             throw "Authentication method does not exist: $($Authentication)"
         }
 
@@ -619,7 +619,7 @@ function Add-PodeStaticRoute
 
     # if an auth name was supplied, setup the auth as the first middleware
     if (![string]::IsNullOrWhiteSpace($Authentication)) {
-        if (!(Test-PodeAuth -Name $Authentication)) {
+        if (!(Test-PodeAuthExists -Name $Authentication)) {
             throw "Authentication method does not exist: $($Authentication)"
         }
 

--- a/src/Public/Utilities.ps1
+++ b/src/Public/Utilities.ps1
@@ -686,6 +686,14 @@ function Test-PodeIsMacOS
     return ([bool]$IsMacOS)
 }
 
+function Test-PodeInRunspace
+{
+    [CmdletBinding()]
+    param()
+
+    return ([bool]$PODE_SCOPE_RUNSPACE)
+}
+
 <#
 .SYNOPSIS
 Outputs an object to the main Host.

--- a/src/Public/Utilities.ps1
+++ b/src/Public/Utilities.ps1
@@ -686,6 +686,16 @@ function Test-PodeIsMacOS
     return ([bool]$IsMacOS)
 }
 
+<#
+.SYNOPSIS
+Tests if the scope you're in is currently within a Pode runspace.
+
+.DESCRIPTION
+Tests if the scope you're in is currently within a Pode runspace.
+
+.EXAMPLE
+If (Test-PodeInRunspace) { ... }
+#>
 function Test-PodeInRunspace
 {
     [CmdletBinding()]

--- a/tests/unit/Authentication.Tests.ps1
+++ b/tests/unit/Authentication.Tests.ps1
@@ -8,26 +8,40 @@ Describe 'Set-PodeAuthStatus' {
     Mock Move-PodeResponseUrl {}
     Mock Set-PodeResponseStatus {}
 
+    $PodeContext = @{
+        Server = @{
+            Authentications = @{
+                Methods = @{
+                    ExampleAuth = @{
+                        Failure = @{ Url = '/url' }
+                        Success = @{ Url = '/url' }
+                        Cache = @{}
+                    }
+                }
+            }
+        }
+    }
+
     It 'Redirects to a failure URL' {
-        Set-PodeAuthStatus -StatusCode 500 -Failure @{ 'Url' = 'url'} | Should Be $false
+        Set-PodeAuthStatus -StatusCode 500 -Name ExampleAuth | Should Be $false
         Assert-MockCalled Move-PodeResponseUrl -Times 1 -Scope It
         Assert-MockCalled Set-PodeResponseStatus -Times 0 -Scope It
     }
 
     It 'Sets status to failure' {
-        Set-PodeAuthStatus -StatusCode 500 | Should Be $false
-        Assert-MockCalled Move-PodeResponseUrl -Times 0 -Scope It
-        Assert-MockCalled Set-PodeResponseStatus -Times 1 -Scope It
+        Set-PodeAuthStatus -StatusCode 500 -Name ExampleAuth | Should Be $false
+        Assert-MockCalled Move-PodeResponseUrl -Times 1 -Scope It
+        Assert-MockCalled Set-PodeResponseStatus -Times 0 -Scope It
     }
 
     It 'Redirects to a success URL' {
-        Set-PodeAuthStatus -Success @{ 'Url' = 'url' } -LoginRoute | Should Be $false
+        Set-PodeAuthStatus -Name ExampleAuth -LoginRoute | Should Be $false
         Assert-MockCalled Move-PodeResponseUrl -Times 1 -Scope It
         Assert-MockCalled Set-PodeResponseStatus -Times 0 -Scope It
     }
 
     It 'Returns true for next middleware' {
-        Set-PodeAuthStatus | Should Be $true
+        Set-PodeAuthStatus -Name ExampleAuth -NoSuccessRedirect | Should Be $true
         Assert-MockCalled Move-PodeResponseUrl -Times 0 -Scope It
         Assert-MockCalled Set-PodeResponseStatus -Times 0 -Scope It
     }


### PR DESCRIPTION
### Description of the Change
This adds `Merge-PodeAuth` and `Merge-PodeAuthAccess` functions to allow merging multiple Authentication and Access methods together for advanced use cases. For either, the default is to allow auth/access on the first valid result, but you can specify that all methods must be valid to pass. You can also merge other merged methods for really advanced use cases.

Also added are:
* `Test-PodeAuth` - returns true/false for if a user's credentials on a request are valid for an authentication method.
* `Test-PodeAuthExists` - return true/false for if an authentication method exists.
* `Get-PodeAuthUser` - returns an authenticated user object from either the WebEvent or Session.

### Related Issue
Resolves #588 

### Examples
### Authentication
If you require an API Key and Basic authentication for a user to view a Route, you would set something up as follows:

```powershell
# setup apikey auth
New-PodeAuthScheme -ApiKey -Location Header | Add-PodeAuth -Name 'ApiKey' -Sessionless -ScriptBlock {
    param($key)

    # here you'd check a real user storage, this is just for example
    if ($key -ieq 'test-api-key') {
        return @{ User = @{ Name = 'Morty' } }
    }

    return $null
}

# setup basic auth
New-PodeAuthScheme -Basic | Add-PodeAuth -Name 'Basic' -Sessionless -ScriptBlock {
    param($username, $password)

    # here you'd check a real user storage, this is just for example
    if ($username -eq 'morty' -and $password -eq 'pickle') {
        return @{ User = @{ Name = 'Morty' } }
    }

    return @{ Message = 'Invalid details supplied' }
}

# merge the authentications together, and require all to pass
Merge-PodeAuth -Name 'MergedAuth' -Authentication 'ApiKey', 'Basic' -Valid All

# use the merged auth in a route
Add-PodeRoute -Method Get -Path '/users' -Authentication 'MergedAuth' -ScriptBlock {
    Write-PodeJsonResponse -Value @{
        Users = $WebEvent.Auth.User
    }
}
```

### Authorisation
If you need RBAC and GBAC authorisation, such as Developers have to be in a Software Group, and the Admins in a Operations Group:

```powershell
Start-PodeServer {
    Add-PodeEndpoint -Address * -Port 8080 -Protocol Http

    # create simple role and group access methods
    Add-PodeAuthAccess -Name 'RoleExample' -Type Role
    Add-PodeAuthAccess -Name 'GroupExample' -Type Group

    # setup a merged access
    Merge-PodeAuthAccess -Name 'MergedExample' -Access 'RoleExample', 'GroupExample' -Valid All

    # setup Basic authentication
    New-PodeAuthScheme -Basic | Add-PodeAuth -Name 'AuthExample' -Sessionless -Access 'MergedExample' -ScriptBlock {
        param($username, $password)

        # here you'd check a real user storage, this is just for example
        if (($username -eq 'morty') -and ($password -eq 'pickle')) {
            return @{
                User = @{
                    Username = 'Morty'
                    Roles = @('Developer')
                    Groups = @('Software')
                }
            }
        }

        # authentication failed
        return $null
    }

    # create a route which only developers can access
    Add-PodeRoute -Method Get -Path '/route1' -Role 'Developer' -Group 'Software' -Authentication 'AuthExample' -ScriptBlock {
        Write-PodeJsonResponse -Value @{ 'Value' = 'Hello!' }
    }

    # create a route which only admins can access
    Add-PodeRoute -Method Get -Path '/route2' -Role 'Admin' -Group 'Operations' -Authentication 'AuthExample' -ScriptBlock {
        Write-PodeJsonResponse -Value @{ 'Value' = 'Hi!' }
    }
}
```