### PR TITLE
Have Dependabot ensure that GitHub actions are up-to-date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
### Description of the Change
Have Dependabot ensure that GitHub actions are up-to-date.
