### PR TITLE
When available, add the username to the request log output

### DIFF
--- a/docs/Tutorials/Logging/Types/Requests.md
+++ b/docs/Tutorials/Logging/Types/Requests.md
@@ -31,6 +31,22 @@ $method = New-PodeLoggingMethod -Custom -ScriptBlock {
 $method | Enable-PodeRequestLogging -Raw
 ```
 
+### Username
+
+If you're not using any Authentication then the "user" field in the log will always be "-". However, if you're using Authentication, and it passes, then the Username of the user accessing the Route will attempt to be retrieved from `$WebEvent.Auth.User`. The property within the authenticated user object by default is `Username`, but you can customise this using `-UsernameProperty`.
+
+For example, if the username was actually user "ID":
+
+```powershell
+Enable-PodeRequestLogging -UsernameProperty 'ID'
+```
+
+Or if the username was inside another "Meta" property, and then within a "Username" property inside the Meta object:
+
+```powershell
+Enable-PodeRequestLogging -UsernameProperty 'Meta.Username'
+```
+
 ## Raw Request
 
 The raw Request hashtable that will be supplied to any Custom logging methods will look as follows:

--- a/examples/rest-api.ps1
+++ b/examples/rest-api.ps1
@@ -9,6 +9,9 @@ Start-PodeServer {
 
     Add-PodeEndpoint -Address * -Port 8086 -Protocol Http
 
+    # request logging
+    New-PodeLoggingMethod -Terminal -Batch 10 -BatchTimeout 10 | Enable-PodeRequestLogging
+
     # can be hit by sending a GET request to "localhost:8086/api/test"
     Add-PodeRoute -Method Get -Path '/api/test' -ScriptBlock {
         Write-PodeJsonResponse -Value @{ 'hello' = 'world'; }

--- a/examples/web-auth-basic.ps1
+++ b/examples/web-auth-basic.ps1
@@ -25,6 +25,9 @@ Start-PodeServer -Threads 2 {
     # listen on localhost:8085
     Add-PodeEndpoint -Address * -Port 8085 -Protocol Http
 
+    # request logging
+    New-PodeLoggingMethod -Terminal -Batch 10 -BatchTimeout 10 | Enable-PodeRequestLogging
+
     # setup basic auth (base64> username:password in header)
     New-PodeAuthScheme -Basic -Realm 'Pode Example Page' | Add-PodeAuth -Name 'Validate' -Sessionless -ScriptBlock {
         param($username, $password)
@@ -33,6 +36,7 @@ Start-PodeServer -Threads 2 {
         if ($username -eq 'morty' -and $password -eq 'pickle') {
             return @{
                 User = @{
+                    Username = 'morty'
                     ID ='M0R7Y302'
                     Name = 'Morty'
                     Type = 'Human'

--- a/examples/web-auth-merged.ps1
+++ b/examples/web-auth-merged.ps1
@@ -17,6 +17,9 @@ Start-PodeServer -Threads 2 {
     Add-PodeEndpoint -Address * -Port 8085 -Protocol Http
     New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
 
+    # request logging
+    New-PodeLoggingMethod -Terminal -Batch 10 -BatchTimeout 10 | Enable-PodeRequestLogging
+
     # setup access
     Add-PodeAuthAccess -Type Role -Name 'Rbac'
     Add-PodeAuthAccess -Type Group -Name 'Gbac'
@@ -51,6 +54,7 @@ Start-PodeServer -Threads 2 {
         if ($username -eq 'morty' -and $password -eq 'pickle') {
             return @{
                 User = @{
+                    Username = 'morty'
                     ID ='M0R7Y302'
                     Name = 'Morty'
                     Type = 'Human'

--- a/src/Public/Authentication.ps1
+++ b/src/Public/Authentication.ps1
@@ -2489,7 +2489,7 @@ function Add-PodeAuthAccess
     }
 
     # default path
-    if ([string]::IsNullOrEmpty($Path)) {
+    if ([string]::IsNullOrWhiteSpace($Path)) {
         if ($Type -ieq 'user') {
             $Path = 'Username'
         }

--- a/src/Public/Logging.ps1
+++ b/src/Public/Logging.ps1
@@ -231,6 +231,9 @@ Enables Request Logging using a supplied output method.
 .PARAMETER Method
 The Method to use for output the log entry (From New-PodeLoggingMethod).
 
+.PARAMETER UsernameProperty
+An optional property path within the $WebEvent.Auth.User object for the user's Username. (Default: Username).
+
 .PARAMETER Raw
 If supplied, the log item returned will be the raw Request item as a hashtable and not a string (for Custom methods).
 
@@ -244,6 +247,10 @@ function Enable-PodeRequestLogging
         [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
         [hashtable]
         $Method,
+
+        [Parameter()]
+        [string]
+        $UsernameProperty,
 
         [switch]
         $Raw
@@ -263,10 +270,18 @@ function Enable-PodeRequestLogging
         throw "The supplied output Method for Request Logging requires a valid ScriptBlock"
     }
 
+    # username property
+    if ([string]::IsNullOrWhiteSpace($UsernameProperty)) {
+        $UsernameProperty = 'Username'
+    }
+
     # add the request logger
     $PodeContext.Server.Logging.Types[$name] = @{
         Method = $Method
         ScriptBlock = (Get-PodeLoggingInbuiltType -Type Requests)
+        Properties = @{
+            Username = $UsernameProperty
+        }
         Arguments = @{
             Raw = $Raw
         }


### PR DESCRIPTION
### Description of the Change
When Request logging is enabled, the "user" field has always been hardcoded to "-" for a very long time. This now sets that field to a username if available.

By default it will look in `$WebEvent.Auth.User` for the `Username` property, but this property can be customised using `-UsernameProperty` parameter on `Enable-PodeRequestLogging`.

### Related Issue
Resolves #1130 
