### PR TITLE
Removal of erroneous break command when filtering websocket clients by path

### DIFF
--- a/src/Private/PodeServer.ps1
+++ b/src/Private/PodeServer.ps1
@@ -309,7 +309,6 @@ function Start-PodeWebServer {
                                 $sockets = @(foreach ($socket in $sockets) {
                                         if ($socket.Path -ieq $message.Path) {
                                             $socket
-                                            break
                                         }
                                     })
                             }


### PR DESCRIPTION
### Description of the Change
Removal of an erroneous `break` command when filtering for websocket clients which match a path, causing the filter to break out earlier than it should be and only send a message to a single client rather than all.

### Related Issue
Resolves #1280 
