### PR TITLE
Update PowerShell to 7.2.24 for CI environment due to unavailability of 7.2.19

### DIFF
--- a/.github/workflows/ci-pwsh7_2.yml
+++ b/.github/workflows/ci-pwsh7_2.yml
@@ -25,7 +25,7 @@ on:
 
 env:
   INVOKE_BUILD_VERSION: '5.11.1'
-  POWERSHELL_VERSION: '7.2.19'
+  POWERSHELL_VERSION: '7.2.24'
 
 jobs:
   build:


### PR DESCRIPTION
 
### Description of the Change

This pull request updates the PowerShell version used by Pester in the CI environment from **7.2.19** to **7.2.24**. The previously specified version, 7.2.19, is no longer available, which may lead to compatibility issues or failed builds.

### Rationale

Upgrading PowerShell to version 7.2.24 ensures continued compatibility with Pester and access to the latest patches and stability improvements in the 7.2.x release line. This change aligns the environment with currently available versions, preventing potential disruptions in CI workflows.

### Changes Made

- **PowerShell Version Update**: Updated `POWERSHELL_VERSION` to **7.2.24** in the environment configuration for consistent use across all CI processes.
 

### Impact

- **CI Stability**: This update will ensure that all CI pipelines can continue to run smoothly without dependency issues on an outdated PowerShell version.
- **No Impact on End Users**: This change only affects the internal build and testing environments and does not impact end users or the runtime behavior of Pode.

### Environment Configuration

Updated environment variables:
```yaml
env:
  INVOKE_BUILD_VERSION: '5.11.1'
  POWERSHELL_VERSION: '7.2.24'
```

 