### PR TITLE
Fix for Static Route ordering, and redirecting to Default file option

### DIFF
--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -816,8 +816,9 @@ function Set-PodeWebConfiguration {
     # setup the main web config
     $Context.Server.Web = @{
         Static           = @{
-            Defaults = $Configuration.Static.Defaults
-            Cache    = @{
+            Defaults          = $Configuration.Static.Defaults
+            RedirectToDefault = [bool]$Configuration.Static.RedirectToDefault
+            Cache             = @{
                 Enabled = [bool]$Configuration.Static.Cache.Enable
                 MaxAge  = [int](Protect-PodeValue -Value $Configuration.Static.Cache.MaxAge -Default 3600)
                 Include = (Convert-PodePathPatternsToRegex -Paths @($Configuration.Static.Cache.Include) -NotSlashes)

--- a/src/Private/PodeServer.ps1
+++ b/src/Private/PodeServer.ps1
@@ -189,6 +189,10 @@ function Start-PodeWebServer {
                                         if ($WebEvent.StaticContent.IsDownload) {
                                             Set-PodeResponseAttachment -Path $WebEvent.Path -EndpointName $WebEvent.Endpoint.Name
                                         }
+                                        elseif ($WebEvent.StaticContent.RedirectToDefault) {
+                                            $file = [System.IO.Path]::GetFileName($WebEvent.StaticContent.Source)
+                                            Move-PodeResponseUrl -Url "$($WebEvent.Path)/$($file)"
+                                        }
                                         else {
                                             $cachable = $WebEvent.StaticContent.IsCachable
                                             Write-PodeFileResponse -Path $WebEvent.StaticContent.Source -MaxAge $PodeContext.Server.Web.Static.Cache.MaxAge -Cache:$cachable

--- a/src/Private/Routes.ps1
+++ b/src/Private/Routes.ps1
@@ -50,23 +50,31 @@ function Find-PodeRoute {
         }
     }
 
-    # is this a static route?
-    $isStatic = ($Method -ieq 'static')
-
     # first ensure we have the method
     $_method = $PodeContext.Server.Routes[$Method]
     if ($null -eq $_method) {
         return $null
     }
 
+    # is this a static route?
+    $isStatic = ($Method -ieq 'static')
+
     # if we have a perfect match for the route, return it if the protocol is right
-    $found = Get-PodeRouteByUrl -Routes $_method[$Path] -EndpointName $EndpointName
-    if (!$isStatic -and ($null -ne $found)) {
-        return $found
+    if (!$isStatic) {
+        $found = Get-PodeRouteByUrl -Routes $_method[$Path] -EndpointName $EndpointName
+        if ($null -ne $found) {
+            return $found
+        }
     }
 
     # otherwise, match the path to routes on regex (first match only)
-    $valid = @(foreach ($key in $_method.Keys) {
+    $paths = @($_method.Keys)
+    if ($isStatic) {
+        [array]::Sort($paths)
+        [array]::Reverse($paths)
+    }
+
+    $valid = @(foreach ($key in $paths) {
             if ($Path -imatch "^$($key)$") {
                 $key
                 break

--- a/src/Private/Serverless.ps1
+++ b/src/Private/Serverless.ps1
@@ -85,6 +85,10 @@ function Start-PodeAzFuncServer {
                         if ($WebEvent.StaticContent.IsDownload) {
                             Set-PodeResponseAttachment -Path $WebEvent.Path -EndpointName $WebEvent.Endpoint.Name
                         }
+                        elseif ($WebEvent.StaticContent.RedirectToDefault) {
+                            $file = [System.IO.Path]::GetFileName($WebEvent.StaticContent.Source)
+                            Move-PodeResponseUrl -Url "$($WebEvent.Path)/$($file)"
+                        }
                         else {
                             $cachable = $WebEvent.StaticContent.IsCachable
                             Write-PodeFileResponse -Path $WebEvent.StaticContent.Source -MaxAge $PodeContext.Server.Web.Static.Cache.MaxAge -Cache:$cachable
@@ -193,6 +197,10 @@ function Start-PodeAwsLambdaServer {
                     if ($null -ne $WebEvent.StaticContent) {
                         if ($WebEvent.StaticContent.IsDownload) {
                             Set-PodeResponseAttachment -Path $WebEvent.Path -EndpointName $WebEvent.Endpoint.Name
+                        }
+                        elseif ($WebEvent.StaticContent.RedirectToDefault) {
+                            $file = [System.IO.Path]::GetFileName($WebEvent.StaticContent.Source)
+                            Move-PodeResponseUrl -Url "$($WebEvent.Path)/$($file)"
                         }
                         else {
                             $cachable = $WebEvent.StaticContent.IsCachable

--- a/src/Public/Routes.ps1
+++ b/src/Public/Routes.ps1
@@ -476,6 +476,9 @@ One or more optional Scopes that will be authorised to access this Route, when u
 .PARAMETER User
 One or more optional Users that will be authorised to access this Route, when using Authentication with an Access method.
 
+.PARAMETER RedirectToDefault
+If supplied, the user will be redirected to the default page if found instead of the page being rendered as the folder path.
+
 .EXAMPLE
 Add-PodeStaticRoute -Path '/assets' -Source './assets'
 
@@ -484,6 +487,9 @@ Add-PodeStaticRoute -Path '/assets' -Source './assets' -Defaults @('index.html')
 
 .EXAMPLE
 Add-PodeStaticRoute -Path '/installers' -Source './exes' -DownloadOnly
+
+.EXAMPLE
+Add-PodeStaticRoute -Path '/assets' -Source './assets' -Defaults @('index.html') -RedirectToDefault
 #>
 function Add-PodeStaticRoute {
     [CmdletBinding()]
@@ -558,7 +564,10 @@ function Add-PodeStaticRoute {
         $DownloadOnly,
 
         [switch]
-        $PassThru
+        $PassThru,
+
+        [switch]
+        $RedirectToDefault
     )
 
     # check if we have any route group info defined
@@ -609,6 +618,10 @@ function Add-PodeStaticRoute {
 
         if ($RouteGroup.DownloadOnly) {
             $DownloadOnly = $RouteGroup.DownloadOnly
+        }
+
+        if ($RouteGroup.RedirectToDefault) {
+            $RedirectToDefault = $RouteGroup.RedirectToDefault
         }
 
         if ($RouteGroup.IfExists -ine 'default') {
@@ -700,6 +713,10 @@ function Add-PodeStaticRoute {
         $Defaults = Get-PodeStaticRouteDefaults
     }
 
+    if (!$RedirectToDefault) {
+        $RedirectToDefault = $PodeContext.Server.Web.Static.RedirectToDefault
+    }
+
     # convert any middleware into valid hashtables
     $Middleware = @(ConvertTo-PodeMiddleware -Middleware $Middleware -PSSession $PSCmdlet.SessionState)
 
@@ -744,30 +761,31 @@ function Add-PodeStaticRoute {
     Write-Verbose "Adding Route: [$($Method)] $($Path)"
     $newRoutes = @(foreach ($_endpoint in $endpoints) {
             @{
-                Source           = $Source
-                Path             = $Path
-                Method           = $Method
-                Defaults         = $Defaults
-                Middleware       = $Middleware
-                Authentication   = $Authentication
-                Access           = $Access
-                AccessMeta       = @{
+                Source            = $Source
+                Path              = $Path
+                Method            = $Method
+                Defaults          = $Defaults
+                RedirectToDefault = $RedirectToDefault
+                Middleware        = $Middleware
+                Authentication    = $Authentication
+                Access            = $Access
+                AccessMeta        = @{
                     Role   = $Role
                     Group  = $Group
                     Scope  = $Scope
                     User   = $User
                     Custom = $CustomAccess
                 }
-                Endpoint         = @{
+                Endpoint          = @{
                     Protocol = $_endpoint.Protocol
                     Address  = $_endpoint.Address.Trim()
                     Name     = $_endpoint.Name
                 }
-                ContentType      = $ContentType
-                TransferEncoding = $TransferEncoding
-                ErrorType        = $ErrorContentType
-                Download         = $DownloadOnly
-                OpenApi          = @{
+                ContentType       = $ContentType
+                TransferEncoding  = $TransferEncoding
+                ErrorType         = $ErrorContentType
+                Download          = $DownloadOnly
+                OpenApi           = @{
                     Path           = $OpenApiPath
                     Responses      = @{
                         '200'     = @{ description = 'OK' }
@@ -777,8 +795,8 @@ function Add-PodeStaticRoute {
                     RequestBody    = @{}
                     Authentication = @()
                 }
-                IsStatic         = $true
-                Metrics          = @{
+                IsStatic          = $true
+                Metrics           = @{
                     Requests = @{
                         Total       = 0
                         StatusCodes = @{}
@@ -1235,6 +1253,9 @@ One or more optional Scopes that will be authorised to access this Route, when u
 .PARAMETER User
 One or more optional Users that will be authorised to access this Route, when using Authentication with an Access method.
 
+.PARAMETER RedirectToDefault
+If supplied, the user will be redirected to the default page if found instead of the page being rendered as the folder path.
+
 .EXAMPLE
 Add-PodeStaticRouteGroup -Path '/static' -Routes { Add-PodeStaticRoute -Path '/images' -Etc }
 #>
@@ -1312,7 +1333,10 @@ function Add-PodeStaticRouteGroup {
         $AllowAnon,
 
         [switch]
-        $DownloadOnly
+        $DownloadOnly,
+
+        [switch]
+        $RedirectToDefault
     )
 
     if (Test-PodeIsEmpty $Routes) {
@@ -1376,6 +1400,10 @@ function Add-PodeStaticRouteGroup {
             $DownloadOnly = $RouteGroup.DownloadOnly
         }
 
+        if ($RouteGroup.RedirectToDefault) {
+            $RedirectToDefault = $RouteGroup.RedirectToDefault
+        }
+
         if ($RouteGroup.IfExists -ine 'default') {
             $IfExists = $RouteGroup.IfExists
         }
@@ -1402,20 +1430,21 @@ function Add-PodeStaticRouteGroup {
     }
 
     $RouteGroup = @{
-        Path             = $Path
-        Source           = $Source
-        Middleware       = $Middleware
-        EndpointName     = $EndpointName
-        ContentType      = $ContentType
-        TransferEncoding = $TransferEncoding
-        Defaults         = $Defaults
-        ErrorContentType = $ErrorContentType
-        Authentication   = $Authentication
-        Access           = $Access
-        AllowAnon        = $AllowAnon
-        DownloadOnly     = $DownloadOnly
-        IfExists         = $IfExists
-        AccessMeta       = @{
+        Path              = $Path
+        Source            = $Source
+        Middleware        = $Middleware
+        EndpointName      = $EndpointName
+        ContentType       = $ContentType
+        TransferEncoding  = $TransferEncoding
+        Defaults          = $Defaults
+        RedirectToDefault = $RedirectToDefault
+        ErrorContentType  = $ErrorContentType
+        Authentication    = $Authentication
+        Access            = $Access
+        AllowAnon         = $AllowAnon
+        DownloadOnly      = $DownloadOnly
+        IfExists          = $IfExists
+        AccessMeta        = @{
             Role   = $Role
             Group  = $Group
             Scope  = $Scope


### PR DESCRIPTION
### Description of the Change
Fix for the ordering of Static Routes, where a `/` static route would override any other static route created, like `/download`.

For example, currently the route ordering will put `/` before `/download`, where as now it will be:
* `/download`
* `/`

Or as a more complex example for for routes like `/any/*/files` and `/any/stuff/files`. Before the `*` route would come first, but now it will be:
* `/any/stuff/files`
* `/any/*/files`

Also added is a new `-RedirectToDefault` switch on `Add-PodeStaticRoute` and `Add-PodeStaticRouteGroup`. If supplied, then instead of loading the content of an `index.html` on the folder of a static route, it will instead redirect directly to `/index.html` on the URL.

### Related Issue
Resolves #1228 
