### PR TITLE
Ported a more concise and stable version of the PowerShell installer for workflows; Bumps InvokeBuild to 5.11.1

### DIFF
--- a/.github/workflows/ci-coverage.yml
+++ b/.github/workflows/ci-coverage.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Install Invoke-Build
       shell: pwsh
       run: |
-        Install-Module -Name InvokeBuild -RequiredVersion '5.10.5' -Force
+        Install-Module -Name InvokeBuild -RequiredVersion '5.11.1' -Force
 
     - name: Run Pester Tests
       shell: pwsh

--- a/.github/workflows/ci-coverage.yml
+++ b/.github/workflows/ci-coverage.yml
@@ -9,6 +9,9 @@ on:
     branches:
     - '*'
 
+env:
+  INVOKE_BUILD_VERSION: '5.11.1'
+
 jobs:
   build:
 
@@ -30,7 +33,7 @@ jobs:
     - name: Install Invoke-Build
       shell: pwsh
       run: |
-        Install-Module -Name InvokeBuild -RequiredVersion '5.11.1' -Force
+        Install-Module -Name InvokeBuild -RequiredVersion $env:INVOKE_BUILD_VERSION -Force
 
     - name: Run Pester Tests
       shell: pwsh

--- a/.github/workflows/ci-powershell.yml
+++ b/.github/workflows/ci-powershell.yml
@@ -9,6 +9,9 @@ on:
     branches:
     - '*'
 
+env:
+  INVOKE_BUILD_VERSION: '5.11.1'
+
 jobs:
   build:
 
@@ -34,7 +37,7 @@ jobs:
       shell: powershell
       run: |
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-        Install-Module -Name InvokeBuild -RequiredVersion '5.11.1' -Force
+        Install-Module -Name InvokeBuild -RequiredVersion $env:INVOKE_BUILD_VERSION -Force
 
     - name: Run Pester Tests
       shell: powershell

--- a/.github/workflows/ci-powershell.yml
+++ b/.github/workflows/ci-powershell.yml
@@ -34,7 +34,7 @@ jobs:
       shell: powershell
       run: |
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-        Install-Module -Name InvokeBuild -RequiredVersion '5.10.5' -Force
+        Install-Module -Name InvokeBuild -RequiredVersion '5.11.1' -Force
 
     - name: Run Pester Tests
       shell: powershell

--- a/.github/workflows/ci-pwsh7_2.yml
+++ b/.github/workflows/ci-pwsh7_2.yml
@@ -9,6 +9,10 @@ on:
     branches:
     - '*'
 
+env:
+  INVOKE_BUILD_VERSION: '5.11.1'
+  POWERSHELL_VERSION: '7.2.19'
+
 jobs:
   build:
 
@@ -22,25 +26,34 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Setup Powershell
-      uses: bjompen/UpdatePWSHAction@v1.0.0
-      with:
-        FixedVersion: '7.2.18'
-
-    - name: Check PowerShell version
-      shell: pwsh
-      run: |
-        $PSVersionTable.PSVersion
-
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 8.0.x
 
+    - name: Setup Powershell - Unix
+      shell: pwsh
+      if: runner.os == 'Linux' || runner.os == 'macOS'
+      run: |
+        Install-Module -Name InvokeBuild -RequiredVersion $env:INVOKE_BUILD_VERSION -Force
+        Invoke-Build SetupPowerShell -PowerShellVersion $env:POWERSHELL_VERSION
+
+    - name: Setup Powershell - Windows
+      shell: PowerShell
+      if: runner.os == 'Windows'
+      run: |
+        Install-Module -Name InvokeBuild -RequiredVersion $env:INVOKE_BUILD_VERSION -Force
+        Invoke-Build SetupPowerShell -PowerShellVersion $env:POWERSHELL_VERSION
+
+    - name: Output PowerShell version
+      shell: pwsh
+      run: |
+        $PSVersionTable.PSVersion
+
     - name: Install Invoke-Build
       shell: pwsh
       run: |
-        Install-Module -Name InvokeBuild -RequiredVersion '5.11.1' -Force
+        Install-Module -Name InvokeBuild -RequiredVersion $env:INVOKE_BUILD_VERSION -Force
 
     - name: Run Pester Tests
       shell: pwsh

--- a/.github/workflows/ci-pwsh7_2.yml
+++ b/.github/workflows/ci-pwsh7_2.yml
@@ -39,8 +39,8 @@ jobs:
 
     - name: Install Invoke-Build
       shell: pwsh
-      run: | 
-        Install-Module -Name InvokeBuild -RequiredVersion '5.10.5' -Force
+      run: |
+        Install-Module -Name InvokeBuild -RequiredVersion '5.11.1' -Force
 
     - name: Run Pester Tests
       shell: pwsh

--- a/.github/workflows/ci-pwsh7_3.yml
+++ b/.github/workflows/ci-pwsh7_3.yml
@@ -9,6 +9,10 @@ on:
     branches:
     - '*'
 
+env:
+  INVOKE_BUILD_VERSION: '5.11.1'
+  POWERSHELL_VERSION: '7.3.12'
+
 jobs:
   build:
 
@@ -22,25 +26,34 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Setup Powershell
-      uses: bjompen/UpdatePWSHAction@v1.0.0
-      with:
-        FixedVersion: '7.3.11'
-
-    - name: Check PowerShell version
-      shell: pwsh
-      run: |
-        $PSVersionTable.PSVersion
-
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 8.0.x
 
+    - name: Setup Powershell - Unix
+      shell: pwsh
+      if: runner.os == 'Linux' || runner.os == 'macOS'
+      run: |
+        Install-Module -Name InvokeBuild -RequiredVersion $env:INVOKE_BUILD_VERSION -Force
+        Invoke-Build SetupPowerShell -PowerShellVersion $env:POWERSHELL_VERSION
+
+    - name: Setup Powershell - Windows
+      shell: PowerShell
+      if: runner.os == 'Windows'
+      run: |
+        Install-Module -Name InvokeBuild -RequiredVersion $env:INVOKE_BUILD_VERSION -Force
+        Invoke-Build SetupPowerShell -PowerShellVersion $env:POWERSHELL_VERSION
+
+    - name: Output PowerShell version
+      shell: pwsh
+      run: |
+        $PSVersionTable.PSVersion
+
     - name: Install Invoke-Build
       shell: pwsh
       run: |
-        Install-Module -Name InvokeBuild -RequiredVersion '5.11.1' -Force
+        Install-Module -Name InvokeBuild -RequiredVersion $env:INVOKE_BUILD_VERSION -Force
 
     - name: Run Pester Tests
       shell: pwsh

--- a/.github/workflows/ci-pwsh7_3.yml
+++ b/.github/workflows/ci-pwsh7_3.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Install Invoke-Build
       shell: pwsh
       run: |
-        Install-Module -Name InvokeBuild -RequiredVersion '5.10.5' -Force
+        Install-Module -Name InvokeBuild -RequiredVersion '5.11.1' -Force
 
     - name: Run Pester Tests
       shell: pwsh

--- a/.github/workflows/ci-pwsh_lts.yml
+++ b/.github/workflows/ci-pwsh_lts.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Install Invoke-Build
       shell: pwsh
       run: |
-        Install-Module -Name InvokeBuild -RequiredVersion '5.10.5' -Force
+        Install-Module -Name InvokeBuild -RequiredVersion '5.11.1' -Force
 
     - name: Run Pester Tests
       shell: pwsh
@@ -49,5 +49,5 @@ jobs:
 
     - name: Test docker builds
       shell: pwsh
-      run: | 
+      run: |
         Invoke-Build DockerPack -Version '0.0.0'

--- a/.github/workflows/ci-pwsh_lts.yml
+++ b/.github/workflows/ci-pwsh_lts.yml
@@ -9,6 +9,10 @@ on:
     branches:
     - '*'
 
+env:
+  INVOKE_BUILD_VERSION: '5.11.1'
+  POWERSHELL_VERSION: 'lts'
+
 jobs:
   build:
 
@@ -22,25 +26,34 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Setup Powershell
-      uses: bjompen/UpdatePWSHAction@v1.0.0
-      with:
-        ReleaseVersion: 'lts'
-
-    - name: Check PowerShell version
-      shell: pwsh
-      run: |
-        $PSVersionTable.PSVersion
-
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 8.0.x
 
+    - name: Setup Powershell - Unix
+      shell: pwsh
+      if: runner.os == 'Linux' || runner.os == 'macOS'
+      run: |
+        Install-Module -Name InvokeBuild -RequiredVersion $env:INVOKE_BUILD_VERSION -Force
+        Invoke-Build SetupPowerShell -PowerShellVersion $env:POWERSHELL_VERSION
+
+    - name: Setup Powershell - Windows
+      shell: PowerShell
+      if: runner.os == 'Windows'
+      run: |
+        Install-Module -Name InvokeBuild -RequiredVersion $env:INVOKE_BUILD_VERSION -Force
+        Invoke-Build SetupPowerShell -PowerShellVersion $env:POWERSHELL_VERSION
+
+    - name: Output PowerShell version
+      shell: pwsh
+      run: |
+        $PSVersionTable.PSVersion
+
     - name: Install Invoke-Build
       shell: pwsh
       run: |
-        Install-Module -Name InvokeBuild -RequiredVersion '5.11.1' -Force
+        Install-Module -Name InvokeBuild -RequiredVersion $env:INVOKE_BUILD_VERSION -Force
 
     - name: Run Pester Tests
       shell: pwsh

--- a/.github/workflows/ci-pwsh_preview.yml
+++ b/.github/workflows/ci-pwsh_preview.yml
@@ -9,6 +9,10 @@ on:
     branches:
     - '*'
 
+env:
+  INVOKE_BUILD_VERSION: '5.11.1'
+  POWERSHELL_VERSION: 'Preview'
+
 jobs:
   build:
 
@@ -22,16 +26,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    # - name: Setup Powershell
-    #   uses: bjompen/UpdatePWSHAction@v1.0.0
-    #   with:
-    #     ReleaseVersion: 'Preview'
-
-    # - name: Check PowerShell version
-    #   shell: pwsh
-    #   run: |
-    #     $PSVersionTable.PSVersion
-
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
@@ -41,15 +35,15 @@ jobs:
       shell: pwsh
       if: runner.os == 'Linux' || runner.os == 'macOS'
       run: |
-        Install-Module -Name InvokeBuild -RequiredVersion '5.11.1' -Force
-        Invoke-Build SetupPowerShell -PowerShellVersion 'Preview'
+        Install-Module -Name InvokeBuild -RequiredVersion $env:INVOKE_BUILD_VERSION -Force
+        Invoke-Build SetupPowerShell -PowerShellVersion $env:POWERSHELL_VERSION
 
     - name: Setup Powershell - Windows
       shell: PowerShell
       if: runner.os == 'Windows'
       run: |
-        Install-Module -Name InvokeBuild -RequiredVersion '5.11.1' -Force
-        Invoke-Build SetupPowerShell -PowerShellVersion 'Preview'
+        Install-Module -Name InvokeBuild -RequiredVersion $env:INVOKE_BUILD_VERSION -Force
+        Invoke-Build SetupPowerShell -PowerShellVersion $env:POWERSHELL_VERSION
 
     - name: Output PowerShell version
       shell: pwsh
@@ -59,7 +53,7 @@ jobs:
     - name: Install Invoke-Build
       shell: pwsh
       run: |
-        Install-Module -Name InvokeBuild -RequiredVersion '5.11.1' -Force
+        Install-Module -Name InvokeBuild -RequiredVersion $env:INVOKE_BUILD_VERSION -Force
 
     - name: Run Pester Tests
       shell: pwsh

--- a/.github/workflows/ci-pwsh_preview.yml
+++ b/.github/workflows/ci-pwsh_preview.yml
@@ -22,25 +22,44 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Setup Powershell
-      uses: bjompen/UpdatePWSHAction@v1.0.0
-      with:
-        ReleaseVersion: 'Preview'
+    # - name: Setup Powershell
+    #   uses: bjompen/UpdatePWSHAction@v1.0.0
+    #   with:
+    #     ReleaseVersion: 'Preview'
 
-    - name: Check PowerShell version
-      shell: pwsh
-      run: |
-        $PSVersionTable.PSVersion
+    # - name: Check PowerShell version
+    #   shell: pwsh
+    #   run: |
+    #     $PSVersionTable.PSVersion
 
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 8.0.x
 
+    - name: Setup Powershell - Unix
+      shell: pwsh
+      if: runner.os == 'Linux' || runner.os == 'macOS'
+      run: |
+        Install-Module -Name InvokeBuild -RequiredVersion '5.11.1' -Force
+        Invoke-Build SetupPowerShell -PowerShellVersion 'Preview'
+
+    - name: Setup Powershell - Windows
+      shell: PowerShell
+      if: runner.os == 'Windows'
+      run: |
+        Install-Module -Name InvokeBuild -RequiredVersion '5.11.1' -Force
+        Invoke-Build SetupPowerShell -PowerShellVersion 'Preview'
+
+    - name: Output PowerShell version
+      shell: pwsh
+      run: |
+        $PSVersionTable.PSVersion
+
     - name: Install Invoke-Build
       shell: pwsh
       run: |
-        Install-Module -Name InvokeBuild -RequiredVersion '5.10.5' -Force
+        Install-Module -Name InvokeBuild -RequiredVersion '5.11.1' -Force
 
     - name: Run Pester Tests
       shell: pwsh

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -871,7 +871,7 @@ SECTION 2: BSD-STYLE, MIT-STYLE, OR SIMILAR STYLE LICENSES
 
         ADDITIONAL LICENSE INFORMATION
         name: swagger-ui
-        version: 5.10.5
+        version: 5.11.1
         contributors (in alphabetical order) :
             Anna Bodnia <anna.bodnia@gmail.com>
             Buu Nguyen <buunguyen@gmail.com>

--- a/pode.build.ps1
+++ b/pode.build.ps1
@@ -678,7 +678,7 @@ Task SetupPowerShell {
 
     # is the version valid?
     $tags = @('preview', 'lts', 'daily', 'stable')
-    if (($PowerShellVersion -inotin $tags) -or ($PowerShellVersion -inotmatch '^\d+\.\d+\.\d+(-\w+(\.\d+)?)?$')) {
+    if (($PowerShellVersion -inotin $tags) -and ($PowerShellVersion -inotmatch '^\d+\.\d+\.\d+(-\w+(\.\d+)?)?$')) {
         throw "Invalid PowerShell version supplied: $($PowerShellVersion)"
     }
 

--- a/pode.build.ps1
+++ b/pode.build.ps1
@@ -222,6 +222,10 @@ function Install-PodeBuildPwshUnix($target) {
     & $sudo ln -fs $targetFullPath $symlink
 }
 
+function Get-PodeBuildCurrentPwshVersion {
+    return ("$(pwsh -v)" -split ' ')[1].Trim()
+}
+
 
 <#
 # Helper Tasks
@@ -702,8 +706,10 @@ Task SetupPowerShell {
     $baseVersion = $atoms[0]
 
     # do nothing if the current version is the version we're trying to set up
-    Write-Host "Current PowerShell version: $($PSVersionTable.PSVersion)"
-    if ($baseVersion -ieq $PSVersionTable.PSVersion.ToString()) {
+    $currentVersion = Get-PodeBuildCurrentPwshVersion
+    Write-Host "Current PowerShell version: $($currentVersion)"
+
+    if ($baseVersion -ieq $currentVersion) {
         Write-Host "PowerShell version $($PowerShellVersion) is already installed"
         return
     }

--- a/pode.build.ps1
+++ b/pode.build.ps1
@@ -176,6 +176,7 @@ function Get-PodeBuildOSPwshArchitecture {
         'x86_64' { return 'x64' }
         'armv7*' { return 'arm32' }
         'aarch64*' { return 'arm64' }
+        'arm64' { return 'arm64' }
         'arm64*' { return 'arm64' }
         'armv8*' { return 'arm64' }
         default { throw "Unsupported architecture: $($arch)" }
@@ -690,7 +691,7 @@ Task SetupPowerShell {
     # base/prefix versions
     $atoms = $PowerShellVersion -split '\-'
     $baseVersion = $atoms[0]
-    $prefixVersion = $atoms[1]
+    # $prefixVersion = $atoms[1]
 
     # do nothing if the current version is the version we're trying to set up
     if ($baseVersion -ieq $PSVersionTable.PSVersion.ToString()) {
@@ -709,10 +710,10 @@ Task SetupPowerShell {
         })[$os]
 
     # build the blob name
-    $blobName = $baseVersion -replace '\.', '-'
-    if (![string]::IsNullOrEmpty($prefixVersion)) {
-        $blobName += "-$($prefixVersion)"
-    }
+    $blobName = "v$($PowerShellVersion -replace '\.', '-')"
+    # if (![string]::IsNullOrEmpty($prefixVersion)) {
+    #     $blobName += "-$($prefixVersion)"
+    # }
 
     # download the package to a temp location
     $outputFile = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath $packageName
@@ -723,6 +724,10 @@ Task SetupPowerShell {
     }
 
     # https://pscoretestdata.blob.core.windows.net/v7-5-0-preview-2/PowerShell-7.5.0-preview.2-win-arm64.zip
+
+    # https://pscoretestdata.blob.core.windows.net/7-5-0-preview.2/powershell-7.5.0-preview.2-linux-x64.tar.gz
+    # https://pscoretestdata.blob.core.windows.net/7-5-0-preview.2/PowerShell-7.5.0-preview.2-win-x64.zip
+
     # https://pscoretestdata.blob.core.windows.net/7-5/PowerShell-7.5.0-preview.2-win-x64.zip
 
     Write-Host "Downloading $($packageName) from $($downloadParams.Uri)"

--- a/pode.build.ps1
+++ b/pode.build.ps1
@@ -421,7 +421,13 @@ Task TestNoBuild TestDeps, {
         Import-Module Pester -Force -RequiredVersion $Versions.Pester
     }
 
+    # for windows, output current netsh excluded ports
+    if (Test-PodeBuildIsWindows) {
+        netsh int ipv4 show excludedportrange protocol=tcp | Out-Default
+    }
+
     $Script:TestResultFile = "$($pwd)/TestResults.xml"
+
     # get default from static property
     $configuration = [PesterConfiguration]::Default
     $configuration.run.path = @('./tests/unit', './tests/integration')
@@ -429,15 +435,16 @@ Task TestNoBuild TestDeps, {
     $configuration.TestResult.OutputFormat = 'NUnitXml'
     $configuration.Output.Verbosity = $PesterVerbosity
     $configuration.TestResult.OutputPath = $Script:TestResultFile
+
     # if run code coverage if enabled
     if (Test-PodeBuildCanCodeCoverage) {
         $srcFiles = (Get-ChildItem "$($pwd)/src/*.ps1" -Recurse -Force).FullName
         $configuration.CodeCoverage.Enabled = $true
         $configuration.CodeCoverage.Path = $srcFiles
-        $Script:TestStatus = Invoke-Pester   -Configuration $configuration
+        $Script:TestStatus = Invoke-Pester -Configuration $configuration
     }
     else {
-        $Script:TestStatus = Invoke-Pester  -Configuration $configuration
+        $Script:TestStatus = Invoke-Pester -Configuration $configuration
     }
 }, PushCodeCoverage, CheckFailedTests
 

--- a/pode.build.ps1
+++ b/pode.build.ps1
@@ -167,9 +167,6 @@ function Get-PodeBuildOSPwshArchitecture {
     # unix
     if ($IsLinux -or $IsMacOS) {
         $arch = uname -m
-        switch -Wildcard ($uname) {
-            default { throw "Unsupported architecture: $uname" }
-        }
     }
 
     # convert to pwsh arch
@@ -691,7 +688,7 @@ Task SetupPowerShell {
     Write-Host "Release version: $($PowerShellVersion)"
 
     # base/prefix versions
-    $atoms = $PowerShellVersion -split '\.'
+    $atoms = $PowerShellVersion -split '\-'
     $baseVersion = $atoms[0]
     $prefixVersion = $atoms[1]
 
@@ -724,6 +721,9 @@ Task SetupPowerShell {
         OutFile     = $outputFile
         ErrorAction = 'Stop'
     }
+
+    # https://pscoretestdata.blob.core.windows.net/v7-5-0-preview-2/PowerShell-7.5.0-preview.2-win-arm64.zip
+    # https://pscoretestdata.blob.core.windows.net/7-5/PowerShell-7.5.0-preview.2-win-x64.zip
 
     Write-Host "Downloading $($packageName) from $($downloadParams.Uri)"
     Write-Host "Output file: $($outputFile)"

--- a/pode.build.ps1
+++ b/pode.build.ps1
@@ -695,6 +695,7 @@ Task SetupPowerShell {
     $baseVersion = $atoms[0]
 
     # do nothing if the current version is the version we're trying to set up
+    Write-Host "Current PowerShell version: $($PSVersionTable.PSVersion)"
     if ($baseVersion -ieq $PSVersionTable.PSVersion.ToString()) {
         Write-Host "PowerShell version $($PowerShellVersion) is already installed"
         return

--- a/pode.build.ps1
+++ b/pode.build.ps1
@@ -211,10 +211,12 @@ function Install-PodeBuildPwshUnix($target) {
     }
 
     $uid = id -u
-    $sudo = (@{
-            '0'     = ''
-            default = 'sudo'
-        })[$uid]
+    if ($uid -ne '0') {
+        $sudo = 'sudo'
+    }
+    else {
+        $sudo = ''
+    }
 
     # Make symbolic link point to installed path
     & $sudo ln -fs $targetFullPath $symlink
@@ -691,7 +693,6 @@ Task SetupPowerShell {
     # base/prefix versions
     $atoms = $PowerShellVersion -split '\-'
     $baseVersion = $atoms[0]
-    # $prefixVersion = $atoms[1]
 
     # do nothing if the current version is the version we're trying to set up
     if ($baseVersion -ieq $PSVersionTable.PSVersion.ToString()) {
@@ -711,9 +712,6 @@ Task SetupPowerShell {
 
     # build the blob name
     $blobName = "v$($PowerShellVersion -replace '\.', '-')"
-    # if (![string]::IsNullOrEmpty($prefixVersion)) {
-    #     $blobName += "-$($prefixVersion)"
-    # }
 
     # download the package to a temp location
     $outputFile = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath $packageName
@@ -722,13 +720,6 @@ Task SetupPowerShell {
         OutFile     = $outputFile
         ErrorAction = 'Stop'
     }
-
-    # https://pscoretestdata.blob.core.windows.net/v7-5-0-preview-2/PowerShell-7.5.0-preview.2-win-arm64.zip
-
-    # https://pscoretestdata.blob.core.windows.net/7-5-0-preview.2/powershell-7.5.0-preview.2-linux-x64.tar.gz
-    # https://pscoretestdata.blob.core.windows.net/7-5-0-preview.2/PowerShell-7.5.0-preview.2-win-x64.zip
-
-    # https://pscoretestdata.blob.core.windows.net/7-5/PowerShell-7.5.0-preview.2-win-x64.zip
 
     Write-Host "Downloading $($packageName) from $($downloadParams.Uri)"
     Write-Host "Output file: $($outputFile)"

--- a/tests/integration/Authentication.Tests.ps1
+++ b/tests/integration/Authentication.Tests.ps1
@@ -11,7 +11,7 @@ BeforeAll {
 Describe 'Authentication Requests' {
 
     BeforeAll {
-        $Port = 60000
+        $Port = 8080
         $Endpoint = "http://127.0.0.1:$($Port)"
 
         Start-Job -Name 'Pode' -ErrorAction Stop -ScriptBlock {

--- a/tests/integration/Endpoints.Tests.ps1
+++ b/tests/integration/Endpoints.Tests.ps1
@@ -4,10 +4,10 @@ param()
 Describe 'Endpoint Requests' {
 
     BeforeAll {
-        $Port1 = 60000
+        $Port1 = 8080
         $Endpoint1 = "http://127.0.0.1:$($Port1)"
 
-        $Port2 = 60001
+        $Port2 = 8081
         $Endpoint2 = "http://127.0.0.1:$($Port2)"
 
         Start-Job -Name 'Pode' -ErrorAction Stop -ScriptBlock {

--- a/tests/integration/RestApi.Https.Tests.ps1
+++ b/tests/integration/RestApi.Https.Tests.ps1
@@ -45,7 +45,7 @@ public bool CheckValidationResult(
         }
 
 
-        $Port = 60010
+        $Port = 8080
         $Endpoint = "https://127.0.0.1:$($Port)"
 
         Start-Job -Name 'Pode' -ErrorAction Stop -ScriptBlock {

--- a/tests/integration/RestApi.Tests.ps1
+++ b/tests/integration/RestApi.Tests.ps1
@@ -5,7 +5,7 @@ param()
 Describe 'REST API Requests' {
 
     BeforeAll {
-        $Port = 60000
+        $Port = 8080
         $Endpoint = "http://127.0.0.1:$($Port)"
 
         Start-Job -Name 'Pode' -ErrorAction Stop -ScriptBlock {

--- a/tests/integration/Schedules.Tests.ps1
+++ b/tests/integration/Schedules.Tests.ps1
@@ -4,7 +4,7 @@ param()
 Describe 'Schedules' {
 
     BeforeAll {
-        $Port = 60000
+        $Port = 8080
         $Endpoint = "http://127.0.0.1:$($Port)"
 
         Start-Job -Name 'Pode' -ErrorAction Stop -ScriptBlock {

--- a/tests/integration/Sessions.Tests.ps1
+++ b/tests/integration/Sessions.Tests.ps1
@@ -5,7 +5,7 @@ param()
 Describe 'Session Requests' {
 
     BeforeAll {
-        $Port = 60000
+        $Port = 8080
         $Endpoint = "http://127.0.0.1:$($Port)"
 
         Start-Job -Name 'Pode' -ErrorAction Stop -ScriptBlock {

--- a/tests/integration/Timers.Tests.ps1
+++ b/tests/integration/Timers.Tests.ps1
@@ -4,7 +4,7 @@ param()
 Describe 'Timers' {
 
     BeforeAll {
-        $Port = 60000
+        $Port = 8080
         $Endpoint = "http://127.0.0.1:$($Port)"
 
         Start-Job -Name 'Pode' -ErrorAction Stop -ScriptBlock {

--- a/tests/integration/WebPages.Tests.ps1
+++ b/tests/integration/WebPages.Tests.ps1
@@ -3,7 +3,7 @@ param()
 Describe 'Web Page Requests' {
 
     BeforeAll {
-        $Port = 60000
+        $Port = 8080
         $Endpoint = "http://127.0.0.1:$($Port)"
 
         Start-Job -Name 'Pode' -ErrorAction Stop -ScriptBlock {


### PR DESCRIPTION
### Description of the Change
The PowerShell installer action was fairly unstable at times, especially when trying to install versions for Windows - or if the version was already installed. The job would either timeout, fail to retrieve the installer, or crash.

I've had a gander at the code from the below links, and ported a more concise stable version into `pode.build.ps1`. The CI workflows have all been updated accordingly.

* https://github.com/bjompen/UpdatePWSHAction/blob/main/UpgradePwsh.ps1
* https://raw.githubusercontent.com/PowerShell/PowerShell/master/tools/install-powershell.ps1
