### PR TITLE
Adds new/missing CSP parmeters in security headers

### DIFF
--- a/docs/Tutorials/Middleware/Types/Security.md
+++ b/docs/Tutorials/Middleware/Types/Security.md
@@ -2,7 +2,7 @@
 
 The security headers middleware runs at the beginning of every request, and if any security headers are defined they will be added onto the response.
 
-The following headers are currently supported, but you can add custom header values:
+The following headers are currently supported, but you can add custom header values via [`Add-PodeSecurityHeader`](../../../../Functions/Security/Add-PodeSecurityHeader) for any missing:
 
 * Access-Control-Max-Age
 * Access-Control-Allow-Methods
@@ -13,6 +13,7 @@ The following headers are currently supported, but you can add custom header val
 * Cross-Origin-Opener-Policy
 * Strict-Transport-Security
 * Content-Security-Policy
+* Content-Security-Policy-Report-Only
 * X-XSS-Protection
 * Permissions-Policy
 * X-Frame-Options
@@ -37,21 +38,21 @@ To remove all configured values, use [`Remove-PodeSecurity`](../../../../Functio
 
 The following values are used for each header when the `Simple` type is supplied:
 
-| Name | Value |
-| ---- | ----- |
-| Access-Control-Max-Age | 7200 |
-| Access-Control-Allow-Origin | * |
-| Access-Control-Allow-Methods | * |
-| Access-Control-Allow-Headers | * |
-| Cross-Origin-Embedder-Policy | require-corp |
-| Cross-Origin-Resource-Policy | same-origin |
-| Cross-Origin-Opener-Policy | same-origin |
-| Content-Security-Policy | default-src 'self' |
-| X-XSS-Protection | 0 |
-| Permissions-Policy | accelerometer=(), autoplay=(self), camera=(), display-capture=(self), fullscreen=(self), geolocation=(self), gyroscope=(self), magnetometer=(self), microphone=(), payment=(), picture-in-picture=(self), sync-xhr=(), usb=() |
-| X-Frame-Options | SAMEORIGIN |
-| X-Content-Type-Options | nosniff |
-| Referred-Policy | strict-origin |
+| Name                         | Value                                                                                                                                                                                                                         |
+| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Access-Control-Max-Age       | 7200                                                                                                                                                                                                                          |
+| Access-Control-Allow-Origin  | *                                                                                                                                                                                                                             |
+| Access-Control-Allow-Methods | *                                                                                                                                                                                                                             |
+| Access-Control-Allow-Headers | *                                                                                                                                                                                                                             |
+| Cross-Origin-Embedder-Policy | require-corp                                                                                                                                                                                                                  |
+| Cross-Origin-Resource-Policy | same-origin                                                                                                                                                                                                                   |
+| Cross-Origin-Opener-Policy   | same-origin                                                                                                                                                                                                                   |
+| Content-Security-Policy      | default-src 'self'                                                                                                                                                                                                            |
+| X-XSS-Protection             | 0                                                                                                                                                                                                                             |
+| Permissions-Policy           | accelerometer=(), autoplay=(self), camera=(), display-capture=(self), fullscreen=(self), geolocation=(self), gyroscope=(self), magnetometer=(self), microphone=(), payment=(), picture-in-picture=(self), sync-xhr=(), usb=() |
+| X-Frame-Options              | SAMEORIGIN                                                                                                                                                                                                                    |
+| X-Content-Type-Options       | nosniff                                                                                                                                                                                                                       |
+| Referred-Policy              | strict-origin                                                                                                                                                                                                                 |
 
 The Server header is also hidden.
 
@@ -59,22 +60,22 @@ The Server header is also hidden.
 
 The following values are used for each header when the `Strict` type is supplied:
 
-| Name | Value |
-| ---- | ----- |
-| Access-Control-Max-Age | 7200 |
-| Access-Control-Allow-Methods | * |
-| Access-Control-Allow-Origin | * |
-| Access-Control-Allow-Headers | * |
-| Cross-Origin-Embedder-Policy | require-corp |
-| Cross-Origin-Resource-Policy | same-origin |
-| Cross-Origin-Opener-Policy | same-origin |
-| Strict-Transport-Security | max-age=31536000; includeSubDomains |
-| Content-Security-Policy | default-src 'self' |
-| X-XSS-Protection | 0 |
-| Permissions-Policy | accelerometer=(), autoplay=(self), camera=(), display-capture=(self), fullscreen=(self), geolocation=(self), gyroscope=(self), magnetometer=(self), microphone=(), payment=(), picture-in-picture=(self), sync-xhr=(), usb=() |
-| X-Frame-Options | DENY |
-| X-Content-Type-Options | nosniff |
-| Referred-Policy | no-referrer |
+| Name                         | Value                                                                                                                                                                                                                         |
+| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Access-Control-Max-Age       | 7200                                                                                                                                                                                                                          |
+| Access-Control-Allow-Methods | *                                                                                                                                                                                                                             |
+| Access-Control-Allow-Origin  | *                                                                                                                                                                                                                             |
+| Access-Control-Allow-Headers | *                                                                                                                                                                                                                             |
+| Cross-Origin-Embedder-Policy | require-corp                                                                                                                                                                                                                  |
+| Cross-Origin-Resource-Policy | same-origin                                                                                                                                                                                                                   |
+| Cross-Origin-Opener-Policy   | same-origin                                                                                                                                                                                                                   |
+| Strict-Transport-Security    | max-age=31536000; includeSubDomains                                                                                                                                                                                           |
+| Content-Security-Policy      | default-src 'self'                                                                                                                                                                                                            |
+| X-XSS-Protection             | 0                                                                                                                                                                                                                             |
+| Permissions-Policy           | accelerometer=(), autoplay=(self), camera=(), display-capture=(self), fullscreen=(self), geolocation=(self), gyroscope=(self), magnetometer=(self), microphone=(), payment=(), picture-in-picture=(self), sync-xhr=(), usb=() |
+| X-Frame-Options              | DENY                                                                                                                                                                                                                          |
+| X-Content-Type-Options       | nosniff                                                                                                                                                                                                                       |
+| Referred-Policy              | no-referrer                                                                                                                                                                                                                   |
 
 The Server header is also hidden.
 
@@ -153,11 +154,13 @@ The following functions exist:
 * [`Set-PodeSecurityContentSecurityPolicy`](../../../../Functions/Security/Set-PodeSecurityContentSecurityPolicy)
 * [`Remove-PodeSecurityContentSecurityPolicy`](../../../../Functions/Security/Remove-PodeSecurityContentSecurityPolicy)
 
-The `Content-Security-Policy` header controls a whitelist of approved sourced from which the browser can load resoures. For example:
+The `Content-Security-Policy` header controls a whitelist of approved sources from which the browser can load resources. For example:
 
 ```powershell
 Set-PodeSecurityContentSecurityPolicy -Default 'self' -Image 'self', 'data'
 ```
+
+By supplying the `-ReportOnly` switch, the `Content-Security-Policy-Report-Only` header will be used instead.
 
 ### Permissions Policy
 

--- a/src/Public/Security.ps1
+++ b/src/Public/Security.ps1
@@ -302,14 +302,41 @@ The values to use for the FormAction portion of the header.
 .PARAMETER FrameAncestor
 The values to use for the FrameAncestor portion of the header.
 
+.PARAMETER FencedFrame
+The values to use for the FencedFrame portion of the header.
+
+.PARAMETER Prefetch
+The values to use for the Prefetch portion of the header.
+
+.PARAMETER ScriptAttr
+The values to use for the ScriptAttr portion of the header.
+
+.PARAMETER ScriptElem
+The values to use for the ScriptElem portion of the header.
+
+.PARAMETER StyleAttr
+The values to use for the StyleAttr portion of the header.
+
+.PARAMETER StyleElem
+The values to use for the StyleElem portion of the header.
+
+.PARAMETER Worker
+The values to use for the Worker portion of the header.
+
 .PARAMETER Sandbox
 The value to use for the Sandbox portion of the header.
+
+.PARAMETER ReportUri
+The value to use for the ReportUri portion of the header.
 
 .PARAMETER UpgradeInsecureRequests
 If supplied, the header will have the upgrade-insecure-requests value added.
 
 .PARAMETER XssBlock
 If supplied, the X-XSS-Protection header will be set to blocking mode. (Default: Off)
+
+.PARAMETER ReportOnly
+If supplied, the header will be set as a report-only header.
 
 .EXAMPLE
 Set-PodeSecurityContentSecurityPolicy -Default 'self'
@@ -374,17 +401,52 @@ function Set-PodeSecurityContentSecurityPolicy {
         $FrameAncestor,
 
         [Parameter()]
+        [string[]]
+        $FencedFrame,
+
+        [Parameter()]
+        [string[]]
+        $Prefetch,
+
+        [Parameter()]
+        [string[]]
+        $ScriptAttr,
+
+        [Parameter()]
+        [string[]]
+        $ScriptElem,
+
+        [Parameter()]
+        [string[]]
+        $StyleAttr,
+
+        [Parameter()]
+        [string[]]
+        $StyleElem,
+
+        [Parameter()]
+        [string[]]
+        $Worker,
+
+        [Parameter()]
         [ValidateSet('', 'Allow-Downloads', 'Allow-Downloads-Without-User-Activation', 'Allow-Forms', 'Allow-Modals', 'Allow-Orientation-Lock',
             'Allow-Pointer-Lock', 'Allow-Popups', 'Allow-Popups-To-Escape-Sandbox', 'Allow-Presentation', 'Allow-Same-Origin', 'Allow-Scripts',
             'Allow-Storage-Access-By-User-Activation', 'Allow-Top-Navigation', 'Allow-Top-Navigation-By-User-Activation', 'None')]
         [string]
         $Sandbox = 'None',
 
+        [Parameter()]
+        [string]
+        $ReportUri,
+
         [switch]
         $UpgradeInsecureRequests,
 
         [switch]
-        $XssBlock
+        $XssBlock,
+
+        [switch]
+        $ReportOnly
     )
 
     Set-PodeSecurityContentSecurityPolicyInternal -Params $PSBoundParameters
@@ -439,17 +501,43 @@ The values to add for the FormAction portion of the header.
 .PARAMETER FrameAncestor
 The values to add for the FrameAncestor portion of the header.
 
+.PARAMETER FencedFrame
+The values to add for the FencedFrame portion of the header.
+
+.PARAMETER Prefetch
+The values to add for the Prefetch portion of the header.
+
+.PARAMETER ScriptAttr
+The values to add for the ScriptAttr portion of the header.
+
+.PARAMETER ScriptElem
+The values to add for the ScriptElem portion of the header.
+
+.PARAMETER StyleAttr
+The values to add for the StyleAttr portion of the header.
+
+.PARAMETER StyleElem
+The values to add for the StyleElem portion of the header.
+
+.PARAMETER Worker
+The values to add for the Worker portion of the header.
+
 .PARAMETER Sandbox
 The value to use for the Sandbox portion of the header.
 
+.PARAMETER ReportUri
+The value to use for the ReportUri portion of the header.
+
 .PARAMETER UpgradeInsecureRequests
 If supplied, the header will have the upgrade-insecure-requests value added.
+
+.PARAMETER ReportOnly
+If supplied, the header will be set as a report-only header.
 
 .EXAMPLE
 Add-PodeSecurityContentSecurityPolicy -Default '*.twitter.com' -Image 'data'
 #>
 function Add-PodeSecurityContentSecurityPolicy {
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSPossibleIncorrectComparisonWithNull', '')]
     [CmdletBinding()]
     param(
         [Parameter()]
@@ -509,14 +597,49 @@ function Add-PodeSecurityContentSecurityPolicy {
         $FrameAncestor,
 
         [Parameter()]
+        [string[]]
+        $FencedFrame,
+
+        [Parameter()]
+        [string[]]
+        $Prefetch,
+
+        [Parameter()]
+        [string[]]
+        $ScriptAttr,
+
+        [Parameter()]
+        [string[]]
+        $ScriptElem,
+
+        [Parameter()]
+        [string[]]
+        $StyleAttr,
+
+        [Parameter()]
+        [string[]]
+        $StyleElem,
+
+        [Parameter()]
+        [string[]]
+        $Worker,
+
+        [Parameter()]
         [ValidateSet('', 'Allow-Downloads', 'Allow-Downloads-Without-User-Activation', 'Allow-Forms', 'Allow-Modals', 'Allow-Orientation-Lock',
             'Allow-Pointer-Lock', 'Allow-Popups', 'Allow-Popups-To-Escape-Sandbox', 'Allow-Presentation', 'Allow-Same-Origin', 'Allow-Scripts',
             'Allow-Storage-Access-By-User-Activation', 'Allow-Top-Navigation', 'Allow-Top-Navigation-By-User-Activation', 'None')]
         [string]
         $Sandbox = 'None',
 
+        [Parameter()]
+        [string]
+        $ReportUri,
+
         [switch]
-        $UpgradeInsecureRequests
+        $UpgradeInsecureRequests,
+
+        [switch]
+        $ReportOnly
     )
 
     Set-PodeSecurityContentSecurityPolicyInternal -Params $PSBoundParameters -Append


### PR DESCRIPTION
### Description of the Change
Found while updating a library in Pode.Web, but there have been some new attributes added for the `Content-Security-Policy` header - as well as some pre-existing ones that needed adding:

* fenched-frame-src
* prefetch-src
* script-src-attr
* script-src-elem
* style-src-attr
* style-src-elem
* worker-src
* report-uri

Also added the following schemes:

* blob
* data
* mediastream
* ftp
* mailto
* tel
* filesystem

And the following keywords:

* strict-dynamic
* report-sample
* inline-speculation-rules
* unsafe-hashes
* wasm-unsafe-eval

Also added a `-ReportOnly` switch to toggle using `Content-Security-Policy-Report-Only`