### PR TITLE
Quickfix to set C# language version to 7.3, which is officially supported by .NET

### DIFF
--- a/src/Listener/Pode.csproj
+++ b/src/Listener/Pode.csproj
@@ -2,6 +2,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
     <NoWarn>$(NoWarn);SYSLIB0001</NoWarn>
-    <LangVersion>9.0</LangVersion>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 </Project>

--- a/src/Listener/PodeContext.cs
+++ b/src/Listener/PodeContext.cs
@@ -21,7 +21,7 @@ namespace Pode
         public Hashtable Data { get; private set; }
         public string EndpointName => PodeSocket.Name;
 
-        private object _lockable = new();
+        private object _lockable = new object();
 
         private PodeContextState _state;
         public PodeContextState State

--- a/src/Listener/PodeHttpRequest.cs
+++ b/src/Listener/PodeHttpRequest.cs
@@ -314,7 +314,10 @@ namespace Pode
         private async Task ParseBody(byte[] bytes, string newline, int start, CancellationToken cancellationToken)
         {
             // set the body stream
-            BodyStream ??= new MemoryStream();
+            if (BodyStream == default(MemoryStream))
+            {
+                BodyStream = new MemoryStream();
+            }
 
             // are we chunked?
             var isChunked = !string.IsNullOrWhiteSpace(TransferEncoding) && TransferEncoding.Contains("chunked");


### PR DESCRIPTION
### Description of the Change
Changes the `LangVersion` to use C# 7.3 from 9.0 from #1291, as this is officially support by netstandard2.0.