### PR TITLE
Fixes the Write-Pode(*)Response functions so the Value parameter appropriately handles when an array is passed using piping

### DIFF
--- a/examples/Write-Response.ps1
+++ b/examples/Write-Response.ps1
@@ -91,7 +91,7 @@ Start-PodeServer {
 
 
     Add-PodeRoute -Path '/xml/hash'  -Method Get -ScriptBlock {
-        Write-PodeXmlResponse -Value @(@{ Name = 'Rick' }, @{ Name = 'Don' }) -UsePropertyName
+        Write-PodeXmlResponse -Value @(@{ Name = 'Rick' }, @{ Name = 'Don' })
     }
 
     #   nopipe
@@ -110,7 +110,7 @@ Start-PodeServer {
     }
     Start-Job -ScriptBlock {
         Start-Sleep -Seconds 5
-   <#      Start-Process http://localhost:8081/html/processesPiped
+        Start-Process http://localhost:8081/html/processesPiped
         Start-Process http://localhost:8081/html/processes
         Start-Process http://localhost:8081/text/processesPiped
         Start-Process http://localhost:8081/text/processes
@@ -120,7 +120,7 @@ Start-PodeServer {
         Start-Process http://localhost:8081/csv/hash
         Start-Process http://localhost:8081/json/processesPiped
         Start-Process http://localhost:8081/json/processes
-      #>  Start-Process http://localhost:8081/xml/processesPiped
+        Start-Process http://localhost:8081/xml/processesPiped
         Start-Process http://localhost:8081/xml/processes
         Start-Process http://localhost:8081/xml/hash
         Start-Process http://localhost:8081/yaml/processesPiped

--- a/examples/Write-Response.ps1
+++ b/examples/Write-Response.ps1
@@ -1,0 +1,133 @@
+$podePath = Split-Path -Parent -Path (Split-Path -Parent -Path $MyInvocation.MyCommand.Path)
+if (Test-Path -Path "$($podePath)/src/Pode.psm1" -PathType Leaf) {
+    Import-Module "$($podePath)/src/Pode.psm1" -Force -ErrorAction Stop
+}
+else {
+    Import-Module -Name 'Pode'
+}
+
+Start-PodeServer {
+    Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http
+    #   nopipe
+    Add-PodeRoute -Path '/html/processes'  -Method Get -ScriptBlock {
+        $myProcess = Get-Process | .{ process { if ($_.WS -gt 100mb) { $_ } } } |
+            Select-Object Name, @{e = { [int]($_.WS / 1mb) }; n = 'WS' } |
+            Sort-Object WS -Descending
+        Write-PodeHtmlResponse -Value $myProcess  -StatusCode 200
+    }
+    #    pipe
+    Add-PodeRoute -Path '/html/processesPiped'  -Method Get -ScriptBlock {
+        Get-Process | .{ process { if ($_.WS -gt 100mb) { $_ } } } |
+            Select-Object Name, @{e = { [int]($_.WS / 1mb) }; n = 'WS' } |
+            Sort-Object WS -Descending | Write-PodeHtmlResponse  -StatusCode 200
+    }
+
+    #   nopipe
+    Add-PodeRoute -Path '/text/processes'  -Method Get -ScriptBlock {
+        $myProcess = Get-Process | .{ process { if ($_.WS -gt 100mb) { $_ } } } |
+            Select-Object Name, @{e = { [int]($_.WS / 1mb) }; n = 'WS' } |
+            Sort-Object WS -Descending | Out-String
+        Write-PodeTextResponse -Value $myProcess  -StatusCode 200
+    }
+    #    pipe
+    Add-PodeRoute -Path '/text/processesPiped'  -Method Get -ScriptBlock {
+        Get-Process | .{ process { if ($_.WS -gt 100mb) { $_ } } } |
+            Select-Object Name, @{e = { [int]($_.WS / 1mb) }; n = 'WS' } |
+            Sort-Object WS -Descending | Out-String | Write-PodeTextResponse  -StatusCode 200
+    }
+
+    #   nopipe
+    Add-PodeRoute -Path '/csv/processes'  -Method Get -ScriptBlock {
+        $myProcess = Get-Process | .{ process { if ($_.WS -gt 100mb) { $_ } } } |
+            Select-Object Name, @{e = { [int]($_.WS / 1mb) }; n = 'WS' } |
+            Sort-Object WS -Descending
+        Write-PodeCsvResponse -Value $myProcess  -StatusCode 200
+    }
+
+    #    pipe
+    Add-PodeRoute -Path '/csv/processesPiped'  -Method Get -ScriptBlock {
+        Get-Process | .{ process { if ($_.WS -gt 100mb) { $_ } } } |
+            Select-Object Name, @{e = { [int]($_.WS / 1mb) }; n = 'WS' } |
+            Sort-Object WS -Descending | Write-PodeCsvResponse  -StatusCode 200
+    }
+
+    Add-PodeRoute -Path '/csv/string'  -Method Get -ScriptBlock {
+        Write-PodeCsvResponse -Value "Name`nRick`nDon"
+    }
+
+    Add-PodeRoute -Path '/csv/hash'  -Method Get -ScriptBlock {
+        Write-PodeCsvResponse -Value @(@{ Name = 'Rick' }, @{ Name = 'Don' })
+    }
+
+    #   nopipe
+    Add-PodeRoute -Path '/json/processes'  -Method Get -ScriptBlock {
+        $myProcess = Get-Process | .{ process { if ($_.WS -gt 100mb) { $_ } } } |
+            Select-Object Name, @{e = { [int]($_.WS / 1mb) }; n = 'WS' } |
+            Sort-Object WS -Descending
+        Write-PodeJsonResponse -Value $myProcess  -StatusCode 200
+    }
+
+    #    pipe
+    Add-PodeRoute -Path '/json/processesPiped'  -Method Get -ScriptBlock {
+        Get-Process | .{ process { if ($_.WS -gt 100mb) { $_ } } } |
+            Select-Object Name, @{e = { [int]($_.WS / 1mb) }; n = 'WS' } |
+            Sort-Object WS -Descending | Write-PodeJsonResponse  -StatusCode 200
+    }
+
+    #   nopipe
+    Add-PodeRoute -Path '/xml/processes'  -Method Get -ScriptBlock {
+        $myProcess = Get-Process | .{ process { if ($_.WS -gt 100mb) { $_ } } } |
+            Select-Object Name, @{e = { [int]($_.WS / 1mb) }; n = 'WS' } |
+            Sort-Object WS -Descending
+        Write-PodeXmlResponse -Value $myProcess  -StatusCode 200
+    }
+
+    #    pipe
+    Add-PodeRoute -Path '/xml/processesPiped'  -Method Get -ScriptBlock {
+        Get-Process | .{ process { if ($_.WS -gt 100mb) { $_ } } } |
+            Select-Object Name, @{e = { [int]($_.WS / 1mb) }; n = 'WS' } |
+            Sort-Object WS -Descending | Write-PodeXmlResponse  -StatusCode 200
+    }
+
+    Add-PodeRoute -Path '/xml/string'  -Method Get -ScriptBlock {
+        Write-PodeXmlResponse -Value "Name`nRick`nDon"
+    }
+
+    Add-PodeRoute -Path '/xml/hash'  -Method Get -ScriptBlock {
+        Write-PodeXmlResponse -Value @(@{ Name = 'Rick' }, @{ Name = 'Don' })
+    }
+
+    #   nopipe
+    Add-PodeRoute -Path '/yaml/processes'  -Method Get -ScriptBlock {
+        $myProcess = Get-Process | .{ process { if ($_.WS -gt 100mb) { $_ } } } |
+            Select-Object Name, @{e = { [int]($_.WS / 1mb) }; n = 'WS' } |
+            Sort-Object WS -Descending
+        Write-PodeYamlResponse -Value $myProcess  -StatusCode 200  -ContentType 'text/yaml'
+    }
+
+    #    pipe
+    Add-PodeRoute -Path '/yaml/processesPiped'  -Method Get -ScriptBlock {
+        Get-Process | .{ process { if ($_.WS -gt 100mb) { $_ } } } |
+            Select-Object Name, @{e = { [int]($_.WS / 1mb) }; n = 'WS' } |
+            Sort-Object WS -Descending | Write-PodeYamlResponse   -StatusCode 200 -ContentType 'text/yaml'
+    }
+    Start-Job -ScriptBlock {
+        Start-Sleep -Seconds 5
+        Start-Process http://localhost:8081/html/processesPiped
+        Start-Process http://localhost:8081/html/processes
+        Start-Process http://localhost:8081/text/processesPiped
+        Start-Process http://localhost:8081/text/processes
+        Start-Process http://localhost:8081/csv/processesPiped
+        Start-Process http://localhost:8081/csv/processes
+        Start-Process http://localhost:8081/csv/string
+        Start-Process http://localhost:8081/csv/hash
+        Start-Process http://localhost:8081/json/processesPiped
+        Start-Process http://localhost:8081/json/processes
+        Start-Process http://localhost:8081/xml/processesPiped
+        Start-Process http://localhost:8081/xml/processes
+        Start-Process http://localhost:8081/xml/string
+        Start-Process http://localhost:8081/xml/hash
+        Start-Process http://localhost:8081/yaml/processesPiped
+        Start-Process http://localhost:8081/yaml/processes
+    }
+}

--- a/examples/Write-Response.ps1
+++ b/examples/Write-Response.ps1
@@ -89,12 +89,9 @@ Start-PodeServer {
             Sort-Object WS -Descending | Write-PodeXmlResponse  -StatusCode 200
     }
 
-    Add-PodeRoute -Path '/xml/string'  -Method Get -ScriptBlock {
-        Write-PodeXmlResponse -Value "Name`nRick`nDon"
-    }
 
     Add-PodeRoute -Path '/xml/hash'  -Method Get -ScriptBlock {
-        Write-PodeXmlResponse -Value @(@{ Name = 'Rick' }, @{ Name = 'Don' })
+        Write-PodeXmlResponse -Value @(@{ Name = 'Rick' }, @{ Name = 'Don' }) -UsePropertyName
     }
 
     #   nopipe
@@ -113,7 +110,7 @@ Start-PodeServer {
     }
     Start-Job -ScriptBlock {
         Start-Sleep -Seconds 5
-        Start-Process http://localhost:8081/html/processesPiped
+   <#      Start-Process http://localhost:8081/html/processesPiped
         Start-Process http://localhost:8081/html/processes
         Start-Process http://localhost:8081/text/processesPiped
         Start-Process http://localhost:8081/text/processes
@@ -123,9 +120,8 @@ Start-PodeServer {
         Start-Process http://localhost:8081/csv/hash
         Start-Process http://localhost:8081/json/processesPiped
         Start-Process http://localhost:8081/json/processes
-        Start-Process http://localhost:8081/xml/processesPiped
+      #>  Start-Process http://localhost:8081/xml/processesPiped
         Start-Process http://localhost:8081/xml/processes
-        Start-Process http://localhost:8081/xml/string
         Start-Process http://localhost:8081/xml/hash
         Start-Process http://localhost:8081/yaml/processesPiped
         Start-Process http://localhost:8081/yaml/processes

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -3317,3 +3317,31 @@ function ConvertTo-PodeYamlInternal {
         }
     }
 }
+
+
+
+function Resolve-PodeObjectArray {
+    param (
+        [AllowNull()]
+        $Property
+    )
+    if ($Property -is [hashtable]) {
+        if ($Property.Count -eq 1) {
+            return   New-Object psobject -Property $Property
+        }
+        else {
+            return @(foreach ($v in $Property) {
+                Resolve-PodeObjectArray -Property $v
+                })
+        }
+    }
+    elseif ($Property -is [object[]]) {
+        return @(foreach ($v in $Property) {
+            Resolve-PodeObjectArray -Property $v
+
+            })
+    }
+    else {
+        return   New-Object psobject -Property $Property
+    }
+}

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -3018,31 +3018,31 @@ function Test-PodeVersionDev {
 
 <#
 .SYNOPSIS
-Tests the running PowerShell version for compatibility with Pode, identifying end-of-life (EOL) and untested versions.
+    Tests the running PowerShell version for compatibility with Pode, identifying end-of-life (EOL) and untested versions.
 
 .DESCRIPTION
-The `Test-PodeVersionPwshEOL` function checks the current PowerShell version against a list of versions that were either supported or EOL at the time of the Pode release. It uses the module manifest to determine which PowerShell versions are considered EOL and which are officially supported. If the current version is EOL or was not tested with the current release of Pode, the function generates a warning. This function aids in maintaining best practices for using supported PowerShell versions with Pode.
+    The `Test-PodeVersionPwshEOL` function checks the current PowerShell version against a list of versions that were either supported or EOL at the time of the Pode release. It uses the module manifest to determine which PowerShell versions are considered EOL and which are officially supported. If the current version is EOL or was not tested with the current release of Pode, the function generates a warning. This function aids in maintaining best practices for using supported PowerShell versions with Pode.
 
 .PARAMETER ReportUntested
-If specified, the function will report if the current PowerShell version was not available and thus untested at the time of the Pode release. This is useful for identifying potential compatibility issues with newer versions of PowerShell.
+    If specified, the function will report if the current PowerShell version was not available and thus untested at the time of the Pode release. This is useful for identifying potential compatibility issues with newer versions of PowerShell.
 
 .OUTPUTS
-A hashtable containing two keys:
-- `eol`: A boolean indicating if the current PowerShell version was EOL at the time of the Pode release.
-- `supported`: A boolean indicating if the current PowerShell version was officially supported by Pode at the time of the release.
+    A hashtable containing two keys:
+    - `eol`: A boolean indicating if the current PowerShell version was EOL at the time of the Pode release.
+    - `supported`: A boolean indicating if the current PowerShell version was officially supported by Pode at the time of the release.
 
 .EXAMPLE
-Test-PodeVersionPwshEOL
+    Test-PodeVersionPwshEOL
 
-Checks the current PowerShell version against Pode's supported and EOL versions list. Outputs a warning if the version is EOL or untested, and returns a hashtable indicating the compatibility status.
+    Checks the current PowerShell version against Pode's supported and EOL versions list. Outputs a warning if the version is EOL or untested, and returns a hashtable indicating the compatibility status.
 
 .EXAMPLE
-Test-PodeVersionPwshEOL -ReportUntested
+    Test-PodeVersionPwshEOL -ReportUntested
 
-Similar to the basic usage, but also reports if the current PowerShell version was untested because it was not available at the time of the Pode release.
+    Similar to the basic usage, but also reports if the current PowerShell version was untested because it was not available at the time of the Pode release.
 
 .NOTES
-This function is part of the Pode module's utilities to ensure compatibility and encourage the use of supported PowerShell versions.
+    This function is part of the Pode module's utilities to ensure compatibility and encourage the use of supported PowerShell versions.
 
 #>
 function Test-PodeVersionPwshEOL {
@@ -3081,15 +3081,19 @@ function Test-PodeVersionPwshEOL {
 
 <#
 .SYNOPSIS
-creates a YAML description of the data in the object - based on https://github.com/Phil-Factor/PSYaml
+    creates a YAML description of the data in the object - based on https://github.com/Phil-Factor/PSYaml
+
 .DESCRIPTION
-This produces YAML from any object you pass to it. It isn't suitable for the huge objects produced by some of the cmdlets such as Get-Process, but fine for simple objects
-.PARAMETER Object
-the object that you want scripted out
+    This produces YAML from any object you pass to it. It isn't suitable for the huge objects produced by some of the cmdlets such as Get-Process, but fine for simple objects
+
+    .PARAMETER Object
+    The object that you want scripted out
+
 .PARAMETER Depth
-The depth that you want your object scripted to
+    The depth that you want your object scripted to
+
 .EXAMPLE
-Get-PodeOpenApiDefinition|ConvertTo-PodeYaml
+    Get-PodeOpenApiDefinition|ConvertTo-PodeYaml
 #>
 function ConvertTo-PodeYaml {
     [CmdletBinding()]
@@ -3118,36 +3122,36 @@ function ConvertTo-PodeYaml {
 
 <#
 .SYNOPSIS
-  Converts PowerShell objects into a YAML-formatted string.
+    Converts PowerShell objects into a YAML-formatted string.
 
 .DESCRIPTION
-  This function takes PowerShell objects and converts them to a YAML string representation.
-  It supports various data types including arrays, hashtables, strings, and more.
-  The depth of conversion can be controlled, allowing for nested objects to be accurately represented.
+    This function takes PowerShell objects and converts them to a YAML string representation.
+    It supports various data types including arrays, hashtables, strings, and more.
+    The depth of conversion can be controlled, allowing for nested objects to be accurately represented.
 
 .PARAMETER InputObject
-  The PowerShell object to convert to YAML. This parameter accepts input via the pipeline.
+    The PowerShell object to convert to YAML. This parameter accepts input via the pipeline.
 
 .PARAMETER Depth
-  Specifies the maximum depth of object nesting to convert. Default is 10 levels deep.
+    Specifies the maximum depth of object nesting to convert. Default is 10 levels deep.
 
 .PARAMETER NestingLevel
-  Used internally to track the current depth of recursion. Generally not specified by the user.
+    Used internally to track the current depth of recursion. Generally not specified by the user.
 
 .PARAMETER NoNewLine
-  If specified, suppresses the newline characters in the output to create a single-line string.
+    If specified, suppresses the newline characters in the output to create a single-line string.
 
 .OUTPUTS
-  System.String. Returns a string in YAML format.
+    System.String. Returns a string in YAML format.
 
 .EXAMPLE
-  $object | ConvertTo-PodeYamlInternal
+    $object | ConvertTo-PodeYamlInternal
 
-  Converts the object piped to it into a YAML string.
+    Converts the object piped to it into a YAML string.
 
 .NOTES
-  This is an internal function and may change in future releases of Pode.
-  It converts only basic PowerShell types, such as strings, integers, booleans, arrays, hashtables, and ordered dictionaries into a YAML format.
+    This is an internal function and may change in future releases of Pode.
+    It converts only basic PowerShell types, such as strings, integers, booleans, arrays, hashtables, and ordered dictionaries into a YAML format.
 
 #>
 
@@ -3319,29 +3323,64 @@ function ConvertTo-PodeYamlInternal {
 }
 
 
+<#
+.SYNOPSIS
+    Resolves various types of object arrays into PowerShell objects.
 
+.DESCRIPTION
+    This function takes an input property and determines its type.
+    It then resolves the property into a PowerShell object or an array of objects,
+    depending on whether the property is a hashtable, array, or single object.
+
+.PARAMETER Property
+    The property to be resolved. It can be a hashtable, an object array, or a single object.
+
+.RETURNS
+    Returns a PowerShell object or an array of PowerShell objects, depending on the input property type.
+
+.EXAMPLE
+    $result = Resolve-PodeObjectArray -Property $myProperty
+    This example resolves the $myProperty into a PowerShell object or an array of objects.
+
+.NOTES
+    This is an internal function and may change in future releases of Pode.
+#>
 function Resolve-PodeObjectArray {
+    [CmdletBinding()]
+    [OutputType([object[]])]
+    [OutputType([psobject])]
     param (
         [AllowNull()]
+        [object]
         $Property
     )
+
+    # Check if the property is a hashtable
     if ($Property -is [hashtable]) {
+        # If the hashtable has only one item, convert it to a PowerShell object
         if ($Property.Count -eq 1) {
-            return   New-Object psobject -Property $Property
+            return New-Object psobject -Property $Property
         }
         else {
-            return @(foreach ($v in $Property) {
-                Resolve-PodeObjectArray -Property $v
-                })
+            # If the hashtable has more than one item, recursively resolve each item
+            return @(foreach ($p in $Property) {
+                Resolve-PodeObjectArray -Property $p
+            })
         }
     }
+    # Check if the property is an array of objects
     elseif ($Property -is [object[]]) {
-        return @(foreach ($v in $Property) {
-            Resolve-PodeObjectArray -Property $v
-
-            })
+        # Recursively resolve each item in the array
+        return @(foreach ($p in $Property) {
+            Resolve-PodeObjectArray -Property $p
+        })
+    }
+    # Check if the property is already a PowerShell object
+    elseif ($Property -is [psobject]) {
+        return $Property
     }
     else {
-        return   New-Object psobject -Property $Property
+        # For any other type, convert it to a PowerShell object
+        return New-Object psobject -Property $Property
     }
 }

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -3120,7 +3120,7 @@ function ConvertTo-PodeYaml {
         if ($null -eq $PodeContext.Server.InternalCache.YamlModuleImported) {
             $PodeContext.Server.InternalCache.YamlModuleImported = ((Test-PodeModuleInstalled -Name 'PSYaml') -or (Test-PodeModuleInstalled -Name 'powershell-yaml'))
         }
-        if ($pipelineObject) {
+        if ($pipelineObject -and $pipelineObject.Count -gt 1) {
             $InputObject = $pipelineObject
         }
 

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -3120,7 +3120,7 @@ function ConvertTo-PodeYaml {
         if ($null -eq $PodeContext.Server.InternalCache.YamlModuleImported) {
             $PodeContext.Server.InternalCache.YamlModuleImported = ((Test-PodeModuleInstalled -Name 'PSYaml') -or (Test-PodeModuleInstalled -Name 'powershell-yaml'))
         }
-        if ($pipelineObject -and $pipelineObject.Count -gt 1) {
+        if ($pipelineObject.Count -gt 1) {
             $InputObject = $pipelineObject
         }
 

--- a/src/Public/Responses.ps1
+++ b/src/Public/Responses.ps1
@@ -474,7 +474,7 @@ function Write-PodeCsvResponse {
             }
 
             'value' {
-                if ($pipelineValue -and $pipelineValue.Count -gt 1) {
+                if ($pipelineValue.Count -gt 1) {
                     $Value = $pipelineValue
                 }
 
@@ -560,7 +560,7 @@ function Write-PodeHtmlResponse {
             }
 
             'value' {
-                if ($pipelineValue -and $pipelineValue.Count -gt 1) {
+                if ($pipelineValue.Count -gt 1) {
                     $Value = $pipelineValue
                 }
                 if ($Value -isnot [string]) {
@@ -724,7 +724,7 @@ function Write-PodeJsonResponse {
             }
 
             'value' {
-                if ($pipelineValue -and $pipelineValue.Count -gt 1) {
+                if ($pipelineValue.Count -gt 1) {
                     $Value = $pipelineValue
                 }
                 if ($Value -isnot [string]) {
@@ -831,7 +831,7 @@ function Write-PodeXmlResponse {
             }
 
             'value' {
-                if ($pipelineValue -and $pipelineValue.Count -gt 1) {
+                if ($pipelineValue.Count -gt 1) {
                     $Value = $pipelineValue
                 }
 
@@ -928,7 +928,7 @@ function Write-PodeYamlResponse {
             }
 
             'value' {
-                if ($pipelineValue -and $pipelineValue.Count -gt 1) {
+                if ($pipelineValue.Count -gt 1) {
                     $Value = $pipelineValue
                 }
 

--- a/src/Public/Responses.ps1
+++ b/src/Public/Responses.ps1
@@ -474,7 +474,7 @@ function Write-PodeCsvResponse {
             }
 
             'value' {
-                if ($pipelineValue) {
+                if ($pipelineValue -and $pipelineValue.Count -gt 1) {
                     $Value = $pipelineValue
                 }
 
@@ -560,7 +560,7 @@ function Write-PodeHtmlResponse {
             }
 
             'value' {
-                if ($pipelineValue) {
+                if ($pipelineValue -and $pipelineValue.Count -gt 1) {
                     $Value = $pipelineValue
                 }
                 if ($Value -isnot [string]) {
@@ -724,7 +724,7 @@ function Write-PodeJsonResponse {
             }
 
             'value' {
-                if ($pipelineValue) {
+                if ($pipelineValue -and $pipelineValue.Count -gt 1) {
                     $Value = $pipelineValue
                 }
                 if ($Value -isnot [string]) {
@@ -831,7 +831,7 @@ function Write-PodeXmlResponse {
             }
 
             'value' {
-                if ($pipelineValue) {
+                if ($pipelineValue -and $pipelineValue.Count -gt 1) {
                     $Value = $pipelineValue
                 }
 
@@ -928,7 +928,7 @@ function Write-PodeYamlResponse {
             }
 
             'value' {
-                if ($pipelineValue) {
+                if ($pipelineValue -and $pipelineValue.Count -gt 1) {
                     $Value = $pipelineValue
                 }
 

--- a/src/Public/Responses.ps1
+++ b/src/Public/Responses.ps1
@@ -932,12 +932,6 @@ function Write-PodeYamlResponse {
                     $Value = $pipelineValue
                 }
 
-                if ($Value -is [hashtable]) {
-                    $Value = @(foreach ($v in $Value) {
-                            New-Object psobject -Property $v
-                        })
-                }
-
                 if ($Value -isnot [string]) {
                     $Value = ConvertTo-PodeYaml -InputObject $Value -Depth $Depth
 

--- a/src/Public/Responses.ps1
+++ b/src/Public/Responses.ps1
@@ -431,9 +431,6 @@ The path to a CSV file.
 .PARAMETER StatusCode
 The status code to set against the response.
 
-.PARAMETER UsePropertyName
-The elements name is equal to the key value
-
 .EXAMPLE
 Write-PodeCsvResponse -Value "Name`nRick"
 
@@ -455,19 +452,20 @@ function Write-PodeCsvResponse {
 
         [Parameter()]
         [int]
-        $StatusCode = 200,
-
-        [switch]
-        $UsePropertyName
+        $StatusCode = 200
     )
+
     begin {
         $pipelineValue = @()
     }
+
     process {
         if ($PSCmdlet.ParameterSetName -eq 'Value') {
             $pipelineValue += $_
         }
-    }    end {
+    }
+
+    end {
         switch ($PSCmdlet.ParameterSetName.ToLowerInvariant()) {
             'file' {
                 if (Test-PodePath $Path) {
@@ -481,9 +479,7 @@ function Write-PodeCsvResponse {
                 }
 
                 if ($Value -isnot [string]) {
-                    if ($UsePropertyName.IsPresent) {
-                        $Value = Resolve-PodeObjectArray -Property $Value
-                    }
+                    $Value = Resolve-PodeObjectArray -Property $Value
 
                     if (Test-PodeIsPSCore) {
                         $Value = ($Value | ConvertTo-Csv -Delimiter ',' -IncludeTypeInformation:$false)
@@ -765,17 +761,35 @@ The Depth to generate the XML document - the larger this value the worse perform
 .PARAMETER StatusCode
 The status code to set against the response.
 
-.PARAMETER UsePropertyName
-The elements name is equal to the key value
-
 .EXAMPLE
 Write-PodeXmlResponse -Value '<root><name>Rick</name></root>'
 
 .EXAMPLE
-Write-PodeXmlResponse -Value @{ Name = 'Rick' } -StatusCode 201 -UsePropertyName
+Write-PodeXmlResponse -Value @{ Name = 'Rick' } -StatusCode 201
+
+.EXAMPLE
+@(@{ Name = 'Rick' }, @{ Name = 'Don' }) | Write-PodeXmlResponse
+
+.EXAMPLE
+$users = @([PSCustomObject]@{
+                Name = 'Rick'
+            }, [PSCustomObject]@{
+                Name = 'Don'
+            }
+        )
+Write-PodeXmlResponse -Value $users
+
+.EXAMPLE
+@([PSCustomObject]@{
+        Name = 'Rick'
+    }, [PSCustomObject]@{
+        Name = 'Don'
+    }
+) | Write-PodeXmlResponse
 
 .EXAMPLE
 Write-PodeXmlResponse -Path 'E:/Files/Names.xml'
+
 #>
 function Write-PodeXmlResponse {
     [CmdletBinding(DefaultParameterSetName = 'Value')]
@@ -795,10 +809,7 @@ function Write-PodeXmlResponse {
 
         [Parameter()]
         [int]
-        $StatusCode = 200,
-
-        [switch]
-        $UsePropertyName
+        $StatusCode = 200
     )
     begin {
         $pipelineValue = @()
@@ -825,10 +836,7 @@ function Write-PodeXmlResponse {
                 }
 
                 if ($Value -isnot [string]) {
-                    if ($UsePropertyName.IsPresent) {
-                        $Value = Resolve-PodeObjectArray -Property $Value
-                    }
-                    $Value = ($Value | ConvertTo-Xml -Depth $Depth -As String -NoTypeInformation)
+                    $Value = Resolve-PodeObjectArray -Property $Value | ConvertTo-Xml -Depth $Depth -As String -NoTypeInformation
                 }
             }
         }

--- a/tests/unit/Helpers.Tests.ps1
+++ b/tests/unit/Helpers.Tests.ps1
@@ -1717,21 +1717,25 @@ Describe 'New-PodeCron' {
 
 
 
-Describe 'ConvertTo-PodeYamlInternal Tests' {
+
+Describe 'ConvertTo-PodeYaml Tests' {
+    BeforeAll {
+        $PodeContext = @{ Server = @{InternalCache = @{} } }
+    }
     Context 'When converting basic types' {
         It 'Converts strings correctly' {
-            $result = 'hello world' | ConvertTo-PodeYamlInternal
+            $result = 'hello world' | ConvertTo-PodeYaml
             $result | Should -Be 'hello world'
         }
 
         It 'Converts arrays correctly' {
-            $result =  ConvertTo-PodeYamlInternal -InputObject  @('one', 'two', 'three') -NoNewLine
+            $result = @('one', 'two', 'three') | ConvertTo-PodeYaml
             $expected = (@'
 - one
 - two
 - three
 '@)
-            $result | Should -Be ($expected.Trim() -Replace "`r`n","`n")
+            $result | Should -Be ($expected.Trim() -Replace "`r`n", "`n")
         }
 
         It 'Converts hashtables correctly' {
@@ -1739,7 +1743,7 @@ Describe 'ConvertTo-PodeYamlInternal Tests' {
                 key1 = 'value1'
                 key2 = 'value2'
             }
-            $result = $hashTable | ConvertTo-PodeYamlInternal -NoNewLine
+            $result = $hashTable | ConvertTo-PodeYaml
             $result | Should -Be "key1: value1`nkey2: value2"
         }
     }
@@ -1751,7 +1755,7 @@ Describe 'ConvertTo-PodeYamlInternal Tests' {
                     child = 'value'
                 }
             }
-            $result = $nestedHash | ConvertTo-PodeYamlInternal -NoNewLine
+            $result = $nestedHash | ConvertTo-PodeYaml
 
             $result | Should -Be "parent: `n  child: value"
         }
@@ -1759,7 +1763,57 @@ Describe 'ConvertTo-PodeYamlInternal Tests' {
 
     Context 'Error handling' {
         It 'Returns empty string for null input' {
-            $result = $null | ConvertTo-PodeYamlInternal
+            $result = $null | ConvertTo-PodeYaml
+            $result | Should -Be ''
+        }
+    }
+}
+
+
+Describe 'ConvertTo-PodeYamlInternal Tests' {
+    Context 'When converting basic types' {
+        It 'Converts strings correctly' {
+
+            $result = ConvertTo-PodeYamlInternal -InputObject 'hello world'
+            $result | Should -Be 'hello world'
+        }
+
+        It 'Converts arrays correctly' {
+            $result = ConvertTo-PodeYamlInternal -InputObject  @('one', 'two', 'three') -NoNewLine
+            $expected = (@'
+- one
+- two
+- three
+'@)
+            $result | Should -Be ($expected.Trim() -Replace "`r`n", "`n")
+        }
+
+        It 'Converts hashtables correctly' {
+            $hashTable = [ordered]@{
+                key1 = 'value1'
+                key2 = 'value2'
+            }
+            $result = ConvertTo-PodeYamlInternal -InputObject $hashTable -NoNewLine
+            $result | Should -Be "key1: value1`nkey2: value2"
+        }
+    }
+
+    Context 'When converting complex objects' {
+        It 'Handles nested hashtables' {
+            $nestedHash = @{
+                parent = @{
+                    child = 'value'
+                }
+            }
+            $result = ConvertTo-PodeYamlInternal -InputObject  $nestedHash -NoNewLine
+
+            $result | Should -Be "parent: `n  child: value"
+        }
+    }
+
+    Context 'Error handling' {
+        It 'Returns empty string for null input' {
+            $result = ConvertTo-PodeYamlInternal -InputObject $null
             $result | Should -Be ''
         }
     }

--- a/tests/unit/Responses.Tests.ps1
+++ b/tests/unit/Responses.Tests.ps1
@@ -239,6 +239,41 @@ Describe 'Write-PodeCsvResponse' {
         $r.ContentType | Should -Be $_ContentType
     }
 
+    It 'Converts and returns a value from a array of hashtable' {
+        $r = Write-PodeCsvResponse -Value @(@{ Name = 'Rick' }, @{ Name = 'Don' })
+        $r.Value | Should -Be "`"Name`"$([environment]::NewLine)`"Rick`"$([environment]::NewLine)`"Don`""
+        $r.ContentType | Should -Be $_ContentType
+    }
+
+    It 'Converts and returns a value from a array of hashtable by Pipe' {
+        $r = @(@{ Name = 'Rick' }, @{ Name = 'Don' }) | Write-PodeCsvResponse
+        $r.Value | Should -Be "`"Name`"$([environment]::NewLine)`"Rick`"$([environment]::NewLine)`"Don`""
+        $r.ContentType | Should -Be $_ContentType
+    }
+
+    It 'Converts and returns a value from a array of PSCustomObject' {
+        $users = @([PSCustomObject]@{
+                Name = 'Rick'
+            }, [PSCustomObject]@{
+                Name = 'Don'
+            }
+        )
+        $r = Write-PodeCsvResponse -Value $users
+        $r.Value | Should -Be "`"Name`"$([environment]::NewLine)`"Rick`"$([environment]::NewLine)`"Don`""
+        $r.ContentType | Should -Be $_ContentType
+    }
+
+    It 'Converts and returns a value from a array of PSCustomObject by Pipe' {
+        $r = @([PSCustomObject]@{
+                Name = 'Rick'
+            }, [PSCustomObject]@{
+                Name = 'Don'
+            }
+        ) | Write-PodeCsvResponse
+        $r.Value | Should -Be "`"Name`"$([environment]::NewLine)`"Rick`"$([environment]::NewLine)`"Don`""
+        $r.ContentType | Should -Be $_ContentType
+    }
+
     It 'Does nothing for an invalid file path' {
         Mock Test-PodePath { return $false }
         Write-PodeCsvResponse -Path 'fake-file' | Out-Null
@@ -274,35 +309,47 @@ Describe 'Write-PodeXmlResponse' {
     }
 
     It 'Converts and returns a value from a hashtable' {
-        $r = Write-PodeXmlResponse -Value @{ 'name' = 'john' } -UsePropertyName
+        $r = Write-PodeXmlResponse -Value @{ 'name' = 'john' }
         ($r.Value -ireplace '[\r\n ]', '') | Should -Be '<?xmlversion="1.0"encoding="utf-8"?><Objects><Object><PropertyName="name">john</Property></Object></Objects>'
         $r.ContentType | Should -Be $_ContentType
     }
 
     It 'Converts and returns a value from a array of hashtable by pipe' {
-        $r = @(@{ Name = 'Rick' }, @{ Name = 'Don' }) | Write-PodeXmlResponse -UsePropertyName
+        $r = @(@{ Name = 'Rick' }, @{ Name = 'Don' }) | Write-PodeXmlResponse
         ($r.Value -ireplace '[\r\n ]', '') | Should -Be '<?xmlversion="1.0"encoding="utf-8"?><Objects><Object><PropertyName="Name">Rick</Property></Object><Object><PropertyName="Name">Don</Property></Object></Objects>'
         $r.ContentType | Should -Be $_ContentType
     }
 
     It 'Converts and returns a value from a array of hashtable' {
-        $r = Write-PodeXmlResponse -Value @(@{ Name = 'Rick' }, @{ Name = 'Don' }) -UsePropertyName
+        $r = Write-PodeXmlResponse -Value @(@{ Name = 'Rick' }, @{ Name = 'Don' })
         ($r.Value -ireplace '[\r\n ]', '') | Should -Be '<?xmlversion="1.0"encoding="utf-8"?><Objects><Object><PropertyName="Name">Rick</Property></Object><Object><PropertyName="Name">Don</Property></Object></Objects>'
         $r.ContentType | Should -Be $_ContentType
     }
-    It 'Converts and returns a value from a array of process' {
-    $myProcess = Get-Process | .{ process { if ($_.WS -gt 100mb) { $_ } } } |
-    Select-Object Name, @{e = { [int]($_.WS / 1mb) }; n = 'WS' } |
-    Sort-Object WS -Descending
-    Write-PodeXmlResponse  -StatusCode 200 -Value $myProcess
-}
 
-It 'Converts and returns a value from a array of process pipe' {
-    $myProcess = Get-Process | .{ process { if ($_.WS -gt 100mb) { $_ } } } |
-    Select-Object Name, @{e = { [int]($_.WS / 1mb) }; n = 'WS' } |
-    Sort-Object WS -Descending|
-    Write-PodeXmlResponse  -StatusCode 200
-}
+    It 'Converts and returns a value from a array of PSCustomObject' {
+        $users = @([PSCustomObject]@{
+                Name = 'Rick'
+            }, [PSCustomObject]@{
+                Name = 'Don'
+            }
+        )
+        $r = Write-PodeXmlResponse -Value $users
+        ($r.Value -ireplace '[\r\n ]', '') | Should -Be '<?xmlversion="1.0"encoding="utf-8"?><Objects><Object><PropertyName="Name">Rick</Property></Object><Object><PropertyName="Name">Don</Property></Object></Objects>'
+        $r.ContentType | Should -Be $_ContentType
+    }
+
+    It 'Converts and returns a value from a array of PSCustomObject passed by pipe' {
+        $r = @([PSCustomObject]@{
+                Name = 'Rick'
+            }, [PSCustomObject]@{
+                Name = 'Don'
+            }
+        ) | Write-PodeXmlResponse
+        ($r.Value -ireplace '[\r\n ]', '') | Should -Be '<?xmlversion="1.0"encoding="utf-8"?><Objects><Object><PropertyName="Name">Rick</Property></Object><Object><PropertyName="Name">Don</Property></Object></Objects>'
+        $r.ContentType | Should -Be $_ContentType
+    }
+
+
     It 'Does nothing for an invalid file path' {
         Mock Test-PodePath { return $false }
         Write-PodeXmlResponse -Path 'fake-file' | Out-Null


### PR DESCRIPTION
Address the #1272 bug (Write-PodeHtmlResponse returns the wrong result when an array of strings is piped.)
The same issue is present with the following functions:

- Write-PodeCsvResponse
- Write-PodeHtmlResponse
- Write-PodeJsonResponse
- Write-PodeXmlResponse
- Write-PodeYamlResponse
 

 

### Description of the Change
Added support for array values passed using piping

### Related Issue
Issue @1272

### Examples
```
Add-PodeRoute -Path '/processesPipedNotWorking'  -Method Get -ScriptBlock {
        Get-Process | .{ process { if ($_.WS -gt 100mb) { $_ } } } |
            Select-Object Name, @{e = { [int]($_.WS / 1mb) }; n = 'WS' } |
            Sort-Object WS -Descending | Write-PodeHtmlResponse  -StatusCode 200
    }
```