### PR TITLE
Fixes for OpenAPI Generation: Exception with oneOf/anyOf/allOf; Correct Schema with -NoProperties; Accurate Output with -NoDefaultResponses; Include Min/Max Properties; Prevent Request Body on GET Operations

### DIFF
--- a/src/Locales/ar/Pode.psd1
+++ b/src/Locales/ar/Pode.psd1
@@ -211,7 +211,7 @@
     viewsFolderNameAlreadyExistsExceptionMessage                      = 'اسم مجلد العرض موجود بالفعل: {0}'
     noNameForWebSocketResetExceptionMessage                           = 'لا يوجد اسم لإعادة تعيين WebSocket من المزود.'
     mergeDefaultAuthNotInListExceptionMessage                         = "المصادقة MergeDefault '{0}' غير موجودة في قائمة المصادقة المقدمة."
-    descriptionRequiredExceptionMessage                               = 'الوصف مطلوب.'
+    descriptionRequiredExceptionMessage                               = 'مطلوب وصف للمسار: {0} الاستجابة: {1}'
     pageNameShouldBeAlphaNumericExceptionMessage                      = 'يجب أن يكون اسم الصفحة قيمة أبجدية رقمية صالحة: {0}'
     defaultValueNotBooleanOrEnumExceptionMessage                      = 'القيمة الافتراضية ليست من نوع boolean وليست جزءًا من التعداد.'
     openApiComponentSchemaDoesNotExistExceptionMessage                = 'مخطط مكون OpenApi {0} غير موجود.'
@@ -284,6 +284,6 @@
     requestLoggingAlreadyEnabledExceptionMessage                      = 'تم تمكين تسجيل الطلبات بالفعل.'
     invalidAccessControlMaxAgeDurationExceptionMessage                = 'مدة Access-Control-Max-Age غير صالحة المقدمة: {0}. يجب أن تكون أكبر من 0.'
     openApiDefinitionAlreadyExistsExceptionMessage                    = 'تعريف OpenAPI باسم {0} موجود بالفعل.'
-    renamePodeOADefinitionTagExceptionMessage                     = "لا يمكن استخدام Rename-PodeOADefinitionTag داخل Select-PodeOADefinition 'ScriptBlock'."
-    DefinitionTagChangeNotAllowedExceptionMessage                     = 'لا يمكن تغيير علامة التعريف لمسار.'
+    renamePodeOADefinitionTagExceptionMessage                         = "لا يمكن استخدام Rename-PodeOADefinitionTag داخل Select-PodeOADefinition 'ScriptBlock'."
+    definitionTagChangeNotAllowedExceptionMessage                     = 'لا يمكن تغيير علامة التعريف لمسار.'
 }

--- a/src/Locales/ar/Pode.psd1
+++ b/src/Locales/ar/Pode.psd1
@@ -286,5 +286,5 @@
     openApiDefinitionAlreadyExistsExceptionMessage                    = 'تعريف OpenAPI باسم {0} موجود بالفعل.'
     renamePodeOADefinitionTagExceptionMessage                         = "لا يمكن استخدام Rename-PodeOADefinitionTag داخل Select-PodeOADefinition 'ScriptBlock'."
     definitionTagChangeNotAllowedExceptionMessage                     = 'لا يمكن تغيير علامة التعريف لمسار.'
-    getRequestBodyNotAllowedExceptionMessage                          = 'لا يمكن أن تحتوي عمليات GET على محتوى الطلب.'
+    getRequestBodyNotAllowedExceptionMessage                          = 'لا يمكن أن تحتوي عمليات {0} على محتوى الطلب.'
 }

--- a/src/Locales/ar/Pode.psd1
+++ b/src/Locales/ar/Pode.psd1
@@ -286,4 +286,5 @@
     openApiDefinitionAlreadyExistsExceptionMessage                    = 'تعريف OpenAPI باسم {0} موجود بالفعل.'
     renamePodeOADefinitionTagExceptionMessage                         = "لا يمكن استخدام Rename-PodeOADefinitionTag داخل Select-PodeOADefinition 'ScriptBlock'."
     definitionTagChangeNotAllowedExceptionMessage                     = 'لا يمكن تغيير علامة التعريف لمسار.'
+    getRequestBodyNotAllowedExceptionMessage                          = 'لا يمكن أن تحتوي عمليات GET على محتوى الطلب.'
 }

--- a/src/Locales/de/Pode.psd1
+++ b/src/Locales/de/Pode.psd1
@@ -211,7 +211,7 @@
     viewsFolderNameAlreadyExistsExceptionMessage                      = 'Der Name des Ansichtsordners existiert bereits: {0}'
     noNameForWebSocketResetExceptionMessage                           = 'Kein Name für das Zurücksetzen des WebSocket angegeben.'
     mergeDefaultAuthNotInListExceptionMessage                         = "Die MergeDefault-Authentifizierung '{0}' befindet sich nicht in der angegebenen Authentifizierungsliste."
-    descriptionRequiredExceptionMessage                               = 'Eine Beschreibung ist erforderlich.'
+    descriptionRequiredExceptionMessage                               = 'Eine Beschreibung ist erforderlich für Pfad:{0} Antwort:{1}'
     pageNameShouldBeAlphaNumericExceptionMessage                      = 'Der Seitenname sollte einen gültigen alphanumerischen Wert haben: {0}'
     defaultValueNotBooleanOrEnumExceptionMessage                      = 'Der Standardwert ist kein Boolean und gehört nicht zum Enum.'
     openApiComponentSchemaDoesNotExistExceptionMessage                = 'Das OpenApi-Komponentenschema {0} existiert nicht.'
@@ -285,5 +285,5 @@
     invalidAccessControlMaxAgeDurationExceptionMessage                = 'Ungültige Access-Control-Max-Age-Dauer angegeben: {0}. Sollte größer als 0 sein.'
     openApiDefinitionAlreadyExistsExceptionMessage                    = 'Die OpenAPI-Definition mit dem Namen {0} existiert bereits.'
     renamePodeOADefinitionTagExceptionMessage                     = "Rename-PodeOADefinitionTag kann nicht innerhalb eines 'ScriptBlock' von Select-PodeOADefinition verwendet werden."
-    DefinitionTagChangeNotAllowedExceptionMessage                     = 'Definitionstag für eine Route kann nicht geändert werden.'
+    definitionTagChangeNotAllowedExceptionMessage                     = 'Definitionstag für eine Route kann nicht geändert werden.'
 }

--- a/src/Locales/de/Pode.psd1
+++ b/src/Locales/de/Pode.psd1
@@ -286,5 +286,5 @@
     openApiDefinitionAlreadyExistsExceptionMessage                    = 'Die OpenAPI-Definition mit dem Namen {0} existiert bereits.'
     renamePodeOADefinitionTagExceptionMessage                         = "Rename-PodeOADefinitionTag kann nicht innerhalb eines 'ScriptBlock' von Select-PodeOADefinition verwendet werden."
     definitionTagChangeNotAllowedExceptionMessage                     = 'Definitionstag für eine Route kann nicht geändert werden.'
-    getRequestBodyNotAllowedExceptionMessage                          = 'GET-Operationen können keinen Anforderungstext haben.'
+    getRequestBodyNotAllowedExceptionMessage                          = '{0}-Operationen können keinen Anforderungstext haben.'
 }

--- a/src/Locales/de/Pode.psd1
+++ b/src/Locales/de/Pode.psd1
@@ -284,6 +284,7 @@
     requestLoggingAlreadyEnabledExceptionMessage                      = 'Die Anforderungsprotokollierung wurde bereits aktiviert.'
     invalidAccessControlMaxAgeDurationExceptionMessage                = 'Ungültige Access-Control-Max-Age-Dauer angegeben: {0}. Sollte größer als 0 sein.'
     openApiDefinitionAlreadyExistsExceptionMessage                    = 'Die OpenAPI-Definition mit dem Namen {0} existiert bereits.'
-    renamePodeOADefinitionTagExceptionMessage                     = "Rename-PodeOADefinitionTag kann nicht innerhalb eines 'ScriptBlock' von Select-PodeOADefinition verwendet werden."
+    renamePodeOADefinitionTagExceptionMessage                         = "Rename-PodeOADefinitionTag kann nicht innerhalb eines 'ScriptBlock' von Select-PodeOADefinition verwendet werden."
     definitionTagChangeNotAllowedExceptionMessage                     = 'Definitionstag für eine Route kann nicht geändert werden.'
+    getRequestBodyNotAllowedExceptionMessage                          = 'GET-Operationen können keinen Anforderungstext haben.'
 }

--- a/src/Locales/en-us/Pode.psd1
+++ b/src/Locales/en-us/Pode.psd1
@@ -211,7 +211,7 @@
   viewsFolderNameAlreadyExistsExceptionMessage                      = 'The Views folder name already exists: {0}'
   noNameForWebSocketResetExceptionMessage                           = 'No Name for a WebSocket to reset supplied.'
   mergeDefaultAuthNotInListExceptionMessage                         = "The MergeDefault Authentication '{0}' is not in the Authentication list supplied."
-  descriptionRequiredExceptionMessage                               = 'A Description is required.'
+  descriptionRequiredExceptionMessage                               = 'A Description is required for Path:{0} Response:{1}'
   pageNameShouldBeAlphaNumericExceptionMessage                      = 'The Page name should be a valid Alphanumeric value: {0}'
   defaultValueNotBooleanOrEnumExceptionMessage                      = 'The default value is not a boolean and is not part of the enum.'
   openApiComponentSchemaDoesNotExistExceptionMessage                = "The OpenApi component schema {0} doesn't exist."
@@ -285,5 +285,5 @@
   invalidAccessControlMaxAgeDurationExceptionMessage                = 'Invalid Access-Control-Max-Age duration supplied: {0}. Should be greater than 0.'
   openApiDefinitionAlreadyExistsExceptionMessage                    = 'OpenAPI definition named {0} already exists.'
   renamePodeOADefinitionTagExceptionMessage                     = "Rename-PodeOADefinitionTag cannot be used inside a Select-PodeOADefinition 'ScriptBlock'."
-  DefinitionTagChangeNotAllowedExceptionMessage                     = 'Definition Tag for a Route cannot be changed.'
+  definitionTagChangeNotAllowedExceptionMessage                     = 'Definition Tag for a Route cannot be changed.'
 }

--- a/src/Locales/en-us/Pode.psd1
+++ b/src/Locales/en-us/Pode.psd1
@@ -286,5 +286,5 @@
   openApiDefinitionAlreadyExistsExceptionMessage                    = 'OpenAPI definition named {0} already exists.'
   renamePodeOADefinitionTagExceptionMessage                         = "Rename-PodeOADefinitionTag cannot be used inside a Select-PodeOADefinition 'ScriptBlock'."
   definitionTagChangeNotAllowedExceptionMessage                     = 'Definition Tag for a Route cannot be changed.'
-  getRequestBodyNotAllowedExceptionMessage                          = 'GET operations cannot have a Request Body.'
+  getRequestBodyNotAllowedExceptionMessage                          = '{0} operations cannot have a Request Body.'
 }

--- a/src/Locales/en-us/Pode.psd1
+++ b/src/Locales/en-us/Pode.psd1
@@ -284,6 +284,7 @@
   requestLoggingAlreadyEnabledExceptionMessage                      = 'Request Logging has already been enabled.'
   invalidAccessControlMaxAgeDurationExceptionMessage                = 'Invalid Access-Control-Max-Age duration supplied: {0}. Should be greater than 0.'
   openApiDefinitionAlreadyExistsExceptionMessage                    = 'OpenAPI definition named {0} already exists.'
-  renamePodeOADefinitionTagExceptionMessage                     = "Rename-PodeOADefinitionTag cannot be used inside a Select-PodeOADefinition 'ScriptBlock'."
+  renamePodeOADefinitionTagExceptionMessage                         = "Rename-PodeOADefinitionTag cannot be used inside a Select-PodeOADefinition 'ScriptBlock'."
   definitionTagChangeNotAllowedExceptionMessage                     = 'Definition Tag for a Route cannot be changed.'
+  getRequestBodyNotAllowedExceptionMessage                          = 'GET operations cannot have a Request Body.'
 }

--- a/src/Locales/en/Pode.psd1
+++ b/src/Locales/en/Pode.psd1
@@ -286,6 +286,6 @@
     openApiDefinitionAlreadyExistsExceptionMessage                    = 'OpenAPI definition named {0} already exists.'
     renamePodeOADefinitionTagExceptionMessage                         = "Rename-PodeOADefinitionTag cannot be used inside a Select-PodeOADefinition 'ScriptBlock'."
     definitionTagChangeNotAllowedExceptionMessage                     = 'Definition Tag for a Route cannot be changed.'
-    getRequestBodyNotAllowedExceptionMessage                          = 'GET operations cannot have a Request Body.'
+    getRequestBodyNotAllowedExceptionMessage                          = '{0} operations cannot have a Request Body.'
 }
 

--- a/src/Locales/en/Pode.psd1
+++ b/src/Locales/en/Pode.psd1
@@ -212,7 +212,7 @@
     viewsFolderNameAlreadyExistsExceptionMessage                      = 'The Views folder name already exists: {0}'
     noNameForWebSocketResetExceptionMessage                           = 'No Name for a WebSocket to reset supplied.'
     mergeDefaultAuthNotInListExceptionMessage                         = "The MergeDefault Authentication '{0}' is not in the Authentication list supplied."
-    descriptionRequiredExceptionMessage                               = 'A Description is required.'
+    descriptionRequiredExceptionMessage                               = 'A Description is required for Path:{0} Response:{1}'
     pageNameShouldBeAlphaNumericExceptionMessage                      = 'The Page name should be a valid Alphanumeric value: {0}'
     defaultValueNotBooleanOrEnumExceptionMessage                      = 'The default value is not a boolean and is not part of the enum.'
     openApiComponentSchemaDoesNotExistExceptionMessage                = "The OpenApi component schema {0} doesn't exist."
@@ -285,6 +285,6 @@
     invalidAccessControlMaxAgeDurationExceptionMessage                = 'Invalid Access-Control-Max-Age duration supplied: {0}. Should be greater than 0.'
     openApiDefinitionAlreadyExistsExceptionMessage                    = 'OpenAPI definition named {0} already exists.'
     renamePodeOADefinitionTagExceptionMessage                         = "Rename-PodeOADefinitionTag cannot be used inside a Select-PodeOADefinition 'ScriptBlock'."
-    DefinitionTagChangeNotAllowedExceptionMessage                     = 'Definition Tag for a Route cannot be changed.'
+    definitionTagChangeNotAllowedExceptionMessage                     = 'Definition Tag for a Route cannot be changed.'
 }
 

--- a/src/Locales/en/Pode.psd1
+++ b/src/Locales/en/Pode.psd1
@@ -286,5 +286,6 @@
     openApiDefinitionAlreadyExistsExceptionMessage                    = 'OpenAPI definition named {0} already exists.'
     renamePodeOADefinitionTagExceptionMessage                         = "Rename-PodeOADefinitionTag cannot be used inside a Select-PodeOADefinition 'ScriptBlock'."
     definitionTagChangeNotAllowedExceptionMessage                     = 'Definition Tag for a Route cannot be changed.'
+    getRequestBodyNotAllowedExceptionMessage                          = 'GET operations cannot have a Request Body.'
 }
 

--- a/src/Locales/es/Pode.psd1
+++ b/src/Locales/es/Pode.psd1
@@ -211,7 +211,7 @@
     viewsFolderNameAlreadyExistsExceptionMessage                      = 'El nombre de la carpeta Views ya existe: {0}'
     noNameForWebSocketResetExceptionMessage                           = 'No se proporcionó ningún nombre para restablecer el WebSocket.'
     mergeDefaultAuthNotInListExceptionMessage                         = "La autenticación MergeDefault '{0}' no está en la lista de autenticación proporcionada."
-    descriptionRequiredExceptionMessage                               = 'Se requiere una descripción.'
+    descriptionRequiredExceptionMessage                               = 'Se requiere una descripción para la Ruta:{0} Respuesta:{1}'
     pageNameShouldBeAlphaNumericExceptionMessage                      = 'El nombre de la página debe ser un valor alfanumérico válido: {0}'
     defaultValueNotBooleanOrEnumExceptionMessage                      = 'El valor predeterminado no es un booleano y no forma parte del enum.'
     openApiComponentSchemaDoesNotExistExceptionMessage                = 'El esquema del componente OpenApi {0} no existe.'
@@ -285,5 +285,5 @@
     invalidAccessControlMaxAgeDurationExceptionMessage                = 'Duración inválida para Access-Control-Max-Age proporcionada: {0}. Debe ser mayor que 0.'
     openApiDefinitionAlreadyExistsExceptionMessage                    = 'La definición de OpenAPI con el nombre {0} ya existe.'
     renamePodeOADefinitionTagExceptionMessage                     = "Rename-PodeOADefinitionTag no se puede usar dentro de un 'ScriptBlock' de Select-PodeOADefinition."
-    DefinitionTagChangeNotAllowedExceptionMessage                     = 'La etiqueta de definición para una Route no se puede cambiar.'
+    definitionTagChangeNotAllowedExceptionMessage                     = 'La etiqueta de definición para una Route no se puede cambiar.'
 }

--- a/src/Locales/es/Pode.psd1
+++ b/src/Locales/es/Pode.psd1
@@ -286,5 +286,5 @@
     openApiDefinitionAlreadyExistsExceptionMessage                    = 'La definición de OpenAPI con el nombre {0} ya existe.'
     renamePodeOADefinitionTagExceptionMessage                         = "Rename-PodeOADefinitionTag no se puede usar dentro de un 'ScriptBlock' de Select-PodeOADefinition."
     definitionTagChangeNotAllowedExceptionMessage                     = 'La etiqueta de definición para una Route no se puede cambiar.'
-    getRequestBodyNotAllowedExceptionMessage                          = 'Las operaciones GET no pueden tener un cuerpo de solicitud.'
+    getRequestBodyNotAllowedExceptionMessage                          = 'Las operaciones {0} no pueden tener un cuerpo de solicitud.'
 }

--- a/src/Locales/es/Pode.psd1
+++ b/src/Locales/es/Pode.psd1
@@ -284,6 +284,7 @@
     requestLoggingAlreadyEnabledExceptionMessage                      = 'El registro de solicitudes ya está habilitado.'
     invalidAccessControlMaxAgeDurationExceptionMessage                = 'Duración inválida para Access-Control-Max-Age proporcionada: {0}. Debe ser mayor que 0.'
     openApiDefinitionAlreadyExistsExceptionMessage                    = 'La definición de OpenAPI con el nombre {0} ya existe.'
-    renamePodeOADefinitionTagExceptionMessage                     = "Rename-PodeOADefinitionTag no se puede usar dentro de un 'ScriptBlock' de Select-PodeOADefinition."
+    renamePodeOADefinitionTagExceptionMessage                         = "Rename-PodeOADefinitionTag no se puede usar dentro de un 'ScriptBlock' de Select-PodeOADefinition."
     definitionTagChangeNotAllowedExceptionMessage                     = 'La etiqueta de definición para una Route no se puede cambiar.'
+    getRequestBodyNotAllowedExceptionMessage                          = 'Las operaciones GET no pueden tener un cuerpo de solicitud.'
 }

--- a/src/Locales/fr/Pode.psd1
+++ b/src/Locales/fr/Pode.psd1
@@ -284,7 +284,8 @@
     requestLoggingAlreadyEnabledExceptionMessage                      = 'La journalisation des requêtes est déjà activée.'
     invalidAccessControlMaxAgeDurationExceptionMessage                = 'Durée Access-Control-Max-Age invalide fournie : {0}. Doit être supérieure à 0.'
     openApiDefinitionAlreadyExistsExceptionMessage                    = 'La définition OpenAPI nommée {0} existe déjà.'
-    renamePodeOADefinitionTagExceptionMessage                     = "Rename-PodeOADefinitionTag ne peut pas être utilisé à l'intérieur d'un 'ScriptBlock' de Select-PodeOADefinition."
+    renamePodeOADefinitionTagExceptionMessage                         = "Rename-PodeOADefinitionTag ne peut pas être utilisé à l'intérieur d'un 'ScriptBlock' de Select-PodeOADefinition."
     definitionTagChangeNotAllowedExceptionMessage                     = 'Le tag de définition pour une Route ne peut pas être modifié.'
+    getRequestBodyNotAllowedExceptionMessage                          = 'Les opérations GET ne peuvent pas avoir de corps de requête.'
 }
 

--- a/src/Locales/fr/Pode.psd1
+++ b/src/Locales/fr/Pode.psd1
@@ -286,6 +286,6 @@
     openApiDefinitionAlreadyExistsExceptionMessage                    = 'La définition OpenAPI nommée {0} existe déjà.'
     renamePodeOADefinitionTagExceptionMessage                         = "Rename-PodeOADefinitionTag ne peut pas être utilisé à l'intérieur d'un 'ScriptBlock' de Select-PodeOADefinition."
     definitionTagChangeNotAllowedExceptionMessage                     = 'Le tag de définition pour une Route ne peut pas être modifié.'
-    getRequestBodyNotAllowedExceptionMessage                          = 'Les opérations GET ne peuvent pas avoir de corps de requête.'
+    getRequestBodyNotAllowedExceptionMessage                          = 'Les opérations {0} ne peuvent pas avoir de corps de requête.'
 }
 

--- a/src/Locales/fr/Pode.psd1
+++ b/src/Locales/fr/Pode.psd1
@@ -211,7 +211,7 @@
     viewsFolderNameAlreadyExistsExceptionMessage                      = 'Le nom du dossier Views existe déjà: {0}'
     noNameForWebSocketResetExceptionMessage                           = 'Aucun Nom fourni pour réinitialiser le WebSocket.'
     mergeDefaultAuthNotInListExceptionMessage                         = "L'authentification MergeDefault '{0}' n'est pas dans la liste d'authentification fournie."
-    descriptionRequiredExceptionMessage                               = 'Une description est requise.'
+    descriptionRequiredExceptionMessage                               = 'Une description est requise pour le chemin:{0} Réponse:{1}'
     pageNameShouldBeAlphaNumericExceptionMessage                      = 'Le nom de la page doit être une valeur alphanumérique valide: {0}'
     defaultValueNotBooleanOrEnumExceptionMessage                      = "La valeur par défaut n'est pas un booléen et ne fait pas partie de l'énumération."
     openApiComponentSchemaDoesNotExistExceptionMessage                = "Le schéma du composant OpenApi {0} n'existe pas."
@@ -285,6 +285,6 @@
     invalidAccessControlMaxAgeDurationExceptionMessage                = 'Durée Access-Control-Max-Age invalide fournie : {0}. Doit être supérieure à 0.'
     openApiDefinitionAlreadyExistsExceptionMessage                    = 'La définition OpenAPI nommée {0} existe déjà.'
     renamePodeOADefinitionTagExceptionMessage                     = "Rename-PodeOADefinitionTag ne peut pas être utilisé à l'intérieur d'un 'ScriptBlock' de Select-PodeOADefinition."
-    DefinitionTagChangeNotAllowedExceptionMessage                     = 'Le tag de définition pour une Route ne peut pas être modifié.'
+    definitionTagChangeNotAllowedExceptionMessage                     = 'Le tag de définition pour une Route ne peut pas être modifié.'
 }
 

--- a/src/Locales/it/Pode.psd1
+++ b/src/Locales/it/Pode.psd1
@@ -286,5 +286,5 @@
     openApiDefinitionAlreadyExistsExceptionMessage                    = 'La definizione OpenAPI denominata {0} esiste già.'
     renamePodeOADefinitionTagExceptionMessage                         = "Rename-PodeOADefinitionTag non può essere utilizzato all'interno di un 'ScriptBlock' di Select-PodeOADefinition."
     definitionTagChangeNotAllowedExceptionMessage                     = 'Il tag di definizione per una Route non può essere cambiato.'
-    getRequestBodyNotAllowedExceptionMessage                          = 'Le operazioni GET non possono avere un corpo della richiesta.'
+    getRequestBodyNotAllowedExceptionMessage                          = 'Le operazioni {0} non possono avere un corpo della richiesta.'
 }

--- a/src/Locales/it/Pode.psd1
+++ b/src/Locales/it/Pode.psd1
@@ -284,6 +284,7 @@
     requestLoggingAlreadyEnabledExceptionMessage                      = 'La registrazione delle richieste è già abilitata.'
     invalidAccessControlMaxAgeDurationExceptionMessage                = 'Durata non valida fornita per Access-Control-Max-Age: {0}. Deve essere maggiore di 0.'
     openApiDefinitionAlreadyExistsExceptionMessage                    = 'La definizione OpenAPI denominata {0} esiste già.'
-    renamePodeOADefinitionTagExceptionMessage                     = "Rename-PodeOADefinitionTag non può essere utilizzato all'interno di un 'ScriptBlock' di Select-PodeOADefinition."
+    renamePodeOADefinitionTagExceptionMessage                         = "Rename-PodeOADefinitionTag non può essere utilizzato all'interno di un 'ScriptBlock' di Select-PodeOADefinition."
     definitionTagChangeNotAllowedExceptionMessage                     = 'Il tag di definizione per una Route non può essere cambiato.'
+    getRequestBodyNotAllowedExceptionMessage                          = 'Le operazioni GET non possono avere un corpo della richiesta.'
 }

--- a/src/Locales/it/Pode.psd1
+++ b/src/Locales/it/Pode.psd1
@@ -211,7 +211,7 @@
     viewsFolderNameAlreadyExistsExceptionMessage                      = "Il nome della cartella 'Views' esiste già: {0}"
     noNameForWebSocketResetExceptionMessage                           = 'Nessun nome fornito per reimpostare il WebSocket.'
     mergeDefaultAuthNotInListExceptionMessage                         = "L'autenticazione MergeDefault '{0}' non è nella lista di autenticazione fornita."
-    descriptionRequiredExceptionMessage                               = 'È necessaria una descrizione.'
+    descriptionRequiredExceptionMessage                               = 'È necessaria una descrizione per il percorso:{0} Risposta:{1}'
     pageNameShouldBeAlphaNumericExceptionMessage                      = 'Il nome della pagina dovrebbe essere un valore alfanumerico valido: {0}'
     defaultValueNotBooleanOrEnumExceptionMessage                      = "Il valore predefinito non è un booleano e non fa parte dell'enum."
     openApiComponentSchemaDoesNotExistExceptionMessage                = 'Lo schema del componente OpenAPI {0} non esiste.'
@@ -285,5 +285,5 @@
     invalidAccessControlMaxAgeDurationExceptionMessage                = 'Durata non valida fornita per Access-Control-Max-Age: {0}. Deve essere maggiore di 0.'
     openApiDefinitionAlreadyExistsExceptionMessage                    = 'La definizione OpenAPI denominata {0} esiste già.'
     renamePodeOADefinitionTagExceptionMessage                     = "Rename-PodeOADefinitionTag non può essere utilizzato all'interno di un 'ScriptBlock' di Select-PodeOADefinition."
-    DefinitionTagChangeNotAllowedExceptionMessage                     = 'Il tag di definizione per una Route non può essere cambiato.'
+    definitionTagChangeNotAllowedExceptionMessage                     = 'Il tag di definizione per una Route non può essere cambiato.'
 }

--- a/src/Locales/ja/Pode.psd1
+++ b/src/Locales/ja/Pode.psd1
@@ -286,6 +286,6 @@
     openApiDefinitionAlreadyExistsExceptionMessage                    = '名前が {0} の OpenAPI 定義は既に存在します。'
     renamePodeOADefinitionTagExceptionMessage                         = "Rename-PodeOADefinitionTag は Select-PodeOADefinition 'ScriptBlock' 内で使用できません。"
     definitionTagChangeNotAllowedExceptionMessage                     = 'Routeの定義タグは変更できません。'
-    getRequestBodyNotAllowedExceptionMessage                          = 'GET操作にはリクエストボディを含めることはできません。'
+    getRequestBodyNotAllowedExceptionMessage                          = '{0}操作にはリクエストボディを含めることはできません。'
 }
 

--- a/src/Locales/ja/Pode.psd1
+++ b/src/Locales/ja/Pode.psd1
@@ -284,7 +284,8 @@
     requestLoggingAlreadyEnabledExceptionMessage                      = 'リクエストロギングは既に有効になっています。'
     invalidAccessControlMaxAgeDurationExceptionMessage                = '無効な Access-Control-Max-Age 期間が提供されました：{0}。0 より大きくする必要があります。'
     openApiDefinitionAlreadyExistsExceptionMessage                    = '名前が {0} の OpenAPI 定義は既に存在します。'
-    renamePodeOADefinitionTagExceptionMessage                     = "Rename-PodeOADefinitionTag は Select-PodeOADefinition 'ScriptBlock' 内で使用できません。"
+    renamePodeOADefinitionTagExceptionMessage                         = "Rename-PodeOADefinitionTag は Select-PodeOADefinition 'ScriptBlock' 内で使用できません。"
     definitionTagChangeNotAllowedExceptionMessage                     = 'Routeの定義タグは変更できません。'
+    getRequestBodyNotAllowedExceptionMessage                          = 'GET操作にはリクエストボディを含めることはできません。'
 }
 

--- a/src/Locales/ja/Pode.psd1
+++ b/src/Locales/ja/Pode.psd1
@@ -211,7 +211,7 @@
     viewsFolderNameAlreadyExistsExceptionMessage                      = 'ビューのフォルダ名は既に存在します: {0}'
     noNameForWebSocketResetExceptionMessage                           = 'リセットする WebSocket の名前が指定されていません。'
     mergeDefaultAuthNotInListExceptionMessage                         = "MergeDefault認証'{0}'は提供された認証リストにありません。"
-    descriptionRequiredExceptionMessage                               = '説明が必要です。'
+    descriptionRequiredExceptionMessage                               = 'パス:{0} 応答:{1} に説明が必要です'
     pageNameShouldBeAlphaNumericExceptionMessage                      = 'ページ名は有効な英数字である必要があります: {0}'
     defaultValueNotBooleanOrEnumExceptionMessage                      = 'デフォルト値は boolean ではなく、enum に含まれていません。'
     openApiComponentSchemaDoesNotExistExceptionMessage                = 'OpenApi コンポーネントスキーマ {0} は存在しません。'
@@ -285,6 +285,6 @@
     invalidAccessControlMaxAgeDurationExceptionMessage                = '無効な Access-Control-Max-Age 期間が提供されました：{0}。0 より大きくする必要があります。'
     openApiDefinitionAlreadyExistsExceptionMessage                    = '名前が {0} の OpenAPI 定義は既に存在します。'
     renamePodeOADefinitionTagExceptionMessage                     = "Rename-PodeOADefinitionTag は Select-PodeOADefinition 'ScriptBlock' 内で使用できません。"
-    DefinitionTagChangeNotAllowedExceptionMessage                     = 'Routeの定義タグは変更できません。'
+    definitionTagChangeNotAllowedExceptionMessage                     = 'Routeの定義タグは変更できません。'
 }
 

--- a/src/Locales/ko/Pode.psd1
+++ b/src/Locales/ko/Pode.psd1
@@ -286,5 +286,5 @@
     openApiDefinitionAlreadyExistsExceptionMessage                    = '이름이 {0}인 OpenAPI 정의가 이미 존재합니다.'
     renamePodeOADefinitionTagExceptionMessage                         = "Rename-PodeOADefinitionTag은 Select-PodeOADefinition 'ScriptBlock' 내에서 사용할 수 없습니다."
     definitionTagChangeNotAllowedExceptionMessage                     = 'Route에 대한 정의 태그는 변경할 수 없습니다.'
-    getRequestBodyNotAllowedExceptionMessage                          = 'GET 작업에는 요청 본문이 있을 수 없습니다.'
+    getRequestBodyNotAllowedExceptionMessage                          = '{0} 작업에는 요청 본문이 있을 수 없습니다.'
 }

--- a/src/Locales/ko/Pode.psd1
+++ b/src/Locales/ko/Pode.psd1
@@ -211,7 +211,7 @@
     viewsFolderNameAlreadyExistsExceptionMessage                      = '뷰 폴더 이름이 이미 존재합니다: {0}'
     noNameForWebSocketResetExceptionMessage                           = '재설정할 WebSocket의 이름이 제공되지 않았습니다.'
     mergeDefaultAuthNotInListExceptionMessage                         = "병합 기본 인증 '{0}'이(가) 제공된 인증 목록에 없습니다."
-    descriptionRequiredExceptionMessage                               = '설명이 필요합니다.'
+    descriptionRequiredExceptionMessage                               = '경로:{0} 응답:{1} 에 대한 설명이 필요합니다'
     pageNameShouldBeAlphaNumericExceptionMessage                      = '페이지 이름은 유효한 알파벳 숫자 값이어야 합니다: {0}'
     defaultValueNotBooleanOrEnumExceptionMessage                      = '기본값이 boolean이 아니며 enum에 속하지 않습니다.'
     openApiComponentSchemaDoesNotExistExceptionMessage                = 'OpenApi 구성 요소 스키마 {0}이(가) 존재하지 않습니다.'
@@ -285,5 +285,5 @@
     invalidAccessControlMaxAgeDurationExceptionMessage                = '잘못된 Access-Control-Max-Age 기간이 제공되었습니다: {0}. 0보다 커야 합니다.'
     openApiDefinitionAlreadyExistsExceptionMessage                    = '이름이 {0}인 OpenAPI 정의가 이미 존재합니다.'
     renamePodeOADefinitionTagExceptionMessage                     = "Rename-PodeOADefinitionTag은 Select-PodeOADefinition 'ScriptBlock' 내에서 사용할 수 없습니다."
-    DefinitionTagChangeNotAllowedExceptionMessage                     = 'Route에 대한 정의 태그는 변경할 수 없습니다.'
+    definitionTagChangeNotAllowedExceptionMessage                     = 'Route에 대한 정의 태그는 변경할 수 없습니다.'
 }

--- a/src/Locales/ko/Pode.psd1
+++ b/src/Locales/ko/Pode.psd1
@@ -284,6 +284,7 @@
     requestLoggingAlreadyEnabledExceptionMessage                      = '요청 로깅이 이미 활성화되었습니다.'
     invalidAccessControlMaxAgeDurationExceptionMessage                = '잘못된 Access-Control-Max-Age 기간이 제공되었습니다: {0}. 0보다 커야 합니다.'
     openApiDefinitionAlreadyExistsExceptionMessage                    = '이름이 {0}인 OpenAPI 정의가 이미 존재합니다.'
-    renamePodeOADefinitionTagExceptionMessage                     = "Rename-PodeOADefinitionTag은 Select-PodeOADefinition 'ScriptBlock' 내에서 사용할 수 없습니다."
+    renamePodeOADefinitionTagExceptionMessage                         = "Rename-PodeOADefinitionTag은 Select-PodeOADefinition 'ScriptBlock' 내에서 사용할 수 없습니다."
     definitionTagChangeNotAllowedExceptionMessage                     = 'Route에 대한 정의 태그는 변경할 수 없습니다.'
+    getRequestBodyNotAllowedExceptionMessage                          = 'GET 작업에는 요청 본문이 있을 수 없습니다.'
 }

--- a/src/Locales/nl/Pode.psd1
+++ b/src/Locales/nl/Pode.psd1
@@ -212,7 +212,7 @@
     viewsFolderNameAlreadyExistsExceptionMessage                      = 'De mapnaam Views bestaat al: {0}'
     noNameForWebSocketResetExceptionMessage                           = 'Geen naam opgegeven voor een WebSocket om te resetten.'
     mergeDefaultAuthNotInListExceptionMessage                         = "De standaardauthenticatie '{0}' staat niet in de opgegeven authenticatielijst."
-    descriptionRequiredExceptionMessage                               = 'Een beschrijving is vereist.'
+    descriptionRequiredExceptionMessage                               = 'Een beschrijving is vereist voor Pad:{0} Antwoord:{1}'
     pageNameShouldBeAlphaNumericExceptionMessage                      = 'De paginanaam moet een geldige alfanumerieke waarde zijn: {0}'
     defaultValueNotBooleanOrEnumExceptionMessage                      = 'De standaardwaarde is geen boolean en maakt geen deel uit van de enum.'
     openApiComponentSchemaDoesNotExistExceptionMessage                = 'Het OpenApi-component schema {0} bestaat niet.'
@@ -285,6 +285,6 @@
     invalidAccessControlMaxAgeDurationExceptionMessage                = 'Ongeldige Access-Control-Max-Age duur opgegeven: {0}. Moet groter zijn dan 0.'
     openApiDefinitionAlreadyExistsExceptionMessage                    = 'OpenAPI-definitie met de naam {0} bestaat al.'
     renamePodeOADefinitionTagExceptionMessage                         = "Rename-PodeOADefinitionTag kan niet worden gebruikt binnen een Select-PodeOADefinition 'ScriptBlock'."
-    DefinitionTagChangeNotAllowedExceptionMessage                     = 'Definitietag voor een route kan niet worden gewijzigd.'
+    definitionTagChangeNotAllowedExceptionMessage                     = 'Definitietag voor een route kan niet worden gewijzigd.'
 }
 

--- a/src/Locales/nl/Pode.psd1
+++ b/src/Locales/nl/Pode.psd1
@@ -286,5 +286,6 @@
     openApiDefinitionAlreadyExistsExceptionMessage                    = 'OpenAPI-definitie met de naam {0} bestaat al.'
     renamePodeOADefinitionTagExceptionMessage                         = "Rename-PodeOADefinitionTag kan niet worden gebruikt binnen een Select-PodeOADefinition 'ScriptBlock'."
     definitionTagChangeNotAllowedExceptionMessage                     = 'Definitietag voor een route kan niet worden gewijzigd.'
+    getRequestBodyNotAllowedExceptionMessage                          = 'GET-operaties kunnen geen Request Body hebben.'
 }
 

--- a/src/Locales/nl/Pode.psd1
+++ b/src/Locales/nl/Pode.psd1
@@ -286,6 +286,6 @@
     openApiDefinitionAlreadyExistsExceptionMessage                    = 'OpenAPI-definitie met de naam {0} bestaat al.'
     renamePodeOADefinitionTagExceptionMessage                         = "Rename-PodeOADefinitionTag kan niet worden gebruikt binnen een Select-PodeOADefinition 'ScriptBlock'."
     definitionTagChangeNotAllowedExceptionMessage                     = 'Definitietag voor een route kan niet worden gewijzigd.'
-    getRequestBodyNotAllowedExceptionMessage                          = 'GET-operaties kunnen geen Request Body hebben.'
+    getRequestBodyNotAllowedExceptionMessage                          = '{0}-operaties kunnen geen Request Body hebben.'
 }
 

--- a/src/Locales/pl/Pode.psd1
+++ b/src/Locales/pl/Pode.psd1
@@ -286,6 +286,6 @@
     openApiDefinitionAlreadyExistsExceptionMessage                    = 'Definicja OpenAPI o nazwie {0} już istnieje.'
     renamePodeOADefinitionTagExceptionMessage                         = "Rename-PodeOADefinitionTag nie może być używany wewnątrz 'ScriptBlock' Select-PodeOADefinition."
     definitionTagChangeNotAllowedExceptionMessage                     = 'Tag definicji dla Route nie może zostać zmieniony.'
-    getRequestBodyNotAllowedExceptionMessage                          = 'Operacje GET nie mogą mieć treści żądania.'
+    getRequestBodyNotAllowedExceptionMessage                          = 'Operacje {0} nie mogą mieć treści żądania.'
 }
 

--- a/src/Locales/pl/Pode.psd1
+++ b/src/Locales/pl/Pode.psd1
@@ -211,7 +211,7 @@
     viewsFolderNameAlreadyExistsExceptionMessage                      = 'Nazwa folderu Widoków już istnieje: {0}'
     noNameForWebSocketResetExceptionMessage                           = 'Nie podano nazwy dla resetowania WebSocket.'
     mergeDefaultAuthNotInListExceptionMessage                         = "Uwierzytelnianie MergeDefault '{0}' nie znajduje się na dostarczonej liście uwierzytelniania."
-    descriptionRequiredExceptionMessage                               = 'Wymagany jest opis.'
+    descriptionRequiredExceptionMessage                               = 'Wymagany jest opis dla ścieżki:{0} Odpowiedź:{1}'
     pageNameShouldBeAlphaNumericExceptionMessage                      = 'Nazwa strony powinna być poprawną wartością alfanumeryczną: {0}'
     defaultValueNotBooleanOrEnumExceptionMessage                      = 'Wartość domyślna nie jest typu boolean i nie należy do enum.'
     openApiComponentSchemaDoesNotExistExceptionMessage                = 'Schemat komponentu OpenApi {0} nie istnieje.'
@@ -285,6 +285,6 @@
     invalidAccessControlMaxAgeDurationExceptionMessage                = 'Podano nieprawidłowy czas trwania Access-Control-Max-Age: {0}. Powinien być większy niż 0.'
     openApiDefinitionAlreadyExistsExceptionMessage                    = 'Definicja OpenAPI o nazwie {0} już istnieje.'
     renamePodeOADefinitionTagExceptionMessage                     = "Rename-PodeOADefinitionTag nie może być używany wewnątrz 'ScriptBlock' Select-PodeOADefinition."
-    DefinitionTagChangeNotAllowedExceptionMessage                     = 'Tag definicji dla Route nie może zostać zmieniony.'
+    definitionTagChangeNotAllowedExceptionMessage                     = 'Tag definicji dla Route nie może zostać zmieniony.'
 }
 

--- a/src/Locales/pl/Pode.psd1
+++ b/src/Locales/pl/Pode.psd1
@@ -284,7 +284,8 @@
     requestLoggingAlreadyEnabledExceptionMessage                      = 'Rejestrowanie żądań jest już włączone.'
     invalidAccessControlMaxAgeDurationExceptionMessage                = 'Podano nieprawidłowy czas trwania Access-Control-Max-Age: {0}. Powinien być większy niż 0.'
     openApiDefinitionAlreadyExistsExceptionMessage                    = 'Definicja OpenAPI o nazwie {0} już istnieje.'
-    renamePodeOADefinitionTagExceptionMessage                     = "Rename-PodeOADefinitionTag nie może być używany wewnątrz 'ScriptBlock' Select-PodeOADefinition."
+    renamePodeOADefinitionTagExceptionMessage                         = "Rename-PodeOADefinitionTag nie może być używany wewnątrz 'ScriptBlock' Select-PodeOADefinition."
     definitionTagChangeNotAllowedExceptionMessage                     = 'Tag definicji dla Route nie może zostać zmieniony.'
+    getRequestBodyNotAllowedExceptionMessage                          = 'Operacje GET nie mogą mieć treści żądania.'
 }
 

--- a/src/Locales/pt/Pode.psd1
+++ b/src/Locales/pt/Pode.psd1
@@ -211,7 +211,7 @@
     viewsFolderNameAlreadyExistsExceptionMessage                      = 'O nome da pasta Views já existe: {0}'
     noNameForWebSocketResetExceptionMessage                           = 'Nenhum nome fornecido para redefinir o WebSocket.'
     mergeDefaultAuthNotInListExceptionMessage                         = "A Autenticação MergeDefault '{0}' não está na lista de Autenticação fornecida."
-    descriptionRequiredExceptionMessage                               = 'É necessária uma descrição.'
+    descriptionRequiredExceptionMessage                               = 'Uma descrição é necessária para o Caminho:{0} Resposta:{1}'
     pageNameShouldBeAlphaNumericExceptionMessage                      = 'O nome da página deve ser um valor alfanumérico válido: {0}'
     defaultValueNotBooleanOrEnumExceptionMessage                      = 'O valor padrão não é booleano e não faz parte do enum.'
     openApiComponentSchemaDoesNotExistExceptionMessage                = 'O esquema do componente OpenApi {0} não existe.'
@@ -285,5 +285,5 @@
     invalidAccessControlMaxAgeDurationExceptionMessage                = 'Duração inválida fornecida para Access-Control-Max-Age: {0}. Deve ser maior que 0.'
     openApiDefinitionAlreadyExistsExceptionMessage                    = 'A definição OpenAPI com o nome {0} já existe.'
     renamePodeOADefinitionTagExceptionMessage                     = "Rename-PodeOADefinitionTag não pode ser usado dentro de um 'ScriptBlock' Select-PodeOADefinition."
-    DefinitionTagChangeNotAllowedExceptionMessage                     = 'A Tag de definição para uma Route não pode ser alterada.'
+    definitionTagChangeNotAllowedExceptionMessage                     = 'A Tag de definição para uma Route não pode ser alterada.'
 }

--- a/src/Locales/pt/Pode.psd1
+++ b/src/Locales/pt/Pode.psd1
@@ -284,6 +284,7 @@
     requestLoggingAlreadyEnabledExceptionMessage                      = 'O registro de solicitações já está habilitado.'
     invalidAccessControlMaxAgeDurationExceptionMessage                = 'Duração inválida fornecida para Access-Control-Max-Age: {0}. Deve ser maior que 0.'
     openApiDefinitionAlreadyExistsExceptionMessage                    = 'A definição OpenAPI com o nome {0} já existe.'
-    renamePodeOADefinitionTagExceptionMessage                     = "Rename-PodeOADefinitionTag não pode ser usado dentro de um 'ScriptBlock' Select-PodeOADefinition."
+    renamePodeOADefinitionTagExceptionMessage                         = "Rename-PodeOADefinitionTag não pode ser usado dentro de um 'ScriptBlock' Select-PodeOADefinition."
     definitionTagChangeNotAllowedExceptionMessage                     = 'A Tag de definição para uma Route não pode ser alterada.'
+    getRequestBodyNotAllowedExceptionMessage                          = 'As operações GET não podem ter um corpo de solicitação.'
 }

--- a/src/Locales/pt/Pode.psd1
+++ b/src/Locales/pt/Pode.psd1
@@ -286,5 +286,5 @@
     openApiDefinitionAlreadyExistsExceptionMessage                    = 'A definição OpenAPI com o nome {0} já existe.'
     renamePodeOADefinitionTagExceptionMessage                         = "Rename-PodeOADefinitionTag não pode ser usado dentro de um 'ScriptBlock' Select-PodeOADefinition."
     definitionTagChangeNotAllowedExceptionMessage                     = 'A Tag de definição para uma Route não pode ser alterada.'
-    getRequestBodyNotAllowedExceptionMessage                          = 'As operações GET não podem ter um corpo de solicitação.'
+    getRequestBodyNotAllowedExceptionMessage                          = 'As operações {0} não podem ter um corpo de solicitação.'
 }

--- a/src/Locales/zh/Pode.psd1
+++ b/src/Locales/zh/Pode.psd1
@@ -211,7 +211,7 @@
     viewsFolderNameAlreadyExistsExceptionMessage                      = '视图文件夹名称已存在: {0}'
     noNameForWebSocketResetExceptionMessage                           = '没有提供要重置的 WebSocket 的名称。'
     mergeDefaultAuthNotInListExceptionMessage                         = "MergeDefault 身份验证 '{0}' 不在提供的身份验证列表中。"
-    descriptionRequiredExceptionMessage                               = '描述是必需的。'
+    descriptionRequiredExceptionMessage                               = '路径:{0} 响应:{1} 需要描述'
     pageNameShouldBeAlphaNumericExceptionMessage                      = '页面名称应为有效的字母数字值: {0}'
     defaultValueNotBooleanOrEnumExceptionMessage                      = '默认值不是布尔值且不属于枚举。'
     openApiComponentSchemaDoesNotExistExceptionMessage                = 'OpenApi 组件架构 {0} 不存在。'
@@ -285,5 +285,5 @@
     invalidAccessControlMaxAgeDurationExceptionMessage                = '提供的 Access-Control-Max-Age 时长无效：{0}。应大于 0。'
     openApiDefinitionAlreadyExistsExceptionMessage                    = '名为 {0} 的 OpenAPI 定义已存在。'
     renamePodeOADefinitionTagExceptionMessage                     = "Rename-PodeOADefinitionTag 不能在 Select-PodeOADefinition 'ScriptBlock' 内使用。"
-    DefinitionTagChangeNotAllowedExceptionMessage                     = 'Route的定义标签无法更改。'
+    definitionTagChangeNotAllowedExceptionMessage                     = 'Route的定义标签无法更改。'
 }

--- a/src/Locales/zh/Pode.psd1
+++ b/src/Locales/zh/Pode.psd1
@@ -284,6 +284,7 @@
     requestLoggingAlreadyEnabledExceptionMessage                      = '请求日志记录已启用。'
     invalidAccessControlMaxAgeDurationExceptionMessage                = '提供的 Access-Control-Max-Age 时长无效：{0}。应大于 0。'
     openApiDefinitionAlreadyExistsExceptionMessage                    = '名为 {0} 的 OpenAPI 定义已存在。'
-    renamePodeOADefinitionTagExceptionMessage                     = "Rename-PodeOADefinitionTag 不能在 Select-PodeOADefinition 'ScriptBlock' 内使用。"
+    renamePodeOADefinitionTagExceptionMessage                         = "Rename-PodeOADefinitionTag 不能在 Select-PodeOADefinition 'ScriptBlock' 内使用。"
     definitionTagChangeNotAllowedExceptionMessage                     = 'Route的定义标签无法更改。'
+    getRequestBodyNotAllowedExceptionMessage                          = 'GET 操作不能包含请求体。'
 }

--- a/src/Locales/zh/Pode.psd1
+++ b/src/Locales/zh/Pode.psd1
@@ -286,5 +286,5 @@
     openApiDefinitionAlreadyExistsExceptionMessage                    = '名为 {0} 的 OpenAPI 定义已存在。'
     renamePodeOADefinitionTagExceptionMessage                         = "Rename-PodeOADefinitionTag 不能在 Select-PodeOADefinition 'ScriptBlock' 内使用。"
     definitionTagChangeNotAllowedExceptionMessage                     = 'Route的定义标签无法更改。'
-    getRequestBodyNotAllowedExceptionMessage                          = 'GET 操作不能包含请求体。'
+    getRequestBodyNotAllowedExceptionMessage                          = '{0} 操作不能包含请求体。'
 }

--- a/src/Misc/default-swagger.html.pode
+++ b/src/Misc/default-swagger.html.pode
@@ -1,137 +1,143 @@
 <!doctype html>
 <html lang="en">
-    <head>
-        <title>$($data.Title)</title>
-        <meta charset="utf-8"/>
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="stylesheet" type="text/css" href="https://unpkg.com/swagger-ui-dist@5/swagger-ui.css">
-        <script src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js" crossorigin></script>
-        <script type="text/javascript">
-            window.onload = function() {
-                SwaggerUIBundle({
-                    deepLinking: true,
-                    dom_id: '#swagger-ui',
-                    showExtensions: true,
-                    showCommonExtensions: true,
-                    url: '$($data.OpenApi)'
-                });
-            };
-        </script>
 
-        $(if ($data.DarkMode) {
-            "<style>
-                .swagger-ui button {
-                    outline: none !important;
-                }
+<head>
+    <title>$($data.Title)</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" type="text/css" href="https://unpkg.com/swagger-ui-dist@5/swagger-ui.css">
+    <script src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js" crossorigin></script>
+    <script type="text/javascript">
+        window.onload = function() {
+            SwaggerUIBundle({
+                deepLinking: true,
+                dom_id: '#swagger-ui',
+                showExtensions: true,
+                showCommonExtensions: true,
+                url: '$($data.OpenApi)',
+                requestSnippetsEnabled: true
 
-                .swagger-ui .info .title,
-                .swagger-ui a.nostyle,
-                .swagger-ui .parameter__name,
-                .swagger-ui .parameter__type,
-                .swagger-ui .parameter__deprecated,
-                .swagger-ui .parameter__in,
-                .swagger-ui .parameter__enum,
-                .swagger-ui table thead tr th,
-                .swagger-ui .response-col_status,
-                .swagger-ui .response-col_description,
-                .swagger-ui .response-control-media-type__title,
-                .swagger-ui table thead tr td,
-                .swagger-ui .opblock .opblock-section-header h4,
-                .swagger-ui label,
-                .swagger-ui .tab li,
-                .swagger-ui .opblock .opblock-section-header label,
-                .swagger-ui .opblock .opblock-summary-path span,
-                .swagger-ui .opblock-tag span,
-                .swagger-ui .response-col_links,
-                .swagger-ui .response-col_links i,
-                .swagger-ui .btn {
-                    color: #CCCCCC !important;
-                }
+            });
+        };
+    </script>
 
-                .swagger-ui svg.arrow,
-                .swagger-ui button.unlocked,
-                .swagger-ui .authorization__btn.locked {
-                    fill: #CCCCCC;
-                    opacity: 1 !important;
-                }
+    $(if ($data.DarkMode) {
+    "<style>
+        .swagger-ui button {
+            outline: none !important;
+        }
 
-                .swagger-ui select,
-                .swagger-ui select:hover,
-                .swagger-ui select:focus,
-                .swagger-ui select:focus-visible {
-                    color: #BBB;
-                    border: solid 1px #777;
-                }
+        .swagger-ui .info .title,
+        .swagger-ui a.nostyle,
+        .swagger-ui .parameter__name,
+        .swagger-ui .parameter__type,
+        .swagger-ui .parameter__deprecated,
+        .swagger-ui .parameter__in,
+        .swagger-ui .parameter__enum,
+        .swagger-ui table thead tr th,
+        .swagger-ui .response-col_status,
+        .swagger-ui .response-col_description,
+        .swagger-ui .response-control-media-type__title,
+        .swagger-ui table thead tr td,
+        .swagger-ui .opblock .opblock-section-header h4,
+        .swagger-ui label,
+        .swagger-ui .tab li,
+        .swagger-ui .opblock .opblock-section-header label,
+        .swagger-ui .opblock .opblock-summary-path span,
+        .swagger-ui .opblock-tag span,
+        .swagger-ui .response-col_links,
+        .swagger-ui .response-col_links i,
+        .swagger-ui .btn {
+            color: #CCCCCC !important;
+        }
 
-                .swagger-ui .try-out button,
-                .swagger-ui div.model-example .tab .tabitem button.tablinks {
-                    background: #CCCCCC44;
-                    border: solid 1px #777;
-                    color: #CCC;
-                    border-radius: 4px;
-                    padding: 7px;
-                }
-                .swagger-ui div.model-example .tab .tabitem.active button.tablinks {
-                    font-weight: bold;
-                }
+        .swagger-ui svg.arrow,
+        .swagger-ui button.unlocked,
+        .swagger-ui .authorization__btn.locked {
+            fill: #CCCCCC;
+            opacity: 1 !important;
+        }
 
-                .swagger-ui .try-out button:hover,
-                .swagger-ui div.model-example .tab .tabitem button.tablinks:hover {
-                    background: #CCCCCC88;
-                }
+        .swagger-ui select,
+        .swagger-ui select:hover,
+        .swagger-ui select:focus,
+        .swagger-ui select:focus-visible {
+            color: #BBB;
+            border: solid 1px #777;
+        }
 
-                .swagger-ui div.model-example .highlight-code pre {
-                    border: solid 1px #777;
-                    border-radius: 6px;
-                }
+        .swagger-ui .try-out button,
+        .swagger-ui div.model-example .tab .tabitem button.tablinks {
+            background: #CCCCCC44;
+            border: solid 1px #777;
+            color: #CCC;
+            border-radius: 4px;
+            padding: 7px;
+        }
 
-                .swagger-ui .scheme-container {
-                    box-shadow: none;
-                    border-bottom: 1px solid #CCCCCC;
-                }
+        .swagger-ui div.model-example .tab .tabitem.active button.tablinks {
+            font-weight: bold;
+        }
 
-                .swagger-ui .opblock .opblock-summary-description,
-                .swagger-ui .opblock-description-wrapper p,
-                .swagger-ui h4,
-                .swagger-ui h5 {
-                    color: #BBBBBB !important;
-                }
+        .swagger-ui .try-out button:hover,
+        .swagger-ui div.model-example .tab .tabitem button.tablinks:hover {
+            background: #CCCCCC88;
+        }
 
-                body,
-                .swagger-ui .info .title,
-                .swagger-ui .scheme-container,
-                .swagger-ui select,
-                .modal-ux {
-                    background-color: #222 !important;
-                    color: #CCC;
-                }
+        .swagger-ui div.model-example .highlight-code pre {
+            border: solid 1px #777;
+            border-radius: 6px;
+        }
 
-                .modal-ux-header h3 {
-                    color: #CCC !important;
-                }
+        .swagger-ui .scheme-container {
+            box-shadow: none;
+            border-bottom: 1px solid #CCCCCC;
+        }
 
-                .close-modal svg {
-                    filter: invert(1) brightness(0.5);
-                }
+        .swagger-ui .opblock .opblock-summary-description,
+        .swagger-ui .opblock-description-wrapper p,
+        .swagger-ui h4,
+        .swagger-ui h5 {
+            color: #BBBBBB !important;
+        }
 
-                .swagger-ui .opblock .opblock-section-header {
-                    background-color: transparent;
-                }
+        body,
+        .swagger-ui .info .title,
+        .swagger-ui .scheme-container,
+        .swagger-ui select,
+        .modal-ux {
+            background-color: #222 !important;
+            color: #CCC;
+        }
 
-                .swagger-ui textarea,
-                .swagger-ui input[type=text],
-                .swagger-ui input[type=password] {
-                    background-color: #41444e;
-                    color: #CCC;
-                }
+        .modal-ux-header h3 {
+            color: #CCC !important;
+        }
 
-                .swagger-ui .topbar {
-                    background-color: #000;
-                }
-            </style>"
-        })
-    </head>
-    <body>
-        <div id="swagger-ui"></div>
-    </body>
+        .close-modal svg {
+            filter: invert(1) brightness(0.5);
+        }
+
+        .swagger-ui .opblock .opblock-section-header {
+            background-color: transparent;
+        }
+
+        .swagger-ui textarea,
+        .swagger-ui input[type=text],
+        .swagger-ui input[type=password] {
+            background-color: #41444e;
+            color: #CCC;
+        }
+
+        .swagger-ui .topbar {
+            background-color: #000;
+        }
+    </style>"
+    })
+</head>
+
+<body>
+    <div id="swagger-ui"></div>
+</body>
+
 </html>

--- a/src/Private/OpenApi.ps1
+++ b/src/Private/OpenApi.ps1
@@ -1324,7 +1324,7 @@ function Initialize-PodeOpenApiTable {
     )
     # Initialization of the OpenAPI table with default settings
     $OpenAPI = @{
-        DefinitionTagSelectionStack = New-Object 'System.Collections.Generic.Stack[System.Object]'
+        DefinitionTagSelectionStack = [System.Collections.Generic.Stack[System.Object]]::new()
     }
 
     # Set the currently selected definition tag

--- a/src/Private/OpenApi.ps1
+++ b/src/Private/OpenApi.ps1
@@ -321,10 +321,21 @@ function ConvertTo-PodeOAOfProperty {
     if (@('allOf', 'oneOf', 'anyOf') -inotcontains $Property.type) {
         return @{}
     }
-
     # Initialize the schema with the 'Of' type
-    $schema = [ordered]@{
-        $Property.type = @()
+    if ($Property.name) {
+        $schema = [ordered]@{
+            $Property.name = @{
+                $Property.type = @()
+            }
+        }
+        if ($Property.description) {
+            $schema[$Property.name].description = $Property.description
+        }
+    }
+    else {
+        $schema = [ordered]@{
+            $Property.type = @()
+        }
     }
 
     # Process each schema defined in the property
@@ -333,11 +344,21 @@ function ConvertTo-PodeOAOfProperty {
             if ($prop -is [string]) {
                 # Validate the schema component and add a reference to it
                 Test-PodeOAComponentInternal -Field schemas -DefinitionTag $DefinitionTag -Name $prop -PostValidation
-                $schema[$Property.type] += @{ '$ref' = "#/components/schemas/$prop" }
+                if ($Property.name) {
+                    $schema[$Property.name][$Property.type] += @{ '$ref' = "#/components/schemas/$prop" }
+                }
+                else {
+                    $schema[$Property.type] += @{ '$ref' = "#/components/schemas/$prop" }
+                }
             }
             else {
                 # Convert the property to an OpenAPI schema property
-                $schema[$Property.type] += $prop | ConvertTo-PodeOASchemaProperty -DefinitionTag $DefinitionTag
+                if ($Property.name) {
+                    $schema[$Property.name][$Property.type] += $prop | ConvertTo-PodeOASchemaProperty -DefinitionTag $DefinitionTag
+                }
+                else {
+                    $schema[$Property.type] += $prop | ConvertTo-PodeOASchemaProperty -DefinitionTag $DefinitionTag
+                }
             }
         }
     }
@@ -453,11 +474,11 @@ function ConvertTo-PodeOASchemaProperty {
         }
     }
     if (Test-PodeOAVersion -Version 3.0 -DefinitionTag $DefinitionTag ) {
-        if ($Property.minimum) {
+        if ($Property.ContainsKey('minimum')) {
             $schema['minimum'] = $Property.minimum
         }
 
-        if ($Property.maximum) {
+        if ($Property.ContainsKey('maximum')) {
             $schema['maximum'] = $Property.maximum
         }
 
@@ -470,7 +491,7 @@ function ConvertTo-PodeOASchemaProperty {
         }
     }
     else {
-        if ($Property.maximum) {
+        if ($Property.ContainsKey('maximum')) {
             if ($Property.exclusiveMaximum) {
                 $schema['exclusiveMaximum'] = $Property.maximum
             }
@@ -478,7 +499,7 @@ function ConvertTo-PodeOASchemaProperty {
                 $schema['maximum'] = $Property.maximum
             }
         }
-        if ($Property.minimum) {
+        if ($Property.ContainsKey('minimum')) {
             if ($Property.exclusiveMinimum) {
                 $schema['exclusiveMinimum'] = $Property.minimum
             }
@@ -495,11 +516,11 @@ function ConvertTo-PodeOASchemaProperty {
         $schema['pattern'] = $Property.pattern
     }
 
-    if ($Property.minLength) {
+    if ($Property.ContainsKey('minLength')) {
         $schema['minLength'] = $Property.minLength
     }
 
-    if ($Property.maxLength) {
+    if ($Property.ContainsKey('maxLength')) {
         $schema['maxLength'] = $Property.maxLength
     }
 
@@ -518,11 +539,11 @@ function ConvertTo-PodeOASchemaProperty {
 
     # are we using an array?
     if ($Property.array) {
-        if ($Property.maxItems ) {
+        if ($Property.ContainsKey('maxItems') ) {
             $schema['maxItems'] = $Property.maxItems
         }
 
-        if ($Property.minItems ) {
+        if ($Property.ContainsKey('minItems') ) {
             $schema['minItems'] = $Property.minItems
         }
 
@@ -587,6 +608,7 @@ function ConvertTo-PodeOASchemaProperty {
     }
 
     if ($Property.type -ieq 'object') {
+        $schema['properties'] = @{}
         foreach ($prop in $Property.properties) {
             if ( @('allOf', 'oneOf', 'anyOf') -icontains $prop.type) {
                 switch ($prop.type.ToLower()) {
@@ -594,24 +616,22 @@ function ConvertTo-PodeOASchemaProperty {
                     'oneof' { $prop.type = 'oneOf' }
                     'anyof' { $prop.type = 'anyOf' }
                 }
-                $schema += ConvertTo-PodeOAofProperty -DefinitionTag $DefinitionTag -Property $prop
+                if ($prop.name) {
+                    $schema['properties'] += ConvertTo-PodeOAofProperty -DefinitionTag $DefinitionTag -Property $prop
+                }
+                else {
+                    $schema += ConvertTo-PodeOAofProperty -DefinitionTag $DefinitionTag -Property $prop
+                }
 
             }
         }
         if ($Property.properties) {
-            $schema['properties'] = (ConvertTo-PodeOASchemaObjectProperty -DefinitionTag $DefinitionTag -Properties $Property.properties)
+            $schema['properties'] += (ConvertTo-PodeOASchemaObjectProperty -DefinitionTag $DefinitionTag -Properties $Property.properties)
             $RequiredList = @(($Property.properties | Where-Object { $_.required }) )
             if ( $RequiredList.Count -gt 0) {
                 $schema['required'] = @($RequiredList.name)
             }
         }
-        else {
-            #if noproperties parameter create an empty properties
-            if ( $Property.properties.Count -eq 1 -and $null -eq $Property.properties[0]) {
-                $schema['properties'] = @{}
-            }
-        }
-
 
         if ($Property.minProperties) {
             $schema['minProperties'] = $Property.minProperties
@@ -1092,6 +1112,11 @@ function Get-PodeOpenApiDefinitionInternal {
                 # add path's http method to defintition
 
                 $pm = Set-PodeOpenApiRouteValue -Route $_route -DefinitionTag $DefinitionTag
+                if ($pm.responses.Count -eq 0) {
+                    $pm.responses += @{
+                        'default' = @{'description' = 'No description' }
+                    }
+                }
                 $def.paths[$_route.OpenApi.Path][$method] = $pm
 
                 # add any custom server endpoints for route
@@ -1684,15 +1709,15 @@ function New-PodeOAPropertyInternal {
 
     if ($Params.UniqueItems.IsPresent) { $param.uniqueItems = $Params.UniqueItems.IsPresent }
 
-    if ($Params.MaxItems) { $param.maxItems = $Params.MaxItems }
+    if ($Params.ContainsKey('MaxItems')) { $param.maxItems = $Params.MaxItems }
 
-    if ($Params.MinItems) { $param.minItems = $Params.MinItems }
+    if ($Params.ContainsKey('MinItems')) { $param.minItems = $Params.MinItems }
 
     if ($Params.Enum) { $param.enum = $Params.Enum }
 
-    if ($Params.Minimum) { $param.minimum = $Params.Minimum }
+    if ($Params.ContainsKey('Minimum')) { $param.minimum = $Params.Minimum }
 
-    if ($Params.Maximum) { $param.maximum = $Params.Maximum }
+    if ($Params.ContainsKey('Maximum')) { $param.maximum = $Params.Maximum }
 
     if ($Params.ExclusiveMaximum.IsPresent) { $param.exclusiveMaximum = $Params.ExclusiveMaximum.IsPresent }
 
@@ -1701,13 +1726,13 @@ function New-PodeOAPropertyInternal {
 
     if ($Params.Pattern) { $param.pattern = $Params.Pattern }
 
-    if ($Params.MinLength) { $param.minLength = $Params.MinLength }
+    if ($Params.ContainsKey('MinLength')) { $param.minLength = $Params.MinLength }
 
-    if ($Params.MaxLength) { $param.maxLength = $Params.MaxLength }
+    if ($Params.ContainsKey('MaxLength')) { $param.maxLength = $Params.MaxLength }
 
-    if ($Params.MinProperties) { $param.minProperties = $Params.MinProperties }
+    if ($Params.ContainsKey('MinProperties')) { $param.minProperties = $Params.MinProperties }
 
-    if ($Params.MaxProperties) { $param.maxProperties = $Params.MaxProperties }
+    if ($Params.ContainsKey('MaxProperties')) { $param.maxProperties = $Params.MaxProperties }
 
     if ($Params.XmlName -or $Params.XmlNamespace -or $Params.XmlPrefix -or $Params.XmlAttribute.IsPresent -or $Params.XmlWrapped.IsPresent) {
 
@@ -1902,12 +1927,12 @@ function New-PodeOResponseInternal {
         if ($Params.Default) {
             $Description = 'Default Response.'
         }
-        elseif ($Params.StatusCode) {
+        elseif ([int]::TryParse($Params.StatusCode, [ref]$null)) {
             $Description = Get-PodeStatusDescription -StatusCode $Params.StatusCode
         }
         else {
             # A Description is required
-            throw ($PodeLocale.descriptionRequiredExceptionMessage)
+            throw ($PodeLocale.descriptionRequiredExceptionMessage -f $params.Route.path, $Params.StatusCode )
         }
     }
     else {

--- a/src/Public/OAProperties.ps1
+++ b/src/Public/OAProperties.ps1
@@ -1652,7 +1652,6 @@ function New-PodeOAObjectProperty {
                 # The parameter `NoProperties` is mutually exclusive with `Properties`, `MinProperties` and `MaxProperties`
                 throw ($PodeLocale.noPropertiesMutuallyExclusiveExceptionMessage)
             }
-            $param.properties = @($null)
             $PropertiesFromPipeline = $false
         }
         elseif ($Properties) {
@@ -1734,20 +1733,34 @@ This string value represents the property in the payload that indicates which sp
 It's essential in scenarios where an API endpoint handles data that conforms to one of several derived schemas from a common base schema.
 
 .PARAMETER DiscriminatorMapping
-If supplied, define a mapping between the values of the discriminator property and the corresponding subtype schemas.
+If supplied, defines a mapping between the values of the discriminator property and the corresponding subtype schemas.
 This parameter accepts a HashTable where each key-value pair maps a discriminator value to a specific subtype schema name.
 It's used in conjunction with the -DiscriminatorProperty to provide complete discrimination logic in polymorphic scenarios.
 
-.EXAMPLE
-Add-PodeOAComponentSchema -Name 'Pets' -Component (  Merge-PodeOAProperty  -Type OneOf -ObjectDefinitions @( 'Cat','Dog') -Discriminator "petType")
+.PARAMETER NoObjectDefinitionsFromPipeline
+Prevents object definitions from being used in the computation but still passes them through the pipeline.
 
+.PARAMETER Name
+Specifies the name of the OpenAPI object.
+
+.PARAMETER Required
+Indicates if the object is required.
+
+.PARAMETER Description
+Provides a description for the OpenAPI object.
+
+.EXAMPLE
+Add-PodeOAComponentSchema -Name 'Pets' -Component (Merge-PodeOAProperty -Type OneOf -ObjectDefinitions @('Cat', 'Dog') -Discriminator "petType")
 
 .EXAMPLE
 Add-PodeOAComponentSchema -Name 'Cat' -Component (
-        Merge-PodeOAProperty  -Type AllOf -ObjectDefinitions @( 'Pet', ( New-PodeOAObjectProperty -Properties @(
-                (New-PodeOAStringProperty -Name 'huntingSkill' -Description 'The measured skill for hunting' -Enum @(  'clueless', 'lazy', 'adventurous', 'aggressive'))
-                ))
+    Merge-PodeOAProperty -Type AllOf -ObjectDefinitions @(
+        'Pet',
+        (New-PodeOAObjectProperty -Properties @(
+            (New-PodeOAStringProperty -Name 'huntingSkill' -Description 'The measured skill for hunting' -Enum @('clueless', 'lazy', 'adventurous', 'aggressive'))
         ))
+    )
+)
 #>
 function Merge-PodeOAProperty {
     [CmdletBinding(DefaultParameterSetName = 'Inbuilt')]
@@ -1771,11 +1784,28 @@ function Merge-PodeOAProperty {
         $DiscriminatorProperty,
 
         [hashtable]
-        $DiscriminatorMapping
+        $DiscriminatorMapping,
+
+        [switch]
+        $NoObjectDefinitionsFromPipeline,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'Name')]
+        [string]
+        $Name,
+
+        [Parameter( ParameterSetName = 'Name')]
+        [switch]
+        $Required,
+
+        [Parameter( ParameterSetName = 'Name')]
+        [string]
+        $Description
     )
     begin {
-
+        # Initialize an ordered dictionary
         $param = [ordered]@{}
+
+        # Set the type of validation
         switch ($type.ToLower()) {
             'oneof' {
                 $param.type = 'oneOf'
@@ -1788,7 +1818,25 @@ function Merge-PodeOAProperty {
             }
         }
 
+        # Add name to the parameter dictionary if provided
+        if ($Name) {
+            $param.name = $Name
+        }
+
+        # Add description to the parameter dictionary if provided
+        if ($Description) {
+            $param.description = $Description
+        }
+
+        # Set the required field if the switch is present
+        if ($Required.IsPresent) {
+            $param.required = $Required.IsPresent
+        }
+
+        # Initialize schemas array
         $param.schemas = @()
+
+        # Add object definitions to the schemas array
         if ($ObjectDefinitions) {
             foreach ($schema in $ObjectDefinitions) {
                 if ($schema -is [System.Object[]] -or ($schema -is [hashtable] -and
@@ -1799,6 +1847,8 @@ function Merge-PodeOAProperty {
                 $param.schemas += $schema
             }
         }
+
+        # Add discriminator property and mapping if provided
         if ($DiscriminatorProperty) {
             if ($type.ToLower() -eq 'allof' ) {
                 # The parameter 'Discriminator' is incompatible with `allOf`
@@ -1816,19 +1866,31 @@ function Merge-PodeOAProperty {
             throw ($PodeLocale.discriminatorMappingRequiresDiscriminatorPropertyExceptionMessage)
         }
 
+        # Initialize a list to collect input from the pipeline
+        $collectedInput = [System.Collections.Generic.List[hashtable]]::new()
     }
     process {
         if ($ParamsList) {
-            if ($ParamsList.type -ine 'object' -and !$ParamsList.object) {
-                # {0} can only be associated with an Object
-                throw ($PodeLocale.typeCanOnlyBeAssociatedWithObjectExceptionMessage -f $type)
+            if ($NoObjectDefinitionsFromPipeline) {
+                # Add to collected input if the switch is present
+                $collectedInput.AddRange($ParamsList)
             }
-            $param.schemas += $ParamsList
+            else {
+                # Add to schemas if the switch is not present
+                $param.schemas += $ParamsList
+            }
         }
     }
 
     end {
-        return $param
+        if ($NoObjectDefinitionsFromPipeline) {
+            # Return collected input and param dictionary if switch is present
+            return $collectedInput + $param
+        }
+        else {
+            # Return the param dictionary
+            return $param
+        }
     }
 }
 

--- a/src/Public/OpenApi.ps1
+++ b/src/Public/OpenApi.ps1
@@ -771,6 +771,10 @@ function Set-PodeOARequest {
         }
 
         if ($null -ne $RequestBody) {
+            if ($r.Method -eq 'Get') {
+                # GET operations cannot have a Request Body.
+                throw $PodeLocale.getRequestBodyNotAllowedExceptionMessage
+            }
             $r.OpenApi.RequestBody = $RequestBody
         }
 

--- a/src/Public/OpenApi.ps1
+++ b/src/Public/OpenApi.ps1
@@ -118,9 +118,11 @@ function Enable-PodeOpenApi {
         [string]
         $RouteFilter = '/*',
 
+        [Parameter()]
         [string[]]
         $EndpointName,
 
+        [Parameter()]
         [object[]]
         $Middleware,
 
@@ -144,21 +146,26 @@ function Enable-PodeOpenApi {
         [switch]
         $RestrictRoutes,
 
+        [Parameter()]
         [ValidateSet('View', 'Download')]
         [String]
         $Mode = 'view',
 
+        [Parameter()]
         [ValidateSet('Json', 'Json-Compress', 'Yaml')]
         [String]
         $MarkupLanguage = 'Json',
 
+        [Parameter()]
         [switch]
         $EnableSchemaValidation,
 
+        [Parameter()]
         [ValidateRange(1, 100)]
         [int]
         $Depth = 20,
 
+        [Parameter()]
         [switch]
         $DisableMinimalDefinitions,
 
@@ -170,6 +177,7 @@ function Enable-PodeOpenApi {
         [switch]
         $NoDefaultResponses,
 
+        [Parameter()]
         [string]
         $DefinitionTag
 

--- a/src/Public/OpenApi.ps1
+++ b/src/Public/OpenApi.ps1
@@ -780,7 +780,7 @@ function Set-PodeOARequest {
 
         if ($null -ne $RequestBody) {
             # Only 'POST', 'PUT', 'PATCH' can have a request body
-            if (('POST', 'PUT', 'PATCH') -icontains $r.Method ) {
+            if (('POST', 'PUT', 'PATCH') -inotcontains $r.Method ) {
                 # {0} operations cannot have a Request Body.
                 throw ($PodeLocale.getRequestBodyNotAllowedExceptionMessage -f $r.Method)
             }

--- a/src/Public/OpenApi.ps1
+++ b/src/Public/OpenApi.ps1
@@ -779,9 +779,10 @@ function Set-PodeOARequest {
         }
 
         if ($null -ne $RequestBody) {
-            if ($r.Method -eq 'Get') {
-                # GET operations cannot have a Request Body.
-                throw $PodeLocale.getRequestBodyNotAllowedExceptionMessage
+            # Only 'POST', 'PUT', 'PATCH' can have a request body
+            if (('POST', 'PUT', 'PATCH') -icontains $r.Method ) {
+                # {0} operations cannot have a Request Body.
+                throw ($PodeLocale.getRequestBodyNotAllowedExceptionMessage -f $r.Method)
             }
             $r.OpenApi.RequestBody = $RequestBody
         }

--- a/src/Public/OpenApi.ps1
+++ b/src/Public/OpenApi.ps1
@@ -1564,7 +1564,7 @@ function Set-PodeOARouteInfo {
         if ((Compare-Object -ReferenceObject $r.OpenApi.DefinitionTag -DifferenceObject  $DefinitionTag).Count -ne 0) {
             if ($r.OpenApi.IsDefTagConfigured ) {
                 # Definition Tag for a Route cannot be changed.
-                throw ($PodeLocale.DefinitionTagChangeNotAllowedExceptionMessage)
+                throw ($PodeLocale.definitionTagChangeNotAllowedExceptionMessage)
             }
             else {
                 $r.OpenApi.DefinitionTag = $DefinitionTag

--- a/tests/unit/OpenApi.Tests.ps1
+++ b/tests/unit/OpenApi.Tests.ps1
@@ -3107,6 +3107,70 @@ Describe 'OpenApi' {
     }
 
 
+    Describe 'Set-PodeOARequest' {
+
+        It 'Sets Parameters on the route if provided' {
+            $route = @{
+                Method = 'GET'
+                OpenApi = @{}
+            }
+            $parameters = @(
+                @{ Name = 'param1'; In = 'query' }
+            )
+
+            Set-PodeOARequest -Route $route -Parameters $parameters
+
+            $route.OpenApi.Parameters | Should -BeExactly $parameters
+        }
+
+        It 'Sets RequestBody on the route if method is POST' {
+            $route = @{
+                Method = 'POST'
+                OpenApi = @{}
+            }
+            $requestBody = @{ Content = 'application/json' }
+
+            Set-PodeOARequest -Route $route -RequestBody $requestBody
+
+            $route.OpenApi.RequestBody | Should -BeExactly $requestBody
+        }
+
+        It 'Throws an exception if RequestBody is set on a method that does not allow it' {
+            $route = @{
+                Method = 'GET'
+                OpenApi = @{}
+            }
+            $requestBody = @{ Content = 'application/json' }
+
+            {
+                Set-PodeOARequest -Route $route -RequestBody $requestBody
+            } | Should -Throw -ExpectedMessage ($PodeLocale.getRequestBodyNotAllowedExceptionMessage -f 'GET')
+        }
+
+        It 'Returns the route when PassThru is used' {
+            $route = @{
+                Method = 'POST'
+                OpenApi = @{}
+            }
+
+            $result = Set-PodeOARequest -Route $route -PassThru
+
+            $result | Should -BeExactly $route
+        }
+
+        It 'Does not set RequestBody if not provided' {
+            $route = @{
+                Method = 'PUT'
+                OpenApi = @{}
+            }
+
+            Set-PodeOARequest -Route $route
+
+            $route.OpenApi.RequestBody | Should -BeNullOrEmpty
+        }
+    }
+
+
 
     Context 'Pet Object example' {
         BeforeEach {


### PR DESCRIPTION
Fix the following bugs
- Exception When Generating OpenAPI Object with oneOf ,anyOf and allOf Property in Pode #1368
- Incorrect OpenAPI Schema Generation with New-PodeOAObjectProperty and -NoProperties Parameter #1367
- Incorrect OpenAPI Generation with -NoDefaultResponses Parameter #1366
- Missing Minimum and Maximum Property in OpenAPI Generation #1365
- GET Operations Incorrectly Allowing Request Body in OpenAPI Generation #1371