### PR TITLE
Remove Global Variables $TimerEvent and $WebEvent

### DIFF
--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -495,6 +495,8 @@ function New-PodeRunspaceState {
     $variables = @(
         (New-Object System.Management.Automation.Runspaces.SessionStateVariableEntry -ArgumentList 'PodeContext', $session, $null),
         (New-Object System.Management.Automation.Runspaces.SessionStateVariableEntry -ArgumentList 'Console', $Host, $null),
+        (New-Object System.Management.Automation.Runspaces.SessionStateVariableEntry -ArgumentList 'TimerEvent', $TimerEvent, $null),
+        (New-Object System.Management.Automation.Runspaces.SessionStateVariableEntry -ArgumentList 'WebEvent', $WebEvent, $null),
         (New-Object System.Management.Automation.Runspaces.SessionStateVariableEntry -ArgumentList 'PODE_SCOPE_RUNSPACE', $true, $null)
     )
 

--- a/src/Private/Serverless.ps1
+++ b/src/Private/Serverless.ps1
@@ -26,7 +26,7 @@ function Start-PodeAzFuncServer {
             $response.Headers = @{}
 
             # reset event data
-            $global:WebEvent = @{
+            $WebEvent += @{
                 OnEnd            = @()
                 Auth             = @{}
                 Response         = $response
@@ -154,7 +154,7 @@ function Start-PodeAwsLambdaServer {
             }
 
             # reset event data
-            $global:WebEvent = @{
+            $WebEvent += @{
                 OnEnd            = @()
                 Auth             = @{}
                 Response         = $response

--- a/src/Private/Serverless.ps1
+++ b/src/Private/Serverless.ps1
@@ -1,5 +1,4 @@
 function Start-PodeAzFuncServer {
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidGlobalVars', '')]
     param(
         [Parameter(Mandatory = $true)]
         $Data
@@ -126,7 +125,6 @@ function Start-PodeAzFuncServer {
 }
 
 function Start-PodeAwsLambdaServer {
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidGlobalVars', '')]
     param(
         [Parameter(Mandatory = $true)]
         $Data

--- a/src/Private/Timers.ps1
+++ b/src/Private/Timers.ps1
@@ -62,8 +62,6 @@ function Start-PodeTimerRunspace {
 }
 
 function Invoke-PodeInternalTimer {
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidGlobalVars', '')]
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
     param(
         [Parameter(Mandatory = $true)]
         $Timer,

--- a/src/Private/Timers.ps1
+++ b/src/Private/Timers.ps1
@@ -72,7 +72,7 @@ function Invoke-PodeInternalTimer {
     )
 
     try {
-        $global:TimerEvent = @{
+        $TimerEvent += @{
             Lockable = $PodeContext.Threading.Lockables.Global
             Sender   = $Timer
             Metadata = @{}

--- a/src/Public/Core.ps1
+++ b/src/Public/Core.ps1
@@ -176,6 +176,12 @@ function Start-PodeServer {
             [Console]::TreatControlCAsInput = $true
         }
 
+        # create TimerEvent  object
+        $script:TimerEvent = @{}
+
+        # create WebEvent  object
+        $script:WebEvent = @{}
+
         # start the file monitor for interally restarting
         Start-PodeFileMonitor
 


### PR DESCRIPTION
### Description of the Change
This request aims to remove the global variables $TimerEvent and $WebEvent from the codebase to enhance security. These variables will be passed to the runspaces using System.Management.Automation.Runspaces.SessionStateVariableEntry.

### Background:
Global variables can lead to several issues, including namespace pollution, difficulty in tracking modifications, unintended side effects, and security risks. To address these concerns, we are refactoring the code to avoid the use of global variables.

### Changes:

1.	Removed the global definitions of $TimerEvent and $WebEvent.
2.	Passed these variables to the runspaces using System.Management.Automation.Runspaces.SessionStateVariableEntry.

### Code changes
#### Before
``` powershell
function Start-PodeAzFuncServer {
    param(
        [Parameter(Mandatory = $true)]
        $Data
    )
    ....
    # reset event data
    $global:WebEvent = @{
        OnEnd            = @()
        Auth             = @{}
        Response         = $response
        Request          = $request
        Lockable         = $PodeContext.Threading.Lockables.Global
        Path             = [string]::Empty
        Method           = $request.Method.ToLowerInvariant()
        Query            = $request.Query
        Endpoint         = @{
            Protocol = ($request.Url -split '://')[0]
            Address  = $null
            Name     = $null
        }
        ContentType      = $null
        ErrorType        = $null
        Cookies          = @{}
        PendingCookies   = @{}
        Parameters       = $null
        Data             = $null
        Files            = $null
        Streamed         = $false
        Route            = $null
        StaticContent    = $null
        Timestamp        = [datetime]::UtcNow
        TransferEncoding = $null
        AcceptEncoding   = $null
        Ranges           = $null
        Metadata         = @{}
    }
}

function New-PodeRunspaceState {
    # create the state, and add the pode modules
    $state = [initialsessionstate]::CreateDefault()
    $state.ImportPSModule($PodeContext.Server.PodeModule.DataPath)
    $state.ImportPSModule($PodeContext.Server.PodeModule.InternalPath)

    # load the vars into the share state
    $session = New-PodeStateContext -Context $PodeContext

    $variables = @(
        (New-Object System.Management.Automation.Runspaces.SessionStateVariableEntry -ArgumentList 'PodeContext', $session, $null),
        (New-Object System.Management.Automation.Runspaces.SessionStateVariableEntry -ArgumentList 'Console', $Host, $null),
        (New-Object System.Management.Automation.Runspaces.SessionStateVariableEntry -ArgumentList 'PODE_SCOPE_RUNSPACE', $true, $null)
    )

    foreach ($var in $variables) {
        $state.Variables.Add($var)
    }

    $PodeContext.RunspaceState = $state
}
```

#### After
```powershell
function Start-PodeAzFuncServer {
    param(
        [Parameter(Mandatory = $true)]
        $Data
    )
    ....
    # reset event data
    $WebEvent += @{
        OnEnd            = @()
        Auth             = @{}
        Response         = $response
        Request          = $request
        Lockable         = $PodeContext.Threading.Lockables.Global
        Path             = [string]::Empty
        Method           = $request.Method.ToLowerInvariant()
        Query            = $request.Query
        Endpoint         = @{
            Protocol = ($request.Url -split '://')[0]
            Address  = $null
            Name     = $null
        }
        ContentType      = $null
        ErrorType        = $null
        Cookies          = @{}
        PendingCookies   = @{}
        Parameters       = $null
        Data             = $null
        Files            = $null
        Streamed         = $false
        Route            = $null
        StaticContent    = $null
        Timestamp        = [datetime]::UtcNow
        TransferEncoding = $null
        AcceptEncoding   = $null
        Ranges           = $null
        Metadata         = @{}
    }
}

function New-PodeRunspaceState {
    # create the state, and add the pode modules
    $state = [initialsessionstate]::CreateDefault()
    $state.ImportPSModule($PodeContext.Server.PodeModule.DataPath)
    $state.ImportPSModule($PodeContext.Server.PodeModule.InternalPath)

    # load the vars into the share state
    $session = New-PodeStateContext -Context $PodeContext

    $variables = @(
        (New-Object System.Management.Automation.Runspaces.SessionStateVariableEntry -ArgumentList 'PodeContext', $session, $null),
        (New-Object System.Management.Automation.Runspaces.SessionStateVariableEntry -ArgumentList 'Console', $Host, $null),
        (New-Object System.Management.Automation.Runspaces.SessionStateVariableEntry -ArgumentList 'TimerEvent', $TimerEvent, $null),
        (New-Object System.Management.Automation.Runspaces.SessionStateVariableEntry -ArgumentList 'WebEvent', $WebEvent, $null),
        (New-Object System.Management.Automation.Runspaces.SessionStateVariableEntry -ArgumentList 'PODE_SCOPE_RUNSPACE', $true, $null)
    )

    foreach ($var in $variables) {
        $state.Variables.Add($var)
    }

    $PodeContext.RunspaceState = $state
}
```