### PR TITLE
Issue after invoke-build clean

### DIFF
--- a/pode.build.ps1
+++ b/pode.build.ps1
@@ -233,6 +233,10 @@ Task Build BuildDeps, {
     finally {
         Pop-Location
     }
+
+    if (Test-Path ./src/Listener/bin/Release) {
+        Copy-Item -Path ./src/Listener/bin/Release -Destination ./src/Libs -Recurse
+    }
 }
 
 


### PR DESCRIPTION
after `Invoke-Build -clean` is invoked the /src/Libs folder is removed.
the `invoke-Build -build` is not going to create it back.
this issue I think precede the `build.ps1` changes.
This should fix the issue restoring the `/src/Libs` anytime a build is invoked