### PR TITLE
Fix scoping issue when using variables to create route groups

### DIFF
--- a/examples/web-route-group.ps1
+++ b/examples/web-route-group.ps1
@@ -43,7 +43,7 @@ Start-PodeServer -Threads 2 {
         # here you'd check a real user storage, this is just for example
         if ($username -eq 'morty' -and $password -eq 'pickle') {
             return @{
-                User = @{ ID ='M0R7Y302' }
+                User = @{ ID = 'M0R7Y302' }
             }
         }
 

--- a/src/Public/Routes.ps1
+++ b/src/Public/Routes.ps1
@@ -1176,7 +1176,7 @@ function Add-PodeRouteGroup {
     }
 
     # add routes
-    $null = Invoke-PodeScriptBlock -ScriptBlock $Routes -UsingVariables $usingVars -Splat
+    $null = Invoke-PodeScriptBlock -ScriptBlock $Routes -UsingVariables $usingVars -Splat -NoNewClosure
 }
 
 <#
@@ -1441,7 +1441,7 @@ function Add-PodeStaticRouteGroup {
     }
 
     # add routes
-    $null = Invoke-PodeScriptBlock -ScriptBlock $Routes -UsingVariables $usingVars -Splat
+    $null = Invoke-PodeScriptBlock -ScriptBlock $Routes -UsingVariables $usingVars -Splat -NoNewClosure
 }
 
 
@@ -1521,7 +1521,7 @@ function Add-PodeSignalRouteGroup {
     }
 
     # add routes
-    $null = Invoke-PodeScriptBlock -ScriptBlock $Routes -UsingVariables $usingVars -Splat
+    $null = Invoke-PodeScriptBlock -ScriptBlock $Routes -UsingVariables $usingVars -Splat -NoNewClosure
 }
 
 <#


### PR DESCRIPTION
### Description of the Change
Adds `-NoNewClosure` to `Invoke-PodeScriptBlock` when calling `Add-PodeRouteGroup`, `Add-PodeStaticRouteGroup`, or `Add-PodeSignalRouteGroup` to resolve a variable scoping issue.

### Related Issue
Resolves #1278 
