### PR TITLE
Pull Request: Enhanced Error Handling for Internal Pode Errors

### DIFF
--- a/docs/Tutorials/Routes/Utilities/ErrorPages.md
+++ b/docs/Tutorials/Routes/Utilities/ErrorPages.md
@@ -53,6 +53,33 @@ Start-PodeServer {
 }
 ```
 
+### Internal Server Errors
+By default, any internal Pode error will now generate an HTTP `500` status code without returning any additional internal information to the user.
+This change enhances security by preventing the exposure of internal server details.
+
+For debugging purposes, detailed error information can be included in HTTP 500 responses using the `Code500Details` switch parameter.
+
+Example Usage with `Code500Details`:
+
+```powershell
+# Start the Pode server with detailed error information in HTTP 500 responses for debugging
+Start-PodeServer -Code500Details
+```
+
+The `Code500Details` parameter can also be configured using the `server.psd1` configuration file in the following format:
+
+```powershell
+@{
+    # omit
+    Server = @{
+        # omit
+        Debug = @{
+            Code500Details = $true
+        }
+    }
+}
+```
+This configuration ensures that any internal error generates a code 500 with detailed exception information, aiding in the debugging process.
 ## Error Pages
 
 When a response is returned with a status code of 400+, then Pode will attempt to render these as styled error pages. By default, Pode has inbuilt error pages that will be used (these show the status code, description, the URL, and if enabled the exception message/stacktrace).

--- a/examples/FileBrowser/FileBrowser.ps1
+++ b/examples/FileBrowser/FileBrowser.ps1
@@ -9,7 +9,7 @@ else {
 
 $directoryPath = $podePath
 # Start Pode server
-Start-PodeServer -ScriptBlock {
+Start-PodeServer -Browse -ScriptBlock {
 
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http -Default
 

--- a/examples/code500.ps1
+++ b/examples/code500.ps1
@@ -1,18 +1,25 @@
-$path = Split-Path -Parent -Path (Split-Path -Parent -Path $MyInvocation.MyCommand.Path)
-Import-Module "$($path)/src/Pode.psm1" -Force -ErrorAction Stop
+try {
+    $ScriptPath = (Split-Path -Parent -Path $MyInvocation.MyCommand.Path)
+    $podePath = Split-Path -Parent -Path $ScriptPath
+    if (Test-Path -Path "$($podePath)/src/Pode.psm1" -PathType Leaf) {
+        Import-Module "$($podePath)/src/Pode.psm1" -Force -ErrorAction Stop
+    }
+    else {
+        Import-Module -Name 'Pode' -ErrorAction Stop
+    }
+}
+catch { throw }
 
 # or just:
 # Import-Module Pode
 
 # create a server, and start listening on port 8081
-Start-PodeServer -Code500Details {
+Start-PodeServer -Browse -Code500Details {
 
     # listen on localhost:8081
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http
-    New-PodeLoggingMethod -Terminal | Enable-PodeRequestLogging
+
     New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
-
-
 
     Add-PodeRoute -Method Get -Path '/' -ScriptBlock {
         $result = @{

--- a/examples/code500.ps1
+++ b/examples/code500.ps1
@@ -1,0 +1,26 @@
+$path = Split-Path -Parent -Path (Split-Path -Parent -Path $MyInvocation.MyCommand.Path)
+Import-Module "$($path)/src/Pode.psm1" -Force -ErrorAction Stop
+
+# or just:
+# Import-Module Pode
+
+# create a server, and start listening on port 8081
+Start-PodeServer -Code500Details {
+
+    # listen on localhost:8081
+    Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http
+    New-PodeLoggingMethod -Terminal | Enable-PodeRequestLogging
+    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+
+
+
+    Add-PodeRoute -Method Get -Path '/' -ScriptBlock {
+        $result = @{
+            something = 'here'
+            complex   = 10 / 0
+        }
+        Write-PodeJsonResponse -Value  $result
+    }
+
+
+}

--- a/examples/server.psd1
+++ b/examples/server.psd1
@@ -60,6 +60,7 @@
             Breakpoints = @{
                 Enable = $true
             }
+            Code500Details= $true
         }
     }
 }

--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -50,7 +50,10 @@ function New-PodeContext {
         $Quiet,
 
         [switch]
-        $EnableBreakpoints
+        $EnableBreakpoints,
+
+        [switch]
+        $Code500Details
     )
 
     # set a random server name if one not supplied
@@ -94,6 +97,7 @@ function New-PodeContext {
     $ctx.Server.DisableTermination = $DisableTermination.IsPresent
     $ctx.Server.Quiet = $Quiet.IsPresent
     $ctx.Server.ComputerName = [System.Net.DNS]::GetHostName()
+    $ctx.Server.Code500Details = $Code500Details.IsPresent
 
     # list of created listeners/receivers
     $ctx.Listeners = @()

--- a/src/Private/PodeServer.ps1
+++ b/src/Private/PodeServer.ps1
@@ -1,5 +1,27 @@
 using namespace Pode
 
+<#
+.SYNOPSIS
+    Starts the Pode web server with specified configurations.
+
+.DESCRIPTION
+    Initializes and starts the Pode web server, setting up inbuilt middleware,
+    registering endpoints, and starting listeners for HTTP and WebSocket protocols.
+    Configures and manages the server's behavior, including error handling and signal
+    processing.
+
+.PARAMETER Browse
+    Optional switch to automatically open the first endpoint URL in the default web browser.
+
+.EXAMPLE
+    Start-PodeWebServer
+
+.EXAMPLE
+    Start-PodeWebServer -Browse
+
+.NOTES
+    This is an internal function and may change in future releases of Pode.
+#>
 function Start-PodeWebServer {
     param(
         [switch]
@@ -252,7 +274,14 @@ function Start-PodeWebServer {
                         catch {
                             $_ | Write-PodeErrorLog
                             $_.Exception | Write-PodeErrorLog -CheckInnerException
-                            Set-PodeResponseStatus -Code 500 -Exception $_
+
+                            # Check if Code 500 has to return the internal details
+                            if ($PodeContext.Server.Code500Details) {
+                                Set-PodeResponseStatus -Code 500  -Exception $_
+                            }
+                            else {
+                                Set-PodeResponseStatus -Code 500
+                            }
                         }
                         finally {
                             Update-PodeServerRequestMetric -WebEvent $WebEvent

--- a/src/Private/PodeServer.ps1
+++ b/src/Private/PodeServer.ps1
@@ -276,8 +276,8 @@ function Start-PodeWebServer {
                             $_.Exception | Write-PodeErrorLog -CheckInnerException
 
                             # Check if Code 500 has to return the internal details
-                            if ($PodeContext.Server.Code500Details) {
-                                Set-PodeResponseStatus -Code 500  -Exception $_
+                            if ($PodeContext.Server.Debug.Code500Details) {
+                                Set-PodeResponseStatus -Code 500 -Exception $_
                             }
                             else {
                                 Set-PodeResponseStatus -Code 500

--- a/src/Private/Server.ps1
+++ b/src/Private/Server.ps1
@@ -1,3 +1,28 @@
+<#
+.SYNOPSIS
+    Starts the internal Pode server with the specified configurations.
+
+.DESCRIPTION
+    Initializes and starts the Pode internal server, setting up necessary variables,
+    runspaces, and middleware. Handles the configuration and startup process for
+    different server types, including HTTP, WebSocket, and serverless (Azure Functions
+    and AWS Lambda).
+
+.PARAMETER Request
+    The incoming request data, used when running in serverless mode.
+
+.PARAMETER Browse
+    Optional switch to automatically open the first endpoint URL in the default web browser.
+
+.EXAMPLE
+    Start-PodeInternalServer
+
+.EXAMPLE
+    Start-PodeInternalServer -Browse
+
+.NOTES
+    This is an internal function and may change in future releases of Pode.
+#>
 function Start-PodeInternalServer {
     param(
         [Parameter()]

--- a/src/Public/Core.ps1
+++ b/src/Public/Core.ps1
@@ -1,60 +1,63 @@
 <#
 .SYNOPSIS
-Starts a Pode Server with the supplied ScriptBlock.
+    Starts a Pode Server with the supplied ScriptBlock.
 
 .DESCRIPTION
-Starts a Pode Server with the supplied ScriptBlock.
+    Starts a Pode Server with the supplied ScriptBlock.
 
 .PARAMETER ScriptBlock
-The main logic for the Server.
+    The main logic for the Server.
 
 .PARAMETER FilePath
-A literal, or relative, path to a file containing a ScriptBlock for the Server's logic.
-The directory of this file will be used as the Server's root path - unless a specific -RootPath is supplied.
+    A literal, or relative, path to a file containing a ScriptBlock for the Server's logic.
+    The directory of this file will be used as the Server's root path - unless a specific -RootPath is supplied.
 
 .PARAMETER Interval
-For 'Service' type Servers, will invoke the ScriptBlock every X seconds.
+    For 'Service' type Servers, will invoke the ScriptBlock every X seconds.
 
 .PARAMETER Name
-An optional name for the Server (intended for future ideas).
+    An optional name for the Server (intended for future ideas).
 
 .PARAMETER Threads
-The numbers of threads to use for Web, SMTP, and TCP servers.
+    The numbers of threads to use for Web, SMTP, and TCP servers.
 
 .PARAMETER RootPath
-An override for the Server's root path.
+    An override for the Server's root path.
 
 .PARAMETER Request
-Intended for Serverless environments, this is Requests details that Pode can parse and use.
+    Intended for Serverless environments, this is Requests details that Pode can parse and use.
 
 .PARAMETER ServerlessType
-Optional, this is the serverless type, to define how Pode should run and deal with incoming Requests.
+    Optional, this is the serverless type, to define how Pode should run and deal with incoming Requests.
 
 .PARAMETER StatusPageExceptions
-An optional value of Show/Hide to control where Stacktraces are shown in the Status Pages.
-If supplied this value will override the ShowExceptions setting in the server.psd1 file.
+    An optional value of Show/Hide to control where Stacktraces are shown in the Status Pages.
+    If supplied this value will override the ShowExceptions setting in the server.psd1 file.
 
 .PARAMETER ListenerType
-An optional value to use a custom Socket Listener. The default is Pode's inbuilt listener.
-There's the Pode.Kestrel module, so the value here should be "Kestrel" if using that.
+    An optional value to use a custom Socket Listener. The default is Pode's inbuilt listener.
+    There's the Pode.Kestrel module, so the value here should be "Kestrel" if using that.
 
 .PARAMETER DisableTermination
-Disables the ability to terminate the Server.
+    Disables the ability to terminate the Server.
 
 .PARAMETER Quiet
-Disables any output from the Server.
+    Disables any output from the Server.
 
 .PARAMETER Browse
-Open the web Server's default endpoint in your default browser.
+    Open the web Server's default endpoint in your default browser.
 
 .PARAMETER CurrentPath
-Sets the Server's root path to be the current working path - for -FilePath only.
+    Sets the Server's root path to be the current working path - for -FilePath only.
 
 .PARAMETER EnablePool
-Tells Pode to configure certain RunspacePools when they're being used adhoc, such as Timers or Schedules.
+    Tells Pode to configure certain RunspacePools when they're being used adhoc, such as Timers or Schedules.
 
 .PARAMETER EnableBreakpoints
-If supplied, any breakpoints created by using Wait-PodeDebugger will be enabled - or disabled if false passed explicitly, or not supplied.
+    If supplied, any breakpoints created by using Wait-PodeDebugger will be enabled - or disabled if false passed explicitly, or not supplied.
+
+.PARAMETER Code500Details
+    Optional switch to include detailed error information in HTTP 500 responses.
 
 .EXAMPLE
 Start-PodeServer { /* logic */ }
@@ -64,6 +67,9 @@ Start-PodeServer -Interval 10 { /* logic */ }
 
 .EXAMPLE
 Start-PodeServer -Request $LambdaInput -ServerlessType AwsLambda { /* logic */ }
+
+.EXAMPLE
+Start-PodeServer -Code500Details -ScriptBlock { /* logic */ }
 #>
 function Start-PodeServer {
     [CmdletBinding(DefaultParameterSetName = 'Script')]
@@ -128,7 +134,10 @@ function Start-PodeServer {
         $CurrentPath,
 
         [switch]
-        $EnableBreakpoints
+        $EnableBreakpoints,
+
+        [switch]
+        $Code500Details
     )
 
     # ensure the session is clean
@@ -169,7 +178,8 @@ function Start-PodeServer {
             -StatusPageExceptions $StatusPageExceptions `
             -DisableTermination:$DisableTermination `
             -Quiet:$Quiet `
-            -EnableBreakpoints:$EnableBreakpoints
+            -EnableBreakpoints:$EnableBreakpoints `
+            -Code500Details:$Code500Details
 
         # set it so ctrl-c can terminate, unless serverless/iis, or disabled
         if (!$PodeContext.Server.DisableTermination -and ($null -eq $psISE)) {


### PR DESCRIPTION
#### Description

This pull request introduces a modification to the error handling mechanism within Pode. The key change is the enhancement of how internal errors are reported. Previously, any internal Pode error would generate an HTTP 500 status code along with the associated exception's internal information. This approach has been updated to improve security and user experience.

#### Key Changes:

1. **Default Error Handling**:
    - By default, any internal Pode error will now generate an HTTP 500 status code without returning any additional internal information to the user. This change enhances security by preventing the exposure of internal server details.

2. **Debugging Support**:
    - Added a new `-Code500Details` switch parameter to the `Start-PodeServer` function.
    - When this switch is present, the server will return an HTTP 500 status code along with the exception details. This is particularly useful for debugging purposes.
    - The `Code500Details` parameter can also be passed using `server.psd1` in the following format:

    ```powershell
    @{
        # omit
        Server = @{
            # omit
            Debug = @{ 
                Code500Details = $true
            }
        }
    }
    ```

#### Implementation Details:

- Updated the `Start-PodeServer` function to include the `-Code500Details` switch parameter.
- Modified the error handling logic to conditionally include exception details based on the presence of the `-Code500Details` switch.
- Ensured backward compatibility by maintaining the default behavior of omitting exception details unless explicitly requested by the `-Code500Details` switch.

#### Example Usage:

```powershell
# Start the Pode server with default error handling
Start-PodeServer

# Start the Pode server with detailed error information in HTTP 500 responses for debugging
Start-PodeServer -Code500Details
```

#### Documentation:

Updated the function headers and inline documentation to reflect the changes.
Updated the documentation to reflect the changes.
