### PR TITLE
Don't setup the Caching Housekeeper Timer in a Serverless context

### DIFF
--- a/src/Private/Caching.ps1
+++ b/src/Private/Caching.ps1
@@ -95,7 +95,8 @@ function Clear-PodeCacheInternal {
 }
 
 function Start-PodeCacheHousekeeper {
-    if (![string]::IsNullOrEmpty((Get-PodeCacheDefaultStorage))) {
+    # if we have a custom default storage, or we're in serverless mode, then we don't need to run the housekeeper
+    if (![string]::IsNullOrEmpty((Get-PodeCacheDefaultStorage)) -or $PodeContext.Server.IsServerless) {
         return
     }
 

--- a/src/Private/Server.ps1
+++ b/src/Private/Server.ps1
@@ -206,11 +206,10 @@ function Start-PodeInternalServer {
                     }
                 }
             }
-
         }
     }
     catch {
-        throw $_.Exception
+        throw
     }
 }
 


### PR DESCRIPTION
### Description of the Change
When running via Serverless, don't configure the Caching Housekeeper Timer - Timers aren't supported in a Serverless context, so they'll always error.

### Related Issue
Resolves #1435 
