### PR TITLE
Ignore accepted PSAnalyzer warnings

### DIFF
--- a/PSScriptAnalyzerSettings.psd1
+++ b/PSScriptAnalyzerSettings.psd1
@@ -25,7 +25,9 @@
         'PSUseProcessBlockForPipelineCommand',
         'PSAvoidUsingConvertToSecureStringWithPlainText',
         'PSReviewUnusedParameter',
-        'PSAvoidAssignmentToAutomaticVariable'
+        'PSAvoidAssignmentToAutomaticVariable',
+        'PSUseBOMForUnicodeEncodedFile',
+        'PSAvoidTrailingWhitespace'
     )
 
 }

--- a/examples/Web-Sse.ps1
+++ b/examples/Web-Sse.ps1
@@ -49,9 +49,9 @@ Start-PodeServer -Threads 3 {
     # open local sse connection, and send back data
     Add-PodeRoute -Method Get -Path '/data' -ScriptBlock {
         ConvertTo-PodeSseConnection -Name 'Data' -Scope Local
-        Send-PodeSseEvent -Id 1234 -EventType Action -Data 'hello, there!'
+        Send-PodeSseEvent -Id 1234 -EventType Action -Data 'hello, there!' -FromEvent
         Start-Sleep -Seconds 3
-        Send-PodeSseEvent -Id 1337 -EventType BoldOne -Data 'general kenobi'
+        Send-PodeSseEvent -Id 1337 -EventType BoldOne -Data 'general kenobi' -FromEvent
     }
 
     # home page to get sse events

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -926,7 +926,7 @@ function Remove-PodeEmptyItemsFromArray {
     param(
         [Parameter()]
         $Array
-    ) 
+    )
     if ($null -eq $Array) {
         return @()
     }

--- a/src/Private/Timers.ps1
+++ b/src/Private/Timers.ps1
@@ -80,7 +80,7 @@ function Start-PodeTimerRunspace {
         }
     }
 
-    Add-PodeRunspace -Type Timers -Name "Scheduler" -ScriptBlock $script
+    Add-PodeRunspace -Type Timers -Name 'Scheduler' -ScriptBlock $script
 }
 
 function Invoke-PodeInternalTimer {

--- a/src/Public/Access.ps1
+++ b/src/Public/Access.ps1
@@ -388,6 +388,7 @@ The Name of the Access method.
 if (Test-PodeAccessExists -Name 'Example') { }
 #>
 function Test-PodeAccessExists {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '')]
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]

--- a/src/Public/Authentication.ps1
+++ b/src/Public/Authentication.ps1
@@ -1102,6 +1102,7 @@ The Name of the Authentication method.
 if (Test-PodeAuthExists -Name BasicAuth) { ... }
 #>
 function Test-PodeAuthExists {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '')]
     [CmdletBinding()]
     [OutputType([bool])]
     param(

--- a/src/Public/Events.ps1
+++ b/src/Public/Events.ps1
@@ -202,6 +202,7 @@ Use-PodeEvents
 Use-PodeEvents -Path './my-events'
 #>
 function Use-PodeEvents {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '')]
     [CmdletBinding()]
     param(
         [Parameter()]

--- a/src/Public/FileWatchers.ps1
+++ b/src/Public/FileWatchers.ps1
@@ -143,7 +143,7 @@ function Add-PodeFileWatcher {
 
     # test if we have the file watcher already
     if (Test-PodeFileWatcher -Name $Name) {
-        # A File Watcher named has already been defined 
+        # A File Watcher named has already been defined
         throw ($PodeLocale.fileWatcherAlreadyDefinedExceptionMessage -f $Name)
     }
 
@@ -292,6 +292,7 @@ Removes all File Watchers.
 Clear-PodeFileWatchers
 #>
 function Clear-PodeFileWatchers {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '')]
     [CmdletBinding()]
     param()
 
@@ -315,6 +316,7 @@ Use-PodeFileWatchers
 Use-PodeFileWatchers -Path './my-watchers'
 #>
 function Use-PodeFileWatchers {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '')]
     [CmdletBinding()]
     param(
         [Parameter()]

--- a/src/Public/Flash.ps1
+++ b/src/Public/Flash.ps1
@@ -57,6 +57,7 @@ Clears all of the flash messages currently stored in the session.
 Clear-PodeFlashMessages
 #>
 function Clear-PodeFlashMessages {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '')]
     [CmdletBinding()]
     param()
 
@@ -127,6 +128,7 @@ Returns all of the names for each of the messages currently being stored. This d
 Get-PodeFlashMessageNames
 #>
 function Get-PodeFlashMessageNames {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '')]
     [CmdletBinding()]
     [OutputType([System.Object[]])]
     param()

--- a/src/Public/Handlers.ps1
+++ b/src/Public/Handlers.ps1
@@ -59,7 +59,7 @@ function Add-PodeHandler {
 
     # ensure handler isn't already set
     if ($PodeContext.Server.Handlers[$Type].ContainsKey($Name)) {
-        # [Type] Name: Handler already defined 
+        # [Type] Name: Handler already defined
         throw ($PodeLocale.handlerAlreadyDefinedExceptionMessage -f $Type, $Name)
     }
 
@@ -132,6 +132,7 @@ The Type of Handlers to remove.
 Clear-PodeHandlers -Type Smtp
 #>
 function Clear-PodeHandlers {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '')]
     [CmdletBinding()]
     param(
         [Parameter()]
@@ -167,6 +168,7 @@ Use-PodeHandlers
 Use-PodeHandlers -Path './my-handlers'
 #>
 function Use-PodeHandlers {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '')]
     [CmdletBinding()]
     param(
         [Parameter()]

--- a/src/Public/Logging.ps1
+++ b/src/Public/Logging.ps1
@@ -501,6 +501,7 @@ Clears all Logging methods that have been configured.
 Clear-PodeLoggers
 #>
 function Clear-PodeLoggers {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '')]
     [CmdletBinding()]
     param()
 

--- a/src/Public/OpenApi.ps1
+++ b/src/Public/OpenApi.ps1
@@ -651,15 +651,15 @@ function Add-PodeOAResponse {
             $code = "$($StatusCode)"
         }
 
-    # add the respones to the routes
-    foreach ($r in @($Route)) {
-        foreach ($tag in $DefinitionTag) {
-            if (! $r.OpenApi.Responses.$tag) {
-                $r.OpenApi.Responses.$tag = [ordered]@{}
+        # add the respones to the routes
+        foreach ($r in @($Route)) {
+            foreach ($tag in $DefinitionTag) {
+                if (! $r.OpenApi.Responses.$tag) {
+                    $r.OpenApi.Responses.$tag = [ordered]@{}
+                }
+                $r.OpenApi.Responses.$tag[$code] = New-PodeOResponseInternal  -DefinitionTag $tag -Params $PSBoundParameters
             }
-            $r.OpenApi.Responses.$tag[$code] = New-PodeOResponseInternal  -DefinitionTag $tag -Params $PSBoundParameters
         }
-    }
 
         if ($PassThru) {
             return $Route
@@ -809,16 +809,16 @@ function Set-PodeOARequest {
                 $r.OpenApi.Parameters = @($Parameters)
             }
 
-        if ($null -ne $RequestBody) {
-            # Only 'POST', 'PUT', 'PATCH' can have a request body
-            if (('POST', 'PUT', 'PATCH') -inotcontains $r.Method ) {
-                # {0} operations cannot have a Request Body.
-                throw ($PodeLocale.getRequestBodyNotAllowedExceptionMessage -f $r.Method)
+            if ($null -ne $RequestBody) {
+                # Only 'POST', 'PUT', 'PATCH' can have a request body
+                if (('POST', 'PUT', 'PATCH') -inotcontains $r.Method ) {
+                    # {0} operations cannot have a Request Body.
+                    throw ($PodeLocale.getRequestBodyNotAllowedExceptionMessage -f $r.Method)
+                }
+                $r.OpenApi.RequestBody = $RequestBody
             }
-            $r.OpenApi.RequestBody = $RequestBody
-        }
 
-    }
+        }
 
         if ($PassThru) {
             return $Route
@@ -892,6 +892,7 @@ New-PodeOARequestBody -Content @{'multipart/form-data' =
 function New-PodeOARequestBody {
     [CmdletBinding(DefaultParameterSetName = 'BuiltIn' )]
     [OutputType([hashtable])]
+    [OutputType([System.Collections.Specialized.OrderedDictionary])]
     param(
         [Parameter(Mandatory = $true, ParameterSetName = 'Reference')]
         [string]
@@ -1360,27 +1361,27 @@ function ConvertTo-PodeOAParameter {
                     $prop['allowReserved'] = $AllowReserved.IsPresent
                 }
 
-            if ($Example ) {
-                $prop.example = $Example
-            }
-            elseif ($Examples) {
-                $prop.examples = $Examples
-            }
-        }
-    }
-    elseif ($PSCmdlet.ParameterSetName -ieq 'Reference') {
-        # return a reference
-        Test-PodeOAComponentInternal -Field parameters  -DefinitionTag $DefinitionTag  -Name $Reference -PostValidation
-        $prop = [ordered]@{
-            '$ref' = "#/components/parameters/$Reference"
-        }
-        foreach ($tag in $DefinitionTag) {
-            if ($PodeContext.Server.OpenAPI.Definitions[$tag].components.parameters.$Reference.In -eq 'Header' -and $PodeContext.Server.Security.autoHeaders) {
-                Add-PodeSecurityHeader -Name 'Access-Control-Allow-Headers' -Value $Reference -Append
+                if ($Example ) {
+                    $prop.example = $Example
+                }
+                elseif ($Examples) {
+                    $prop.examples = $Examples
+                }
             }
         }
-    }
-    else {
+        elseif ($PSCmdlet.ParameterSetName -ieq 'Reference') {
+            # return a reference
+            Test-PodeOAComponentInternal -Field parameters  -DefinitionTag $DefinitionTag  -Name $Reference -PostValidation
+            $prop = [ordered]@{
+                '$ref' = "#/components/parameters/$Reference"
+            }
+            foreach ($tag in $DefinitionTag) {
+                if ($PodeContext.Server.OpenAPI.Definitions[$tag].components.parameters.$Reference.In -eq 'Header' -and $PodeContext.Server.Security.autoHeaders) {
+                    Add-PodeSecurityHeader -Name 'Access-Control-Allow-Headers' -Value $Reference -Append
+                }
+            }
+        }
+        else {
 
             if (!$Name ) {
                 if ($Property.name) {
@@ -1633,17 +1634,17 @@ function Set-PodeOARouteInfo {
 
         $DefinitionTag = Test-PodeOADefinitionTag -Tag $DefinitionTag
 
-    foreach ($r in @($Route)) {
-        if ((Compare-Object -ReferenceObject $r.OpenApi.DefinitionTag -DifferenceObject  $DefinitionTag).Count -ne 0) {
-            if ($r.OpenApi.IsDefTagConfigured ) {
-                # Definition Tag for a Route cannot be changed.
-                throw ($PodeLocale.definitionTagChangeNotAllowedExceptionMessage)
+        foreach ($r in @($Route)) {
+            if ((Compare-Object -ReferenceObject $r.OpenApi.DefinitionTag -DifferenceObject  $DefinitionTag).Count -ne 0) {
+                if ($r.OpenApi.IsDefTagConfigured ) {
+                    # Definition Tag for a Route cannot be changed.
+                    throw ($PodeLocale.definitionTagChangeNotAllowedExceptionMessage)
+                }
+                else {
+                    $r.OpenApi.DefinitionTag = $DefinitionTag
+                    $r.OpenApi.IsDefTagConfigured = $true
+                }
             }
-            else {
-                $r.OpenApi.DefinitionTag = $DefinitionTag
-                $r.OpenApi.IsDefTagConfigured = $true
-            }
-        }
 
             if ($OperationId) {
                 if ($Route.Count -gt 1) {
@@ -2712,28 +2713,28 @@ function Add-PodeOACallBack {
 
         $DefinitionTag = Test-PodeOADefinitionTag -Tag $DefinitionTag
 
-    foreach ($r in @($Route)) {
-        foreach ($tag in $DefinitionTag) {
-            if ($Reference) {
-                Test-PodeOAComponentInternal -Field callbacks -DefinitionTag $tag -Name $Reference -PostValidation
-                if (!$Name) {
-                    $Name = $Reference
+        foreach ($r in @($Route)) {
+            foreach ($tag in $DefinitionTag) {
+                if ($Reference) {
+                    Test-PodeOAComponentInternal -Field callbacks -DefinitionTag $tag -Name $Reference -PostValidation
+                    if (!$Name) {
+                        $Name = $Reference
+                    }
+                    if (! $r.OpenApi.CallBacks.ContainsKey($tag)) {
+                        $r.OpenApi.CallBacks[$tag] = [ordered]@{}
+                    }
+                    $r.OpenApi.CallBacks[$tag].$Name = [ordered]@{
+                        '$ref' = "#/components/callbacks/$Reference"
+                    }
                 }
-                if (! $r.OpenApi.CallBacks.ContainsKey($tag)) {
-                    $r.OpenApi.CallBacks[$tag] = [ordered]@{}
+                else {
+                    if (! $r.OpenApi.CallBacks.ContainsKey($tag)) {
+                        $r.OpenApi.CallBacks[$tag] = [ordered]@{}
+                    }
+                    $r.OpenApi.CallBacks[$tag].$Name = New-PodeOAComponentCallBackInternal -Params $PSBoundParameters -DefinitionTag $tag
                 }
-                $r.OpenApi.CallBacks[$tag].$Name = [ordered]@{
-                    '$ref' = "#/components/callbacks/$Reference"
-                }
-            }
-            else {
-                if (! $r.OpenApi.CallBacks.ContainsKey($tag)) {
-                    $r.OpenApi.CallBacks[$tag] = [ordered]@{}
-                }
-                $r.OpenApi.CallBacks[$tag].$Name = New-PodeOAComponentCallBackInternal -Params $PSBoundParameters -DefinitionTag $tag
             }
         }
-    }
 
         if ($PassThru) {
             return $Route
@@ -3307,36 +3308,36 @@ function Add-PodeOAExternalRoute {
     end {
         $DefinitionTag = Test-PodeOADefinitionTag -Tag $DefinitionTag
 
-    switch ($PSCmdlet.ParameterSetName.ToLowerInvariant()) {
-        'builtin' {
+        switch ($PSCmdlet.ParameterSetName.ToLowerInvariant()) {
+            'builtin' {
 
-            # ensure the route has appropriate slashes
-            $Path = Update-PodeRouteSlash -Path $Path
-            $OpenApiPath = ConvertTo-PodeOpenApiRoutePath -Path $Path
-            $Path = Resolve-PodePlaceholder -Path $Path
-            $extRoute = @{
-                Method  = $Method.ToLower()
-                Path    = $Path
-                Local   = $false
-                OpenApi = @{
-                    Path           = $OpenApiPath
-                    Responses      = $null
-                    Parameters     = $null
-                    RequestBody    = $null
-                    callbacks      = [ordered]@{}
-                    Authentication = @()
-                    Servers        = $Servers
-                    DefinitionTag  = $DefinitionTag
+                # ensure the route has appropriate slashes
+                $Path = Update-PodeRouteSlash -Path $Path
+                $OpenApiPath = ConvertTo-PodeOpenApiRoutePath -Path $Path
+                $Path = Resolve-PodePlaceholder -Path $Path
+                $extRoute = @{
+                    Method  = $Method.ToLower()
+                    Path    = $Path
+                    Local   = $false
+                    OpenApi = @{
+                        Path           = $OpenApiPath
+                        Responses      = $null
+                        Parameters     = $null
+                        RequestBody    = $null
+                        callbacks      = [ordered]@{}
+                        Authentication = @()
+                        Servers        = $Servers
+                        DefinitionTag  = $DefinitionTag
+                    }
                 }
-            }
-            foreach ($tag in $DefinitionTag) {
-                #add the default OpenApi responses
-                if ( $PodeContext.Server.OpenAPI.Definitions[$tag].hiddenComponents.defaultResponses) {
-                    $extRoute.OpenApi.Responses = Copy-PodeObjectDeepClone -InputObject $PodeContext.Server.OpenAPI.Definitions[$tag].hiddenComponents.defaultResponses
-                }
-                if (! (Test-PodeOAComponentExternalPath -DefinitionTag $tag -Name $Path)) {
-                    $PodeContext.Server.OpenAPI.Definitions[$tag].hiddenComponents.externalPath[$Path] = [ordered]@{}
-                }
+                foreach ($tag in $DefinitionTag) {
+                    #add the default OpenApi responses
+                    if ( $PodeContext.Server.OpenAPI.Definitions[$tag].hiddenComponents.defaultResponses) {
+                        $extRoute.OpenApi.Responses = Copy-PodeObjectDeepClone -InputObject $PodeContext.Server.OpenAPI.Definitions[$tag].hiddenComponents.defaultResponses
+                    }
+                    if (! (Test-PodeOAComponentExternalPath -DefinitionTag $tag -Name $Path)) {
+                        $PodeContext.Server.OpenAPI.Definitions[$tag].hiddenComponents.externalPath[$Path] = [ordered]@{}
+                    }
 
                     $PodeContext.Server.OpenAPI.Definitions[$tag].hiddenComponents.externalPath.$Path[$Method] = $extRoute
                 }

--- a/src/Public/Responses.ps1
+++ b/src/Public/Responses.ps1
@@ -270,20 +270,20 @@ function Write-PodeTextResponse {
                 }
             }
 
-        # check if we need to compress the response
-        if ($PodeContext.Server.Web.Compression.Enabled -and ![string]::IsNullOrWhiteSpace($WebEvent.AcceptEncoding)) {
-            try {
-                $ms = [System.IO.MemoryStream]::new()
-                $stream = Get-PodeCompressionStream -InputStream $ms -Encoding $WebEvent.AcceptEncoding -Mode Compress
-                $stream.Write($Bytes, 0, $Bytes.Length)
-                $stream.Close()
-                $ms.Position = 0
-                $Bytes = $ms.ToArray()
-            }
-            finally {
-                if ($null -ne $stream) {
+            # check if we need to compress the response
+            if ($PodeContext.Server.Web.Compression.Enabled -and ![string]::IsNullOrWhiteSpace($WebEvent.AcceptEncoding)) {
+                try {
+                    $ms = [System.IO.MemoryStream]::new()
+                    $stream = Get-PodeCompressionStream -InputStream $ms -Encoding $WebEvent.AcceptEncoding -Mode Compress
+                    $stream.Write($Bytes, 0, $Bytes.Length)
                     $stream.Close()
+                    $ms.Position = 0
+                    $Bytes = $ms.ToArray()
                 }
+                finally {
+                    if ($null -ne $stream) {
+                        $stream.Close()
+                    }
 
                     if ($null -ne $ms) {
                         $ms.Close()
@@ -297,15 +297,15 @@ function Write-PodeTextResponse {
             # write the content to the response stream
             $res.ContentLength64 = $Bytes.Length
 
-        try {
-            $ms = [System.IO.MemoryStream]::new()
-            $ms.Write($Bytes, 0, $Bytes.Length)
-            $ms.WriteTo($res.OutputStream)
-        }
-        catch {
-            if ((Test-PodeValidNetworkFailure $_.Exception)) {
-                return
+            try {
+                $ms = [System.IO.MemoryStream]::new()
+                $ms.Write($Bytes, 0, $Bytes.Length)
+                $ms.WriteTo($res.OutputStream)
             }
+            catch {
+                if ((Test-PodeValidNetworkFailure $_.Exception)) {
+                    return
+                }
 
                 $_ | Write-PodeErrorLog
                 throw

--- a/src/Public/Routes.ps1
+++ b/src/Public/Routes.ps1
@@ -399,7 +399,7 @@ function Add-PodeRoute {
         if ( $PodeContext.Server.OpenAPI.Definitions[$DefinitionTag].hiddenComponents.defaultResponses) {
             $DefaultResponse = [ordered]@{}
             foreach ($tag in $DefinitionTag) {
-                 $DefaultResponse[$tag] = Copy-PodeObjectDeepClone -InputObject $PodeContext.Server.OpenAPI.Definitions[$tag].hiddenComponents.defaultResponses
+                $DefaultResponse[$tag] = Copy-PodeObjectDeepClone -InputObject $PodeContext.Server.OpenAPI.Definitions[$tag].hiddenComponents.defaultResponses
             }
         }
 
@@ -1835,6 +1835,7 @@ Clear-PodeRoutes
 Clear-PodeRoutes -Method Get
 #>
 function Clear-PodeRoutes {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '')]
     [CmdletBinding()]
     param(
         [Parameter()]
@@ -1864,6 +1865,7 @@ Removes all added static Routes.
 Clear-PodeStaticRoutes
 #>
 function Clear-PodeStaticRoutes {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '')]
     [CmdletBinding()]
     param()
 
@@ -1881,6 +1883,7 @@ Removes all added Signal Routes.
 Clear-PodeSignalRoutes
 #>
 function Clear-PodeSignalRoutes {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '')]
     [CmdletBinding()]
     param()
 
@@ -2598,6 +2601,7 @@ Use-PodeRoutes
 Use-PodeRoutes -Path './my-routes' -IfExists Skip
 #>
 function Use-PodeRoutes {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '')]
     [CmdletBinding()]
     param(
         [Parameter()]

--- a/src/Public/Runspaces.ps1
+++ b/src/Public/Runspaces.ps1
@@ -18,7 +18,8 @@
 #>
 
 function Set-PodeCurrentRunspaceName {
-    param (
+    [CmdletBinding()]
+    param(
         [Parameter(Mandatory = $true)]
         [string]
         $Name
@@ -26,7 +27,7 @@ function Set-PodeCurrentRunspaceName {
 
     # Get the current runspace
     $currentRunspace = [System.Management.Automation.Runspaces.Runspace]::DefaultRunspace
-     # Set the name of the current runspace if the name is not already set
+    # Set the name of the current runspace if the name is not already set
     if ( $currentRunspace.Name -ne $Name) {
         # Set the name of the current runspace
         $currentRunspace.Name = $Name
@@ -49,6 +50,9 @@ function Set-PodeCurrentRunspaceName {
     This is an internal function and may change in future releases of Pode.
 #>
 function Get-PodeCurrentRunspaceName {
+    [CmdletBinding()]
+    param()
+
     # Get the current runspace
     $currentRunspace = [System.Management.Automation.Runspaces.Runspace]::DefaultRunspace
 

--- a/src/Public/SSE.ps1
+++ b/src/Public/SSE.ps1
@@ -245,7 +245,7 @@ function Send-PodeSseEvent {
     }
 
     process {
-            $pipelineValue += $_
+        $pipelineValue += $_
     }
 
     end {

--- a/src/Public/Schedules.ps1
+++ b/src/Public/Schedules.ps1
@@ -277,6 +277,7 @@ Removes all Schedules.
 Clear-PodeSchedules
 #>
 function Clear-PodeSchedules {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '')]
     [CmdletBinding()]
     param()
 
@@ -556,6 +557,7 @@ Use-PodeSchedules
 Use-PodeSchedules -Path './my-schedules'
 #>
 function Use-PodeSchedules {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '')]
     [CmdletBinding()]
     param(
         [Parameter()]

--- a/src/Public/ScopedVariables.ps1
+++ b/src/Public/ScopedVariables.ps1
@@ -23,6 +23,7 @@ $ScriptBlock, $usingVars = Convert-PodeScopedVariables -ScriptBlock $ScriptBlock
 $ScriptBlock = Convert-PodeScopedVariables -ScriptBlock $ScriptBlock -Exclude Session, Using
 #>
 function Convert-PodeScopedVariables {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '')]
     [CmdletBinding()]
     [OutputType([System.Object[]])]
     [OutputType([scriptblock])]
@@ -301,6 +302,10 @@ Removes all Scoped Variables.
 Clear-PodeScopedVariables
 #>
 function Clear-PodeScopedVariables {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '')]
+    [CmdletBinding()]
+    param()
+
     $null = $PodeContext.Server.ScopedVariables.Clear()
 }
 
@@ -357,6 +362,7 @@ Use-PodeScopedVariables
 Use-PodeScopedVariables -Path './my-vars'
 #>
 function Use-PodeScopedVariables {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '')]
     [CmdletBinding()]
     param(
         [Parameter()]

--- a/src/Public/Security.ps1
+++ b/src/Public/Security.ps1
@@ -223,6 +223,7 @@ The Type to use.
 Set-PodeSecurityFrameOptions -Type SameOrigin
 #>
 function Set-PodeSecurityFrameOptions {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '')]
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
@@ -245,6 +246,7 @@ Removes definition for the X-Frame-Options header.
 Remove-PodeSecurityFrameOptions
 #>
 function Remove-PodeSecurityFrameOptions {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '')]
     [CmdletBinding()]
     param()
 
@@ -1062,6 +1064,7 @@ Set a value for the X-Content-Type-Options header to "nosniff".
 Set-PodeSecurityContentTypeOptions
 #>
 function Set-PodeSecurityContentTypeOptions {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '')]
     [CmdletBinding()]
     param()
 
@@ -1079,6 +1082,7 @@ Removes definitions for the X-Content-Type-Options header.
 Remove-PodeSecurityContentTypeOptions
 #>
 function Remove-PodeSecurityContentTypeOptions {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '')]
     [CmdletBinding()]
     param()
 

--- a/src/Public/State.ps1
+++ b/src/Public/State.ps1
@@ -131,6 +131,7 @@ $names = Get-PodeStateNames -Scope '<scope>'
 $names = Get-PodeStateNames -Pattern '^\w+[0-9]{0,2}$'
 #>
 function Get-PodeStateNames {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '')]
     [CmdletBinding()]
     param(
         [Parameter()]

--- a/src/Public/Tasks.ps1
+++ b/src/Public/Tasks.ps1
@@ -196,8 +196,8 @@ function Invoke-PodeTask {
             throw ($PodeLocale.taskDoesNotExistExceptionMessage -f $Name)
         }
 
-    # run task logic
-    $task = Invoke-PodeInternalTask -Task $PodeContext.Tasks.Items[$Name] -ArgumentList $ArgumentList -Timeout $Timeout -TimeoutFrom $TimeoutFrom
+        # run task logic
+        $task = Invoke-PodeInternalTask -Task $PodeContext.Tasks.Items[$Name] -ArgumentList $ArgumentList -Timeout $Timeout -TimeoutFrom $TimeoutFrom
 
         # wait, and return result?
         if ($Wait) {
@@ -245,6 +245,7 @@ Removes all Tasks.
 Clear-PodeTasks
 #>
 function Clear-PodeTasks {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '')]
     [CmdletBinding()]
     param()
 
@@ -368,6 +369,7 @@ Use-PodeTasks
 Use-PodeTasks -Path './my-tasks'
 #>
 function Use-PodeTasks {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '')]
     [CmdletBinding()]
     param(
         [Parameter()]

--- a/src/Public/Threading.ps1
+++ b/src/Public/Threading.ps1
@@ -376,6 +376,7 @@ Remove all Lockables.
 Clear-PodeLockables
 #>
 function Clear-PodeLockables {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '')]
     [CmdletBinding()]
     param()
 
@@ -667,6 +668,7 @@ Removes all Mutexes.
 Clear-PodeMutexes
 #>
 function Clear-PodeMutexes {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '')]
     [CmdletBinding()]
     param()
 
@@ -980,6 +982,7 @@ Removes all Semaphores.
 Clear-PodeSemaphores
 #>
 function Clear-PodeSemaphores {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '')]
     [CmdletBinding()]
     param()
 

--- a/src/Public/Timers.ps1
+++ b/src/Public/Timers.ps1
@@ -211,6 +211,7 @@ Removes all Timers.
 Clear-PodeTimers
 #>
 function Clear-PodeTimers {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '')]
     [CmdletBinding()]
     param()
 
@@ -370,6 +371,7 @@ Use-PodeTimers
 Use-PodeTimers -Path './my-timers'
 #>
 function Use-PodeTimers {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '')]
     [CmdletBinding()]
     param(
         [Parameter()]

--- a/src/Public/Utilities.ps1
+++ b/src/Public/Utilities.ps1
@@ -612,6 +612,9 @@ $Arguments = @(Merge-PodeScriptblockArguments -ArgumentList $Arguments -UsingVar
 $Arguments = @(Merge-PodeScriptblockArguments -UsingVariables $UsingVariables)
 #>
 function Merge-PodeScriptblockArguments {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '')]
+    [CmdletBinding()]
+    [OutputType([object[]])]
     param(
         [Parameter()]
         [object[]]

--- a/src/Public/Verbs.ps1
+++ b/src/Public/Verbs.ps1
@@ -176,6 +176,7 @@ Removes all added Verbs.
 Clear-PodeVerbs
 #>
 function Clear-PodeVerbs {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '')]
     [CmdletBinding()]
     param()
 
@@ -261,6 +262,7 @@ Use-PodeVerbs
 Use-PodeVerbs -Path './my-verbs'
 #>
 function Use-PodeVerbs {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '')]
     [CmdletBinding()]
     param(
         [Parameter()]


### PR DESCRIPTION
### Description of the Change
* Adds "SuppressMessageAttribute" for `PSUseSingularNouns` on accepted Public functions.
* Adds missing `[OutputTypes]`
* Excludes `PSUseBOMForUnicodeEncodedFile` and `PSAvoidTrailingWhitespace` in PSAnalyzer settings