### PR TITLE
Fixes User being needlessly splatted when passed to scriptblock for some Authentication methods; Fixes session scoped variable when remapping while setting values

### DIFF
--- a/examples/Web-AuthFormFile.ps1
+++ b/examples/Web-AuthFormFile.ps1
@@ -60,17 +60,21 @@ Start-PodeServer -Threads 2 {
     Enable-PodeSessionMiddleware -Duration 120 -Extend
 
     # setup form auth against user file (<form> in HTML)
-    New-PodeAuthScheme -Form | Add-PodeAuthUserFile -Name 'Login' -FilePath './users/users.json' -FailureUrl '/login' -SuccessUrl '/'
+    New-PodeAuthScheme -Form | Add-PodeAuthUserFile -Name 'Login' -FilePath './users/users.json' -FailureUrl '/login' -SuccessUrl '/' -ScriptBlock {
+        param($user)
+        return @{ User = $user }
+    }
 
 
     # home page:
     # redirects to login page if not authenticated
     Add-PodeRoute -Method Get -Path '/' -Authentication Login -ScriptBlock {
         $WebEvent.Session.Data.Views++
+        $session:TestData | Out-Default
 
         Write-PodeViewResponse -Path 'auth-home' -Data @{
             Username = $WebEvent.Auth.User.Name
-            Views = $WebEvent.Session.Data.Views
+            Views    = $WebEvent.Session.Data.Views
         }
     }
 

--- a/src/Private/Authentication.ps1
+++ b/src/Private/Authentication.ps1
@@ -856,13 +856,10 @@ function Invoke-PodeAuthInbuiltScriptBlock {
         $ScriptBlock,
 
         [Parameter()]
-        $UsingVariables,
-
-        [switch]
-        $NoSplat
+        $UsingVariables
     )
 
-    return (Invoke-PodeScriptBlock -ScriptBlock $ScriptBlock -Arguments $User -UsingVariables $UsingVariables -Return -Splat:(!$NoSplat))
+    return (Invoke-PodeScriptBlock -ScriptBlock $ScriptBlock -Arguments $User -UsingVariables $UsingVariables -Return)
 }
 
 function Get-PodeAuthWindowsLocalMethod {
@@ -1175,7 +1172,7 @@ function Invoke-PodeAuthValidation {
         if ($result.Success -and !$auth.PassOne) {
             # invoke scriptblock, or use result of merge default
             if ($null -ne $auth.ScriptBlock.Script) {
-                $result = Invoke-PodeAuthInbuiltScriptBlock -User $results -ScriptBlock $auth.ScriptBlock.Script -UsingVariables $auth.ScriptBlock.UsingVariables -NoSplat
+                $result = Invoke-PodeAuthInbuiltScriptBlock -User $results -ScriptBlock $auth.ScriptBlock.Script -UsingVariables $auth.ScriptBlock.UsingVariables
             }
             else {
                 $result = $results[$auth.MergeDefault]

--- a/src/Private/ScopedVariables.ps1
+++ b/src/Private/ScopedVariables.ps1
@@ -69,7 +69,7 @@ function Add-PodeScopedVariableInbuiltSecret {
 
 function Add-PodeScopedVariableInbuiltSession {
     Add-PodeScopedVariable -Name 'session' `
-        -SetReplace "`$WebEvent.Session.Data.'{{name}}'" `
+        -SetReplace "`$WebEvent.Session.Data.'{{name}}' = " `
         -GetReplace "`$WebEvent.Session.Data.'{{name}}'"
 }
 


### PR DESCRIPTION
### Description of the Change
* Fixes User being needlessly splatted when passed to scriptblock for some Authentication methods - eg: File, AD, IIS, etc.
* Fixes session scoped variable when remapping while setting values - it was missing an `=`!

### Related Issue
Resolves #1392 
