### PR TITLE
Fix parsing of SMTP headers when there are multiple

### DIFF
--- a/examples/mail-server.ps1
+++ b/examples/mail-server.ps1
@@ -42,6 +42,7 @@ Start-PodeServer -Threads 2 {
         Write-Host '|'
         $SmtpEvent.Email | Out-Default
         $SmtpEvent.Request | out-default
+        $SmtpEvent.Email.Headers | out-default
         Write-Host '- - - - - - - - - - - - - - - - - -'
     }
 

--- a/src/Listener/PodeSmtpRequest.cs
+++ b/src/Listener/PodeSmtpRequest.cs
@@ -320,14 +320,34 @@ namespace Pode
                 if (match.Success)
                 {
                     previousHeader = match.Groups["name"].Value;
-                    headers.Add(match.Groups["name"].Value, match.Groups["value"].Value);
+                    if (headers.ContainsKey(previousHeader))
+                    {
+                        if (!(headers[previousHeader] is List<object>))
+                        {
+                            headers[previousHeader] = new List<object>() { headers[previousHeader] };
+                        }
+
+                        ((List<object>)headers[previousHeader]).Add(match.Groups["value"].Value);
+                    }
+                    else
+                    {
+                        headers.Add(previousHeader, match.Groups["value"].Value);
+                    }
                 }
                 else
                 {
                     match = Regex.Match(line, "^(?<name>.*?)\\:\\s+");
                     if (!match.Success)
                     {
-                        headers[previousHeader] += line;
+                        if (headers[previousHeader] is List<object>)
+                        {
+                            var values = (List<object>)headers[previousHeader];
+                            values[values.Count - 1] += line;
+                        }
+                        else
+                        {
+                            headers[previousHeader] += line;
+                        }
                     }
                 }
 


### PR DESCRIPTION
### Description of the Change
Fixes an SMTP header parsing issue when multiple headers, such as `Received`, were supplied.

Now, when multiple headers are detected, the values will be stored in a List under the same Hashtable property:
```powershell
$SmtpEvent.Email.Headers['Received'][0..2]
```

### Related Issue
Resolves #1087 
