### PR TITLE
Applies a fix for a PS7.5 bug with Remove-Item throwing divide by zero error

### DIFF
--- a/pode.build.ps1
+++ b/pode.build.ps1
@@ -15,6 +15,9 @@ param(
     $ReleaseNoteVersion
 )
 
+# Fix for PS7.5 Preview - https://github.com/PowerShell/PowerShell/issues/23868
+$ProgressPreference = 'SilentlyContinue'
+
 <#
 # Dependency Versions
 #>


### PR DESCRIPTION
### Description of the Change
Applies a fix for a PS7.5-preview.3 bug with Remove-Item throwing divide by zero error

Info here: https://github.com/PowerShell/PowerShell/issues/23868

The fix is to have `$ProgressPreference = 'SilentlyContinue'` in the `pode.build.ps1` file.
