### PR TITLE
Fix build error when dotnet tries to restore from offline NuGet cache

### DIFF
--- a/src/Listener/NuGet.config
+++ b/src/Listener/NuGet.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <packageSources>
+        <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    </packageSources>
+</configuration>


### PR DESCRIPTION
### Description of the Change
Fix build error when dotnet tries to restore from offline NuGet cache, by adding a `NuGet.config` file for the listener to restore from the online NuGet repository.

### Related Issue
Resolves #1039 