### PR TITLE
Resolve a threading issue with secrets; Handle SecretStore vaults better with inbuilt defaults; Write documentation for SecretStore vaults

### DIFF
--- a/.github/workflows/ci-pwsh_preview.yml
+++ b/.github/workflows/ci-pwsh_preview.yml
@@ -23,13 +23,9 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Setup Powershell
-      uses: Wandalen/wretry.action@v3.5.0
+      uses: bjompen/UpdatePWSHAction@v1.0.0
       with:
-        action: bjompen/UpdatePWSHAction@v1.0.0
-        with: |
-          ReleaseVersion: 'Preview'
-        attempt_limit: 3
-        attempt_delay: 10
+        ReleaseVersion: 'Preview'
 
     - name: Check PowerShell version
       shell: pwsh

--- a/.github/workflows/ci-pwsh_preview.yml
+++ b/.github/workflows/ci-pwsh_preview.yml
@@ -23,9 +23,13 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Setup Powershell
-      uses: bjompen/UpdatePWSHAction@v1.0.0
+      uses: Wandalen/wretry.action@v3.5.0
       with:
-        ReleaseVersion: 'Preview'
+        action: bjompen/UpdatePWSHAction@v1.0.0
+        with: |
+          ReleaseVersion: 'Preview'
+        attempt_limit: 3
+        attempt_delay: 10
 
     - name: Check PowerShell version
       shell: pwsh
@@ -44,7 +48,7 @@ jobs:
 
     - name: Run Pester Tests
       shell: pwsh
-      run: | 
+      run: |
         Invoke-Build Test
 
     - name: Test docker builds

--- a/docs/Tutorials/ImportingModules.md
+++ b/docs/Tutorials/ImportingModules.md
@@ -9,7 +9,7 @@ The older [`Import-PodeModule`](../../Functions/Utilities/Import-PodeModule) and
 
 ## Modules
 
-Modules in Pode can be imported in the normal manor using `Import-Module`. The [`Import-PodeModule`](../../Functions/Utilities/Import-PodeModule) function can now be used inside and outside of [`Start-PodeServer`](../../Functions/Core/Start-PodeServer), and should be used if you're using local modules via `ps_modules`.
+Modules in Pode can be imported in the normal manner using `Import-Module`. The [`Import-PodeModule`](../../Functions/Utilities/Import-PodeModule) function can now be used inside and outside of [`Start-PodeServer`](../../Functions/Core/Start-PodeServer), and should be used if you're using local modules via `ps_modules`.
 
 ### Import via Path
 

--- a/docs/Tutorials/Routes/Utilities/RouteGrouping.md
+++ b/docs/Tutorials/Routes/Utilities/RouteGrouping.md
@@ -60,7 +60,7 @@ Add-PodeRouteGroup -Path '/api' -Authentication Basic -Middleware $mid -Routes {
 
 ## Static Routes
 
-The Groups for Static Routes work in the same manor as normal Routes, but you'll need to use [`Add-PodeStaticRouteGroup`](../../../../Functions/Routes/Add-PodeStaticRouteGroup) instead:
+The Groups for Static Routes work in the same manner as normal Routes, but you'll need to use [`Add-PodeStaticRouteGroup`](../../../../Functions/Routes/Add-PodeStaticRouteGroup) instead:
 
 ```powershell
 Add-PodeStaticRouteGroup -Path '/assets' -Source './content/assets' -Routes {
@@ -73,7 +73,7 @@ This will create 2 Static Routes at `/assets/images` and `/assets/videos`, refer
 
 ## Signal Routes
 
-Groupings for Signal Routes also work in the same manor as normal Routes, but you'll need to use [`Add-PodeSignalRouteGroup`](../../../../Functions/Routes/Add-PodeSignalRouteGroup) instead:
+Groupings for Signal Routes also work in the same manner as normal Routes, but you'll need to use [`Add-PodeSignalRouteGroup`](../../../../Functions/Routes/Add-PodeSignalRouteGroup) instead:
 
 ```powershell
 Add-PodeSignalRoute -Path '/ws' -Routes {

--- a/docs/Tutorials/Schedules.md
+++ b/docs/Tutorials/Schedules.md
@@ -37,7 +37,7 @@ Add-PodeSchedule -Name 'date' -Cron @('@minutely', '@hourly') -ScriptBlock {
 }
 ```
 
-Usually all schedules are created within the main `Start-PodeServer` scope, however it is possible to create adhoc schedules with routes/etc. If you create adhoc schedules in this manor, you might notice that they don't run; this is because the Runspace that schedules use to run won't have been configured. You can configure by using `-EnablePool` on [`Start-PodeServer`](../../Functions/Core/Start-PodeServer):
+Usually all schedules are created within the main `Start-PodeServer` scope, however it is possible to create adhoc schedules with routes/etc. If you create adhoc schedules in this manner, you might notice that they don't run; this is because the Runspace that schedules use to run won't have been configured. You can configure by using `-EnablePool` on [`Start-PodeServer`](../../Functions/Core/Start-PodeServer):
 
 ```powershell
 Start-PodeServer -EnablePool Schedules {
@@ -169,18 +169,18 @@ Invoke-PodeSchedule -Name 'date' -ArgumentList @{ Date = [DateTime]::Now }
 
 The following is the structure of the Schedule object internally, as well as the object that is returned from [`Get-PodeSchedule`](../../Functions/Schedules/Get-PodeSchedule):
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| Name | string | The name of the Schedule |
-| StartTime | datetime | The delayed start time of the Schedule |
-| EndTime | datetime | The end time of the Schedule |
-| Crons | hashtable[] | The cron expressions of the Schedule, but parsed into an internal format |
-| CronsRaw | string[] | The raw cron expressions that were supplied |
-| Limit | int | The number of times the Schedule should run - 0 if running infinitely |
-| Count | int | The number of times the Schedule has run |
-| LastTriggerTime | datetime | The datetime the Schedule was last triggered |
-| NextTriggerTime | datetime | The datetime the Schedule will next be triggered |
-| Script | scriptblock | The scriptblock of the Schedule |
-| Arguments | hashtable | The arguments supplied from ArgumentList |
-| OnStart | bool | Should the Schedule run once when the server is starting, or once the server has fully loaded |
-| Completed | bool | Has the Schedule completed all of its runs |
+| Name            | Type        | Description                                                                                   |
+| --------------- | ----------- | --------------------------------------------------------------------------------------------- |
+| Name            | string      | The name of the Schedule                                                                      |
+| StartTime       | datetime    | The delayed start time of the Schedule                                                        |
+| EndTime         | datetime    | The end time of the Schedule                                                                  |
+| Crons           | hashtable[] | The cron expressions of the Schedule, but parsed into an internal format                      |
+| CronsRaw        | string[]    | The raw cron expressions that were supplied                                                   |
+| Limit           | int         | The number of times the Schedule should run - 0 if running infinitely                         |
+| Count           | int         | The number of times the Schedule has run                                                      |
+| LastTriggerTime | datetime    | The datetime the Schedule was last triggered                                                  |
+| NextTriggerTime | datetime    | The datetime the Schedule will next be triggered                                              |
+| Script          | scriptblock | The scriptblock of the Schedule                                                               |
+| Arguments       | hashtable   | The arguments supplied from ArgumentList                                                      |
+| OnStart         | bool        | Should the Schedule run once when the server is starting, or once the server has fully loaded |
+| Completed       | bool        | Has the Schedule completed all of its runs                                                    |

--- a/docs/Tutorials/Secrets/Examples/SecretStore.md
+++ b/docs/Tutorials/Secrets/Examples/SecretStore.md
@@ -1,0 +1,84 @@
+# SecretStore
+
+This page gives some brief details, and an example, of how to use the `Microsoft.PowerShell.SecretStore` PowerShell module secret vault provider.
+
+This is a locally stored secret vault.
+
+## Install
+
+Before using the `Microsoft.PowerShell.SecretStore` provider, you will first need to install the module:
+
+```powershell
+Install-Module Microsoft.PowerShell.SecretManagement, Microsoft.PowerShell.SecretStore
+```
+
+## Register
+
+When registering a new secret vault using `Microsoft.PowerShell.SecretStore`, via [`Register-PodeSecretVault`], the `-UnlockSecret` parameter is **mandatory**. This will be used to assign the required default password for the secret vault and to periodically unlock the vault.
+
+There are also some default values set for some parameters to make life a little easier, however, these can be overwritten if needed by directly supplying the parameter:
+
+| Parameter                            | Default    | Description                                                                                                                       |
+| ------------------------------------ | ---------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `UnlockInterval`                     | 1 minute   | Used to assign an unlock period, as well as the PasswordTimeout to auto-lock the vault                                            |
+| `VaultParameters['Authentication']`  | Password   | Used to tell the vault to to be locked/unlocked                                                                                   |
+| `VaultParameters['Interaction']`     | None       | Used to tell the vault where it should be interactive or not                                                                      |
+| `VaultParameters['PasswordTimeout']` | 70 seconds | Used to auto-lock the vault after being unlocked. The vault if not supplied is based on the `-UnlockInterval` values + 10 seconds |
+
+For example:
+
+```powershell
+Register-PodeSecretVault `
+    -Name 'ExampleVault' `
+    -ModuleName 'Microsoft.PowerShell.SecretStore' `
+    -UnlockSecret 'Sup3rSecur3Pa$$word!'
+```
+
+## Secret Management
+
+Creating, updating, and using secrets are all done in the usual manner, as outlined in the [Overview](../../Overview):
+
+```powershell
+# set a secret in the local vault
+Set-PodeSecret -Key 'example' -Vault 'ExampleVault' -InputObject 'hello, world!'
+
+# mount the "example" secret from local vault, making it accessible via $secret:example
+Mount-PodeSecret -Name 'example' -Vault 'ExampleVault' -Key 'example'
+
+# use the secret in a route
+Add-PodeRoute -Method Get -Path '/' -ScriptBlock {
+    Write-PodeJsonResponse @{ Value = $secret:example }
+}
+```
+
+## Example
+
+The following is a smaller example of the example [found here](https://github.com/Badgerati/Pode/blob/develop/examples/web-secrets-local.ps1) and shows how to set up a server to register a local SecretStore vault, manage a secret within that vault, and return it via a Route.
+
+```powershell
+Start-PodeServer -Threads 2 {
+    Add-PodeEndpoint -Address * -Port 8080 -Protocol Http
+
+    # register the vault
+    Register-PodeSecretVault `
+        -Name 'ExampleVault' `
+        -ModuleName 'Microsoft.PowerShell.SecretStore' `
+        -UnlockSecret 'Sup3rSecur3Pa$$word!'
+
+    # set a secret in the local vault
+    Set-PodeSecret -Key 'example' -Vault 'ExampleVault' -InputObject 'hello, world!'
+
+    # mount the "example" secret from local vault, making it accessible via $secret:example
+    Mount-PodeSecret -Name 'example' -Vault 'ExampleVault' -Key 'example'
+
+    # retrieve the secret in a route
+    Add-PodeRoute -Method Get -Path '/' -ScriptBlock {
+        Write-PodeJsonResponse @{ Value = $secret:example }
+    }
+
+    # update the secret in a route
+    Add-PodeRoute -Method Post -Path '/' -ScriptBlock {
+        $secret:example = $WebEvent.Data.Value
+    }
+}
+```

--- a/docs/Tutorials/Secrets/Examples/SecretStore.md
+++ b/docs/Tutorials/Secrets/Examples/SecretStore.md
@@ -18,12 +18,12 @@ When registering a new secret vault using `Microsoft.PowerShell.SecretStore`, vi
 
 There are also some default values set for some parameters to make life a little easier, however, these can be overwritten if needed by directly supplying the parameter:
 
-| Parameter                            | Default    | Description                                                                                                                       |
-| ------------------------------------ | ---------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| `UnlockInterval`                     | 1 minute   | Used to assign an unlock period, as well as the PasswordTimeout to auto-lock the vault                                            |
-| `VaultParameters['Authentication']`  | Password   | Used to tell the vault to to be locked/unlocked                                                                                   |
-| `VaultParameters['Interaction']`     | None       | Used to tell the vault where it should be interactive or not                                                                      |
-| `VaultParameters['PasswordTimeout']` | 70 seconds | Used to auto-lock the vault after being unlocked. The vault if not supplied is based on the `-UnlockInterval` values + 10 seconds |
+| Parameter                            | Default    | Description                                                                                                                      |
+| ------------------------------------ | ---------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `UnlockInterval`                     | 1 minute   | Used to assign an unlock period, as well as the PasswordTimeout to auto-lock the vault                                           |
+| `VaultParameters['Authentication']`  | Password   | Used to tell the vault to to be locked/unlocked                                                                                  |
+| `VaultParameters['Interaction']`     | None       | Used to tell the vault where it should be interactive or not                                                                     |
+| `VaultParameters['PasswordTimeout']` | 70 seconds | Used to auto-lock the vault after being unlocked. The value if not supplied is based on the `-UnlockInterval` value + 10 seconds |
 
 For example:
 

--- a/docs/Tutorials/Secrets/Overview.md
+++ b/docs/Tutorials/Secrets/Overview.md
@@ -2,13 +2,13 @@
 
 You can register and mount secret values from secret vaults, like Azure KeyVault or HashiCorp Vault, into Pode for use in Routes, Middleware, etc.
 
-Secrets can also be referenced from a vault in an adhoc manor, without needing to mount them first. You can also create, update and remove secrets in vaults.
+Secrets can also be referenced from a vault in an adhoc manner, without needing to mount them first. You can also create, update, and remove secrets in vaults.
 
-The values of mounted secrets may also be cached for a period of time, to reduce load on the vault.
+The values of mounted secrets may also be cached for a period of time, to reduce load on the vault as well as speed up lookups.
 
 ## Registering
 
-In order to reference Secrets from a vault you first need to register that vault using [`Register-PodeSecretVault`](../../../Functions/Secrets/Register-PodeSecretVault). Registering a vault registers the vault within Pode, but will also call any logic needed by the registration type being used. For example, if using Secret Management then Pode will call `Register-SecretVault` for you.
+To reference Secrets from a vault you first need to register that vault using [`Register-PodeSecretVault`](../../../Functions/Secrets/Register-PodeSecretVault). Registering a vault registers the vault within Pode, but will also call any logic needed by the registration type being used. For example, if using Secret Management then Pode will call `Register-SecretVault` for you.
 
 A further example, as follows, will use the Secret Management PowerShell module to register an Azure KeyVault within Pode:
 
@@ -21,23 +21,30 @@ Register-PodeSecretVault -Name 'FriendlyVaultName' -ModuleName 'Az.KeyVault' -Va
 
 You can find more information on the [Secret Management](../Types/SecretManagement) page. The general parameters for all types are:
 
-| Parameter | Description |
-| --------- | ----------- |
-| Name | This is a friendly name for the vault within Pode that you can reference |
+| Parameter       | Description                                                                      |
+| --------------- | -------------------------------------------------------------------------------- |
+| Name            | This is a friendly name for the vault within Pode that you can reference         |
 | VaultParameters | This is a hashtable of options, for the vault, that is supplied to vault scripts |
 
 !!! note
-    You can unregister a vault via [`Unregister-PodeSecretVault`](../../../Functions/Secrets/Unregister-PodeSecretVault). All vaults are automatically unregistered at when the server stops - unless it was auto-imported.
+    You can unregister a vault via [`Unregister-PodeSecretVault`](../../../Functions/Secrets/Unregister-PodeSecretVault). All vaults are automatically unregistered when the server stops - unless it was auto-imported.
 
 ### Types
 
-At present there are just two registration types implemented for registering secret vaults:
+At present, there are just two registration types implemented for registering secret vaults:
 
-* [Secret Management](../Types/SecretManagement) (powershell module)
+* [Secret Management](../Types/SecretManagement) (PowerShell module)
 * [Custom](../Types/Custom)
 
 !!! tip
-    For the SecretManagement module you can read a "getting started" [guide for it here](https://learn.microsoft.com/en-us/powershell/utility-modules/secretmanagement/how-to/using-secrets-in-automation?view=ps-modules) when using the module in automated scenarios.
+    For the SecretManagement module you can read a "getting started" [guide here](https://learn.microsoft.com/en-us/powershell/utility-modules/secretmanagement/how-to/using-secrets-in-automation?view=ps-modules) when using the module in automated scenarios.
+
+### Vault Examples
+
+You can find some quick examples for some vault providers below:
+
+* [SecretStore](../Examples/SecretStore)
+
 
 ### Initialise
 
@@ -59,11 +66,11 @@ Register-PodeSecretVault -Name 'VaultName' -ModuleName 'Az.KeyVault' `
 
 ### Auto-Import
 
-Similar to modules and functions, Pode will auto-import any secret vaults registered outside of vault. You can find more [information here](../../Scoping#secret-vaults)
+Similar to modules and functions, Pode will auto-import any secret vaults registered outside of Pode. You can find more [information here](../../Scoping#secret-vaults)
 
 ### Unlock
 
-Some vaults require unlocking first, or an authorization token to be be acquired to access the vault. Unlocking applies to all registration types, and to configure unlocking for use you'll first need to supply either an `-UnlockSecret` or an `-UnlockSecureSecret` to [`Register-PodeSecretVault`](../../../Functions/Secrets/Register-PodeSecretVault).
+Some vaults require unlocking first, or an authorization token to be acquired to access the vault. Unlocking applies to all registration types, and to configure unlocking for use you'll first need to supply either an `-UnlockSecret` or an `-UnlockSecureSecret` to [`Register-PodeSecretVault`](../../../Functions/Secrets/Register-PodeSecretVault).
 
 !!! important
     If you're using a custom registration type, you'll also need to supply an `-UnlockScriptBlock`.
@@ -86,7 +93,7 @@ Pode will automatically call the unlock logic after registration, but you can st
 Unlock-PodeSecretVault -Name 'VaultName'
 ```
 
-If you need to periodically check/unlock your vault, then Pode can do this automatically for you. To achieve this you can supply a number of minutes for the `-UnlockInterval` parameter on [`Register-PodeSecretVault`](../../../Functions/Secrets/Register-PodeSecretVault), this will tell Pode to automatically check/unlock the vault after the first unlock as occurred.
+If you need to periodically check/unlock your vault, then Pode can do this automatically for you. To achieve this you can supply a number of minutes for the `-UnlockInterval` parameter on [`Register-PodeSecretVault`](../../../Functions/Secrets/Register-PodeSecretVault), this will tell Pode to automatically check/unlock the vault after the first unlock has occurred.
 
 ## Mounting
 
@@ -98,7 +105,7 @@ Mount-PodeSecret -Name 'SecretName' -Vault 'VaultName' -Key 'SecretKeyNameInVaul
 
 The `-Name` is the name of the secret you'll be using to reference the secret throughout Pode. The `-Vault` parameter is the name of the vault from [`Register-PodeSecretVault`](../../../Functions/Secrets/Register-PodeSecretVault), and the `-Key` is the path/name of the secret within the vault itself.
 
-Some secrets will be returned as hashtables - such as from HashiCorp Vault. In some cases you might only want certain properties to be returned from this secret, and you can limit the properties returned by using the `-Property` parameter. For example, if a secret has 5 keys named key1 to key5, you can limit this to just key2 and key4:
+Some secrets will be returned as hashtables - such as from HashiCorp Vault. In some cases, you might only want certain properties to be returned from this secret, and you can limit the properties returned by using the `-Property` parameter. For example, if a secret has 5 keys named key1 to key5, you can limit this to just key2 and key4:
 
 ```powershell
 Mount-PodeSecret -Name 'SecretName' -Vault 'VaultName' -Key 'SecretKeyNameInVault' -Property key2, key4
@@ -149,11 +156,11 @@ Add-PodeRoute -Method Post -Path '/secret' -ScriptBlock {
 ### Caching
 
 !!! important
-    The cache is an in-memory in-application cache, and is unencrypted. It is never stored to disk, and cached values are wiped once their expiry is up; the cache is also wiped when the server is stopped.
+    The cache is an in-memory in-application cache, and is unencrypted. It is never stored on disk, and cached values are wiped once their expiry is up; the cache is also wiped when the server is stopped.
 
 To reduce round-trip time by constantly going to a vault, as well as to reduce stress on a vault, you can optionally enable caching on secrets - the cache by default is disabled.
 
-You can either supply a `-CacheTtl` as a number of minutes to [`Register-PodeSecretVault`](../../../Functions/Secrets/Register-PodeSecretVault), and all secrets mounted will be cached. Or you can supply a `-CacheTtl` only to specific mounted secrets - you can also use this option to disable caching for a secret, by supplying a value of 0, even if the vault itself is registered with a cache TTL.
+You can either supply a `-CacheTtl` as a number of minutes to [`Register-PodeSecretVault`](../../../Functions/Secrets/Register-PodeSecretVault) and all secrets mounted will be cached. Or you can supply a `-CacheTtl` only to specific mounted secrets - you can also use this option to disable caching for a secret, by supplying a value of 0, even if the vault itself is registered with a cache TTL.
 
 To enable caching for all mounted secrets from a vault - but with one disabled, and one overriding:
 
@@ -192,11 +199,11 @@ Mount-PodeSecret -Name 'SecretName2' -Vault 'VaultName' -Key 'SecretKeyNameInVau
 
 ## Adhoc
 
-There is also support for creating/updating, retrieving, and removing secrets in an adhoc manor from registered vaults - without having to mount them.
+There is also support for creating/updating, retrieving, and removing secrets in an adhoc manner from registered vaults - without having to mount them.
 
 ### Create
 
-To create a new secret, and well as update an existing ones value, you can use [`Set-PodeSecret`](../../../Functions/Secrets/Set-PodeSecret):
+To create a new secret, as well as update an existing value, you can use [`Set-PodeSecret`](../../../Functions/Secrets/Set-PodeSecret):
 
 ```powershell
 Add-PodeRoute -Method Post -Path '/adhoc/:key' -ScriptBlock {
@@ -220,7 +227,7 @@ Add-PodeRoute -Method Get -Path '/adhoc/:key' -ScriptBlock {
 
 ### Remove
 
-And to then remove the secret from the vault you can use [`Remove-PodeSecret`](../../../Functions/Secrets/Remove-PodeSecret):
+To remove the secret from the vault you can use [`Remove-PodeSecret`](../../../Functions/Secrets/Remove-PodeSecret):
 
 ```powershell
 Add-PodeRoute -Method Delete -Path '/adhoc/:key' -ScriptBlock {

--- a/docs/Tutorials/Timers.md
+++ b/docs/Tutorials/Timers.md
@@ -15,7 +15,7 @@ Add-PodeTimer -Name 'date' -Interval 5 -ScriptBlock {
 }
 ```
 
-Usually all timers are created within the main `Start-PodeServer` scope, however it is possible to create adhoc timers with routes/etc. If you create adhoc timers in this manor, you might notice that they don't run; this is because the Runspace that timers use to run won't have been configured. You can configure by using `-EnablePool` on [`Start-PodeServer`](../../Functions/Core/Start-PodeServer):
+Usually all timers are created within the main `Start-PodeServer` scope, however it is possible to create adhoc timers with routes/etc. If you create adhoc timers in this manner, you might notice that they don't run; this is because the Runspace that timers use to run won't have been configured. You can configure by using `-EnablePool` on [`Start-PodeServer`](../../Functions/Core/Start-PodeServer):
 
 ```powershell
 Start-PodeServer -EnablePool Timers {
@@ -136,16 +136,16 @@ Invoke-PodeTimer -Name 'date' -ArgumentList 'Arg1', 'Arg2'
 
 The following is the structure of the Timer object internally, as well as the object that is returned from [`Get-PodeTimer`](../../Functions/Timers/Get-PodeTimer):
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| Name | string | The name of the Timer |
-| Interval | int | How often the Timer runs, defined in seconds |
-| Limit | int | The number of times the Timer should run - 0 if running forever |
-| Skip | int | The number of times the Timer should skip being triggered |
-| Count | int | The number of times the Timer has run |
-| LastTriggerTime | datetime | The datetime the Timer was last triggered |
-| NextTriggerTime | datetime | The datetime the Timer will next be triggered |
-| Script | scriptblock | The scriptblock of the Timer |
-| Arguments | object[] | The arguments supplied from ArgumentList |
-| OnStart | bool | Should the Timer run once when the server is starting, or once the server has fully loaded |
-| Completed | bool | Has the Timer completed all of its runs |
+| Name            | Type        | Description                                                                                |
+| --------------- | ----------- | ------------------------------------------------------------------------------------------ |
+| Name            | string      | The name of the Timer                                                                      |
+| Interval        | int         | How often the Timer runs, defined in seconds                                               |
+| Limit           | int         | The number of times the Timer should run - 0 if running forever                            |
+| Skip            | int         | The number of times the Timer should skip being triggered                                  |
+| Count           | int         | The number of times the Timer has run                                                      |
+| LastTriggerTime | datetime    | The datetime the Timer was last triggered                                                  |
+| NextTriggerTime | datetime    | The datetime the Timer will next be triggered                                              |
+| Script          | scriptblock | The scriptblock of the Timer                                                               |
+| Arguments       | object[]    | The arguments supplied from ArgumentList                                                   |
+| OnStart         | bool        | Should the Timer run once when the server is starting, or once the server has fully loaded |
+| Completed       | bool        | Has the Timer completed all of its runs                                                    |

--- a/examples/server.psd1
+++ b/examples/server.psd1
@@ -40,11 +40,16 @@
             }
         }
         AutoImport  = @{
-            Functions = @{
+            Functions    = @{
                 ExportOnly = $true
             }
-            Modules   = @{
+            Modules      = @{
                 ExportOnly = $true
+            }
+            SecretVaults = @{
+                SecretManagement = @{
+                    ExportOnly = $true
+                }
             }
         }
         Request     = @{

--- a/examples/web-secrets-local.ps1
+++ b/examples/web-secrets-local.ps1
@@ -1,0 +1,55 @@
+$path = Split-Path -Parent -Path (Split-Path -Parent -Path $MyInvocation.MyCommand.Path)
+Import-Module "$($path)/src/Pode.psm1" -Force -ErrorAction Stop
+
+# or just:
+# Import-Module Pode
+
+# make sure to install the Microsoft.PowerShell.SecretStore modules!
+# Install-Module Microsoft.PowerShell.SecretManagement, Microsoft.PowerShell.SecretStore
+
+Start-PodeServer -Threads 2 {
+    # listen
+    Add-PodeEndpoint -Address * -Port 8080 -Protocol Http
+
+    # logging
+    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+
+
+    # secret manage local vault
+    $params = @{
+        Name         = 'PodeTest_LocalVault'
+        ModuleName   = 'Microsoft.PowerShell.SecretStore'
+        UnlockSecret = 'Sup3rSecur3Pa$$word!'
+    }
+
+    Register-PodeSecretVault @params
+
+
+    # set a secret in the local vault
+    Set-PodeSecret -Key 'hello' -Vault 'PodeTest_LocalVault' -InputObject 'world'
+
+
+    # mount a secret from local vault
+    Mount-PodeSecret -Name 'hello' -Vault 'PodeTest_LocalVault' -Key 'hello'
+
+
+    # routes to get/update secret in local vault
+    Add-PodeRoute -Method Get -Path '/module' -ScriptBlock {
+        Write-PodeJsonResponse @{ Value = $secret:hello }
+    }
+
+    Add-PodeRoute -Method Post -Path '/module' -ScriptBlock {
+        $secret:hello = $WebEvent.Data.Value
+    }
+
+
+    Add-PodeRoute -Method Post -Path '/adhoc/:key' -ScriptBlock {
+        Set-PodeSecret -Key $WebEvent.Parameters['key'] -Vault 'PodeTest_LocalVault' -InputObject $WebEvent.Data['value']
+        Mount-PodeSecret -Name $WebEvent.Data['name'] -Vault 'PodeTest_LocalVault' -Key $WebEvent.Parameters['key']
+    }
+
+    Add-PodeRoute -Method Delete -Path '/adhoc/:key' -ScriptBlock {
+        Remove-PodeSecret -Key $WebEvent.Parameters['key'] -Vault 'PodeTest_LocalVault'
+        Dismount-PodeSecret -Name $WebEvent.Parameters['key']
+    }
+}

--- a/src/Private/Secrets.ps1
+++ b/src/Private/Secrets.ps1
@@ -36,13 +36,83 @@ function Register-PodeSecretManagementVault {
     $null = Import-Module -Name Microsoft.PowerShell.SecretManagement -Force -DisableNameChecking -Scope Global -ErrorAction Stop -Verbose:$false
     $null = Import-Module -Name $ModuleName -Force -DisableNameChecking -Scope Global -ErrorAction Stop -Verbose:$false
 
+    # export the modules for pode
+    Export-PodeModule -Name @('Microsoft.PowerShell.SecretManagement', $ModuleName)
+
+    # is this the local SecretStore provider?
+    $isSecretStore = ($ModuleName -ieq 'Microsoft.PowerShell.SecretStore')
+
+    # check if we have an unlock password for local secret store
+    if ($isSecretStore) {
+        if ([string]::IsNullOrEmpty($VaultConfig.Unlock.Secret)) {
+            throw 'An "-UnlockSecret" is required when using Microsoft.PowerShell.SecretStore'
+        }
+    }
+
+    # does the local secret store already exist?
+    $secretStoreExists = ($isSecretStore -and (Test-PodeSecretVaultInternal -Name $VaultName))
+
+    # do we have vault params?
+    $hasVaultParams = ($null -ne $VaultConfig.Parameters)
+
     # attempt to register the vault
-    $null = Register-SecretVault -Name $VaultName -ModuleName $ModuleName -VaultParameters $VaultConfig.Parameters -Confirm:$false -AllowClobber -ErrorAction Stop
+    $registerParams = @{
+        Name         = $VaultName
+        ModuleName   = $ModuleName
+        Confirm      = $false
+        AllowClobber = $true
+        ErrorAction  = 'Stop'
+    }
+
+    if (!$isSecretStore -and $hasVaultParams) {
+        $registerParams['VaultParameters'] = $VaultConfig.Parameters
+    }
+
+    $null = Register-SecretVault @registerParams
 
     # all is good, so set the config
     $VaultConfig['SecretManagement'] = @{
         VaultName  = $VaultName
         ModuleName = $ModuleName
+    }
+
+    # set local secret store config
+    if ($isSecretStore) {
+        if (!$hasVaultParams) {
+            $VaultConfig.Parameters = @{}
+        }
+
+        $vaultParams = $VaultConfig.Parameters
+
+        # remove the password
+        $vaultParams.Remove('Password')
+
+        # set default authentication and interaction flags
+        if ([string]::IsNullOrEmpty($vaultParams.Authentication)) {
+            $vaultParams['Authentication'] = 'Password'
+        }
+
+        if ([string]::IsNullOrEmpty($vaultParams.Interaction)) {
+            $vaultParams['Interaction'] = 'None'
+        }
+
+        # set default password timeout and unlock interval to 1 minute
+        if ($VaultConfig.Unlock.Interval -le 0) {
+            $VaultConfig.Unlock.Interval = 1
+        }
+
+        # unlock the vault, and set password
+        $VaultConfig | Unlock-PodeSecretManagementVault
+
+        # set the password timeout for the vault
+        if (!$secretStoreExists) {
+            if ($VaultConfig.Parameters.PasswordTimeout -le 0) {
+                $vaultParams['PasswordTimeout'] = ($VaultConfig.Unlock.Interval * 60) + 10
+            }
+        }
+
+        # set config
+        $null = Set-SecretStoreConfiguration @vaultParams -Confirm:$false -ErrorAction Stop
     }
 }
 
@@ -129,10 +199,10 @@ function Unlock-PodeSecretCustomVault {
     }
 
     # unlock the vault, and get back an expiry
-    $expiry = (Invoke-PodeScriptBlock -ScriptBlock $VaultConfig.Custom.Unlock -Splat -Return -Arguments @(
-            $VaultConfig.Parameters,
+    $expiry = Invoke-PodeScriptBlock -ScriptBlock $VaultConfig.Custom.Unlock -Splat -Return -Arguments @(
+        $VaultConfig.Parameters,
         (ConvertFrom-SecureString -SecureString $VaultConfig.Unlock.Secret -AsPlainText)
-        ))
+    )
 
     # return expiry if given, otherwise check interval
     if ($null -ne $expiry) {
@@ -222,10 +292,10 @@ function Get-PodeSecretCustomKey {
     $_vault = $PodeContext.Server.Secrets.Vaults[$Vault]
 
     # fetch the secret
-    return (Invoke-PodeScriptBlock -ScriptBlock $_vault.Custom.Read -Splat -Return -Arguments (@(
-                $_vault.Parameters,
-                $Key
-            ) + $ArgumentList))
+    return Invoke-PodeScriptBlock -ScriptBlock $_vault.Custom.Read -Splat -Return -Arguments (@(
+            $_vault.Parameters,
+            $Key
+        ) + $ArgumentList)
 }
 
 function Set-PodeSecretManagementKey {
@@ -439,4 +509,14 @@ function Protect-PodeSecretValueType {
     }
 
     return $Value
+}
+
+function Test-PodeSecretVaultInternal {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Name
+    )
+
+    return ($null -ne (Get-SecretVault -Name $Name -ErrorAction Ignore))
 }

--- a/src/Public/AutoImport.ps1
+++ b/src/Public/AutoImport.ps1
@@ -20,6 +20,7 @@ function Export-PodeModule {
     )
 
     $PodeContext.Server.AutoImport.Modules.ExportList += @($Name)
+    $PodeContext.Server.AutoImport.Modules.ExportList = $PodeContext.Server.AutoImport.Modules.ExportList | Sort-Object -Unique
 }
 
 <#
@@ -49,6 +50,7 @@ function Export-PodeSnapin {
     }
 
     $PodeContext.Server.AutoImport.Snapins.ExportList += @($Name)
+    $PodeContext.Server.AutoImport.Snapins.ExportList = $PodeContext.Server.AutoImport.Snapins.ExportList | Sort-Object -Unique
 }
 
 <#
@@ -73,6 +75,7 @@ function Export-PodeFunction {
     )
 
     $PodeContext.Server.AutoImport.Functions.ExportList += @($Name)
+    $PodeContext.Server.AutoImport.Functions.ExportList = $PodeContext.Server.AutoImport.Functions.ExportList | Sort-Object -Unique
 }
 
 <#
@@ -105,4 +108,5 @@ function Export-PodeSecretVault {
     )
 
     $PodeContext.Server.AutoImport.SecretVaults[$Type].ExportList += @($Name)
+    $PodeContext.Server.AutoImport.SecretVaults[$Type].ExportList = $PodeContext.Server.AutoImport.SecretVaults[$Type].ExportList | Sort-Object -Unique
 }

--- a/tests/integration/Authentication.Tests.ps1
+++ b/tests/integration/Authentication.Tests.ps1
@@ -11,7 +11,7 @@ BeforeAll {
 Describe 'Authentication Requests' {
 
     BeforeAll {
-        $Port = 50000
+        $Port = 60000
         $Endpoint = "http://127.0.0.1:$($Port)"
 
         Start-Job -Name 'Pode' -ErrorAction Stop -ScriptBlock {

--- a/tests/integration/Endpoints.Tests.ps1
+++ b/tests/integration/Endpoints.Tests.ps1
@@ -4,10 +4,10 @@ param()
 Describe 'Endpoint Requests' {
 
     BeforeAll {
-        $Port1 = 50000
+        $Port1 = 60000
         $Endpoint1 = "http://127.0.0.1:$($Port1)"
 
-        $Port2 = 50001
+        $Port2 = 60001
         $Endpoint2 = "http://127.0.0.1:$($Port2)"
 
         Start-Job -Name 'Pode' -ErrorAction Stop -ScriptBlock {

--- a/tests/integration/RestApi.Https.Tests.ps1
+++ b/tests/integration/RestApi.Https.Tests.ps1
@@ -45,7 +45,7 @@ public bool CheckValidationResult(
         }
 
 
-        $Port = 50010
+        $Port = 60010
         $Endpoint = "https://127.0.0.1:$($Port)"
 
         Start-Job -Name 'Pode' -ErrorAction Stop -ScriptBlock {

--- a/tests/integration/RestApi.Tests.ps1
+++ b/tests/integration/RestApi.Tests.ps1
@@ -5,7 +5,7 @@ param()
 Describe 'REST API Requests' {
 
     BeforeAll {
-        $Port = 50000
+        $Port = 60000
         $Endpoint = "http://127.0.0.1:$($Port)"
 
         Start-Job -Name 'Pode' -ErrorAction Stop -ScriptBlock {

--- a/tests/integration/Schedules.Tests.ps1
+++ b/tests/integration/Schedules.Tests.ps1
@@ -4,7 +4,7 @@ param()
 Describe 'Schedules' {
 
     BeforeAll {
-        $Port = 50000
+        $Port = 60000
         $Endpoint = "http://127.0.0.1:$($Port)"
 
         Start-Job -Name 'Pode' -ErrorAction Stop -ScriptBlock {

--- a/tests/integration/Sessions.Tests.ps1
+++ b/tests/integration/Sessions.Tests.ps1
@@ -5,7 +5,7 @@ param()
 Describe 'Session Requests' {
 
     BeforeAll {
-        $Port = 50000
+        $Port = 60000
         $Endpoint = "http://127.0.0.1:$($Port)"
 
         Start-Job -Name 'Pode' -ErrorAction Stop -ScriptBlock {

--- a/tests/integration/Timers.Tests.ps1
+++ b/tests/integration/Timers.Tests.ps1
@@ -4,7 +4,7 @@ param()
 Describe 'Timers' {
 
     BeforeAll {
-        $Port = 50000
+        $Port = 60000
         $Endpoint = "http://127.0.0.1:$($Port)"
 
         Start-Job -Name 'Pode' -ErrorAction Stop -ScriptBlock {

--- a/tests/integration/WebPages.Tests.ps1
+++ b/tests/integration/WebPages.Tests.ps1
@@ -3,7 +3,7 @@ param()
 Describe 'Web Page Requests' {
 
     BeforeAll {
-        $Port = 50000
+        $Port = 60000
         $Endpoint = "http://127.0.0.1:$($Port)"
 
         Start-Job -Name 'Pode' -ErrorAction Stop -ScriptBlock {


### PR DESCRIPTION
### Description of the Change
* Resolves a threading issue with secrets and vaults by creating a Lockable per vault, and adding `Lock-PodeObject` wrappers to Get, Set, Read, Update, Remove, and Unlock functions.
* Adds inbuilt defaults when using the SecretStore secret vault provider, so it can be more easily used.
* Adds documentation for SecretStore, and flags that `-UnlockSecret` is mandatory.

### Related Issue
Resolves #1180 
Resolves #1250 

### Examples
```powershell
Start-PodeServer -Threads 2 {
    Add-PodeEndpoint -Address * -Port 8080 -Protocol Http

    # register the vault
    Register-PodeSecretVault `
        -Name 'ExampleVault' `
        -ModuleName 'Microsoft.PowerShell.SecretStore' `
        -UnlockSecret 'Sup3rSecur3Pa$$word!'

    # set a secret in the local vault
    Set-PodeSecret -Key 'example' -Vault 'ExampleVault' -InputObject 'hello, world!'

    # mount the "example" secret from local vault, making it accessible via $secret:example
    Mount-PodeSecret -Name 'example' -Vault 'ExampleVault' -Key 'example'

    # retrieve the secret in a route
    Add-PodeRoute -Method Get -Path '/' -ScriptBlock {
        Write-PodeJsonResponse @{ Value = $secret:example }
    }

    # update the secret in a route
    Add-PodeRoute -Method Post -Path '/' -ScriptBlock {
        $secret:example = $WebEvent.Data.Value
    }
}
```
