### PR TITLE
Allows the setting of SSL protocols per Endpoint

### DIFF
--- a/docs/Tutorials/Endpoints/Basics.md
+++ b/docs/Tutorials/Endpoints/Basics.md
@@ -128,7 +128,8 @@ The following is the structure of the Endpoint object internally, as well as the
 | Hostname | string | The hostname of the Endpoint |
 | FriendlyName | string | A user friendly hostname to use when generating internal URLs |
 | Url | string | The full base URL of the Endpoint |
-| Ssl | bool | Whether or not this Endpoint support support SSL |
+| Ssl.Enabled | bool | Whether or not this Endpoint uses SSL |
+| Ssl.Protocols | SslProtocols | An aggregated integer which specifies the SSL protocols this endpoints supports |
 | Protocol | string | The protocol of the Endpoint. Such as: HTTP, HTTPS, WS, etc. |
 | Type | string | The type of the Endpoint. Such as: HTTP, WS, SMTP, TCP |
 | Certificate | hashtable | Details about the certificate that will be used for SSL Endpoints |

--- a/docs/Tutorials/Endpoints/Basics.md
+++ b/docs/Tutorials/Endpoints/Basics.md
@@ -79,6 +79,13 @@ The below example will create a local self-signed HTTPS endpoint:
 Add-PodeEndpoint -Address * -Port 8443 -Protocol Https -SelfSigned
 ```
 
+### SSL Protocols
+
+By default Pode will use the SSL3 or TLS12 protocols - or just TLS12 if on MacOS. You can override this default in one of two ways:
+
+1. Update the global default in Pode's configuration file, as [described here](../../Certificates#ssl-protocols).
+2. Specify specific SSL Protocols to use per Endpoints using the `-SslProtocol` parameter on [`Add-PodeEndpoint`](../../../Functions/Core/Add-PodeEndpoint).
+
 ## Endpoint Names
 
 You can give endpoints unique names by supplying the `-EndpointName` parameter. This name can then be passed to [`Add-PodeRoute`](../../../Functions/Routes/Add-PodeRoute) or [`Add-PodeStaticRoute`](../../../Functions/Routes/Add-PodeStaticRoute) to bind these routes to that endpoint only.

--- a/src/Private/PodeServer.ps1
+++ b/src/Private/PodeServer.ps1
@@ -44,6 +44,7 @@ function Start-PodeWebServer
             Protocol = $_.Protocol
             Type = $_.Type
             Pool = $_.Runspace.PoolName
+            SslProtocols = $_.Ssl.Protocols
         }
 
         # add endpoint to list
@@ -72,7 +73,7 @@ function Start-PodeWebServer
     {
         # register endpoints on the listener
         $endpoints | ForEach-Object {
-            $socket = (. ([scriptblock]::Create("New-Pode$($PodeContext.Server.ListenerType)ListenerSocket -Address `$_.Address -Port `$_.Port -SslProtocols `$PodeContext.Server.Sockets.Ssl.Protocols -Type `$endpointsMap[`$_.Key].Type -Certificate `$_.Certificate -AllowClientCertificate `$_.AllowClientCertificate")))
+            $socket = (. ([scriptblock]::Create("New-Pode$($PodeContext.Server.ListenerType)ListenerSocket -Address `$_.Address -Port `$_.Port -SslProtocols `$_.SslProtocols -Type `$endpointsMap[`$_.Key].Type -Certificate `$_.Certificate -AllowClientCertificate `$_.AllowClientCertificate")))
             $socket.ReceiveTimeout = $PodeContext.Server.Sockets.ReceiveTimeout
 
             if (!$_.IsIPAddress) {

--- a/src/Private/SmtpServer.ps1
+++ b/src/Private/SmtpServer.ps1
@@ -31,6 +31,7 @@ function Start-PodeSmtpServer
             Type = $_.Type
             Pool = $_.Runspace.PoolName
             Acknowledge = $_.Tcp.Acknowledge
+            SslProtocols = $_.Ssl.Protocols
         }
 
         # add endpoint to list
@@ -48,7 +49,7 @@ function Start-PodeSmtpServer
     {
         # register endpoints on the listener
         $endpoints | ForEach-Object {
-            $socket = [PodeSocket]::new($_.Address, $_.Port, $PodeContext.Server.Sockets.Ssl.Protocols, [PodeProtocolType]::Smtp, $_.Certificate, $_.AllowClientCertificate, $_.TlsMode)
+            $socket = [PodeSocket]::new($_.Address, $_.Port, $_.SslProtocols, [PodeProtocolType]::Smtp, $_.Certificate, $_.AllowClientCertificate, $_.TlsMode)
             $socket.ReceiveTimeout = $PodeContext.Server.Sockets.ReceiveTimeout
             $socket.AcknowledgeMessage = $_.Acknowledge
 

--- a/src/Private/TcpServer.ps1
+++ b/src/Private/TcpServer.ps1
@@ -27,6 +27,7 @@ function Start-PodeTcpServer
             Pool = $_.Runspace.PoolName
             Acknowledge = $_.Tcp.Acknowledge
             CRLFMessageEnd = $_.Tcp.CRLFMessageEnd
+            SslProtocols = $_.Ssl.Protocols
         }
 
         # add endpoint to list
@@ -44,7 +45,7 @@ function Start-PodeTcpServer
     {
         # register endpoints on the listener
         $endpoints | ForEach-Object {
-            $socket = [PodeSocket]::new($_.Address, $_.Port, $PodeContext.Server.Sockets.Ssl.Protocols, [PodeProtocolType]::Tcp, $_.Certificate, $_.AllowClientCertificate, $_.TlsMode)
+            $socket = [PodeSocket]::new($_.Address, $_.Port, $_.SslProtocols, [PodeProtocolType]::Tcp, $_.Certificate, $_.AllowClientCertificate, $_.TlsMode)
             $socket.ReceiveTimeout = $PodeContext.Server.Sockets.ReceiveTimeout
             $socket.AcknowledgeMessage = $_.Acknowledge
             $socket.CRLFMessageEnd = $_.CRLFMessageEnd

--- a/tests/unit/Schedules.Tests.ps1
+++ b/tests/unit/Schedules.Tests.ps1
@@ -220,16 +220,6 @@ Describe 'Get-PodeSchedule' {
         $schedules.Length | Should Be 0
     }
 
-    It 'Returns no schedules by where end just before end' {
-        $PodeContext = @{ Schedules = @{ Items = @{} } }
-        $start = ([DateTime]::Now.AddHours(3))
-        $end = ([DateTime]::Now.AddHours(5))
-
-        Add-PodeSchedule -Name 'test1' -Cron '@hourly' -ScriptBlock { Write-Host 'hello' } -StartTime $start -EndTime $end
-        $schedules = Get-PodeSchedule -StartTime $start.AddHours(1).AddMinutes(1) -EndTime $end.AddHours(-1).AddMinutes(-1)
-        $schedules.Length | Should Be 0
-    }
-
     It 'Returns 2 schedules by name' {
         $PodeContext = @{ Schedules = @{ Items = @{} } }
         $start = ([DateTime]::Now.AddHours(3))


### PR DESCRIPTION
### Description of the Change
Allows the setting of SSL protocols per Endpoint via a new `-SslProtocol` parameter on `Add-PodeEndpoint`.

### Related Issue
Resolves #1101 

### Examples
```powershell
Add-PodeEndpoint -Address * -Port 8443 -Protocol Https -SelfSigned -SslProtocol Tls12
```
