### PR TITLE
Adds a Test-Path check when loading modules; Fixes a stack overflow exception when using: scoped variables are remapped

### DIFF
--- a/src/Private/AutoImport.ps1
+++ b/src/Private/AutoImport.ps1
@@ -85,6 +85,9 @@ function Import-PodeModulesIntoRunspaceState {
 
         # import the module
         $path = Find-PodeModuleFile -Module $module
+        if ([string]::IsNullOrEmpty($path) -or !(Test-Path $path)) {
+            continue
+        }
 
         if (($module.ModuleType -ieq 'Manifest') -or ($path.EndsWith('.ps1'))) {
             $PodeContext.RunspaceState.ImportPSModule($path)

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -937,7 +937,9 @@ function Add-PodePSDrives {
 function Import-PodeModules {
     # import other modules in the session
     foreach ($path in $PodeContext.Server.Modules.Values) {
-        $null = Import-Module $path -DisableNameChecking -Scope Global -ErrorAction Stop
+        if (Test-Path $path) {
+            $null = Import-Module $path -DisableNameChecking -Scope Global -ErrorAction Stop
+        }
     }
 }
 


### PR DESCRIPTION
### Description of the Change
* Adds a Test-Path check when loading modules, to prevent issues when using Oh-My-Posh when auto-import modules is enabled. Oh-My-Posh will generate temp random file locations for module imports, but these don't exist when attempting to auto-import them into Pode's internal runspaces.

Fixes a stack overflow exception when `using:` scoped variables are remapped - this was primarily causing issues with Pode.Web.

### Related Issue
Resolves #1296 