### PR TITLE
Fixes a bug when exporting more than 1 module

### DIFF
--- a/src/Public/AutoImport.ps1
+++ b/src/Public/AutoImport.ps1
@@ -20,7 +20,7 @@ function Export-PodeModule {
     )
 
     $PodeContext.Server.AutoImport.Modules.ExportList += @($Name)
-    $PodeContext.Server.AutoImport.Modules.ExportList = $PodeContext.Server.AutoImport.Modules.ExportList | Sort-Object -Unique
+    $PodeContext.Server.AutoImport.Modules.ExportList = @($PodeContext.Server.AutoImport.Modules.ExportList | Sort-Object -Unique)
 }
 
 <#
@@ -51,7 +51,7 @@ function Export-PodeSnapin {
     }
 
     $PodeContext.Server.AutoImport.Snapins.ExportList += @($Name)
-    $PodeContext.Server.AutoImport.Snapins.ExportList = $PodeContext.Server.AutoImport.Snapins.ExportList | Sort-Object -Unique
+    $PodeContext.Server.AutoImport.Snapins.ExportList = @($PodeContext.Server.AutoImport.Snapins.ExportList | Sort-Object -Unique)
 }
 
 <#
@@ -76,7 +76,7 @@ function Export-PodeFunction {
     )
 
     $PodeContext.Server.AutoImport.Functions.ExportList += @($Name)
-    $PodeContext.Server.AutoImport.Functions.ExportList = $PodeContext.Server.AutoImport.Functions.ExportList | Sort-Object -Unique
+    $PodeContext.Server.AutoImport.Functions.ExportList = @($PodeContext.Server.AutoImport.Functions.ExportList | Sort-Object -Unique)
 }
 
 <#
@@ -109,5 +109,5 @@ function Export-PodeSecretVault {
     )
 
     $PodeContext.Server.AutoImport.SecretVaults[$Type].ExportList += @($Name)
-    $PodeContext.Server.AutoImport.SecretVaults[$Type].ExportList = $PodeContext.Server.AutoImport.SecretVaults[$Type].ExportList | Sort-Object -Unique
+    $PodeContext.Server.AutoImport.SecretVaults[$Type].ExportList = @($PodeContext.Server.AutoImport.SecretVaults[$Type].ExportList | Sort-Object -Unique)
 }


### PR DESCRIPTION
### Description of the Change
Fixes a bug when exporting more than 1 module, and the same for snapins, functions and secret vaults.

When piping into `Sort-Object` for the first module, the name would be converted into a string, so a second module being added simply appends to a string and not an array.
