### PR TITLE
Fixes "collection modified" error when cleaning up sessions

### DIFF
--- a/src/Private/Sessions.ps1
+++ b/src/Private/Sessions.ps1
@@ -290,7 +290,7 @@ function Set-PodeSessionInMemClearDown {
 
         # remove sessions that have expired, or where the parent is gone
         $now = [DateTime]::UtcNow
-        foreach ($key in $store.Memory.Keys) {
+        foreach ($key in $store.Memory.Keys.Clone()) {
             # expired
             if ($store.Memory[$key].Expiry -lt $now) {
                 $null = $store.Memory.Remove($key)


### PR DESCRIPTION
### Description of the Change
* Adds a `.Clone()` call when retrieving session keys, to fix "collection modified" error

### Related Issue
Resolves #1408 
