### PR TITLE
Adds inbuilt support for caching values

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Then navigate to `http://127.0.0.1:8000` in your browser.
 * Generate/bind self-signed certificates
 * Secret management support to load secrets from vaults
 * Support for File Watchers
+* In-memory caching, with optional support for external providers (such as Redis)
 * (Windows) Open the hosted server as a desktop application
 
 ## 📦 Install

--- a/docs/Tutorials/Caching.md
+++ b/docs/Tutorials/Caching.md
@@ -1,12 +1,12 @@
 # Caching
 
-Pode has an inbuilt in-memory caching feature, allowing you to cache values for a duration of time to speed up slower queries. You can also setup custom caching storage solutions - such as Redis, and others.
+Pode has an inbuilt in-memory caching feature, allowing you to cache values for a duration of time to speed up slower queries. You can also set up custom caching storage solutions - such as Redis, and others.
 
 The default TTL for cached items is 3,600 seconds (1 hour), and this value can be customised either globally or per item. There is also a `$cache:` scoped variable available for use.
 
 ## Caching Items
 
-To add an item into the cache use [`Set-PodeCache`](../../Functions/Caching/Set-PodeCache), and then to retrieve the value from the cache use [`Get-PodeCache`](../../Functions/Caching/Get-PodeCache). If the item has expired when `Get-PodeCache` is called then `$null` will be returned.
+To add an item to the cache use [`Set-PodeCache`](../../Functions/Caching/Set-PodeCache), and then to retrieve the value from the cache use [`Get-PodeCache`](../../Functions/Caching/Get-PodeCache). If the item has expired when `Get-PodeCache` is called then `$null` will be returned.
 
 For example, the following would retrieve the current CPU on Windows machines and cache it for 60 seconds:
 
@@ -44,7 +44,7 @@ Add-PodeRoute -Method Get -Path '/' -ScriptBlock {
 }
 ```
 
-You can test if an item exists in the cache, and isn't expired, using [`Test-PodeCache`](../../Functions/Caching/Test-PodeCache) - this is useful to call if the cached value for a key happens to genuinely be `$null`, you can see if the key actually does exist.
+You can test if an item exists in the cache, and isn't expired, using [`Test-PodeCache`](../../Functions/Caching/Test-PodeCache) - this is useful to call if the cached value for a key happens to genuinely be `$null`, so you can see if the key does exist.
 
 If you need to invalidate a cached value you can use [`Remove-PodeCache`](../../Functions/Caching/Remove-PodeCache), or if you need to invalidate the whole cache you can use [`Clear-PodeCache`](../../Functions/Caching/Clear-PodeCache).
 
@@ -58,13 +58,13 @@ Start-PodeServer {
 }
 ```
 
-All new cached items will use this TTL by default, unless the one is explicitly specified on [`Set-PodeCache`](../../Functions/Caching/Set-PodeCache) using the `-Ttl` parameter.
+All new cached items will use this TTL by default unless the one is explicitly specified on [`Set-PodeCache`](../../Functions/Caching/Set-PodeCache) using the `-Ttl` parameter.
 
 ## Custom Storage
 
 The inbuilt storage used by Pode is a simple in-memory synchronized hashtable, if you're running multiple instances of your Pode server then you'll have multiple caches as well - potentially with different values for the keys.
 
-You can setup custom storage devices for your cached values using [`Add-PodeCacheStorage`](../../Functions/Caching/Add-PodeCacheStorage) - you can also setup multiple different storages, and specify where certain items should be cached using the `-Storage` parameter on `Get-PodeCache` and `Set-PodeCache`.
+You can set up custom storage devices for your cached values using [`Add-PodeCacheStorage`](../../Functions/Caching/Add-PodeCacheStorage) - you can also set up multiple different storages, and specify where certain items should be cached using the `-Storage` parameter on `Get-PodeCache` and `Set-PodeCache`.
 
 When setting up a new cache storage, you are required to specific a series of scriptblocks for:
 
@@ -77,9 +77,9 @@ When setting up a new cache storage, you are required to specific a series of sc
 !!! note
     Not all providers will support all options, such as clearing the whole cache. When this is the case simply pass an empty scriptblock to the parameter.
 
-The `-Test` and `-Remove` scriptblocks will each be supplied the key for cached item; the `-Test` scriptblock should return a boolea value. The `-Set` scriptblock will be supplied the key, value and TTL for the cached item. The `-Get` scriptblock will be supplied the key of the item to retrieve, but also a boolean "metadata" flag - if this metadata is flag is false, just return the item's value, but if it's true return a hashtable of the value and other metadata properties for expiry and ttl.
+The `-Test` and `-Remove` scriptblocks will each be supplied the key for the cached item; the `-Test` scriptblock should return a boolean value. The `-Set` scriptblock will be supplied with the key, value, and TTL for the cached item. The `-Get` scriptblock will be supplied with the key of the item to retrieve, but also a boolean "metadata" flag - if this metadata flag is false, just return the item's value, but if it's true return a hashtable of the value and other metadata properties for expiry and ttl.
 
-For example, say you want to use Redis to store your cached items, then you would have a similar setup to the below:
+For example, say you want to use Redis to store your cached items, then you would have a similar setup to the one below.
 
 ```powershell
 $params = @{
@@ -123,7 +123,7 @@ $params = @{
 Add-PodeCacheStorage -Name 'Redis' @params
 ```
 
-And then to use the storage, pass the name to the `-Storage` parameter:
+Then to use the storage, pass the name to the `-Storage` parameter:
 
 ```powershell
 Add-PodeRoute -Method Get -Path '/' -ScriptBlock {
@@ -144,7 +144,7 @@ Add-PodeRoute -Method Get -Path '/' -ScriptBlock {
 
 ### Default Storage
 
-Similar to the TTL, you can change the default cache storage from Pode's in-memory one to a custom added one. This default storage will be used for all cached items when `-Storage` is supplied, and when using `$cache:` as well.
+Similar to the TTL, you can change the default cache storage from Pode's in-memory one to a custom-added one. This default storage will be used for all cached items when `-Storage` is supplied, and when using `$cache:` as well.
 
 ```powershell
 Start-PodeServer {

--- a/docs/Tutorials/Caching.md
+++ b/docs/Tutorials/Caching.md
@@ -1,0 +1,153 @@
+# Caching
+
+Pode has an inbuilt in-memory caching feature, allowing you to cache values for a duration of time to speed up slower queries. You can also setup custom caching storage solutions - such as Redis, and others.
+
+The default TTL for cached items is 3,600 seconds (1 hour), and this value can be customised either globally or per item. There is also a `$cache:` scoped variable available for use.
+
+## Caching Items
+
+To add an item into the cache use [`Set-PodeCache`](../../Functions/Caching/Set-PodeCache), and then to retrieve the value from the cache use [`Get-PodeCache`](../../Functions/Caching/Get-PodeCache). If the item has expired when `Get-PodeCache` is called then `$null` will be returned.
+
+For example, the following would retrieve the current CPU on Windows machines and cache it for 60 seconds:
+
+```powershell
+Add-PodeRoute -Method Get -Path '/' -ScriptBlock {
+    # check cache
+    $cpu = Get-PodeCache -Key 'cpu'
+    if ($null -ne $cpu) {
+        Write-PodeJsonResponse -Value @{ CPU = $cpu }
+        return
+    }
+
+    # get cpu, and cache for 60s
+    $cpu = (Get-Counter '\Processor(_Total)\% Processor Time').CounterSamples.CookedValue
+    $cpu | Set-PodeCache -Key 'cpu' -Ttl 60
+
+    Write-PodeJsonResponse -Value @{ CPU = $cpu }
+}
+```
+
+Alternatively, you could use the `$cache:` scoped variable instead. However, using this there is no way to pass the TTL when setting new cached items, so all items cached in this manner will use the default TTL (1 hour, unless changed). Changing the default TTL is discussed [below](#default-ttl).
+
+```powershell
+Add-PodeRoute -Method Get -Path '/' -ScriptBlock {
+    # check cache
+    $cpu = $cache:cpu
+    if ($null -ne $cpu) {
+        Write-PodeJsonResponse -Value @{ CPU = $cpu }
+        return
+    }
+
+    # get cpu, and cache for 1hr
+    $cache:cpu = (Get-Counter '\Processor(_Total)\% Processor Time').CounterSamples.CookedValue
+    Write-PodeJsonResponse -Value @{ CPU = $cache:cpu }
+}
+```
+
+You can test if an item exists in the cache, and isn't expired, using [`Test-PodeCache`](../../Functions/Caching/Test-PodeCache) - this is useful to call if the cached value for a key happens to genuinely be `$null`, you can see if the key actually does exist.
+
+If you need to invalidate a cached value you can use [`Remove-PodeCache`](../../Functions/Caching/Remove-PodeCache), or if you need to invalidate the whole cache you can use [`Clear-PodeCache`](../../Functions/Caching/Clear-PodeCache).
+
+### Default TTL
+
+The default TTL for cached items, when the server starts, is 1 hour. This can be changed by using [`Set-PodeCacheDefaultTtl`](../../Functions/Caching/Set-PodeCacheDefaultTtl). The following updates the default TTL to 60 seconds:
+
+```powershell
+Start-PodeServer {
+    Set-PodeCacheDefaultTtl -Value 60
+}
+```
+
+All new cached items will use this TTL by default, unless the one is explicitly specified on [`Set-PodeCache`](../../Functions/Caching/Set-PodeCache) using the `-Ttl` parameter.
+
+## Custom Storage
+
+The inbuilt storage used by Pode is a simple in-memory synchronized hashtable, if you're running multiple instances of your Pode server then you'll have multiple caches as well - potentially with different values for the keys.
+
+You can setup custom storage devices for your cached values using [`Add-PodeCacheStorage`](../../Functions/Caching/Add-PodeCacheStorage) - you can also setup multiple different storages, and specify where certain items should be cached using the `-Storage` parameter on `Get-PodeCache` and `Set-PodeCache`.
+
+When setting up a new cache storage, you are required to specific a series of scriptblocks for:
+
+* Setting a cached item (create/update). (`-Set`)
+* Getting a cached item's value. (`-Get`)
+* Testing if a cached item exists. (`-Test`)
+* Removing a cached item. (`-Remove`)
+* Clearing a cache of all items. (`-Clear`)
+
+!!! note
+    Not all providers will support all options, such as clearing the whole cache. When this is the case simply pass an empty scriptblock to the parameter.
+
+The `-Test` and `-Remove` scriptblocks will each be supplied the key for cached item; the `-Test` scriptblock should return a boolea value. The `-Set` scriptblock will be supplied the key, value and TTL for the cached item. The `-Get` scriptblock will be supplied the key of the item to retrieve, but also a boolean "metadata" flag - if this metadata is flag is false, just return the item's value, but if it's true return a hashtable of the value and other metadata properties for expiry and ttl.
+
+For example, say you want to use Redis to store your cached items, then you would have a similar setup to the below:
+
+```powershell
+$params = @{
+    Set    = {
+        param($key, $value, $ttl)
+        $null = redis-cli -h localhost -p 6379 SET $key "$($value)" EX $ttl
+    }
+    Get    = {
+        param($key, $metadata)
+        $result = redis-cli -h localhost -p 6379 GET $key
+        $result = [System.Management.Automation.Internal.StringDecorated]::new($result).ToString('PlainText')
+        if ([string]::IsNullOrEmpty($result) -or ($result -ieq '(nil)')) {
+            return $null
+        }
+
+        if ($metadata) {
+            $ttl = redis-cli -h localhost -p 6379 TTL $key
+            $ttl = [int]([System.Management.Automation.Internal.StringDecorated]::new($result).ToString('PlainText'))
+
+            $result = @{
+                Value = $result
+                Ttl = $ttl
+                Expiry = [datetime]::UtcNow.AddSeconds($ttl)
+            }
+        }
+
+        return $result
+    }
+    Test   = {
+        param($key)
+        $result = redis-cli -h localhost -p 6379 EXISTS $key
+        return ([System.Management.Automation.Internal.StringDecorated]::new($result).ToString('PlainText') -eq '1')
+    }
+    Remove = {
+        param($key)
+        $null = redis-cli -h localhost -p 6379 EXPIRE $key -1
+    }
+    Clear  = {}
+}
+
+Add-PodeCacheStorage -Name 'Redis' @params
+```
+
+And then to use the storage, pass the name to the `-Storage` parameter:
+
+```powershell
+Add-PodeRoute -Method Get -Path '/' -ScriptBlock {
+    # check cache
+    $cpu = Get-PodeCache -Key 'cpu' -Storage 'Redis'
+    if ($null -ne $cpu) {
+        Write-PodeJsonResponse -Value @{ CPU = $cpu }
+        return
+    }
+
+    # get cpu, and cache for 60s
+    $cpu = (Get-Counter '\Processor(_Total)\% Processor Time').CounterSamples.CookedValue
+    $cpu | Set-PodeCache -Key 'cpu' -Ttl 60 -Storage 'Redis'
+
+    Write-PodeJsonResponse -Value @{ CPU = $cpu }
+}
+```
+
+### Default Storage
+
+Similar to the TTL, you can change the default cache storage from Pode's in-memory one to a custom added one. This default storage will be used for all cached items when `-Storage` is supplied, and when using `$cache:` as well.
+
+```powershell
+Start-PodeServer {
+    Set-PodeCacheDefaultStorage -Name 'Redis'
+}
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,7 +43,8 @@ Pode is a Cross-Platform framework to create web servers that host REST APIs, We
 * Support for dynamically building Routes from Functions and Modules
 * Generate/bind self-signed certificates
 * Secret management support to load secrets from vaults
-* Support for File Watchers* In-memory caching, with optional support for external providers (such as Redis)
+* Support for File Watchers
+* In-memory caching, with optional support for external providers (such as Redis)
 * (Windows) Open the hosted server as a desktop application
 
 ## 🏢 Companies using Pode

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,7 +43,7 @@ Pode is a Cross-Platform framework to create web servers that host REST APIs, We
 * Support for dynamically building Routes from Functions and Modules
 * Generate/bind self-signed certificates
 * Secret management support to load secrets from vaults
-* Support for File Watchers
+* Support for File Watchers* In-memory caching, with optional support for external providers (such as Redis)
 * (Windows) Open the hosted server as a desktop application
 
 ## 🏢 Companies using Pode

--- a/examples/caching.ps1
+++ b/examples/caching.ps1
@@ -1,0 +1,31 @@
+$path = Split-Path -Parent -Path (Split-Path -Parent -Path $MyInvocation.MyCommand.Path)
+Import-Module "$($path)/src/Pode.psm1" -Force -ErrorAction Stop
+
+# or just:
+# Import-Module Pode
+
+# create a server, and start listening on port 8085
+Start-PodeServer -Threads 3 {
+
+    # listen on localhost:8085
+    Add-PodeEndpoint -Address * -Port 8090 -Protocol Http
+
+    # log errors
+    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+
+    Set-PodeCacheDefaultTtl -Value 60
+
+    # get cpu, and cache it
+    Add-PodeRoute -Method Get -Path '/' -ScriptBlock {
+        if ($null -ne $cache:cpu) {
+            Write-PodeJsonResponse -Value @{ CPU = $cache:cpu }
+            # Write-PodeHost 'here - cached'
+            return
+        }
+
+        $cache:cpu = (Get-Counter '\Processor(_Total)\% Processor Time').CounterSamples.CookedValue
+        Write-PodeJsonResponse -Value @{ CPU = $cache:cpu }
+        # Write-PodeHost 'here - raw'
+    }
+
+}

--- a/examples/caching.ps1
+++ b/examples/caching.ps1
@@ -17,12 +17,12 @@ Start-PodeServer -Threads 3 {
 
     $params = @{
         Set    = {
-            param($name, $value, $ttl)
-            $null = redis-cli -h localhost -p 6379 SET $name "$($value)" EX $ttl
+            param($key, $value, $ttl)
+            $null = redis-cli -h localhost -p 6379 SET $key "$($value)" EX $ttl
         }
         Get    = {
-            param($name, $metadata)
-            $result = redis-cli -h localhost -p 6379 GET $name
+            param($key, $metadata)
+            $result = redis-cli -h localhost -p 6379 GET $key
             $result = [System.Management.Automation.Internal.StringDecorated]::new($result).ToString('PlainText')
             if ([string]::IsNullOrEmpty($result) -or ($result -ieq '(nil)')) {
                 return $null
@@ -30,13 +30,13 @@ Start-PodeServer -Threads 3 {
             return $result
         }
         Test   = {
-            param($name)
-            $result = redis-cli -h localhost -p 6379 EXISTS $name
+            param($key)
+            $result = redis-cli -h localhost -p 6379 EXISTS $key
             return [System.Management.Automation.Internal.StringDecorated]::new($result).ToString('PlainText')
         }
         Remove = {
-            param($name)
-            $null = redis-cli -h localhost -p 6379 EXPIRE $name -1
+            param($key)
+            $null = redis-cli -h localhost -p 6379 EXPIRE $key -1
         }
         Clear  = {}
     }
@@ -45,7 +45,7 @@ Start-PodeServer -Threads 3 {
 
     # get cpu, and cache it
     Add-PodeRoute -Method Get -Path '/' -ScriptBlock {
-        if ($null -ne $cache:cpu) {
+        if ((Test-PodeCache -Key 'cpu') -and ($null -ne $cache:cpu)) {
             Write-PodeJsonResponse -Value @{ CPU = $cache:cpu }
             # Write-PodeHost 'here - cached'
             return

--- a/src/Pode.psd1
+++ b/src/Pode.psd1
@@ -400,7 +400,22 @@
         'Use-PodeSemaphore',
         'Enter-PodeSemaphore',
         'Exit-PodeSemaphore',
-        'Clear-PodeSemaphores'
+        'Clear-PodeSemaphores',
+
+        # caching
+        'Get-PodeCache',
+        'Set-PodeCache',
+        'Test-PodeCache',
+        'Remove-PodeCache',
+        'Clear-PodeCache',
+        'Add-PodeCacheStorage',
+        'Remove-PodeCacheStorage',
+        'Get-PodeCacheStorage',
+        'Test-PodeCacheStorage',
+        'Set-PodeCacheDefaultStorage',
+        'Get-PodeCacheDefaultStorage',
+        'Set-PodeCacheDefaultTtl',
+        'Get-PodeCacheDefaultTtl'
     )
 
     # Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.

--- a/src/Private/Caching.ps1
+++ b/src/Private/Caching.ps1
@@ -1,0 +1,76 @@
+function Get-PodeCacheInternal {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Name,
+
+        [switch]
+        $Metadata
+    )
+
+    $meta = $PodeContext.Server.Cache.Items[$Name]
+    if ($null -eq $meta) {
+        return $null
+    }
+
+    # check ttl/expiry
+    if ($meta.Expiry -lt [datetime]::UtcNow) {
+        Remove-PodeCache -Name $Name
+        return $null
+    }
+
+    # return value an metadata if required
+    if ($Metadata) {
+        return $meta
+    }
+
+    # return just the value as default
+    return $meta.Value
+}
+
+function Set-PodeCacheInternal {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Name,
+
+        [Parameter(Mandatory = $true)]
+        [object]
+        $InputObject,
+
+        [Parameter()]
+        [int]
+        $Ttl = 0
+    )
+
+    # crete (or update) value value
+    $PodeContext.Server.Cache.Items[$Name] = @{
+        Value  = $InputObject
+        Ttl    = $Ttl
+        Expiry = [datetime]::UtcNow.AddSeconds($Ttl)
+    }
+}
+
+function Test-PodeCacheInternal {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Name
+    )
+
+    return $PodeContext.Server.Cache.Items.ContainsKey($Name)
+}
+
+function Remove-PodeCacheInternal {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Name
+    )
+
+    $null = $PodeContext.Server.Cache.Items.Remove($Name)
+}
+
+function Clear-PodeCacheInternal {
+    $null = $PodeContext.Server.Cache.Items.Clear()
+}

--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -254,6 +254,14 @@ function New-PodeContext {
     # shared state between runspaces
     $ctx.Server.State = @{}
 
+    # setup caching
+    $ctx.Server.Cache = @{
+        Items          = @{}
+        Storage        = @{}
+        DefaultStorage = $null
+        DefaultTtl     = 3600 # 1hr
+    }
+
     # output details, like variables, to be set once the server stops
     $ctx.Server.Output = @{
         Variables = @{}

--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -404,6 +404,7 @@ function New-PodeContext {
     # threading locks, etc.
     $ctx.Threading.Lockables = @{
         Global = [hashtable]::Synchronized(@{})
+        Cache  = [hashtable]::Synchronized(@{})
         Custom = @{}
     }
 

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -2564,12 +2564,12 @@ function Invoke-PodeCacheScriptConversion {
 
     while ($scriptStr -imatch '(?<full>\$cache\:(?<name>[a-z0-9_\?]+)\s*=)') {
         $found = $true
-        $scriptStr = $scriptStr.Replace($Matches['full'], "Set-PodeCache -Name '$($Matches['name'])' -InputObject ")
+        $scriptStr = $scriptStr.Replace($Matches['full'], "Set-PodeCache -Key '$($Matches['name'])' -InputObject ")
     }
 
     while ($scriptStr -imatch '(?<full>\$cache\:(?<name>[a-z0-9_\?]+))') {
         $found = $true
-        $scriptStr = $scriptStr.Replace($Matches['full'], "(Get-PodeCache -Name '$($Matches['name'])')")
+        $scriptStr = $scriptStr.Replace($Matches['full'], "(Get-PodeCache -Key '$($Matches['name'])')")
     }
 
     if ($found) {

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -2435,7 +2435,7 @@ function Convert-PodeScopedVariables {
         $PSSession,
 
         [Parameter()]
-        [ValidateSet('State', 'Session', 'Secret', 'Using')]
+        [ValidateSet('State', 'Session', 'Secret', 'Using', 'Cache')]
         $Skip
     )
 
@@ -2465,6 +2465,10 @@ function Convert-PodeScopedVariables {
 
     if (($null -eq $Skip) -or ($Skip -inotcontains 'Secret')) {
         $ScriptBlock = Invoke-PodeSecretScriptConversion -ScriptBlock $ScriptBlock
+    }
+
+    if (($null -eq $Skip) -or ($Skip -inotcontains 'Cache')) {
+        $ScriptBlock = Invoke-PodeCacheScriptConversion -ScriptBlock $ScriptBlock
     }
 
     # return
@@ -2533,6 +2537,39 @@ function Invoke-PodeSecretScriptConversion {
     while ($scriptStr -imatch '(?<full>\$secret\:(?<name>[a-z0-9_\?]+))') {
         $found = $true
         $scriptStr = $scriptStr.Replace($Matches['full'], "(Get-PodeSecret -Name '$($Matches['name'])')")
+    }
+
+    if ($found) {
+        $ScriptBlock = [scriptblock]::Create($scriptStr)
+    }
+
+    return $ScriptBlock
+}
+
+function Invoke-PodeCacheScriptConversion {
+    param(
+        [Parameter()]
+        [scriptblock]
+        $ScriptBlock
+    )
+
+    # do nothing if no script
+    if ($null -eq $ScriptBlock) {
+        return $ScriptBlock
+    }
+
+    # rename any $secret:<name> vars
+    $scriptStr = "$($ScriptBlock)"
+    $found = $false
+
+    while ($scriptStr -imatch '(?<full>\$cache\:(?<name>[a-z0-9_\?]+)\s*=)') {
+        $found = $true
+        $scriptStr = $scriptStr.Replace($Matches['full'], "Set-PodeCache -Name '$($Matches['name'])' -InputObject ")
+    }
+
+    while ($scriptStr -imatch '(?<full>\$cache\:(?<name>[a-z0-9_\?]+))') {
+        $found = $true
+        $scriptStr = $scriptStr.Replace($Matches['full'], "(Get-PodeCache -Name '$($Matches['name'])')")
     }
 
     if ($found) {

--- a/src/Private/Server.ps1
+++ b/src/Private/Server.ps1
@@ -242,6 +242,10 @@ function Restart-PodeInternalServer {
         # clear up shared state
         $PodeContext.Server.State.Clear()
 
+        # clear cache
+        $PodeContext.Server.Cache.Items.Clear()
+        $PodeContext.Server.Cache.Storage.Clear()
+
         # clear up secret vaults/cache
         Unregister-PodeSecretVaults -ThrowError
         $PodeContext.Server.Secrets.Vaults.Clear()

--- a/src/Private/Server.ps1
+++ b/src/Private/Server.ps1
@@ -41,6 +41,9 @@ function Start-PodeInternalServer {
         # start timer for task housekeeping
         Start-PodeTaskHousekeeper
 
+        # start the cache housekeeper
+        Start-PodeCacheHousekeeper
+
         # create timer/schedules for auto-restarting
         New-PodeAutoRestartServer
 

--- a/src/Public/Caching.ps1
+++ b/src/Public/Caching.ps1
@@ -1,0 +1,303 @@
+#TODO: do we need a housekeeping timer?
+#TODO: test support for custom storage in get/set
+
+
+function Get-PodeCache {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Name,
+
+        [Parameter()]
+        [string]
+        $Storage = $null,
+
+        [switch]
+        $Metadata
+    )
+
+    # inmem or custom storage?
+    if ([string]::IsNullOrEmpty($Storage)) {
+        $Storage = $PodeContext.Server.Cache.DefaultStorage
+    }
+
+    # use inmem cache
+    if ([string]::IsNullOrEmpty($Storage)) {
+        return (Get-PodeCacheInternal -Name $Name -Metadata:$Metadata)
+    }
+
+    # used custom storage
+    if (Test-PodeCacheStorage -Name $Storage) {
+        return (Invoke-PodeScriptBlock -ScriptBlock $PodeContext.Server.Cache.Storage[$Storage].Get -Arguments @($Name, $Metadata.IsPresent) -Splat -Return)
+    }
+
+    # storage not found!
+    throw "Cache storage with name '$($Storage)' not found when attempting to retrieve cached item '$($Name)'"
+}
+
+function Set-PodeCache {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Name,
+
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [object]
+        $InputObject,
+
+        [Parameter()]
+        [int]
+        $Ttl = 0,
+
+        [Parameter()]
+        [string]
+        $Storage = $null
+    )
+
+    # use the global settable default here
+    if ($Ttl -le 0) {
+        $Ttl = $PodeContext.Server.Cache.DefaultTtl
+    }
+
+    # inmem or custom storage?
+    if ([string]::IsNullOrEmpty($Storage)) {
+        $Storage = $PodeContext.Server.Cache.DefaultStorage
+    }
+
+    # use inmem cache
+    if ([string]::IsNullOrEmpty($Storage)) {
+        Set-PodeCacheInternal -Name $Name -InputObject $InputObject -Ttl $Ttl
+    }
+
+    # used custom storage
+    elseif (Test-PodeCacheStorage -Name $Storage) {
+        Invoke-PodeScriptBlock -ScriptBlock $PodeContext.Server.Cache.Storage[$Storage].Set -Arguments @($Name, $Value, $Ttl) -Splat
+    }
+
+    # storage not found!
+    else {
+        throw "Cache storage with name '$($Storage)' not found when attempting to set cached item '$($Name)'"
+    }
+}
+
+function Test-PodeCache {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Name,
+
+        [Parameter()]
+        [string]
+        $Storage = $null
+    )
+
+    # inmem or custom storage?
+    if ([string]::IsNullOrEmpty($Storage)) {
+        $Storage = $PodeContext.Server.Cache.DefaultStorage
+    }
+
+    # use inmem cache
+    if ([string]::IsNullOrEmpty($Storage)) {
+        return (Test-PodeCacheInternal -Name $Name)
+    }
+
+    # used custom storage
+    if (Test-PodeCacheStorage -Name $Storage) {
+        return (Invoke-PodeScriptBlock -ScriptBlock $PodeContext.Server.Cache.Storage[$Storage].Test -Arguments @($Name) -Splat -Return)
+    }
+
+    # storage not found!
+    throw "Cache storage with name '$($Storage)' not found when attempting to check if cached item '$($Name)' exists"
+}
+
+function Remove-PodeCache {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Name,
+
+        [Parameter()]
+        [string]
+        $Storage = $null
+    )
+
+    # inmem or custom storage?
+    if ([string]::IsNullOrEmpty($Storage)) {
+        $Storage = $PodeContext.Server.Cache.DefaultStorage
+    }
+
+    # use inmem cache
+    if ([string]::IsNullOrEmpty($Storage)) {
+        Remove-PodeCacheInternal -Name $Name
+    }
+
+    # used custom storage
+    elseif (Test-PodeCacheStorage -Name $Storage) {
+        Invoke-PodeScriptBlock -ScriptBlock $PodeContext.Server.Cache.Storage[$Storage].Remove -Arguments @($Name) -Splat
+    }
+
+    # storage not found!
+    else {
+        throw "Cache storage with name '$($Storage)' not found when attempting to remove cached item '$($Name)'"
+    }
+}
+
+function Clear-PodeCache {
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [string]
+        $Storage = $null
+    )
+
+    # inmem or custom storage?
+    if ([string]::IsNullOrEmpty($Storage)) {
+        $Storage = $PodeContext.Server.Cache.DefaultStorage
+    }
+
+    # use inmem cache
+    if ([string]::IsNullOrEmpty($Storage)) {
+        Clear-PodeCacheInternal
+    }
+
+    # used custom storage
+    elseif (Test-PodeCacheStorage -Name $Storage) {
+        Invoke-PodeScriptBlock -ScriptBlock $PodeContext.Server.Cache.Storage[$Storage].Clear
+    }
+
+    # storage not found!
+    else {
+        throw "Cache storage with name '$($Storage)' not found when attempting to clear cached"
+    }
+}
+
+function Add-PodeCacheStorage {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $Name,
+
+        [Parameter(Mandatory = $true)]
+        [scriptblock]
+        $Get,
+
+        [Parameter(Mandatory = $true)]
+        [scriptblock]
+        $Set,
+
+        [Parameter(Mandatory = $true)]
+        [scriptblock]
+        $Remove,
+
+        [Parameter(Mandatory = $true)]
+        [scriptblock]
+        $Test,
+
+        [Parameter(Mandatory = $true)]
+        [scriptblock]
+        $Clear,
+
+        [switch]
+        $Default
+    )
+
+    # test if storage already exists
+    if (Test-PodeCacheStorage -Name $Name) {
+        throw "Cache Storage with name '$($Name) already exists"
+    }
+
+    # add cache storage
+    $PodeContext.Server.Cache.Storage[$Name] = @{
+        Name    = $Name
+        Get     = $Get
+        Set     = $Set
+        Remove  = $Remove
+        Test    = $Test
+        Clear   = $Clear
+        Default = $Default.IsPresent
+    }
+
+    # is default storage?
+    if ($Default) {
+        $PodeContext.Server.Cache.DefaultStorage = $Name
+    }
+}
+
+function Remove-PodeCacheStorage {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Name
+    )
+
+    $null = $PodeContext.Server.Cache.Storage.Remove($Name)
+}
+
+function Get-PodeCacheStorage {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Name
+    )
+
+    return $PodeContext.Server.Cache.Storage[$Name]
+}
+
+function Test-PodeCacheStorage {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Name
+    )
+
+    return $PodeContext.Server.Cache.ContainsKey($Name)
+}
+
+function Set-PodeCacheDefaultStorage {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Name
+    )
+
+    $PodeContext.Server.Cache.DefaultStorage = $Name
+}
+
+function Get-PodeCacheDefaultStorage {
+    [CmdletBinding()]
+    param()
+
+    return $PodeContext.Server.Cache.DefaultStorage
+}
+
+function Set-PodeCacheDefaultTtl {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [int]
+        $Value
+    )
+
+    if ($Value -le 0) {
+        return
+    }
+
+    $PodeContext.Server.Cache.DefaultTtl = $Value
+}
+
+function Get-PodeCacheDefaultTtl {
+    [CmdletBinding()]
+    param()
+
+    return $PodeContext.Server.Cache.DefaultTtl
+}

--- a/src/Public/Caching.ps1
+++ b/src/Public/Caching.ps1
@@ -1,7 +1,3 @@
-#TODO: do we need a housekeeping timer?
-#TODO: test support for custom storage in get/set
-
-
 function Get-PodeCache {
     [CmdletBinding()]
     param(
@@ -73,7 +69,7 @@ function Set-PodeCache {
 
     # used custom storage
     elseif (Test-PodeCacheStorage -Name $Storage) {
-        Invoke-PodeScriptBlock -ScriptBlock $PodeContext.Server.Cache.Storage[$Storage].Set -Arguments @($Name, $Value, $Ttl) -Splat
+        Invoke-PodeScriptBlock -ScriptBlock $PodeContext.Server.Cache.Storage[$Storage].Set -Arguments @($Name, $InputObject, $Ttl) -Splat
     }
 
     # storage not found!
@@ -259,7 +255,7 @@ function Test-PodeCacheStorage {
         $Name
     )
 
-    return $PodeContext.Server.Cache.ContainsKey($Name)
+    return $PodeContext.Server.Cache.Storage.ContainsKey($Name)
 }
 
 function Set-PodeCacheDefaultStorage {

--- a/tests/unit/Server.Tests.ps1
+++ b/tests/unit/Server.Tests.ps1
@@ -3,8 +3,8 @@ $src = (Split-Path -Parent -Path $path) -ireplace '[\\/]tests[\\/]unit', '/src/'
 Get-ChildItem "$($src)/*.ps1" -Recurse | Resolve-Path | ForEach-Object { . $_ }
 
 $PodeContext = @{
-    Server = $null
-    Metrics = @{ Server = @{ StartTime = [datetime]::UtcNow } }
+    Server        = $null
+    Metrics       = @{ Server = @{ StartTime = [datetime]::UtcNow } }
     RunspacePools = @{}
 }
 
@@ -98,121 +98,125 @@ Describe 'Restart-PodeInternalServer' {
 
     It 'Resetting the server values' {
         $PodeContext = @{
-            Tokens = @{
+            Tokens    = @{
                 Cancellation = New-Object System.Threading.CancellationTokenSource
-                Restart = New-Object System.Threading.CancellationTokenSource
+                Restart      = New-Object System.Threading.CancellationTokenSource
             }
-            Server = @{
-                Routes = @{
-                    GET = @{ 'key' = 'value' }
+            Server    = @{
+                Routes          = @{
+                    GET  = @{ 'key' = 'value' }
                     POST = @{ 'key' = 'value' }
                 }
-                Handlers = @{
+                Handlers        = @{
                     SMTP = @{}
                 }
-                Verbs = @{
+                Verbs           = @{
                     key = @{}
                 }
-                Logging = @{
+                Logging         = @{
                     Types = @{ 'key' = 'value' }
                 }
-                Middleware = @{ 'key' = 'value' }
-                Endpoints = @{ 'key' = 'value' }
-                EndpointsMap = @{ 'key' = 'value' }
-                Endware = @{ 'key' = 'value' }
-                ViewEngine = @{
-                    Type = 'pode'
+                Middleware      = @{ 'key' = 'value' }
+                Endpoints       = @{ 'key' = 'value' }
+                EndpointsMap    = @{ 'key' = 'value' }
+                Endware         = @{ 'key' = 'value' }
+                ViewEngine      = @{
+                    Type      = 'pode'
                     Extension = 'pode'
-                    Script = $null
+                    Script    = $null
                     IsDynamic = $true
                 }
-                Cookies = @{}
-                Sessions = @{ 'key' = 'value' }
+                Cookies         = @{}
+                Sessions        = @{ 'key' = 'value' }
                 Authentications = @{
                     Methods = @{ 'key' = 'value' }
                 }
-                Authorisations = @{
+                Authorisations  = @{
                     Methods = @{ 'key' = 'value' }
                 }
-                State = @{ 'key' = 'value' }
-                Output = @{
+                State           = @{ 'key' = 'value' }
+                Output          = @{
                     Variables = @{ 'key' = 'value' }
                 }
-                Configuration = @{ 'key' = 'value' }
-                Sockets = @{
+                Configuration   = @{ 'key' = 'value' }
+                Sockets         = @{
                     Listeners = @()
-                    Queues = @{
+                    Queues    = @{
                         Connections = [System.Collections.Concurrent.ConcurrentQueue[System.Net.Sockets.SocketAsyncEventArgs]]::new()
                     }
                 }
-                Signals = @{
+                Signals         = @{
                     Listeners = @()
-                    Queues = @{
-                        Sockets = @{}
+                    Queues    = @{
+                        Sockets     = @{}
                         Connections = [System.Collections.Concurrent.ConcurrentQueue[System.Net.Sockets.SocketAsyncEventArgs]]::new()
                     }
                 }
-                OpenAPI = @{}
-                BodyParsers = @{}
-                AutoImport = @{
-                    Modules = @{ Exported = @() }
-                    Snapins = @{ Exported = @() }
-                    Functions = @{ Exported = @() }
-                    SecretVaults = @{ 
+                OpenAPI         = @{}
+                BodyParsers     = @{}
+                AutoImport      = @{
+                    Modules      = @{ Exported = @() }
+                    Snapins      = @{ Exported = @() }
+                    Functions    = @{ Exported = @() }
+                    SecretVaults = @{
                         SecretManagement = @{ Exported = @() }
                     }
                 }
-                Views = @{ 'key' = 'value' }
-                Events = @{
+                Views           = @{ 'key' = 'value' }
+                Events          = @{
                     Start = @{}
                 }
-                Modules = @{}
-                Security = @{
+                Modules         = @{}
+                Security        = @{
                     Headers = @{}
-                    Cache = @{
-                        ContentSecurity  = @{}
+                    Cache   = @{
+                        ContentSecurity   = @{}
                         PermissionsPolicy = @{}
                     }
                 }
-                Secrets = @{
+                Secrets         = @{
                     Vaults = @{}
-                    Keys = @{}
+                    Keys   = @{}
+                }
+                Cache           = @{
+                    Items   = @{}
+                    Storage = @{}
                 }
             }
-            Metrics = @{
+            Metrics   = @{
                 Server = @{
                     RestartCount = 0
                 }
             }
-            Timers = @{
+            Timers    = @{
                 Enabled = $true
-                Items = @{
+                Items   = @{
                     key = 'value'
                 }
             }
             Schedules = @{
-                Enabled = $true
-                Items = @{
+                Enabled   = $true
+                Items     = @{
                     key = 'value'
                 }
                 Processes = @{}
             }
-            Tasks = @{
+            Tasks     = @{
                 Enabled = $true
-                Items = @{
+                Items   = @{
                     key = 'value'
                 }
                 Results = @{}
             }
-            Fim = @{
+            Fim       = @{
                 Enabled = $true
-                Items = @{
+                Items   = @{
                     key = 'value'
                 }
             }
             Threading = @{
-                Lockables = @{ Custom = @{} }
-                Mutexes = @{}
+                Lockables  = @{ Custom = @{} }
+                Mutexes    = @{}
                 Semaphores = @{}
             }
         }

--- a/tests/unit/Server.Tests.ps1
+++ b/tests/unit/Server.Tests.ps1
@@ -26,6 +26,7 @@ Describe 'Start-PodeInternalServer' {
     Mock Import-PodeModulesIntoRunspaceState { }
     Mock Import-PodeSnapinsIntoRunspaceState { }
     Mock Import-PodeFunctionsIntoRunspaceState { }
+    Mock Start-PodeCacheHousekeeper { }
     Mock Invoke-PodeEvent { }
     Mock Write-Verbose { }
 


### PR DESCRIPTION
### Description of the Change
Adds inbuilt support for caching values, both via functions and a new `$cache:` scoped variable. The inbuilt cache stores values in-memory with a default TTL of 1hr (can be overridden), and there is also support for adding custom storage as well

The following new functions have been added:

* `Get-PodeCache`
* `Set-PodeCache`
* `Test-PodeCache`
* `Remove-PodeCache`
* `Clear-PodeCache`
* `Add-PodeCacheStorage`
* `Remove-PodeCacheStorage`
* `Get-PodeCacheStorage`
* `Test-PodeCacheStorage`
* `Set-PodeCacheDefaultStorage`
* `Get-PodeCacheDefaultStorage`
* `Set-PodeCacheDefaultTtl`
* `Get-PodeCacheDefaultTtl`

### Related Issue
Resolves #1184 

### Examples
```powershell
Add-PodeRoute -Method Get -Path '/' -ScriptBlock {
    # check cache
    $cpu = $cache:cpu
    if ($null -ne $cpu) {
        Write-PodeJsonResponse -Value @{ CPU = $cpu }
        return
    }
    # get cpu, and cache for 1hr
    $cache:cpu = (Get-Counter '\Processor(_Total)\% Processor Time').CounterSamples.CookedValue
    Write-PodeJsonResponse -Value @{ CPU = $cache:cpu }
}
```

or the same using `$cache:` instead:

```powershell
Add-PodeRoute -Method Get -Path '/' -ScriptBlock {
    # check cache
    $cpu = $cache:cpu
    if ($null -ne $cpu) {
        Write-PodeJsonResponse -Value @{ CPU = $cpu }
        return
    }
    # get cpu, and cache for 1hr
    $cache:cpu = (Get-Counter '\Processor(_Total)\% Processor Time').CounterSamples.CookedValue
    Write-PodeJsonResponse -Value @{ CPU = $cache:cpu }
}
```