### PR TITLE
Alter Pode views documentation page to use Get-LocalUser instead of dummy function

### DIFF
--- a/docs/Tutorials/Views/Pode.md
+++ b/docs/Tutorials/Views/Pode.md
@@ -56,10 +56,13 @@ Start-PodeServer {
     Add-PodeRoute -Method Get -Path '/' -ScriptBlock {
         # some logic to get accounts
         $query = $WebEvent.Query['query']
-        $accounts = Find-Account -Query $query
+        $accounts = Get-LocalUser -Name $query
 
         # render the file
-        Write-PodeViewResponse -Path 'search' -Data @{ 'query' = $query; 'accounts' = $accounts; }
+        Write-PodeViewResponse -Path 'search' -Data @{
+            query    = $query
+            accounts = $accounts
+        }
     }
 }
 ```


### PR DESCRIPTION
### Description of the Change
Alter Pode views documentation page to use `Get-LocalUser` instead of a dummy `Find-Account` function.

### Related Issue
Resolves #1112 
