### PR TITLE
Bump images in dockerfiles

### DIFF
--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/powershell:7.3-alpine-3.15
+FROM mcr.microsoft.com/powershell:7.3-alpine-3.17
 LABEL maintainer="Matthew Kelly (Badgerati)"
 RUN mkdir -p /usr/local/share/powershell/Modules/Pode
 COPY ./pkg/ /usr/local/share/powershell/Modules/Pode

--- a/arm32.dockerfile
+++ b/arm32.dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/powershell:preview-7.3-arm32v7-ubuntu-18.04
+FROM mcr.microsoft.com/powershell:7.3-ubuntu-22.04-arm32
 LABEL maintainer="Matthew Kelly (Badgerati)"
 RUN mkdir -p /usr/local/share/powershell/Modules/Pode
 COPY ./pkg/ /usr/local/share/powershell/Modules/Pode


### PR DESCRIPTION
### Description of the Change
Bumps the alpine and arm32 image versions in the dockerfiles to 3.17 and 22.04 respectively.

### Related Issue
Resolves #1170 