### PR TITLE
Add -AllowNonStandardBody Parameter to Enable Request Bodies for Non-Standard HTTP Methods in OpenAPI

### DIFF
--- a/src/Locales/ar/Pode.psd1
+++ b/src/Locales/ar/Pode.psd1
@@ -288,7 +288,7 @@
     taskProcessDoesNotExistExceptionMessage                           = 'عملية المهمة غير موجودة: {0}'
     scheduleProcessDoesNotExistExceptionMessage                       = 'عملية الجدول الزمني غير موجودة: {0}'
     definitionTagChangeNotAllowedExceptionMessage                     = 'لا يمكن تغيير علامة التعريف لمسار.'
-    getRequestBodyNotAllowedExceptionMessage                          = 'لا يمكن أن تحتوي عمليات {0} على محتوى الطلب.'
+    getRequestBodyNotAllowedExceptionMessage                          = "'{0}' لا يمكن أن يحتوي على جسم الطلب. استخدم -AllowNonStandardBody لتجاوز هذا التقييد."
     fnDoesNotAcceptArrayAsPipelineInputExceptionMessage               = "الدالة '{0}' لا تقبل مصفوفة كمدخل لأنبوب البيانات."
     unsupportedStreamCompressionEncodingExceptionMessage              = 'تشفير الضغط غير مدعوم للتشفير {0}'
     LocalEndpointConflictExceptionMessage                             = "تم تعريف كل من '{0}' و '{1}' كنقاط نهاية محلية لـ OpenAPI، لكن يُسمح فقط بنقطة نهاية محلية واحدة لكل تعريف API."

--- a/src/Locales/de/Pode.psd1
+++ b/src/Locales/de/Pode.psd1
@@ -288,7 +288,7 @@
     taskProcessDoesNotExistExceptionMessage                           = "Der Aufgabenprozess '{0}' existiert nicht."
     scheduleProcessDoesNotExistExceptionMessage                       = "Der Aufgabenplanerprozess '{0}' existiert nicht."
     definitionTagChangeNotAllowedExceptionMessage                     = 'Definitionstag für eine Route kann nicht geändert werden.'
-    getRequestBodyNotAllowedExceptionMessage                          = '{0}-Operationen können keinen Anforderungstext haben.'
+    getRequestBodyNotAllowedExceptionMessage                          = "'{0}' Operationen dürfen keinen Anfragekörper haben. Verwenden Sie -AllowNonStandardBody, um diese Einschränkung zu umgehen."
     fnDoesNotAcceptArrayAsPipelineInputExceptionMessage               = "Die Funktion '{0}' akzeptiert kein Array als Pipeline-Eingabe."
     unsupportedStreamCompressionEncodingExceptionMessage              = 'Die Stream-Komprimierungskodierung wird nicht unterstützt: {0}'
     LocalEndpointConflictExceptionMessage                             = "Sowohl '{0}' als auch '{1}' sind als lokale OpenAPI-Endpunkte definiert, aber es ist nur ein lokaler Endpunkt pro API-Definition erlaubt."

--- a/src/Locales/en-us/Pode.psd1
+++ b/src/Locales/en-us/Pode.psd1
@@ -288,7 +288,7 @@
     taskProcessDoesNotExistExceptionMessage                           = 'Task process does not exist: {0}'
     scheduleProcessDoesNotExistExceptionMessage                       = 'Schedule process does not exist: {0}'
     definitionTagChangeNotAllowedExceptionMessage                     = 'Definition Tag for a Route cannot be changed.'
-    getRequestBodyNotAllowedExceptionMessage                          = '{0} operations cannot have a Request Body.'
+    getRequestBodyNotAllowedExceptionMessage                          = "'{0}' operations cannot have a Request Body. Use -AllowNonStandardBody to override this restriction."
     fnDoesNotAcceptArrayAsPipelineInputExceptionMessage               = "The function '{0}' does not accept an array as pipeline input."
     unsupportedStreamCompressionEncodingExceptionMessage              = 'Unsupported stream compression encoding: {0}'
     LocalEndpointConflictExceptionMessage                             = "Both '{0}' and '{1}' are defined as local OpenAPI endpoints, but only one local endpoint is allowed per API definition."}

--- a/src/Locales/en/Pode.psd1
+++ b/src/Locales/en/Pode.psd1
@@ -288,7 +288,7 @@
     taskProcessDoesNotExistExceptionMessage                           = 'Task process does not exist: {0}'
     scheduleProcessDoesNotExistExceptionMessage                       = 'Schedule process does not exist: {0}'
     definitionTagChangeNotAllowedExceptionMessage                     = 'Definition Tag for a Route cannot be changed.'
-    getRequestBodyNotAllowedExceptionMessage                          = '{0} operations cannot have a Request Body.'
+    getRequestBodyNotAllowedExceptionMessage                          = "'{0}' operations cannot have a Request Body. Use -AllowNonStandardBody to override this restriction."
     fnDoesNotAcceptArrayAsPipelineInputExceptionMessage               = "The function '{0}' does not accept an array as pipeline input."
     unsupportedStreamCompressionEncodingExceptionMessage              = 'Unsupported stream compression encoding: {0}'
     LocalEndpointConflictExceptionMessage                             = "Both '{0}' and '{1}' are defined as local OpenAPI endpoints, but only one local endpoint is allowed per API definition."

--- a/src/Locales/es/Pode.psd1
+++ b/src/Locales/es/Pode.psd1
@@ -288,7 +288,7 @@
     taskProcessDoesNotExistExceptionMessage                           = "El proceso de la tarea '{0}' no existe."
     scheduleProcessDoesNotExistExceptionMessage                       = "El proceso del programación '{0}' no existe."
     definitionTagChangeNotAllowedExceptionMessage                     = 'La etiqueta de definición para una Route no se puede cambiar.'
-    getRequestBodyNotAllowedExceptionMessage                          = 'Las operaciones {0} no pueden tener un cuerpo de solicitud.'
+    getRequestBodyNotAllowedExceptionMessage                          = "Las operaciones '{0}' no pueden tener un cuerpo de solicitud. Use -AllowNonStandardBody para evitar esta restricción."
     fnDoesNotAcceptArrayAsPipelineInputExceptionMessage               = "La función '{0}' no acepta una matriz como entrada de canalización."
     unsupportedStreamCompressionEncodingExceptionMessage              = 'La codificación de compresión de transmisión no es compatible: {0}'
     LocalEndpointConflictExceptionMessage                             = "Tanto '{0}' como '{1}' están definidos como puntos finales locales de OpenAPI, pero solo se permite un punto final local por definición de API."

--- a/src/Locales/fr/Pode.psd1
+++ b/src/Locales/fr/Pode.psd1
@@ -288,7 +288,7 @@
     taskProcessDoesNotExistExceptionMessage                           = "Le processus de la tâche '{0}' n'existe pas."
     scheduleProcessDoesNotExistExceptionMessage                       = "Le processus de l'horaire '{0}' n'existe pas."
     definitionTagChangeNotAllowedExceptionMessage                     = 'Le tag de définition pour une Route ne peut pas être modifié.'
-    getRequestBodyNotAllowedExceptionMessage                          = 'Les opérations {0} ne peuvent pas avoir de corps de requête.'
+    getRequestBodyNotAllowedExceptionMessage                          = "Les opérations '{0}' ne peuvent pas avoir de corps de requête. Utilisez -AllowNonStandardBody pour contourner cette restriction."
     fnDoesNotAcceptArrayAsPipelineInputExceptionMessage               = "La fonction '{0}' n'accepte pas un tableau en tant qu'entrée de pipeline."
     unsupportedStreamCompressionEncodingExceptionMessage              = "La compression de flux {0} n'est pas prise en charge."
     LocalEndpointConflictExceptionMessage                             = "Les deux '{0}' et '{1}' sont définis comme des points de terminaison locaux pour OpenAPI, mais un seul point de terminaison local est autorisé par définition d'API."

--- a/src/Locales/it/Pode.psd1
+++ b/src/Locales/it/Pode.psd1
@@ -288,7 +288,7 @@
     taskProcessDoesNotExistExceptionMessage                           = "Il processo dell'attività '{0}' non esiste."
     scheduleProcessDoesNotExistExceptionMessage                       = "Il processo della programma '{0}' non esiste."
     definitionTagChangeNotAllowedExceptionMessage                     = 'Il tag di definizione per una Route non può essere cambiato.'
-    getRequestBodyNotAllowedExceptionMessage                          = 'Le operazioni {0} non possono avere un corpo della richiesta.'
+    getRequestBodyNotAllowedExceptionMessage                          = "Le operazioni '{0}' non possono avere un corpo della richiesta. Utilizzare -AllowNonStandardBody per aggirare questa restrizione."
     fnDoesNotAcceptArrayAsPipelineInputExceptionMessage               = "La funzione '{0}' non accetta una matrice come input della pipeline."
     unsupportedStreamCompressionEncodingExceptionMessage              = 'La compressione dello stream non è supportata per la codifica {0}'
     LocalEndpointConflictExceptionMessage                             = "Sia '{0}' che '{1}' sono definiti come endpoint locali OpenAPI, ma è consentito solo un endpoint locale per definizione API."

--- a/src/Locales/ja/Pode.psd1
+++ b/src/Locales/ja/Pode.psd1
@@ -288,7 +288,7 @@
     taskProcessDoesNotExistExceptionMessage                           = 'タスクプロセスが存在しません: {0}'
     scheduleProcessDoesNotExistExceptionMessage                       = 'スケジュールプロセスが存在しません: {0}'
     definitionTagChangeNotAllowedExceptionMessage                     = 'Routeの定義タグは変更できません。'
-    getRequestBodyNotAllowedExceptionMessage                          = '{0}操作にはリクエストボディを含めることはできません。'
+    getRequestBodyNotAllowedExceptionMessage                          = "'{0}' 操作にはリクエストボディを含めることはできません。-AllowNonStandardBody を使用してこの制限を回避してください。"
     fnDoesNotAcceptArrayAsPipelineInputExceptionMessage               = "関数 '{0}' は配列をパイプライン入力として受け付けません。"
     unsupportedStreamCompressionEncodingExceptionMessage              = 'サポートされていないストリーム圧縮エンコーディングが提供されました: {0}'
     LocalEndpointConflictExceptionMessage                             = "'{0}' と '{1}' は OpenAPI のローカルエンドポイントとして定義されていますが、API 定義ごとに 1 つのローカルエンドポイントのみ許可されます。"

--- a/src/Locales/ko/Pode.psd1
+++ b/src/Locales/ko/Pode.psd1
@@ -288,7 +288,7 @@
     taskProcessDoesNotExistExceptionMessage                           = '작업 프로세스가 존재하지 않습니다: {0}'
     scheduleProcessDoesNotExistExceptionMessage                       = '스케줄 프로세스가 존재하지 않습니다: {0}'
     definitionTagChangeNotAllowedExceptionMessage                     = 'Route에 대한 정의 태그는 변경할 수 없습니다.'
-    getRequestBodyNotAllowedExceptionMessage                          = '{0} 작업에는 요청 본문이 있을 수 없습니다.'
+    getRequestBodyNotAllowedExceptionMessage                          = "'{0}' 작업은 요청 본문을 가질 수 없습니다. 이 제한을 무시하려면 -AllowNonStandardBody를 사용하세요."
     fnDoesNotAcceptArrayAsPipelineInputExceptionMessage               = "함수 '{0}'은(는) 배열을 파이프라인 입력으로 받지 않습니다."
     unsupportedStreamCompressionEncodingExceptionMessage              = '지원되지 않는 스트림 압축 인코딩: {0}'
     LocalEndpointConflictExceptionMessage                             = "'{0}' 와 '{1}' 는 OpenAPI 로컬 엔드포인트로 정의되었지만, API 정의당 하나의 로컬 엔드포인트만 허용됩니다."

--- a/src/Locales/nl/Pode.psd1
+++ b/src/Locales/nl/Pode.psd1
@@ -288,7 +288,7 @@
     taskProcessDoesNotExistExceptionMessage                           = "Taakproces '{0}' bestaat niet."
     scheduleProcessDoesNotExistExceptionMessage                       = "Schema-proces '{0}' bestaat niet."
     definitionTagChangeNotAllowedExceptionMessage                     = 'Definitietag voor een route kan niet worden gewijzigd.'
-    getRequestBodyNotAllowedExceptionMessage                          = '{0}-operaties kunnen geen Request Body hebben.'
+    getRequestBodyNotAllowedExceptionMessage                          = "'{0}' operaties kunnen geen aanvraagbody hebben. Gebruik -AllowNonStandardBody om deze beperking te omzeilen."
     fnDoesNotAcceptArrayAsPipelineInputExceptionMessage               = "De functie '{0}' accepteert geen array als pipeline-invoer."
     unsupportedStreamCompressionEncodingExceptionMessage              = 'Niet-ondersteunde streamcompressie-encodering: {0}'
     LocalEndpointConflictExceptionMessage                             = "Zowel '{0}' als '{1}' zijn gedefinieerd als lokale OpenAPI-eindpunten, maar er is slechts één lokaal eindpunt per API-definitie toegestaan."

--- a/src/Locales/pl/Pode.psd1
+++ b/src/Locales/pl/Pode.psd1
@@ -288,7 +288,7 @@
     taskProcessDoesNotExistExceptionMessage                           = "Proces zadania '{0}' nie istnieje."
     scheduleProcessDoesNotExistExceptionMessage                       = "Proces harmonogramu '{0}' nie istnieje."
     definitionTagChangeNotAllowedExceptionMessage                     = 'Tag definicji dla Route nie może zostać zmieniony.'
-    getRequestBodyNotAllowedExceptionMessage                          = 'Operacje {0} nie mogą mieć treści żądania.'
+    getRequestBodyNotAllowedExceptionMessage                          = "Operacje '{0}' nie mogą zawierać treści żądania. Użyj -AllowNonStandardBody, aby obejść to ograniczenie."
     fnDoesNotAcceptArrayAsPipelineInputExceptionMessage               = "Funkcja '{0}' nie akceptuje tablicy jako wejścia potoku."
     unsupportedStreamCompressionEncodingExceptionMessage              = 'Kodowanie kompresji strumienia nie jest obsługiwane: {0}'
     LocalEndpointConflictExceptionMessage                             = "Zarówno '{0}', jak i '{1}' są zdefiniowane jako lokalne punkty końcowe OpenAPI, ale na jedną definicję API dozwolony jest tylko jeden lokalny punkt końcowy."

--- a/src/Locales/pt/Pode.psd1
+++ b/src/Locales/pt/Pode.psd1
@@ -288,7 +288,7 @@
     taskProcessDoesNotExistExceptionMessage                           = "O processo da tarefa '{0}' não existe."
     scheduleProcessDoesNotExistExceptionMessage                       = "O processo do cronograma '{0}' não existe."
     definitionTagChangeNotAllowedExceptionMessage                     = 'A Tag de definição para uma Route não pode ser alterada.'
-    getRequestBodyNotAllowedExceptionMessage                          = 'As operações {0} não podem ter um corpo de solicitação.'
+    getRequestBodyNotAllowedExceptionMessage                          = "As operações '{0}' não podem ter um corpo de solicitação. Use -AllowNonStandardBody para contornar essa restrição."
     fnDoesNotAcceptArrayAsPipelineInputExceptionMessage               = "A função '{0}' não aceita uma matriz como entrada de pipeline."
     unsupportedStreamCompressionEncodingExceptionMessage              = 'A codificação de compressão de fluxo não é suportada.'
     LocalEndpointConflictExceptionMessage                             = "Tanto '{0}' quanto '{1}' estão definidos como endpoints locais do OpenAPI, mas apenas um endpoint local é permitido por definição de API."

--- a/src/Locales/zh/Pode.psd1
+++ b/src/Locales/zh/Pode.psd1
@@ -288,7 +288,7 @@
     taskProcessDoesNotExistExceptionMessage                           = "任务进程 '{0}' 不存在。"
     scheduleProcessDoesNotExistExceptionMessage                       = "计划进程 '{0}' 不存在。"
     definitionTagChangeNotAllowedExceptionMessage                     = 'Route的定义标签无法更改。'
-    getRequestBodyNotAllowedExceptionMessage                          = '{0} 操作不能包含请求体。'
+    getRequestBodyNotAllowedExceptionMessage                          = "'{0}' 操作无法包含请求体。使用 -AllowNonStandardBody 以解除此限制。"
     fnDoesNotAcceptArrayAsPipelineInputExceptionMessage               = "函数 '{0}' 不接受数组作为管道输入。"
     unsupportedStreamCompressionEncodingExceptionMessage              = '不支持的流压缩编码: {0}'
     LocalEndpointConflictExceptionMessage                             = "'{0}' 和 '{1}' 都被定义为 OpenAPI 的本地端点，但每个 API 定义仅允许一个本地端点。"

--- a/src/Public/OpenApi.ps1
+++ b/src/Public/OpenApi.ps1
@@ -773,22 +773,27 @@ function Remove-PodeOAResponse {
 
 <#
 .SYNOPSIS
-Sets the definition of a request for a route.
+    Sets the OpenAPI request definition for a route.
 
 .DESCRIPTION
-Sets the definition of a request for a route.
+    Configures the OpenAPI request properties for a specified route, including parameters and request body definition.
+    This function defines how the route should handle incoming requests in accordance with OpenAPI standards.
 
 .PARAMETER Route
-The route to set a request definition, usually from -PassThru on Add-PodeRoute.
+    The route to set a request definition for. This is typically passed through from -PassThru on Add-PodeRoute.
 
 .PARAMETER Parameters
-The Parameter definitions the request uses (from ConvertTo-PodeOAParameter).
+    Defines the parameters for the request, provided by ConvertTo-PodeOAParameter.
 
 .PARAMETER RequestBody
-The Request Body definition the request uses (from New-PodeOARequestBody).
+    Specifies the body schema for the request, provided by New-PodeOARequestBody.
+
+.PARAMETER AllowNonStandardBody
+    Allows methods like DELETE and GET to include a request body, which is generally discouraged by RFC 7231.
+    This can be used to relax the default restriction and enable a body for HTTP methods that don’t typically support it.
 
 .PARAMETER PassThru
-If supplied, the route passed in will be returned for further chaining.
+    If specified, returns the original route object for additional chaining after setting the request properties.
 
 .PARAMETER DefinitionTag
 An Array of strings representing the unique tag for the API specification.
@@ -796,7 +801,9 @@ This tag helps distinguish between different versions or types of API specificat
 You can use this tag to reference the specific API documentation, schema, or version that your function interacts with.
 
 .EXAMPLE
-Add-PodeRoute -PassThru | Set-PodeOARequest -RequestBody (New-PodeOARequestBody -Schema 'UserIdBody')
+    Add-PodeRoute -PassThru | Set-PodeOARequest -RequestBody (New-PodeOARequestBody -Schema 'UserIdBody') -AllowNonStandardBody
+
+    Sets the request body for a route and allows non-standard HTTP methods like DELETE to use a request body.
 #>
 function Set-PodeOARequest {
     [CmdletBinding()]
@@ -814,10 +821,17 @@ function Set-PodeOARequest {
         $RequestBody,
 
         [switch]
+<<<<<<< Updated upstream
         $PassThru,
 
         [string[]]
         $DefinitionTag
+=======
+        $AllowNonStandardBody,
+
+        [switch]
+        $PassThru
+>>>>>>> Stashed changes
     )
     begin {
         # Initialize an array to hold piped-in values
@@ -839,9 +853,17 @@ function Set-PodeOARequest {
 
             $oaDefinitionTag = Test-PodeRouteOADefinitionTag -Route $r -DefinitionTag $DefinitionTag
 
+<<<<<<< Updated upstream
             foreach ($tag in $oaDefinitionTag) {
                 if (($null -ne $Parameters) -and ($Parameters.Length -gt 0)) {
                     $r.OpenApi.Parameters[$tag] = @($Parameters)
+=======
+            if ($null -ne $RequestBody) {
+                # Check if AllowNonStandardBody is used or if the method is typically allowed to have a body
+                if (-not $AllowNonStandardBody -and ('POST', 'PUT', 'PATCH') -inotcontains $r.Method) {
+                    # {0} operations cannot have a Request Body.
+                    throw ($PodeLocale.getRequestBodyNotAllowedExceptionMessage -f $r.Method)
+>>>>>>> Stashed changes
                 }
 
                 if ($null -ne $RequestBody) {

--- a/src/Public/OpenApi.ps1
+++ b/src/Public/OpenApi.ps1
@@ -856,7 +856,7 @@ function Set-PodeOARequest {
 
                 if ($null -ne $RequestBody) {
                     # Check if AllowNonStandardBody is used or if the method is typically allowed to have a body
-                    if (-not $AllowNonStandardBody -and ('POST', 'PUT', 'PATCH') -inotcontains $r.Method) {
+                    if (! $AllowNonStandardBody -and ('POST', 'PUT', 'PATCH') -inotcontains $r.Method) {
                         #'{0}' operations cannot have a Request Body. Use -AllowNonStandardBody to override this restriction.
                         throw ($PodeLocale.getRequestBodyNotAllowedExceptionMessage -f $r.Method)
                     }

--- a/src/Public/OpenApi.ps1
+++ b/src/Public/OpenApi.ps1
@@ -796,9 +796,9 @@ function Remove-PodeOAResponse {
     If specified, returns the original route object for additional chaining after setting the request properties.
 
 .PARAMETER DefinitionTag
-An Array of strings representing the unique tag for the API specification.
-This tag helps distinguish between different versions or types of API specifications within the application.
-You can use this tag to reference the specific API documentation, schema, or version that your function interacts with.
+    An Array of strings representing the unique tag for the API specification.
+    This tag helps distinguish between different versions or types of API specifications within the application.
+    You can use this tag to reference the specific API documentation, schema, or version that your function interacts with.
 
 .EXAMPLE
     Add-PodeRoute -PassThru | Set-PodeOARequest -RequestBody (New-PodeOARequestBody -Schema 'UserIdBody') -AllowNonStandardBody
@@ -821,17 +821,13 @@ function Set-PodeOARequest {
         $RequestBody,
 
         [switch]
-<<<<<<< Updated upstream
         $PassThru,
+
+        [switch]
+        $AllowNonStandardBody,
 
         [string[]]
         $DefinitionTag
-=======
-        $AllowNonStandardBody,
-
-        [switch]
-        $PassThru
->>>>>>> Stashed changes
     )
     begin {
         # Initialize an array to hold piped-in values
@@ -853,23 +849,15 @@ function Set-PodeOARequest {
 
             $oaDefinitionTag = Test-PodeRouteOADefinitionTag -Route $r -DefinitionTag $DefinitionTag
 
-<<<<<<< Updated upstream
             foreach ($tag in $oaDefinitionTag) {
                 if (($null -ne $Parameters) -and ($Parameters.Length -gt 0)) {
                     $r.OpenApi.Parameters[$tag] = @($Parameters)
-=======
-            if ($null -ne $RequestBody) {
-                # Check if AllowNonStandardBody is used or if the method is typically allowed to have a body
-                if (-not $AllowNonStandardBody -and ('POST', 'PUT', 'PATCH') -inotcontains $r.Method) {
-                    # {0} operations cannot have a Request Body.
-                    throw ($PodeLocale.getRequestBodyNotAllowedExceptionMessage -f $r.Method)
->>>>>>> Stashed changes
                 }
 
                 if ($null -ne $RequestBody) {
-                    # Only 'POST', 'PUT', 'PATCH' can have a request body
-                    if (('POST', 'PUT', 'PATCH') -inotcontains $r.Method ) {
-                        # {0} operations cannot have a Request Body.
+                    # Check if AllowNonStandardBody is used or if the method is typically allowed to have a body
+                    if (-not $AllowNonStandardBody -and ('POST', 'PUT', 'PATCH') -inotcontains $r.Method) {
+                        #'{0}' operations cannot have a Request Body. Use -AllowNonStandardBody to override this restriction.
                         throw ($PodeLocale.getRequestBodyNotAllowedExceptionMessage -f $r.Method)
                     }
                     $r.OpenApi.RequestBody = $RequestBody

--- a/tests/unit/OpenApi.Tests.ps1
+++ b/tests/unit/OpenApi.Tests.ps1
@@ -3201,6 +3201,18 @@ Describe 'OpenApi' {
             } | Should -Throw -ExpectedMessage ($PodeLocale.getRequestBodyNotAllowedExceptionMessage -f 'GET')
         }
 
+        It 'Allows a RequestBody on non-standard methods with AllowNonStandardBody' {
+            $route = @{
+                Method  = 'DELETE'
+                OpenApi = @{}
+            }
+            $requestBody = @{ Content = 'application/json' }
+
+            Set-PodeOARequest -Route $route -RequestBody $requestBody -AllowNonStandardBody
+
+            $route.OpenApi.RequestBody | Should -BeExactly $requestBody
+        }
+
         It 'Returns the route when PassThru is used' {
             $route = @{
                 Method  = 'POST'
@@ -3221,6 +3233,44 @@ Describe 'OpenApi' {
             Set-PodeOARequest -Route $route
 
             $route.OpenApi.RequestBody | Should -BeNullOrEmpty
+        }
+
+        It 'Sets Parameters with DefinitionTag if provided' {
+            $route = @{
+                Method  = 'GET'
+                OpenApi = @{
+                    Responses   = [ordered]@{}
+                    Parameters  = [ordered]@{}
+                    RequestBody = [ordered]@{}
+                    callbacks   = [ordered]@{}
+                }
+            }
+            $parameters = @(
+                @{ Name = 'param1'; In = 'query' }
+            )
+
+            $definitionTag = 'v1'
+            $PodeContext.Server.OpenAPI.Definitions[ $definitionTag] = Get-PodeOABaseObject
+
+            Set-PodeOARequest -Route $route -Parameters $parameters -DefinitionTag $definitionTag
+
+            $route.OpenApi.Parameters[$definitionTag] | Should -BeExactly $parameters
+        }
+
+        It 'Defaults Parameters to an empty array if not provided' {
+            $route = @{
+                Method  = 'GET'
+                OpenApi = @{
+                    Responses   = [ordered]@{}
+                    Parameters  = [ordered]@{}
+                    RequestBody = [ordered]@{}
+                    callbacks   = [ordered]@{}
+                }
+            }
+
+            Set-PodeOARequest -Route $route
+
+            $route.OpenApi.Parameters['Default'] | Should -BeNullOrEmpty
         }
     }
 


### PR DESCRIPTION
### Description

This pull request introduces a new `-AllowNonStandardBody` parameter to enable request bodies for HTTP methods that typically do not support them, such as `GET` and `DELETE`. By default, Pode adheres to the RFC 7231 standards, which generally reserve request bodies for `POST`, `PUT`, and `PATCH` methods. However, this update provides flexibility for users who require bodies for other HTTP methods, addressing the feature request and limitations outlined in issue #1432.

### Changes

- **New Parameter**: The `-AllowNonStandardBody` switch is added to the `Set-PodeOARequest` function. When specified, this parameter overrides the default behavior, allowing non-standard HTTP methods to include a request body.
- **Enhanced Error Messaging**: The exception message has been updated to suggest using `-AllowNonStandardBody` for methods where request bodies are typically disallowed, improving guidance for users.
- **Localization**: The updated error message has been translated into multiple languages, including Arabic, German, Spanish, French, Italian, Japanese, Korean, Dutch, Polish, Portuguese, and Chinese, to support international users.

### Example

To define a route that allows a request body for a `DELETE` operation:

```powershell
Add-PodeRoute -Method DELETE -Path '/resource' -PassThru | Set-PodeOARequest -RequestBody (New-PodeOARequestBody -Schema 'DeleteRequestSchema') -AllowNonStandardBody
```

### Issue Addressed

- Fixes #1432: Implements an optional relaxation of RFC 7231 by allowing request bodies for `GET`, `DELETE`, and other HTTP methods upon user request.

### Testing

- Unit tests were added to ensure that the `-AllowNonStandardBody` parameter enables request bodies for HTTP methods like `DELETE`.
- Tests verify that without `-AllowNonStandardBody`, the function continues to restrict bodies to `POST`, `PUT`, and `PATCH`.
