### PR TITLE
Fix for missing merged auth docs, and add a quicker default selector for merging All auths

### DIFF
--- a/docs/Tutorials/Authentication/Overview.md
+++ b/docs/Tutorials/Authentication/Overview.md
@@ -1,13 +1,13 @@
 # Overview
 
-Authentication can either be sessionless (requiring validation on every request), or session-persistent (only requiring validation once, and then checks against a session signed-cookie/header).
+Authentication can either be sessionless (requiring validation on every request), or session-persistent (only requiring validation once, and then checks against a session-signed cookie/header).
 
 !!! info
     To use session-persistent authentication you will also need to use [Session Middleware](../../Middleware/Types/Sessions).
 
-To setup and use authentication in Pode you need to use the [`New-PodeAuthScheme`](../../../Functions/Authentication/New-PodeAuthScheme) and [`Add-PodeAuth`](../../../Functions/Authentication/Add-PodeAuth) functions.
+To set up and use authentication in Pode you need to use the [`New-PodeAuthScheme`](../../../Functions/Authentication/New-PodeAuthScheme) and [`Add-PodeAuth`](../../../Functions/Authentication/Add-PodeAuth) functions.
 
-You can also setup [Authorisation](../../Authorisation/Overview) for use with Authentication as well.
+You can also set up [Authorisation](../../Authorisation/Overview) for use with Authentication as well.
 
 ## Schemes
 
@@ -82,9 +82,9 @@ New-PodeAuthScheme -Basic | Add-PodeAuth -Name 'Login' -Sessionless -ScriptBlock
 ```
 
 If you're defining an authenticator that needs to send back a Challenge, then you can also do this by setting the response Code property to 401, and/or by also supplying a Challenge property.
-This Challenge property is a string, and will be automatically appended onto the `WWW-Authenticate` Header. It *does not* need to include the Authentication Type or Realm (these will be added for you).
+This Challenge property is a string and will be automatically appended onto the `WWW-Authenticate` Header. It *does not* need to include the Authentication Type or Realm (these will be added for you).
 
-For example, in Digest you could return:
+For example, in Digest, you could return:
 
 ```powershell
 return @{
@@ -95,9 +95,9 @@ return @{
 
 ### Authenticate Type/Realm
 
-When authentication fails, and a 401 response is returned, then Pode will also attempt to Response back to the client with a `WWW-Authenticate` header (if you've manually set this header using the custom headers from above, then the custom header will be used instead). For the inbuilt types, such as Basic, this Header will always be returned on a 401 response.
+When authentication fails, and a 401 response is returned, then Pode will also attempt to respond to the client with a `WWW-Authenticate` header (if you've manually set this header using the custom headers from above, then the custom header will be used instead). For the inbuilt types, such as Basic, this Header will always be returned on a 401 response.
 
-You can set the `-Name` and `-Realm` of the header using the [`New-PodeAuthScheme`](../../../Functions/Authentication/New-PodeAuthScheme) function. If no Name is supplied, then the header will not be returned - also if there is no Realm, then this will not be added onto the header.
+You can set the `-Name` and `-Realm` of the header using the [`New-PodeAuthScheme`](../../../Functions/Authentication/New-PodeAuthScheme) function. If no Name is supplied, then the header will not be returned - also if there is no Realm, then this will not be added to the header.
 
 For example, if you setup Basic authenticate with a custom Realm as follows:
 
@@ -105,7 +105,7 @@ For example, if you setup Basic authenticate with a custom Realm as follows:
 New-PodeAuthScheme -Basic -Realm 'Enter creds to access site'
 ```
 
-Then on a 401 response the `WWW-Authenticate` header will look as follows:
+Then on a 401 response, the `WWW-Authenticate`` header will look as follows:
 
 ```plain
 WWW-Authenticate: Basic realm="Enter creds to access site"
@@ -116,7 +116,7 @@ WWW-Authenticate: Basic realm="Enter creds to access site"
 
 ### Redirecting
 
-When building custom authenticators, it might be required that you have to redirect mid-auth and stop processing the current request. To achieve this you can return the following from the scriptblock of `New-PodeAuthScheme` or `Add-PodeAuth`:
+When building custom authenticators, it might be required that you redirect mid-auth and stop processing the current request. To achieve this you can return the following from the scriptblock of `New-PodeAuthScheme` or `Add-PodeAuth`:
 
 ```powershell
 return @{ IsRedirected = $true }
@@ -126,7 +126,7 @@ An example of this could be OAuth2, where the authentication needs to redirect t
 
 ## Routes/Middleware
 
-To use an authentication on a specific route, you can use the `-Authentication` parameter on the [`Add-PodeRoute`](../../../Functions/Routes/Add-PodeRoute) function; this takes the Name supplied to the `-Name` parameter on [`Add-PodeAuth`](../../../Functions/Authentication/Add-PodeAuth). This will set the authentication up to run before other route middleware.
+To use authentication on a specific route, you can use the `-Authentication` parameter on the [`Add-PodeRoute`](../../../Functions/Routes/Add-PodeRoute) function; this takes the Name supplied to the `-Name` parameter on [`Add-PodeAuth`](../../../Functions/Authentication/Add-PodeAuth). This will set the authentication up to run before other route middleware.
 
 An example of using some Basic authentication on a REST API route is as follows:
 
@@ -138,7 +138,7 @@ Start-PodeServer {
 }
 ```
 
-The [`Add-PodeAuthMiddleware`](../../../Functions/Authentication/Add-PodeAuthMiddleware) function lets you setup authentication as global middleware - so it will run against all routes.
+The [`Add-PodeAuthMiddleware`](../../../Functions/Authentication/Add-PodeAuthMiddleware) function lets you set up authentication as global middleware - so it will run against all routes.
 
 An example of using some Basic authentication on all REST API routes is as follows:
 
@@ -150,7 +150,7 @@ Start-PodeServer {
 
 If any of the authentication middleware fails, then a 401 response is returned for the route. On success, it will allow the Route logic to be invoked. If Session Middleware has been configured then an authenticated session is also created for future requests, using a signed session cookie/header.
 
-When the user makes another call using the same authenticated session and that cookie/header is present, then the authentication middleware will detect the already authenticated session and skip validation. If you're using sessions and you don't want to check the session, or store the user against a session, then use the `-Sessionless` switch on [`Add-PodeAuth`](../../../Functions/Authentication/Add-PodeAuth).
+When the user makes another call using the same authenticated session and that cookie/header is present, then the authentication middleware will detect the already authenticated session and skip validation. If you're using sessions and you don't want to check the session or store the user against a session, then use the `-Sessionless` switch on [`Add-PodeAuth`](../../../Functions/Authentication/Add-PodeAuth).
 
 ## Users
 
@@ -158,15 +158,15 @@ After successful validation, an `Auth` object will be created for use against th
 
 The `Auth` object will also contain:
 
-| Name | Description |
-| ---- | ----------- |
-| User | Details about the authenticated user |
-| IsAuthenticated | States if the request is for an authenticated user, can be `$true`, `$false` or `$null` |
-| Store | States whether the authentication is for a session, and will be stored as a cookie |
-| IsAuthorised | If using [Authorisation](../../Authorisation/Overview), this value will be `$true` or `$false` depending on whether or not the authenticated user is authorised to access the Route. If not using Authorisation this value will just be `$true` |
-| Name | The name(s) of the Authentication methods which passed - useful if you're using merged Authentications and you want to know which one(s) passed |
+| Name            | Description                                                                                                                                                                                                                                     |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| User            | Details about the authenticated user                                                                                                                                                                                                            |
+| IsAuthenticated | States if the request is for an authenticated user, can be `$true`, `$false` or `$null`                                                                                                                                                         |
+| Store           | States whether the authentication is for a session, and will be stored as a cookie                                                                                                                                                              |
+| IsAuthorised    | If using [Authorisation](../../Authorisation/Overview), this value will be `$true` or `$false` depending on whether or not the authenticated user is authorised to access the Route. If not using Authorisation this value will just be `$true` |
+| Name            | The name(s) of the Authentication methods which passed - useful if you're using merged Authentications and you want to know which one(s) passed                                                                                                 |
 
-The following example get the user's name from the `Auth` object:
+The following example gets the user's name from the `Auth` object:
 
 ```powershell
 Add-PodeRoute -Method Get -Path '/' -Authentication 'Login' -Login -ScriptBlock {
@@ -178,13 +178,13 @@ Add-PodeRoute -Method Get -Path '/' -Authentication 'Login' -Login -ScriptBlock 
 
 ## Merging
 
-For advanced authentication scenarios, you can merge multiple authentication methods together using [`Merge-PodeAuth`](../../../Functions/Authentication/Merge-PodeAuth). This allows you to have an authentication strategy where multiple authentications are required to pass for a user to be fully authenticated, or you could have fallback authentications should the primary authentication fail.
+For advanced authentication scenarios, you can merge multiple authentication methods using [`Merge-PodeAuth`](../../../Functions/Authentication/Merge-PodeAuth). This allows you to have an authentication strategy where multiple authentications are required to pass for a user to be fully authenticated, or you could have fallback authentications should the primary authentication fail.
 
-When you merge authentication methods together, it becomes a new authentication method which you can supply to `-Authentication` on Routes. By default the merged authentications expect just one to pass, but you can state that you require all to pass via the `-Valid` parameter on [`Merge-PodeAuth`](../../../Functions/Authentication/Merge-PodeAuth).
+When you merge authentication methods, they become a new authentication method that you can supply to `-Authentication` on Routes. By default the merged authentications expect just one to pass, but you can state that you require all to pass via the `-Valid` parameter on [`Merge-PodeAuth`](../../../Functions/Authentication/Merge-PodeAuth).
 
 ### All
 
-For example, you might require an API Key and Basic authentication for a user to view a Route, in which case you would set something up as follows:
+For example, you might require both an API Key and Basic authentication for a user to view a Route, in which case you would set something up as follows - in the below example we assume that the User object returned by the Basic authentication method is the User details we want to use for the Route, by specifying `-MergeDefault` on [`Merge-PodeAuth`](../../../Functions/Authentication/Merge-PodeAuth):
 
 ```powershell
 # setup apikey auth
@@ -193,7 +193,10 @@ New-PodeAuthScheme -ApiKey -Location Header | Add-PodeAuth -Name 'ApiKey' -Sessi
 
     # here you'd check a real user storage, this is just for example
     if ($key -ieq 'test-api-key') {
-        return @{ User = @{ Name = 'Morty' } }
+        return @{
+            User   = @{ Name = 'Morty-API' }
+            Groups = @('Software')
+        }
     }
 
     return $null
@@ -205,17 +208,80 @@ New-PodeAuthScheme -Basic | Add-PodeAuth -Name 'Basic' -Sessionless -ScriptBlock
 
     # here you'd check a real user storage, this is just for example
     if ($username -eq 'morty' -and $password -eq 'pickle') {
-        return @{ User = @{ Name = 'Morty' } }
+        return @{
+            User   = @{ Name = 'Morty-BASIC' }
+            Groups = @('Platform')
+        }
     }
 
     return @{ Message = 'Invalid details supplied' }
 }
 
-# merge the authentications together, and require all to pass
-Merge-PodeAuth -Name 'MergedAuth' -Authentication 'ApiKey', 'Basic' -Valid All
+# merge the authentications together, and require all to pass - using the User result object of Basic
+Merge-PodeAuth -Name 'MergedAuth' -Authentication 'ApiKey', 'Basic' -Valid All -MergeDefault 'Basic'
 
 # use the merged auth in a route
 Add-PodeRoute -Method Get -Path '/users' -Authentication 'MergedAuth' -ScriptBlock {
+    # this would write back "Name = Morty-BASIC"
+    Write-PodeJsonResponse -Value @{
+        Users = $WebEvent.Auth.User
+    }
+}
+```
+
+The above example assumes a simple scenario of using the Basic authentication's User object, but what if we did want to use both authentication User objects and merge them into one? Well to achieve this you can supply a `-ScriptBlock`. This scriptblock will be supplied a hashtable of all the result objects, from all authentication methods used in the Valid=All merged authentication method, which you can then use to construct a single result object. The result objects themselves will contain a User and Headers hashtable - more commonly just the User.
+
+Using a similar example to the example above, the following will use a `-ScriptBlock` instead to merge the User objects from the API key and Basic authentication methods into one User object:
+
+```powershell
+# setup apikey auth
+New-PodeAuthScheme -ApiKey -Location Header | Add-PodeAuth -Name 'ApiKey' -Sessionless -ScriptBlock {
+    param($key)
+
+    # here you'd check a real user storage, this is just for example
+    if ($key -ieq 'test-api-key') {
+        return @{ User = @{
+            Name   = 'Morty'
+            Groups = @('Software')
+        } }
+    }
+
+    return $null
+}
+
+# setup basic auth
+New-PodeAuthScheme -Basic | Add-PodeAuth -Name 'Basic' -Sessionless -ScriptBlock {
+    param($username, $password)
+
+    # here you'd check a real user storage, this is just for example
+    if ($username -eq 'morty' -and $password -eq 'pickle') {
+        return @{ User = @{
+            Name   = 'Morty'
+            Groups = @('Platform')
+        } }
+    }
+
+    return @{ Message = 'Invalid details supplied' }
+}
+
+# merge the authentications together, and require all to pass - using the User result object of Basic
+Merge-PodeAuth -Name 'MergedAuth' -Authentication 'ApiKey', 'Basic' -Valid All -ScriptBlock {
+    param($results)
+
+    $apiUser = $results['ApiKey'].User
+    $basicUser = $results['Basic'].User
+
+    return @{
+        User = @{
+            User   = $basicUser.Username
+            Groups = @($apiUser.Groups + $basicUser.Groups) | Sort-Object -Unique
+        }
+    }
+}
+
+# use the merged auth in a route
+Add-PodeRoute -Method Get -Path '/users' -Authentication 'MergedAuth' -ScriptBlock {
+    # this would write back "Name = Morty" and "Groups = Platform, Software"
     Write-PodeJsonResponse -Value @{
         Users = $WebEvent.Auth.User
     }
@@ -256,7 +322,7 @@ Add-PodeRoute -Method Get -Path '/users' -Authentication 'MergedAuth' -ScriptBlo
 
 ### Advanced
 
-You can also merge together other merged authentication methods. This lets you build scenarios where you require an API key, and then need either a JWT Bearer token or OAuth2 to pass. As a very brief example:
+You can also merge other merged authentication methods. This lets you build scenarios where you require an API key, and then need either a JWT Bearer token or OAuth2 to pass. As a very brief example:
 
 ```powershell
 # setup apikey auth
@@ -291,7 +357,7 @@ $scheme | Add-PodeAuth -Name 'AzureAD' -Sessionless -ScriptBlock {
 Merge-PodeAuth -Name 'JwtMergedAuth' -Authentication 'Bearer', 'AzureAD' -Valid One
 
 # merge the above merged auth with the apikey auth, and require both to pass
-Merge-PodeAuth -Name 'ApiMergedAuth' -Authentication 'ApiKey', 'JwtMergedAuth' -Valid All
+Merge-PodeAuth -Name 'ApiMergedAuth' -Authentication 'ApiKey', 'JwtMergedAuth' -Valid All -MergeDefault 'ApiKey'
 
 # use the merged auth in a route
 Add-PodeRoute -Method Get -Path '/users' -Authentication 'ApiMergedAuth' -ScriptBlock {
@@ -303,17 +369,17 @@ Add-PodeRoute -Method Get -Path '/users' -Authentication 'ApiMergedAuth' -Script
 
 ### Users
 
-When using a single authentication method, the authenticated user's details will be accessible at `$WebEvent.Auth.User`. However, when you're using a merged authentication method you could end up with 2 or more user objects being returned from each authentication method.
+When using a single authentication method, the authenticated user's details will be accessible at `$WebEvent.Auth.User`.
 
-Because of this, when using a merged authentication, the user object will instead be found at `$WebEvent.Auth.User[<AuthName>]`. For example, if you have a authentication method with name "BearerAuth", then the user's details would be at `$WebEvent.Auth.User['BearerAuth']` - not `$WebEvent.Auth.User`.
+The same still applies for merged authentication methods; if you're using `Merge-PodeAuth -Valid One` then there will only be one User object to set, but if you're using `Merge-PodeAuth -Valid All` then the User objects of all authentication methods will need to be merged into one User object - this can be done by either supplying `-MergeDefault` or `-ScriptBlock` to [`Merge-PodeAuth`](../../../Functions/Authentication/Merge-PodeAuth) when `-Valid` is set to All. ([see All for more info](#all)).
 
 ### Parameters
 
-Similar to [`Add-PodeAuth`](../../../Functions/Authentication/Add-PodeAuth) the [`Merge-PodeAuth`](../../../Functions/Authentication/Merge-PodeAuth) function also supports the `-FailureUrl`, `-SuccessUrl`, etc. parameters. When set on the merged authentication method, these fails will be used as a fallback if the initial authentication methods don't have them set. This means you can setup 2 authentication methods without Failure URLs, and then merge them together with a default one of `/login` on the merged authentication.
+Similar to [`Add-PodeAuth`](../../../Functions/Authentication/Add-PodeAuth) the [`Merge-PodeAuth`](../../../Functions/Authentication/Merge-PodeAuth) function also supports the `-FailureUrl`, `-SuccessUrl`, etc. parameters. When set on the merged authentication method, they will be used as a fallback if the initial authentication methods don't have them set. This means you can set up 2 authentication methods without Failure URLs, and then merge them with a default Failure URL of `/login` on the merged authentication.
 
 ## Inbuilt Authenticators
 
-Overtime Pode will start to support inbuilt authentication methods - such as [Windows Active Directory](../Inbuilt/WindowsAD). More information can be found in the Inbuilt section.
+Over time Pode will start to support inbuilt authentication methods - such as [Windows Active Directory](../Inbuilt/WindowsAD). More information can be found in the Inbuilt section.
 
 For example, the below would use the inbuilt Windows AD authentication method:
 

--- a/examples/tcp-server-auth.ps1
+++ b/examples/tcp-server-auth.ps1
@@ -14,7 +14,7 @@ Start-PodeServer -Threads 2 {
     New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
 
     # create a role access method get retrieves roles from a database
-    Add-PodeAccess -Name 'RoleExample' -Type Role -ScriptBlock {
+    New-PodeAccessScheme -Type Role | Add-PodeAccess -Name 'RoleExample' -ScriptBlock {
         param($username)
         if ($username -ieq 'morty') {
             return @('Developer')
@@ -26,12 +26,12 @@ Start-PodeServer -Threads 2 {
     # setup a Verb that only allows Developers
     Add-PodeVerb -Verb 'EXAMPLE :username' -ScriptBlock {
         if (!(Test-PodeAccess -Name 'RoleExample' -Destination 'Developer' -ArgumentList $TcpEvent.Parameters.username)) {
-            Write-PodeTcpClient -Message "Forbidden Access"
+            Write-PodeTcpClient -Message 'Forbidden Access'
             'Forbidden!' | Out-Default
             return
         }
 
-        Write-PodeTcpClient -Message "Hello, there!"
+        Write-PodeTcpClient -Message 'Hello, there!'
         'Hello!' | Out-Default
     }
 }

--- a/examples/web-auth-basic-access.ps1
+++ b/examples/web-auth-basic-access.ps1
@@ -26,14 +26,8 @@ Start-PodeServer -Threads 2 {
     Add-PodeEndpoint -Address * -Port 8085 -Protocol Http
 
     # setup RBAC
-    # Add-PodeAccess -Type Role -Name 'TestRbac'
-    # Add-PodeAccess -Type Group -Name 'TestGbac'
     New-PodeAccessScheme -Type Role | Add-PodeAccess -Name 'TestRbac'
     New-PodeAccessScheme -Type Group | Add-PodeAccess -Name 'TestGbac'
-    # Add-PodeAccess -Type Custom -Name 'TestRbac' -Path 'CustomAccess' -Validator {
-    #     param($userRoles, $customValues)
-    #     return $userRoles.Example -iin $customValues.Example
-    # }
 
     Merge-PodeAccess -Name 'TestMergedAll' -Access 'TestRbac', 'TestGbac' -Valid All
     Merge-PodeAccess -Name 'TestMergedOne' -Access 'TestRbac', 'TestGbac' -Valid One
@@ -46,12 +40,12 @@ Start-PodeServer -Threads 2 {
         if ($username -eq 'morty' -and $password -eq 'pickle') {
             return @{
                 User = @{
-                    ID ='M0R7Y302'
-                    Name = 'Morty'
-                    Type = 'Human'
-                    Username = 'm.orty'
-                    Roles = @('Developer')
-                    Groups = @('Software', 'Admins')
+                    ID           = 'M0R7Y302'
+                    Name         = 'Morty'
+                    Type         = 'Human'
+                    Username     = 'm.orty'
+                    Roles        = @('Developer')
+                    Groups       = @('Software', 'Admins')
                     CustomAccess = @{ Example = 'test-val-1' }
                 }
             }

--- a/src/Private/Authentication.ps1
+++ b/src/Private/Authentication.ps1
@@ -828,10 +828,13 @@ function Invoke-PodeAuthInbuiltScriptBlock {
         $ScriptBlock,
 
         [Parameter()]
-        $UsingVariables
+        $UsingVariables,
+
+        [switch]
+        $NoSplat
     )
 
-    return (Invoke-PodeScriptBlock -ScriptBlock $ScriptBlock -Arguments $User -UsingVariables $UsingVariables -Return -Splat)
+    return (Invoke-PodeScriptBlock -ScriptBlock $ScriptBlock -Arguments $User -UsingVariables $UsingVariables -Return -Splat:(!$NoSplat))
 }
 
 function Get-PodeAuthWindowsLocalMethod {
@@ -1120,8 +1123,13 @@ function Invoke-PodeAuthValidation {
 
         # if the last auth succeeded, and we need all to pass, merge users/headers and return result
         if ($result.Success -and !$auth.PassOne) {
-            # invoke scriptblock
-            $result = Invoke-PodeAuthInbuiltScriptBlock -User $results -ScriptBlock $auth.ScriptBlock.Script -UsingVariables $auth.ScriptBlock.UsingVariables
+            # invoke scriptblock, or use result of merge default
+            if ($null -ne $auth.ScriptBlock.Script) {
+                $result = Invoke-PodeAuthInbuiltScriptBlock -User $results -ScriptBlock $auth.ScriptBlock.Script -UsingVariables $auth.ScriptBlock.UsingVariables -NoSplat
+            }
+            else {
+                $result = $results[$auth.MergeDefault]
+            }
 
             # reset default properties and return
             $result.Success = $true

--- a/src/Public/Authentication.ps1
+++ b/src/Public/Authentication.ps1
@@ -804,11 +804,14 @@ Multiple Autentication method Names to be merged.
 How many of the Authentication methods are required to be valid, One or All. (Default: One)
 
 .PARAMETER ScriptBlock
-This is mandatory when Valid is All. A scriptblock to merge the mutliple users/headers returned by valid authentications into 1 user/header objects.
+This is mandatory, and only used, when $Valid=All. A scriptblock to merge the mutliple users/headers returned by valid authentications into 1 user/header objects.
 This scriptblock will receive a hashtable of all result objects returned from Authentication methods. The key for the hashtable will be the authentication names that passed.
 
 .PARAMETER Default
 The Default Authentication method to use as a fallback for Failure URLs and other settings.
+
+.PARAMETER MergeDefault
+The Default Authentication method's User details result object to use, when $Valid=All.
 
 .PARAMETER FailureUrl
 The URL to redirect to when authentication fails.
@@ -831,13 +834,16 @@ If supplied, successful authentication from a login page will redirect back to t
 This will be used as fallback for the merged Authentication methods if not set on them.
 
 .EXAMPLE
-Merge-PodeAuth -Name MergedAuth -Authentication ApiTokenAuth, BasicAuth -Valid All
+Merge-PodeAuth -Name MergedAuth -Authentication ApiTokenAuth, BasicAuth -Valid All -ScriptBlock { ... }
+
+.EXAMPLE
+Merge-PodeAuth -Name MergedAuth -Authentication ApiTokenAuth, BasicAuth -Valid All -MergeDefault BasicAuth
 
 .EXAMPLE
 Merge-PodeAuth -Name MergedAuth -Authentication ApiTokenAuth, BasicAuth -FailureUrl 'http://localhost:8080/login'
 #>
 function Merge-PodeAuth {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'ScriptBlock')]
     param(
         [Parameter(Mandatory = $true)]
         [string]
@@ -853,13 +859,17 @@ function Merge-PodeAuth {
         [string]
         $Valid = 'One',
 
-        [Parameter()]
+        [Parameter(ParameterSetName = 'ScriptBlock')]
         [scriptblock]
         $ScriptBlock,
 
         [Parameter()]
         [string]
         $Default,
+
+        [Parameter(ParameterSetName = 'MergeDefault')]
+        [string]
+        $MergeDefault,
 
         [Parameter()]
         [string]
@@ -890,6 +900,11 @@ function Merge-PodeAuth {
         if (!(Test-PodeAuthExists -Name $authName)) {
             throw "Authentication method does not exist for merging: $($authName)"
         }
+    }
+
+    # ensure the merge default is in the auth list
+    if (![string]::IsNullOrEmpty($MergeDefault) -and ($MergeDefault -inotin @($Authentication))) {
+        throw "the MergeDefault Authentication '$($MergeDefault)' is not in the Authentication list supplied"
     }
 
     # ensure the default is in the auth list
@@ -936,12 +951,17 @@ function Merge-PodeAuth {
     }
 
     # deal with using vars in scriptblock
-    if ($Valid -ieq 'all') {
+    if (($Valid -ieq 'all') -and [string]::IsNullOrEmpty($MergeDefault)) {
         if ($null -eq $ScriptBlock) {
             throw 'A Scriptblock for merging multiple authenticated users into 1 object is required When Valid is All'
         }
 
         $ScriptBlock, $usingVars = Convert-PodeScopedVariables -ScriptBlock $ScriptBlock -PSSession $PSCmdlet.SessionState
+    }
+    else {
+        if ($null -ne $ScriptBlock) {
+            Write-Warning -Message 'The Scriptblock for merged authentications, when Valid=One, will be ignored'
+        }
     }
 
     # set parent auth
@@ -959,6 +979,7 @@ function Merge-PodeAuth {
             UsingVariables = $usingVars
         }
         Default         = $Default
+        MergeDefault    = $MergeDefault
         Sessionless     = $Sessionless.IsPresent
         Failure         = @{
             Url     = $FailureUrl


### PR DESCRIPTION
### Description of the Change
Adds documentation which was missing, describing the need for `-ScriptBlock` on `Merge-PodeAuth` when `-Valid All` was passed.

Also adds a quick new `-MergeDefault` when `-Valid All` is passed, which acts as a faster shorthand for `-ScriptBlock` when we only want to use the User object returned by just one of the authentication methods.

Also fixes some of the merged auth examples, still using an older format.

### Related Issue
Resolves #1179 

### Examples
```powershell
Merge-PodeAuth -Name 'MergedAuth' -Authentication 'ApiKey', 'Basic' -Valid All -ScriptBlock {
    param($results)

    $apiUser = $results['ApiKey'].User
    $basicUser = $results['Basic'].User

    return @{
        User = @{
            Username = $basicUser.Username
            ID       = $apiUser.ID
            Name     = $apiUser.Name
            Type     = $apiUser.Type
            Roles    = @($apiUser.Roles + $basicUser.Roles) | Sort-Object -Unique
            Groups   = @($apiUser.Groups + $basicUser.Groups) | Sort-Object -Unique
        }
    }
}
```
