### PR TITLE
Fix #1257 Collection was modified after..

### DIFF
--- a/src/Public/Routes.ps1
+++ b/src/Public/Routes.ps1
@@ -2166,10 +2166,10 @@ function Add-PodePage {
 
                 # invoke the function (optional splat data)
                 if (Test-PodeIsEmpty $data) {
-                    $result = & $script
+                    $result = Invoke-PodeScriptBlock -ScriptBlock $script -Return
                 }
                 else {
-                    $result = & $script @data
+                    $result = Invoke-PodeScriptBlock -ScriptBlock $script -Arguments $data -Return
                 }
 
                 # if we have a result, convert it to html

--- a/src/Public/Routes.ps1
+++ b/src/Public/Routes.ps1
@@ -2166,10 +2166,10 @@ function Add-PodePage {
 
                 # invoke the function (optional splat data)
                 if (Test-PodeIsEmpty $data) {
-                    $result = (. $script)
+                    $result = & $script
                 }
                 else {
-                    $result = (. $script @data)
+                    $result = & $script @data
                 }
 
                 # if we have a result, convert it to html


### PR DESCRIPTION
Server stops with errors "Collection was modified after..." #1257
```powershell
Start-PodeServer {
    Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http
    #working
    Add-PodeRoute -Path '/processes'  -Method Get -ScriptBlock {
        $r = Get-Process | .{ process { if ($_.WS -gt 100mb) { $_ } } } |
            Select-Object Name, @{e = { [int]($_.WS / 1mb) }; n = 'WS' } |
            Sort-Object WS -Descending

        Write-PodeHtmlResponse -Value $r  -StatusCode 200
    }
    

    # doesn't work
    Add-PodePage -Name NotWorkingProcesses -ScriptBlock {
        Get-Process | .{ process { if ($_.WS -gt 100mb) { $_ } } } |
            Select-Object Name, @{e = { [int]($_.WS / 1mb) }; n = 'WS' } |
            Sort-Object WS -Descending
    }
 
}
```

### Description of the Change
``` powershell
   if (Test-PodeIsEmpty $ScriptBlock) {
                throw 'A non-empty ScriptBlock is required to created a Page Route'
            }

            $arg = @($ScriptBlock, $Data)
            $logic = {
                param($script, $data)

                # invoke the function (optional splat data)
                if (Test-PodeIsEmpty $data) {
# before was $result = (. $script)
                    $result = & $script
                }
                else {
# before was $result = (. $script @data)
                    $result = & $script @data
                }

                # if we have a result, convert it to html
                if (!(Test-PodeIsEmpty $result)) {
                    Write-PodeHtmlResponse -Value $result
                }
            }
``` 
### Related Issue
#1257 
 
