### PR TITLE
Reference the Protected Users group in Windows AD

### DIFF
--- a/docs/Tutorials/Authentication/Inbuilt/WindowsAD.md
+++ b/docs/Tutorials/Authentication/Inbuilt/WindowsAD.md
@@ -149,3 +149,7 @@ New-PodeAuthScheme -Form | Add-PodeAuthWindowsAd -Name 'Login' -ScriptBlock {
     return @{ Message = 'Authorisation failed' }
 }
 ```
+
+## Protected Users
+
+In Windows AD there is a "Protected Users" group that you can assign users into. If users in this group are trying to use your site, then they will fail authentication. Unfortunately, this is just a secure feature of Windows AD, and the only way around this is to take the affected users out of the Protected Users group.


### PR DESCRIPTION
### Description of the Change
In the Windows AD authentication docs, a reference to the Protected Users group has been added. Any users in this group will fail authentication as a feature of being in this group.

### Related Issue
Resolves #1099 
