### PR TITLE
Incorporate PSScriptAnalyzerSettings for Enhanced Code Quality 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,6 +20,7 @@
     "powershell.codeFormatting.whitespaceBeforeOpenParen": true,
     "powershell.codeFormatting.whitespaceBetweenParameters": false,
     "powershell.codeFormatting.whitespaceInsideBrace": true,
+    "powershell.scriptAnalysis.settingsPath": "PSScriptAnalyzerSettings.psd1",
     "files.trimTrailingWhitespace": true,
     "files.associations": {
         "*.pode": "html"

--- a/PSScriptAnalyzerSettings.psd1
+++ b/PSScriptAnalyzerSettings.psd1
@@ -1,0 +1,6 @@
+# PSScriptAnalyzerSettings.psd1
+@{
+    Severity     = @('Error', 'Warning', 'Information')
+    ExcludeRules = @('PSAvoidUsingCmdletAliases' ,'PSAvoidUsingPlainTextForPassword','PSAvoidUsingWriteHost','PSAvoidUsingInvokeExpression','PSUseShouldProcessForStateChangingFunctions',
+    'PSAvoidUsingUsernameAndPasswordParams','PSUseProcessBlockForPipelineCommand','PSAvoidUsingConvertToSecureStringWithPlainText')
+}

--- a/PSScriptAnalyzerSettings.psd1
+++ b/PSScriptAnalyzerSettings.psd1
@@ -1,6 +1,15 @@
 # PSScriptAnalyzerSettings.psd1
 @{
     Severity     = @('Error', 'Warning', 'Information')
+
+    Rules = @{
+        PSReviewUnusedParameter = @{
+            CommandsToTraverse = @(
+                'Where-Object','Remove-PodeRoute'
+            )
+        }
+    }
     ExcludeRules = @('PSAvoidUsingCmdletAliases' ,'PSAvoidUsingPlainTextForPassword','PSAvoidUsingWriteHost','PSAvoidUsingInvokeExpression','PSUseShouldProcessForStateChangingFunctions',
-    'PSAvoidUsingUsernameAndPasswordParams','PSUseProcessBlockForPipelineCommand','PSAvoidUsingConvertToSecureStringWithPlainText')
+    'PSAvoidUsingUsernameAndPasswordParams','PSUseProcessBlockForPipelineCommand','PSAvoidUsingConvertToSecureStringWithPlainText','PSUseSingularNouns','PSReviewUnusedParameter' )
+
 }


### PR DESCRIPTION
The purpose of this improvement request is to propose the inclusion of PSScriptAnalyzerSettings.psd1 in the Pode project. PowerShell Script Analyzer is a static code checker for PowerShell scripts and modules that encourages best practices and improves code quality. By integrating PSScriptAnalyzerSettings.psd1, we can define custom rules and configurations specific to Pode's needs, ensuring consistent code style, adherence to best practices, and early detection of potential issues.


Issue #1244 