### PR TITLE
Only run CI workflows when required

### DIFF
--- a/.github/workflows/PSScriptAnalyzer.yml
+++ b/.github/workflows/PSScriptAnalyzer.yml
@@ -11,9 +11,23 @@ name: PSScriptAnalyzer
 
 on:
   push:
-    branches: [ "develop" ]
+    branches:
+    - 'develop'
+    paths:
+    - 'src/**.ps1'
+    - 'src/*.psm1'
+    - 'src/*.psd1'
+    - 'PSScriptAnalyzerSettings.psd1'
+    - '.github/workflows/PSScriptAnalyzer.yml'
   pull_request:
-    branches: [ "develop" ]
+    branches:
+    - 'develop'
+    paths:
+    - 'src/**.ps1'
+    - 'src/*.psm1'
+    - 'src/*.psd1'
+    - 'PSScriptAnalyzerSettings.psd1'
+    - '.github/workflows/PSScriptAnalyzer.yml'
   schedule:
     - cron: '20 16 * * 6'
 

--- a/.github/workflows/ci-coverage.yml
+++ b/.github/workflows/ci-coverage.yml
@@ -5,16 +5,25 @@ on:
     branches:
     - 'master'
     - 'develop'
+    paths:
+    - 'src/**'
+    - 'tests/**'
+    - 'pode.build.ps1'
+    - '.github/workflows/ci-coverage.yml'
   pull_request:
     branches:
     - '*'
+    paths:
+    - 'src/**'
+    - 'tests/**'
+    - 'pode.build.ps1'
+    - '.github/workflows/ci-coverage.yml'
 
 env:
   INVOKE_BUILD_VERSION: '5.11.1'
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -1,0 +1,47 @@
+name: Pode CI - Docs
+
+on:
+  push:
+    branches:
+    - '*'
+    - '!gh-pages'
+    paths:
+    - 'mkdocs.yml'
+    - 'mkdocs-overrides/**'
+    - 'docs/**'
+    - '.github/workflows/ci-docs.yml'
+    - 'pode.build.ps1'
+    - 'src/Pode.psd1'
+  pull_request:
+    branches:
+    - '*'
+    paths:
+    - 'mkdocs.yml'
+    - 'mkdocs-overrides/**'
+    - 'docs/**'
+    - '.github/workflows/ci-docs.yml'
+    - 'pode.build.ps1'
+    - 'src/Pode.psd1'
+
+env:
+  INVOKE_BUILD_VERSION: '5.11.1'
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    strategy:
+      fail-fast: false
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install Invoke-Build
+      shell: pwsh
+      run: |
+        Install-Module -Name InvokeBuild -RequiredVersion $env:INVOKE_BUILD_VERSION -Force
+
+    - name: Build Documentation
+      shell: pwsh
+      run: |
+        Invoke-Build DocsBuild

--- a/.github/workflows/ci-no-build-needed.yml
+++ b/.github/workflows/ci-no-build-needed.yml
@@ -1,0 +1,53 @@
+name: Pode CI - No Build Needed
+
+on:
+  push:
+    branches:
+    - '*'
+    - '!gh-pages'
+    paths-ignore:
+    - 'mkdocs.yml'
+    - 'mkdocs-overrides/**'
+    - 'docs/**'
+    - 'src/**'
+    - 'tests/**'
+    - '.github/workflows/ci-docs.yml'
+    - '.github/workflows/ci-pwsh*.yml'
+    - '.github/workflows/ci-powershell.yml'
+    - '.github/workflows/ci-coverage.yml'
+    - '.github/workflows/PSScriptAnalyzer.yml'
+    - 'pode.build.ps1'
+    - 'Dockerfile'
+    - '*.dockerfile'
+    - 'PSScriptAnalyzerSettings.psd1'
+  pull_request:
+    branches:
+    - '*'
+    paths-ignore:
+    - 'mkdocs.yml'
+    - 'mkdocs-overrides/**'
+    - 'docs/**'
+    - 'src/**'
+    - 'tests/**'
+    - '.github/workflows/ci-docs.yml'
+    - '.github/workflows/ci-pwsh*.yml'
+    - '.github/workflows/ci-powershell.yml'
+    - '.github/workflows/ci-coverage.yml'
+    - '.github/workflows/PSScriptAnalyzer.yml'
+    - 'pode.build.ps1'
+    - 'Dockerfile'
+    - '*.dockerfile'
+    - 'PSScriptAnalyzerSettings.psd1'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+    steps:
+    - name: Install Invoke-Build
+      shell: pwsh
+      run: |
+        Write-Host "No build needed for this commit"

--- a/.github/workflows/ci-powershell.yml
+++ b/.github/workflows/ci-powershell.yml
@@ -5,16 +5,25 @@ on:
     branches:
     - '*'
     - '!gh-pages'
+    paths:
+    - 'src/**'
+    - 'tests/**'
+    - 'pode.build.ps1'
+    - '.github/workflows/ci-powershell.yml'
   pull_request:
     branches:
     - '*'
+    paths:
+    - 'src/**'
+    - 'tests/**'
+    - 'pode.build.ps1'
+    - '.github/workflows/ci-powershell.yml'
 
 env:
   INVOKE_BUILD_VERSION: '5.11.1'
 
 jobs:
   build:
-
     runs-on: windows-latest
 
     strategy:

--- a/.github/workflows/ci-pwsh7_2.yml
+++ b/.github/workflows/ci-pwsh7_2.yml
@@ -5,9 +5,23 @@ on:
     branches:
     - '*'
     - '!gh-pages'
+    paths:
+    - 'src/**'
+    - 'tests/**'
+    - 'pode.build.ps1'
+    - '.github/workflows/ci-pwsh7_2.yml'
+    - 'Dockerfile'
+    - '*.dockerfile'
   pull_request:
     branches:
     - '*'
+    paths:
+    - 'src/**'
+    - 'tests/**'
+    - 'pode.build.ps1'
+    - '.github/workflows/ci-pwsh7_2.yml'
+    - 'Dockerfile'
+    - '*.dockerfile'
 
 env:
   INVOKE_BUILD_VERSION: '5.11.1'
@@ -15,7 +29,6 @@ env:
 
 jobs:
   build:
-
     runs-on: ${{ matrix.os }}
 
     strategy:

--- a/.github/workflows/ci-pwsh7_3.yml
+++ b/.github/workflows/ci-pwsh7_3.yml
@@ -5,9 +5,23 @@ on:
     branches:
     - '*'
     - '!gh-pages'
+    paths:
+    - 'src/**'
+    - 'tests/**'
+    - 'pode.build.ps1'
+    - '.github/workflows/ci-pwsh7_3.yml'
+    - 'Dockerfile'
+    - '*.dockerfile'
   pull_request:
     branches:
     - '*'
+    paths:
+    - 'src/**'
+    - 'tests/**'
+    - 'pode.build.ps1'
+    - '.github/workflows/ci-pwsh7_3.yml'
+    - 'Dockerfile'
+    - '*.dockerfile'
 
 env:
   INVOKE_BUILD_VERSION: '5.11.1'
@@ -15,7 +29,6 @@ env:
 
 jobs:
   build:
-
     runs-on: ${{ matrix.os }}
 
     strategy:

--- a/.github/workflows/ci-pwsh_lts.yml
+++ b/.github/workflows/ci-pwsh_lts.yml
@@ -5,9 +5,23 @@ on:
     branches:
     - '*'
     - '!gh-pages'
+    paths:
+    - 'src/**'
+    - 'tests/**'
+    - 'pode.build.ps1'
+    - '.github/workflows/ci-pwsh_lts.yml'
+    - 'Dockerfile'
+    - '*.dockerfile'
   pull_request:
     branches:
     - '*'
+    paths:
+    - 'src/**'
+    - 'tests/**'
+    - 'pode.build.ps1'
+    - '.github/workflows/ci-pwsh_lts.yml'
+    - 'Dockerfile'
+    - '*.dockerfile'
 
 env:
   INVOKE_BUILD_VERSION: '5.11.1'
@@ -15,7 +29,6 @@ env:
 
 jobs:
   build:
-
     runs-on: ${{ matrix.os }}
 
     strategy:

--- a/.github/workflows/ci-pwsh_preview.yml
+++ b/.github/workflows/ci-pwsh_preview.yml
@@ -5,9 +5,23 @@ on:
     branches:
     - '*'
     - '!gh-pages'
+    paths:
+    - 'src/**'
+    - 'tests/**'
+    - 'pode.build.ps1'
+    - '.github/workflows/ci-pwsh_preview.yml'
+    - 'Dockerfile'
+    - '*.dockerfile'
   pull_request:
     branches:
     - '*'
+    paths:
+    - 'src/**'
+    - 'tests/**'
+    - 'pode.build.ps1'
+    - '.github/workflows/ci-pwsh_preview.yml'
+    - 'Dockerfile'
+    - '*.dockerfile'
 
 env:
   INVOKE_BUILD_VERSION: '5.11.1'
@@ -15,7 +29,6 @@ env:
 
 jobs:
   build:
-
     runs-on: ${{ matrix.os }}
 
     strategy:

--- a/pode.build.ps1
+++ b/pode.build.ps1
@@ -301,7 +301,7 @@ Task DocsDeps ChocoDeps, {
 
     $_installed = (pip list --format json --disable-pip-version-check | ConvertFrom-Json)
     if (($_installed | Where-Object { $_.name -ieq 'mkdocs-material' -and $_.version -ieq $Versions.MkDocsTheme } | Measure-Object).Count -eq 0) {
-        pip install "mkdocs-material==$($Versions.MkDocsTheme)" --force-reinstall --disable-pip-version-check
+        pip install "mkdocs-material==$($Versions.MkDocsTheme)" --force-reinstall --disable-pip-version-check --quiet
     }
 
     # install platyps
@@ -533,7 +533,7 @@ Task DocsHelpBuild DocsDeps, Build, {
 
 # Synopsis: Build the documentation
 Task DocsBuild DocsDeps, DocsHelpBuild, {
-    mkdocs build
+    mkdocs build --quiet
 }
 
 

--- a/pode.build.ps1
+++ b/pode.build.ps1
@@ -67,7 +67,7 @@ function Invoke-PodeBuildInstall($name, $version) {
 
     if (Test-PodeBuildIsWindows) {
         if (Test-PodeBuildCommand 'choco') {
-            choco install $name --version $version -y
+            choco install $name --version $version -y --no-progress
         }
     }
     else {
@@ -275,6 +275,7 @@ Task BuildDeps {
     else {
         $dotnet = "dotnet-sdk-$($Versions.DotNet)"
     }
+
     if (!(Test-PodeBuildCommand 'dotnet')) {
         Invoke-PodeBuildInstall $dotnet $Versions.DotNet
     }
@@ -317,11 +318,9 @@ Task Build BuildDeps, {
     if (Test-Path ./src/Libs) {
         Remove-Item -Path ./src/Libs -Recurse -Force | Out-Null
     }
-    Write-Host 'Powershell Version:'
-    $PSVersionTable.PSVersion
-    Push-Location ./src/Listener
 
     try {
+        Push-Location ./src/Listener
         Invoke-PodeBuildDotnetBuild -target 'netstandard2.0'
         Invoke-PodeBuildDotnetBuild -target 'net6.0'
         Invoke-PodeBuildDotnetBuild -target 'net7.0'
@@ -489,7 +488,7 @@ Task Docs DocsDeps, DocsHelpBuild, {
 }
 
 # Synopsis: Build the function help documentation
-Task DocsHelpBuild DocsDeps, {
+Task DocsHelpBuild DocsDeps, Build, {
     # import the local module
     Remove-Module Pode -Force -ErrorAction Ignore | Out-Null
     Import-Module ./src/Pode.psm1 -Force | Out-Null


### PR DESCRIPTION
### Description of the Change
* Add in path filters so that CI workflows are only run when required
* Adds a new CI workflow for documentation
* Adds a new CI workflow for "no build", when a path doesn't require a build and just to allow PR checks to pass
