### PR TITLE
Fix the loading of AutoImport config

### DIFF
--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -787,7 +787,7 @@ function Set-PodeServerConfiguration
     }
 
     # auto-import
-    $Context.Server.AutoImport = Read-PodeAutoImportConfiguration
+    $Context.Server.AutoImport = Read-PodeAutoImportConfiguration -Configuration $Configuration
 
     # request
     if ([int]$Configuration.Request.Timeout -gt 0) {


### PR DESCRIPTION
### Description of the Change
The Configuration object wasn't being supplied to the function loading the AutoImport config, so it was all being ignored. This now passes that config object.

### Related Issue
Resolves #1137 
