### PR TITLE
Bumps .NET version to .NET9; Adds PS7.5 workflow; Bumps InvokeBuild to v5.12.0; Bumps MkDocs to v1.6.1; Bumps MkDocs Material Theme to v9.5.44

### DIFF
--- a/.github/workflows/VirusTotal-Releases.yml
+++ b/.github/workflows/VirusTotal-Releases.yml
@@ -9,6 +9,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Check VIRUSTOTAL_API_KEY
+      env:
+        VIRUSTOTAL_API_KEY: ${{ secrets.VIRUSTOTAL_API_KEY }}
+      run: |
+        if [ -z "$VIRUSTOTAL_API_KEY" ]; then
+          echo "VIRUSTOTAL_API_KEY is not set. Exiting workflow."
+          exit 1
+        fi
+        echo "VIRUSTOTAL_API_KEY is set. Proceeding with the workflow.
+        
     - name: Run VirusTotal Scan
       uses: crazy-max/ghaction-virustotal@v4
       with:

--- a/.github/workflows/VirusTotal.yml
+++ b/.github/workflows/VirusTotal.yml
@@ -19,14 +19,25 @@ on:
     - cron: '0 12 * * *'
 
 env:
-  INVOKE_BUILD_VERSION: '5.11.1'
+  INVOKE_BUILD_VERSION: '5.12.0'
   POWERSHELL_VERSION: 'lts'
 
 jobs:
   build:
     runs-on: ubuntu-latest
-
     steps:
+
+
+    - name: Check VIRUSTOTAL_API_KEY
+      env:
+        VIRUSTOTAL_API_KEY: ${{ secrets.VIRUSTOTAL_API_KEY }}
+      run: |
+        if [ -z "$VIRUSTOTAL_API_KEY" ]; then
+          echo "VIRUSTOTAL_API_KEY is not set. Exiting workflow."
+          exit 1
+        fi
+        echo "VIRUSTOTAL_API_KEY is set. Proceeding with the workflow.
+
     - uses: actions/checkout@v4
 
     - name: Setup .NET

--- a/.github/workflows/ci-coverage.yml
+++ b/.github/workflows/ci-coverage.yml
@@ -20,7 +20,7 @@ on:
     - '.github/workflows/ci-coverage.yml'
 
 env:
-  INVOKE_BUILD_VERSION: '5.11.1'
+  INVOKE_BUILD_VERSION: '5.12.0'
 
 jobs:
   build:

--- a/.github/workflows/ci-coverage.yml
+++ b/.github/workflows/ci-coverage.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 9.x
 
     - name: Install Invoke-Build
       shell: pwsh

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -36,6 +36,11 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 9.x
+
     - name: Install Invoke-Build
       shell: pwsh
       run: |

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -24,7 +24,7 @@ on:
     - 'src/Pode.psd1'
 
 env:
-  INVOKE_BUILD_VERSION: '5.11.1'
+  INVOKE_BUILD_VERSION: '5.12.0'
 
 jobs:
   build:

--- a/.github/workflows/ci-powershell.yml
+++ b/.github/workflows/ci-powershell.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 'latest'  # Automatically picks the latest available .NET SDK
 
     - name: Install Invoke-Build
       shell: powershell

--- a/.github/workflows/ci-powershell.yml
+++ b/.github/workflows/ci-powershell.yml
@@ -20,7 +20,7 @@ on:
     - '.github/workflows/ci-powershell.yml'
 
 env:
-  INVOKE_BUILD_VERSION: '5.11.1'
+  INVOKE_BUILD_VERSION: '5.12.0'
 
 jobs:
   build:

--- a/.github/workflows/ci-powershell.yml
+++ b/.github/workflows/ci-powershell.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 'latest'  # Automatically picks the latest available .NET SDK
+        dotnet-version: 9.x
 
     - name: Install Invoke-Build
       shell: powershell

--- a/.github/workflows/ci-pwsh7_2.yml
+++ b/.github/workflows/ci-pwsh7_2.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 'latest'  # Automatically picks the latest available .NET SDK
+        dotnet-version: 9.x
 
     - name: Setup Powershell - Unix
       shell: pwsh

--- a/.github/workflows/ci-pwsh7_2.yml
+++ b/.github/workflows/ci-pwsh7_2.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 'latest'  # Automatically picks the latest available .NET SDK
 
     - name: Setup Powershell - Unix
       shell: pwsh

--- a/.github/workflows/ci-pwsh7_2.yml
+++ b/.github/workflows/ci-pwsh7_2.yml
@@ -25,7 +25,7 @@ on:
 
 env:
   INVOKE_BUILD_VERSION: '5.12.0'
-  POWERSHELL_VERSION: '7.5.0'
+  POWERSHELL_VERSION: '7.2.24'
 
 jobs:
   build:

--- a/.github/workflows/ci-pwsh7_5.yml
+++ b/.github/workflows/ci-pwsh7_5.yml
@@ -1,4 +1,4 @@
-name: Pode CI - pwsh 7.2
+name: Pode CI - pwsh 7.5
 
 on:
   push:
@@ -9,7 +9,7 @@ on:
     - 'src/**'
     - 'tests/**'
     - 'pode.build.ps1'
-    - '.github/workflows/ci-pwsh7_2.yml'
+    - '.github/workflows/ci-pwsh7_5.yml'
     - 'Dockerfile'
     - '*.dockerfile'
   pull_request:
@@ -19,13 +19,13 @@ on:
     - 'src/**'
     - 'tests/**'
     - 'pode.build.ps1'
-    - '.github/workflows/ci-pwsh7_2.yml'
+    - '.github/workflows/ci-pwsh7_5.yml'
     - 'Dockerfile'
     - '*.dockerfile'
 
 env:
-  INVOKE_BUILD_VERSION: '5.12.0'
-  POWERSHELL_VERSION: '7.5.0'
+  INVOKE_BUILD_VERSION: '5.12.1'
+  POWERSHELL_VERSION: '7.2.24'
 
 jobs:
   build:

--- a/.github/workflows/ci-pwsh7_5.yml
+++ b/.github/workflows/ci-pwsh7_5.yml
@@ -24,7 +24,7 @@ on:
     - '*.dockerfile'
 
 env:
-  INVOKE_BUILD_VERSION: '5.12.1'
+  INVOKE_BUILD_VERSION: '5.12.0'
   POWERSHELL_VERSION: '7.5.0-rc.1'
 
 

--- a/.github/workflows/ci-pwsh7_5.yml
+++ b/.github/workflows/ci-pwsh7_5.yml
@@ -25,7 +25,8 @@ on:
 
 env:
   INVOKE_BUILD_VERSION: '5.12.1'
-  POWERSHELL_VERSION: '7.2.24'
+  POWERSHELL_VERSION: '7.5.0-rc.1'
+
 
 jobs:
   build:

--- a/.github/workflows/ci-pwsh_lts.yml
+++ b/.github/workflows/ci-pwsh_lts.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 'latest'  # Automatically picks the latest available .NET SDK
+        dotnet-version: 9.x
 
     - name: Setup Powershell - Unix
       shell: pwsh

--- a/.github/workflows/ci-pwsh_lts.yml
+++ b/.github/workflows/ci-pwsh_lts.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 'latest'  # Automatically picks the latest available .NET SDK
 
     - name: Setup Powershell - Unix
       shell: pwsh

--- a/.github/workflows/ci-pwsh_lts.yml
+++ b/.github/workflows/ci-pwsh_lts.yml
@@ -24,7 +24,7 @@ on:
     - '*.dockerfile'
 
 env:
-  INVOKE_BUILD_VERSION: '5.11.1'
+  INVOKE_BUILD_VERSION: '5.12.0'
   POWERSHELL_VERSION: 'lts'
 
 jobs:

--- a/.github/workflows/ci-pwsh_preview.yml
+++ b/.github/workflows/ci-pwsh_preview.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 'latest'  # Automatically picks the latest available .NET SDK
+        dotnet-version: 9.x
 
     - name: Setup Powershell - Unix
       shell: pwsh

--- a/.github/workflows/ci-pwsh_preview.yml
+++ b/.github/workflows/ci-pwsh_preview.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 'latest'  # Automatically picks the latest available .NET SDK
 
     - name: Setup Powershell - Unix
       shell: pwsh

--- a/.github/workflows/ci-pwsh_preview.yml
+++ b/.github/workflows/ci-pwsh_preview.yml
@@ -24,7 +24,7 @@ on:
     - '*.dockerfile'
 
 env:
-  INVOKE_BUILD_VERSION: '5.11.1'
+  INVOKE_BUILD_VERSION: '5.12.1'
   POWERSHELL_VERSION: 'Preview'
 
 jobs:

--- a/.github/workflows/ci-pwsh_preview.yml
+++ b/.github/workflows/ci-pwsh_preview.yml
@@ -24,7 +24,7 @@ on:
     - '*.dockerfile'
 
 env:
-  INVOKE_BUILD_VERSION: '5.12.1'
+  INVOKE_BUILD_VERSION: '5.12.0'
   POWERSHELL_VERSION: 'Preview'
 
 jobs:

--- a/pode.build.ps1
+++ b/pode.build.ps1
@@ -22,997 +22,1110 @@ param(
     $UICulture = 'en-US'
 )
 
-# Fix for PS7.5 Preview - https://github.com/PowerShell/PowerShell/issues/23868
-$ProgressPreference = 'SilentlyContinue'
 
-<#
-# Dependency Versions
-#>
-$Versions = @{
-    Pester      = '5.6.1'
-    MkDocs      = '1.6.0'
-    PSCoveralls = '1.0.0'
-    SevenZip    = '18.5.0.20180730'
-    DotNet      = '8.0'
-    MkDocsTheme = '9.5.23'
-    PlatyPS     = '0.14.2'
-}
+# Check if the script is running under Invoke-Build
+if (($null -ne $PSCmdlet.MyInvocation) -and ($PSCmdlet.MyInvocation.BoundParameters.ContainsKey('BuildRoot') -or $null -ne $BuildRoot)) {
 
-<#
-# Helper Functions
-#>
-function Test-PodeBuildIsWindows {
-    $v = $PSVersionTable
-    return ($v.Platform -ilike '*win*' -or ($null -eq $v.Platform -and $v.PSEdition -ieq 'desktop'))
-}
-
-function Test-PodeBuildIsGitHub {
-    return (![string]::IsNullOrWhiteSpace($env:GITHUB_REF))
-}
-
-function Test-PodeBuildCanCodeCoverage {
-    return (@('1', 'true') -icontains $env:PODE_RUN_CODE_COVERAGE)
-}
-
-function Get-PodeBuildService {
-    return 'github-actions'
-}
-
-function Test-PodeBuildCommand($cmd) {
-    $path = $null
-
-    if (Test-PodeBuildIsWindows) {
-        $path = (Get-Command $cmd -ErrorAction Ignore)
-    }
-    else {
-        $path = (which $cmd)
+    # Dependency Versions
+    $Versions = @{
+        Pester      = '5.6.1'
+        MkDocs      = '1.6.1'
+        PSCoveralls = '1.0.0'
+        SevenZip    = '18.5.0.20180730'
+        DotNet      = '9.0'
+        MkDocsTheme = '9.5.44'
+        PlatyPS     = '0.14.2'
     }
 
-    return (![string]::IsNullOrWhiteSpace($path))
-}
 
-function Get-PodeBuildBranch {
-    return ($env:GITHUB_REF -ireplace 'refs\/heads\/', '')
-}
+    $NetVersions = 'netstandard2.0', 'netstandard2.1', 'netcoreapp3.1', 'net5.0', 'net6.0', 'net7.0', 'net8.0', 'net9.0'
+    #Unsupported .NET Framework version 'net4.0', 'net4.5', 'net4.5.1', 'net4.5.2', 'net4.6', 'net4.6.1', 'net4.6.2', 'net4.7', 'net4.7.1', 'net4.7.2', 'net4.8'
 
-function Invoke-PodeBuildInstall($name, $version) {
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    # Helper Functions
+    function Test-PodeBuildIsWindows {
+        $v = $PSVersionTable
+        return ($v.Platform -ilike '*win*' -or ($null -eq $v.Platform -and $v.PSEdition -ieq 'desktop'))
+    }
 
-    if (Test-PodeBuildIsWindows) {
-        if (Test-PodeBuildCommand 'choco') {
-            choco install $name --version $version -y --no-progress
+    function Test-PodeBuildIsGitHub {
+        return (![string]::IsNullOrWhiteSpace($env:GITHUB_REF))
+    }
+
+    function Test-PodeBuildCanCodeCoverage {
+        return (@('1', 'true') -icontains $env:PODE_RUN_CODE_COVERAGE)
+    }
+
+    function Get-PodeBuildService {
+        return 'github-actions'
+    }
+
+    function Test-PodeBuildCommand($cmd) {
+        $path = $null
+
+        if (Test-PodeBuildIsWindows) {
+            $path = (Get-Command $cmd -ErrorAction Ignore)
+        }
+        else {
+            $path = (which $cmd)
+        }
+
+        return (![string]::IsNullOrWhiteSpace($path))
+    }
+
+    function Get-PodeBuildBranch {
+        return ($env:GITHUB_REF -ireplace 'refs\/heads\/', '')
+    }
+
+    function Invoke-PodeBuildInstall($name, $version) {
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+        if (Test-PodeBuildIsWindows) {
+            if (Test-PodeBuildCommand 'choco') {
+                choco install $name --version $version -y --no-progress
+            }
+        }
+        else {
+            if (Test-PodeBuildCommand 'brew') {
+                brew install $name
+            }
+            elseif (Test-PodeBuildCommand 'apt-get') {
+                sudo apt-get install $name -y
+            }
+            elseif (Test-PodeBuildCommand 'yum') {
+                sudo yum install $name -y
+            }
         }
     }
-    else {
-        if (Test-PodeBuildCommand 'brew') {
-            brew install $name
+
+    function Install-PodeBuildModule($name) {
+        if ($null -ne ((Get-Module -ListAvailable $name) | Where-Object { $_.Version -ieq $Versions[$name] })) {
+            return
         }
-        elseif (Test-PodeBuildCommand 'apt-get') {
-            sudo apt-get install $name -y
+
+        Write-Host "Installing $($name) v$($Versions[$name])"
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+        Install-Module -Name "$($name)" -Scope CurrentUser -RequiredVersion "$($Versions[$name])" -Force -SkipPublisherCheck
+    }
+
+    function Invoke-PodeBuildDotnetBuild {
+        param (
+            [string]$target
+        )
+
+        # Verify if the target is a known .NET version
+        if ($target -notin $NetVersions) {
+            Write-Host "Unknown target framework '$target'. Please specify a valid .NET framework."
+            return
         }
-        elseif (Test-PodeBuildCommand 'yum') {
-            sudo yum install $name -y
+
+        # Retrieve the installed SDK versions
+        $sdkVersions = dotnet --list-sdks | ForEach-Object { $_.Split('[')[0].Trim() }
+        $majorVersions = $sdkVersions | ForEach-Object { ([version]$_).Major } | Sort-Object -Descending | Select-Object -Unique
+
+        # Map target frameworks to minimum SDK versions
+        $targetSdkMap = @{
+            'netstandard2.0' = 2
+            'netstandard2.1' = 3
+            'netcoreapp3.1'  = 3
+            'net5.0'         = 5
+            'net6.0'         = 6
+            'net7.0'         = 7
+            'net8.0'         = 8
+            'net9.0'         = 9
+        }
+
+        # Determine if the target framework is compatible
+        $isCompatible = $False
+
+        if ($targetSdkMap.ContainsKey($target)) {
+            $requiredSdkVersion = $targetSdkMap[$target]
+
+            foreach ($sdkVersion in $sdkVersions) {
+                $sdkMajor = ([version]$sdkVersion).Major
+                if ($sdkMajor -ge $requiredSdkVersion) {
+                    $isCompatible = $True
+                    break
+                }
+            }
+        }
+        elseif ($target -like 'net4*') {
+            # .NET Framework targets require MSBuild, typically available with Visual Studio
+            $msbuildPath = Get-Command msbuild -ErrorAction SilentlyContinue
+            if ($msbuildPath) {
+                $isCompatible = $True
+            }
+            else {
+                Write-Host 'MSBuild is not available. Cannot build .NET Framework targets.'
+                return
+            }
+        }
+
+        if ($isCompatible) {
+            Write-Host "SDK for target framework '$target' is compatible with the installed SDKs."
+        }
+        else {
+            Write-Host "SDK for target framework '$target' is not compatible with the installed SDKs. Skipping build."
+            return
+        }
+
+        # Optionally set assembly version
+        if ($Version) {
+            Write-Host "Assembly Version: $Version"
+            $AssemblyVersion = "-p:Version=$Version"
+        }
+        else {
+            $AssemblyVersion = ''
+        }
+
+        # Execute dotnet publish or MSBuild depending on the target
+        if ($target -like 'net4*') {
+            # Use MSBuild for .NET Framework targets
+            $projectFile = 'YourProject.csproj' # Replace with your actual project file
+            & msbuild $projectFile /p:Configuration=Release /p:TargetFramework=$target $AssemblyVersion /p:OutputPath="../Libs/$target"
+        }
+        else {
+            # Use dotnet publish for .NET Core and .NET 5+
+            dotnet publish --configuration Release --self-contained --framework $target $AssemblyVersion --output ../Libs/$target
+        }
+
+        if (!$?) {
+            throw "Build failed for target framework '$target'."
         }
     }
-}
 
-function Install-PodeBuildModule($name) {
-    if ($null -ne ((Get-Module -ListAvailable $name) | Where-Object { $_.Version -ieq $Versions[$name] })) {
-        return
+    function Get-PodeBuildPwshEOL {
+        $uri = 'https://endoflife.date/api/powershell.json'
+        try {
+            $eol = Invoke-RestMethod -Uri $uri -Headers @{ Accept = 'application/json' }
+            return @{
+                eol       = ($eol | Where-Object { [datetime]$_.eol -lt [datetime]::Now }).cycle -join ','
+                supported = ($eol | Where-Object { [datetime]$_.eol -ge [datetime]::Now }).cycle -join ','
+            }
+        }
+        catch {
+            Write-Warning "Invoke-RestMethod to $uri failed: $($_.ErrorDetails.Message)"
+            return  @{
+                eol       = ''
+                supported = ''
+            }
+        }
     }
 
-    Write-Host "Installing $($name) v$($Versions[$name])"
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-    Install-Module -Name "$($name)" -Scope CurrentUser -RequiredVersion "$($Versions[$name])" -Force -SkipPublisherCheck
-}
 
-function Invoke-PodeBuildDotnetBuild($target) {
-    # Retrieve the highest installed SDK version
-    $majorVersion = ([version](dotnet --version)).Major
-
-    # Determine if the target framework is compatible
-    $isCompatible = $False
-    switch ($majorVersion) {
-        8 { if ($target -in @('net6.0', 'netstandard2.0', 'net8.0')) { $isCompatible = $True } }
-        7 { if ($target -in @('net6.0', 'netstandard2.0')) { $isCompatible = $True } }
-        6 { if ($target -in @('net6.0', 'netstandard2.0')) { $isCompatible = $True } }
+    function Get-PodeBuildDotNetEOL {
+        $uri = 'https://endoflife.date/api/dotnet.json'
+        try {
+            $eol = Invoke-RestMethod -Uri $uri -Headers @{ Accept = 'application/json' }
+            return @{
+                eol       = ($eol | Where-Object { [datetime]$_.eol -lt [datetime]::Now }).cycle -join ','
+                supported = ($eol | Where-Object { [datetime]$_.eol -ge [datetime]::Now }).cycle -join ','
+            }
+        }
+        catch {
+            Write-Warning "Invoke-RestMethod to $uri failed: $($_.ErrorDetails.Message)"
+            return  @{
+                eol       = ''
+                supported = ''
+            }
+        }
     }
-
-    # Skip build if not compatible
-    if ($isCompatible) {
-        Write-Host "SDK for target framework $target is compatible with the installed SDKs"
-    }
-    else {
-        Write-Host "SDK for target framework $target is not compatible with the installed SDKs. Skipping build."
-        return
-    }
-    if ($Version) {
-        Write-Host "Assembly Version $Version"
-        $AssemblyVersion = "-p:Version=$Version"
-    }
-    else {
-        $AssemblyVersion = ''
-    }
-
-    dotnet publish --configuration Release --self-contained --framework $target $AssemblyVersion --output ../Libs/$target
-    if (!$?) {
-        throw "dotnet publish failed for $($target)"
-    }
-
-}
-
-function Get-PodeBuildPwshEOL {
-    $eol = Invoke-RestMethod -Uri 'https://endoflife.date/api/powershell.json' -Headers @{ Accept = 'application/json' }
-    return @{
-        eol       = ($eol | Where-Object { [datetime]$_.eol -lt [datetime]::Now }).cycle -join ','
-        supported = ($eol | Where-Object { [datetime]$_.eol -ge [datetime]::Now }).cycle -join ','
-    }
-}
-
-function Test-PodeBuildOSWindows {
-    return ($IsWindows -or
-        ![string]::IsNullOrEmpty($env:ProgramFiles) -or
+    function Test-PodeBuildOSWindows {
+        return ($IsWindows -or
+            ![string]::IsNullOrEmpty($env:ProgramFiles) -or
         (($PSVersionTable.Keys -contains 'PSEdition') -and ($PSVersionTable.PSEdition -eq 'Desktop')))
-}
-
-function Get-PodeBuildOSPwshName {
-    if (Test-PodeBuildOSWindows) {
-        return 'win'
     }
 
-    if ($IsLinux) {
-        return 'linux'
+    function Get-PodeBuildOSPwshName {
+        if (Test-PodeBuildOSWindows) {
+            return 'win'
+        }
+
+        if ($IsLinux) {
+            return 'linux'
+        }
+
+        if ($IsMacOS) {
+            return 'osx'
+        }
     }
 
-    if ($IsMacOS) {
-        return 'osx'
-    }
-}
+    function Get-PodeBuildOSPwshArchitecture {
+        $arch = [string]::Empty
 
-function Get-PodeBuildOSPwshArchitecture {
-    $arch = [string]::Empty
+        # windows
+        if (Test-PodeBuildOSWindows) {
+            $arch = $env:PROCESSOR_ARCHITECTURE
+        }
 
-    # windows
-    if (Test-PodeBuildOSWindows) {
-        $arch = $env:PROCESSOR_ARCHITECTURE
-    }
+        # unix
+        if ($IsLinux -or $IsMacOS) {
+            $arch = uname -m
+        }
 
-    # unix
-    if ($IsLinux -or $IsMacOS) {
-        $arch = uname -m
-    }
+        Write-Host "OS Architecture: $($arch)"
 
-    Write-Host "OS Architecture: $($arch)"
-
-    # convert to pwsh arch
-    switch ($arch.ToLowerInvariant()) {
-        'amd64' { return 'x64' }
-        'x86' { return 'x86' }
-        'x86_64' { return 'x64' }
-        'armv7*' { return 'arm32' }
-        'aarch64*' { return 'arm64' }
-        'arm64' { return 'arm64' }
-        'arm64*' { return 'arm64' }
-        'armv8*' { return 'arm64' }
-        default { throw "Unsupported architecture: $($arch)" }
-    }
-}
-
-function Convert-PodeBuildOSPwshTagToVersion {
-    $result = Invoke-RestMethod -Uri "https://aka.ms/pwsh-buildinfo-$($PowerShellVersion)"
-    return $result.ReleaseTag -ireplace '^v'
-}
-
-function Install-PodeBuildPwshWindows($target) {
-    $installFolder = "$($env:ProgramFiles)\PowerShell\7"
-
-    if (Test-Path $installFolder) {
-        Remove-Item $installFolder -Recurse -Force -ErrorAction Stop
+        # convert to pwsh arch
+        switch ($arch.ToLowerInvariant()) {
+            'amd64' { return 'x64' }
+            'x86' { return 'x86' }
+            'x86_64' { return 'x64' }
+            'armv7*' { return 'arm32' }
+            'aarch64*' { return 'arm64' }
+            'arm64' { return 'arm64' }
+            'arm64*' { return 'arm64' }
+            'armv8*' { return 'arm64' }
+            default { throw "Unsupported architecture: $($arch)" }
+        }
     }
 
-    Copy-Item -Path "$($target)\" -Destination "$($installFolder)\" -Recurse -ErrorAction Stop
-}
-
-function Install-PodeBuildPwshUnix($target) {
-    $targetFullPath = Join-Path -Path $target -ChildPath 'pwsh'
-    $null = chmod 755 $targetFullPath
-
-    $symlink = $null
-    if ($IsMacOS) {
-        $symlink = '/usr/local/bin/pwsh'
-    }
-    else {
-        $symlink = '/usr/bin/pwsh'
+    function Convert-PodeBuildOSPwshTagToVersion {
+        $result = Invoke-RestMethod -Uri "https://aka.ms/pwsh-buildinfo-$($PowerShellVersion)"
+        return $result.ReleaseTag -ireplace '^v'
     }
 
-    $uid = id -u
-    if ($uid -ne '0') {
-        $sudo = 'sudo'
-    }
-    else {
-        $sudo = ''
-    }
+    function Install-PodeBuildPwshWindows($target) {
+        $installFolder = "$($env:ProgramFiles)\PowerShell\7"
 
-    # Make symbolic link point to installed path
-    & $sudo ln -fs $targetFullPath $symlink
-}
+        if (Test-Path $installFolder) {
+            Remove-Item $installFolder -Recurse -Force -ErrorAction Stop
+        }
 
-function Get-PodeBuildCurrentPwshVersion {
-    return ("$(pwsh -v)" -split ' ')[1].Trim()
-}
-
-function Invoke-PodeBuildDockerBuild($tag, $file) {
-    docker build -t badgerati/pode:$tag -f $file .
-    if (!$?) {
-        throw "docker build failed for $($tag)"
+        Copy-Item -Path "$($target)\" -Destination "$($installFolder)\" -Recurse -ErrorAction Stop
     }
 
-    docker tag badgerati/pode:$tag docker.pkg.github.com/badgerati/pode/pode:$tag
-    if (!$?) {
-        throw "docker tag failed for $($tag)"
-    }
-}
+    function Install-PodeBuildPwshUnix($target) {
+        $targetFullPath = Join-Path -Path $target -ChildPath 'pwsh'
+        $null = chmod 755 $targetFullPath
 
-function Split-PodeBuildPwshPath {
-    if (Test-PodeBuildOSWindows) {
-        return $env:PSModulePath -split ';'
+        $symlink = $null
+        if ($IsMacOS) {
+            $symlink = '/usr/local/bin/pwsh'
+        }
+        else {
+            $symlink = '/usr/bin/pwsh'
+        }
+
+        $uid = id -u
+        if ($uid -ne '0') {
+            $sudo = 'sudo'
+        }
+        else {
+            $sudo = ''
+        }
+
+        # Make symbolic link point to installed path
+        & $sudo ln -fs $targetFullPath $symlink
     }
-    else {
-        return $env:PSModulePath -split ':'
+
+    function Get-PodeBuildCurrentPwshVersion {
+        return ("$(pwsh -v)" -split ' ')[1].Trim()
     }
-}
+
+    function Invoke-PodeBuildDockerBuild($tag, $file) {
+        docker build -t badgerati/pode:$tag -f $file .
+        if (!$?) {
+            throw "docker build failed for $($tag)"
+        }
+
+        docker tag badgerati/pode:$tag docker.pkg.github.com/badgerati/pode/pode:$tag
+        if (!$?) {
+            throw "docker tag failed for $($tag)"
+        }
+    }
+
+    function Split-PodeBuildPwshPath {
+        if (Test-PodeBuildOSWindows) {
+            return $env:PSModulePath -split ';'
+        }
+        else {
+            return $env:PSModulePath -split ':'
+        }
+    }
 
 
-<#
+    <#
 # Helper Tasks
 #>
 
-# Synopsis: Stamps the version onto the Module
-Task StampVersion {
-    $pwshVersions = Get-PodeBuildPwshEOL
+    # Synopsis: Stamps the version onto the Module
+    Task StampVersion {
+        $pwshVersions = Get-PodeBuildPwshEOL
     (Get-Content ./pkg/Pode.psd1) | ForEach-Object { $_ -replace '\$version\$', $Version -replace '\$versionsUntested\$', $pwshVersions.eol -replace '\$versionsSupported\$', $pwshVersions.supported -replace '\$buildyear\$', ((get-date).Year) } | Set-Content ./pkg/Pode.psd1
     (Get-Content ./pkg/Pode.Internal.psd1) | ForEach-Object { $_ -replace '\$version\$', $Version } | Set-Content ./pkg/Pode.Internal.psd1
     (Get-Content ./packers/choco/pode_template.nuspec) | ForEach-Object { $_ -replace '\$version\$', $Version } | Set-Content ./packers/choco/pode.nuspec
     (Get-Content ./packers/choco/tools/ChocolateyInstall_template.ps1) | ForEach-Object { $_ -replace '\$version\$', $Version } | Set-Content ./packers/choco/tools/ChocolateyInstall.ps1
-}
+    }
 
-# Synopsis: Generating a Checksum of the Zip
-Task PrintChecksum {
-    $Script:Checksum = (Get-FileHash "./deliverable/$Version-Binaries.zip" -Algorithm SHA256).Hash
-    Write-Host "Checksum: $($Checksum)"
-}
+    # Synopsis: Generating a Checksum of the Zip
+    Task PrintChecksum {
+        $Script:Checksum = (Get-FileHash "./deliverable/$Version-Binaries.zip" -Algorithm SHA256).Hash
+        Write-Host "Checksum: $($Checksum)"
+    }
 
 
-<#
+    <#
 # Dependencies
 #>
 
-# Synopsis: Installs Chocolatey
-Task ChocoDeps -If (Test-PodeBuildIsWindows) {
-    if (!(Test-PodeBuildCommand 'choco')) {
-        Set-ExecutionPolicy Bypass -Scope Process -Force
-        Invoke-Expression ([System.Net.WebClient]::new().DownloadString('https://chocolatey.org/install.ps1'))
-    }
-}
-
-# Synopsis: Install dependencies for packaging
-Task PackDeps -If (Test-PodeBuildIsWindows) ChocoDeps, {
-    if (!(Test-PodeBuildCommand '7z')) {
-        Invoke-PodeBuildInstall '7zip' $Versions.SevenZip
-    }
-}
-
-# Synopsis: Install dependencies for compiling/building
-Task BuildDeps {
-    # install dotnet
-    if (Test-PodeBuildIsWindows) {
-        $dotnet = 'dotnet'
-    }
-    else {
-        $dotnet = "dotnet-sdk-$($Versions.DotNet)"
+    # Synopsis: Installs Chocolatey
+    Task ChocoDeps -If (Test-PodeBuildIsWindows) {
+        if (!(Test-PodeBuildCommand 'choco')) {
+            Set-ExecutionPolicy Bypass -Scope Process -Force
+            Invoke-Expression ([System.Net.WebClient]::new().DownloadString('https://chocolatey.org/install.ps1'))
+        }
     }
 
-    if (!(Test-PodeBuildCommand 'dotnet')) {
-        Invoke-PodeBuildInstall $dotnet $Versions.DotNet
-    }
-}
-
-# Synopsis: Install dependencies for running tests
-Task TestDeps {
-    # install pester
-    Install-PodeBuildModule Pester
-
-    # install PSCoveralls
-    if (Test-PodeBuildCanCodeCoverage) {
-        Install-PodeBuildModule PSCoveralls
-    }
-}
-
-# Synopsis: Install dependencies for documentation
-Task DocsDeps ChocoDeps, {
-    # install mkdocs
-    if (!(Test-PodeBuildCommand 'mkdocs')) {
-        Invoke-PodeBuildInstall 'mkdocs' $Versions.MkDocs
+    # Synopsis: Install dependencies for packaging
+    Task PackDeps -If (Test-PodeBuildIsWindows) ChocoDeps, {
+        if (!(Test-PodeBuildCommand '7z')) {
+            Invoke-PodeBuildInstall '7zip' $Versions.SevenZip
+        }
     }
 
-    $_installed = (pip list --format json --disable-pip-version-check | ConvertFrom-Json)
-    if (($_installed | Where-Object { $_.name -ieq 'mkdocs-material' -and $_.version -ieq $Versions.MkDocsTheme } | Measure-Object).Count -eq 0) {
-        pip install "mkdocs-material==$($Versions.MkDocsTheme)" --force-reinstall --disable-pip-version-check --quiet
-    }
-
-    # install platyps
-    Install-PodeBuildModule PlatyPS
-}
-
-Task IndexSamples {
-    $examplesPath = './examples'
-    if (!(Test-Path -PathType Container -Path $examplesPath)) {
-        return
-    }
-
-    # List of directories to exclude
-    $sampleMarkDownPath = './docs/Getting-Started/Samples.md'
-    $excludeDirs = @('scripts', 'views', 'static', 'public', 'assets', 'timers', 'modules',
-        'Authentication', 'certs', 'logs', 'relative', 'routes', 'issues')
-
-    # Convert exlusion list into single regex pattern for directory matching
-    $dirSeparator = [IO.Path]::DirectorySeparatorChar
-    $excludeDirs = "\$($dirSeparator)($($excludeDirs -join '|'))\$($dirSeparator)"
-
-    # build the page content
-    Get-ChildItem -Path $examplesPath -Filter *.ps1 -Recurse -File -Force |
-        Where-Object {
-            $_.FullName -inotmatch $excludeDirs
-        } |
-        Sort-Object -Property FullName |
-        ForEach-Object {
-            Write-Verbose "Processing Sample: $($_.FullName)"
-
-            # get the script help
-            $help = Get-Help -Name $_.FullName -ErrorAction Stop
-
-            # add help content
-            $urlFileName = ($_.FullName -isplit 'examples')[1].Trim('\/') -replace '[\\/]', '/'
-            $markdownContent += "## [$($_.BaseName)](https://github.com/Badgerati/Pode/blob/develop/examples/$($urlFileName))`n`n"
-            $markdownContent += "**Synopsis**`n`n$($help.Synopsis)`n`n"
-            $markdownContent += "**Description**`n`n$($help.Description.Text)`n`n"
+    # Synopsis: Install dependencies for compiling/building
+    Task BuildDeps {
+        # install dotnet
+        if (Test-PodeBuildIsWindows) {
+            $dotnet = 'dotnet'
+        }
+        else {
+            $dotnet = "dotnet-sdk-$($Versions.DotNet)"
         }
 
-    Write-Output "Write Markdown document for the sample files to $($sampleMarkDownPath)"
-    Set-Content -Path $sampleMarkDownPath -Value "# Sample Scripts`n`n$($markdownContent)" -Force
-}
+        if (!(Test-PodeBuildCommand 'dotnet')) {
+            Invoke-PodeBuildInstall $dotnet $Versions.DotNet
+        }
+    }
 
-<#
+    # Synopsis: Install dependencies for running tests
+    Task TestDeps {
+        # install pester
+        Install-PodeBuildModule Pester
+
+        # install PSCoveralls
+        if (Test-PodeBuildCanCodeCoverage) {
+            Install-PodeBuildModule PSCoveralls
+        }
+    }
+
+    # Synopsis: Install dependencies for documentation
+    Task DocsDeps ChocoDeps, {
+        # install mkdocs
+        if (!(Test-PodeBuildCommand 'mkdocs')) {
+            Invoke-PodeBuildInstall 'mkdocs' $Versions.MkDocs
+        }
+
+        $_installed = (pip list --format json --disable-pip-version-check | ConvertFrom-Json)
+        if (($_installed | Where-Object { $_.name -ieq 'mkdocs-material' -and $_.version -ieq $Versions.MkDocsTheme } | Measure-Object).Count -eq 0) {
+            pip install "mkdocs-material==$($Versions.MkDocsTheme)" --force-reinstall --disable-pip-version-check --quiet
+        }
+
+        # install platyps
+        Install-PodeBuildModule PlatyPS
+    }
+
+    Task IndexSamples {
+        $examplesPath = './examples'
+        if (!(Test-Path -PathType Container -Path $examplesPath)) {
+            return
+        }
+
+        # List of directories to exclude
+        $sampleMarkDownPath = './docs/Getting-Started/Samples.md'
+        $excludeDirs = @('scripts', 'views', 'static', 'public', 'assets', 'timers', 'modules',
+            'Authentication', 'certs', 'logs', 'relative', 'routes', 'issues')
+
+        # Convert exlusion list into single regex pattern for directory matching
+        $dirSeparator = [IO.Path]::DirectorySeparatorChar
+        $excludeDirs = "\$($dirSeparator)($($excludeDirs -join '|'))\$($dirSeparator)"
+
+        # build the page content
+        Get-ChildItem -Path $examplesPath -Filter *.ps1 -Recurse -File -Force |
+            Where-Object {
+                $_.FullName -inotmatch $excludeDirs
+            } |
+            Sort-Object -Property FullName |
+            ForEach-Object {
+                Write-Verbose "Processing Sample: $($_.FullName)"
+
+                # get the script help
+                $help = Get-Help -Name $_.FullName -ErrorAction Stop
+
+                # add help content
+                $urlFileName = ($_.FullName -isplit 'examples')[1].Trim('\/') -replace '[\\/]', '/'
+                $markdownContent += "## [$($_.BaseName)](https://github.com/Badgerati/Pode/blob/develop/examples/$($urlFileName))`n`n"
+                $markdownContent += "**Synopsis**`n`n$($help.Synopsis)`n`n"
+                $markdownContent += "**Description**`n`n$($help.Description.Text)`n`n"
+            }
+
+        Write-Output "Write Markdown document for the sample files to $($sampleMarkDownPath)"
+        Set-Content -Path $sampleMarkDownPath -Value "# Sample Scripts`n`n$($markdownContent)" -Force
+    }
+
+    <#
 # Building
 #>
 
-# Synopsis: Build the .NET Listener
-Task Build BuildDeps, {
-    if (Test-Path ./src/Libs) {
-        Remove-Item -Path ./src/Libs -Recurse -Force | Out-Null
+    # Synopsis: Build the .NET Listener
+    Task Build BuildDeps, {
+        if (Test-Path ./src/Libs) {
+            Remove-Item -Path ./src/Libs -Recurse -Force | Out-Null
+        }
+
+        # Retrieve supported .NET versions
+        $eol = Get-PodeBuildDotNetEOL
+
+        $targetFrameworks = @()
+
+        if (![string]::IsNullOrEmpty($eol.supported)) {
+
+            # Parse supported versions into an array
+            $supportedVersions = $eol['supported'] -split ','
+
+            # Construct target framework monikers
+            $targetFrameworks += ($supportedVersions | ForEach-Object { "net$_.0" })
+        }
+
+        # Optionally include netstandard2.0
+        $targetFrameworks += 'netstandard2.0'
+
+
+        # Retrieve the SDK version being used
+        $sdkVersion = dotnet --version
+
+        # Display the SDK version
+        Write-Output "Building target framework '$($targetFrameworks -join "','")' using .NET SDK version '$sdkVersion'"
+
+        # Build for supported target frameworks
+        try {
+            Push-Location ./src/Listener
+            foreach ($target in $targetFrameworks) {
+                Invoke-PodeBuildDotnetBuild -target $target
+                Write-Host
+                Write-Host "***********************" -ForegroundColor DarkMagenta
+
+            }
+        }
+        finally {
+            Pop-Location
+        }
+
     }
 
-    try {
-        Push-Location ./src/Listener
-        Invoke-PodeBuildDotnetBuild -target 'netstandard2.0'
-        Invoke-PodeBuildDotnetBuild -target 'net6.0'
-        Invoke-PodeBuildDotnetBuild -target 'net8.0'
-    }
-    finally {
-        Pop-Location
-    }
-}
 
-
-<#
+    <#
 # Packaging
 #>
 
-# Synopsis: Creates a Zip of the Module
-Task 7Zip -If (Test-PodeBuildIsWindows) PackDeps, StampVersion, {
-    exec { & 7z -tzip a $Version-Binaries.zip ./pkg/* }
-}, PrintChecksum
+    # Synopsis: Creates a Zip of the Module
+    Task 7Zip -If (Test-PodeBuildIsWindows) PackDeps, StampVersion, {
+        exec { & 7z -tzip a $Version-Binaries.zip ./pkg/* }
+    }, PrintChecksum
 
-#Synopsis: Create the Deliverable folder
-Task DeliverableFolder {
-    $path = './deliverable'
-    if (Test-Path $path) {
-        Remove-Item -Path $path -Recurse -Force | Out-Null
+    #Synopsis: Create the Deliverable folder
+    Task DeliverableFolder {
+        $path = './deliverable'
+        if (Test-Path $path) {
+            Remove-Item -Path $path -Recurse -Force | Out-Null
+        }
+
+        # create the deliverable dir
+        New-Item -Path $path -ItemType Directory -Force | Out-Null
     }
 
-    # create the deliverable dir
-    New-Item -Path $path -ItemType Directory -Force | Out-Null
-}
+    # Synopsis: Creates a Zip of the Module
+    Task Compress PackageFolder, StampVersion, DeliverableFolder, {
+        $path = './deliverable'
+        if (Test-Path $path) {
+            Remove-Item -Path $path -Recurse -Force | Out-Null
+        }
+        # create the pkg dir
+        New-Item -Path $path -ItemType Directory -Force | Out-Null
+        Compress-Archive -Path './pkg/*' -DestinationPath "$path/$Version-Binaries.zip"
+    }, PrintChecksum
 
-# Synopsis: Creates a Zip of the Module
-Task Compress PackageFolder, StampVersion, DeliverableFolder, {
-    $path = './deliverable'
-    if (Test-Path $path) {
-        Remove-Item -Path $path -Recurse -Force | Out-Null
-    }
-    # create the pkg dir
-    New-Item -Path $path -ItemType Directory -Force | Out-Null
-    Compress-Archive -Path './pkg/*' -DestinationPath "$path/$Version-Binaries.zip"
-}, PrintChecksum
-
-# Synopsis: Creates a Chocolately package of the Module
-Task ChocoPack -If (Test-PodeBuildIsWindows) PackDeps, PackageFolder, StampVersion, DeliverableFolder, {
-    exec { choco pack ./packers/choco/pode.nuspec }
-    Move-Item -Path "pode.$Version.nupkg" -Destination './deliverable'
-}
-
-# Synopsis: Create docker tags
-Task DockerPack PackageFolder, StampVersion, {
-    # check if github and windows, and output warning
-    if ((Test-PodeBuildIsGitHub) -and (Test-PodeBuildIsWindows)) {
-        Write-Warning 'Docker images are not built on GitHub Windows runners, and Docker is in Windows container only mode. Exiting task.'
-        return
+    # Synopsis: Creates a Chocolately package of the Module
+    Task ChocoPack -If (Test-PodeBuildIsWindows) PackDeps, PackageFolder, StampVersion, DeliverableFolder, {
+        exec { choco pack ./packers/choco/pode.nuspec }
+        Move-Item -Path "pode.$Version.nupkg" -Destination './deliverable'
     }
 
-    try {
-        # Try to get the Docker version to check if Docker is installed
-        docker --version
-    }
-    catch {
-        # If Docker is not available, exit the task
-        Write-Warning 'Docker is not installed or not available in the PATH. Exiting task.'
-        return
-    }
+    # Synopsis: Create docker tags
+    Task DockerPack PackageFolder, StampVersion, {
+        # check if github and windows, and output warning
+        if ((Test-PodeBuildIsGitHub) -and (Test-PodeBuildIsWindows)) {
+            Write-Warning 'Docker images are not built on GitHub Windows runners, and Docker is in Windows container only mode. Exiting task.'
+            return
+        }
 
-    Invoke-PodeBuildDockerBuild -Tag $Version -File './Dockerfile'
-    Invoke-PodeBuildDockerBuild -Tag 'latest' -File './Dockerfile'
-    Invoke-PodeBuildDockerBuild -Tag "$Version-alpine" -File './alpine.dockerfile'
-    Invoke-PodeBuildDockerBuild -Tag 'latest-alpine' -File './alpine.dockerfile'
+        try {
+            # Try to get the Docker version to check if Docker is installed
+            docker --version
+        }
+        catch {
+            # If Docker is not available, exit the task
+            Write-Warning 'Docker is not installed or not available in the PATH. Exiting task.'
+            return
+        }
 
-    if (!(Test-PodeBuildIsGitHub)) {
-        Invoke-PodeBuildDockerBuild -Tag "$Version-arm32" -File './arm32.dockerfile'
-        Invoke-PodeBuildDockerBuild -Tag 'latest-arm32' -File './arm32.dockerfile'
-    }
-    else {
-        Write-Warning 'Docker images for ARM32 are not built on GitHub runners due to having the wrong OS architecture. Skipping.'
-    }
-}
+        Invoke-PodeBuildDockerBuild -Tag $Version -File './Dockerfile'
+        Invoke-PodeBuildDockerBuild -Tag 'latest' -File './Dockerfile'
+        Invoke-PodeBuildDockerBuild -Tag "$Version-alpine" -File './alpine.dockerfile'
+        Invoke-PodeBuildDockerBuild -Tag 'latest-alpine' -File './alpine.dockerfile'
 
-# Synopsis: Package up the Module
-Task Pack Compress, ChocoPack, DockerPack
-
-# Synopsis: Package up the Module into a /pkg folder
-Task PackageFolder Build, {
-    $path = './pkg'
-    if (Test-Path $path) {
-        Remove-Item -Path $path -Recurse -Force | Out-Null
+        if (!(Test-PodeBuildIsGitHub)) {
+            Invoke-PodeBuildDockerBuild -Tag "$Version-arm32" -File './arm32.dockerfile'
+            Invoke-PodeBuildDockerBuild -Tag 'latest-arm32' -File './arm32.dockerfile'
+        }
+        else {
+            Write-Warning 'Docker images for ARM32 are not built on GitHub runners due to having the wrong OS architecture. Skipping.'
+        }
     }
 
-    # create the pkg dir
-    New-Item -Path $path -ItemType Directory -Force | Out-Null
+    # Synopsis: Package up the Module
+    Task Pack Compress, ChocoPack, DockerPack
 
-    # which source folders do we need? create them and copy their contents
-    $folders = @('Private', 'Public', 'Misc', 'Libs', 'Locales')
-    $folders | ForEach-Object {
-        New-Item -ItemType Directory -Path (Join-Path $path $_) -Force | Out-Null
-        Copy-Item -Path "./src/$($_)/*" -Destination (Join-Path $path $_) -Force -Recurse | Out-Null
+    # Synopsis: Package up the Module into a /pkg folder
+    Task PackageFolder Build, {
+        $path = './pkg'
+        if (Test-Path $path) {
+            Remove-Item -Path $path -Recurse -Force | Out-Null
+        }
+
+        # create the pkg dir
+        New-Item -Path $path -ItemType Directory -Force | Out-Null
+
+        # which source folders do we need? create them and copy their contents
+        $folders = @('Private', 'Public', 'Misc', 'Libs', 'Locales')
+        $folders | ForEach-Object {
+            New-Item -ItemType Directory -Path (Join-Path $path $_) -Force | Out-Null
+            Copy-Item -Path "./src/$($_)/*" -Destination (Join-Path $path $_) -Force -Recurse | Out-Null
+        }
+
+        # which route folders to we need? create them and copy their contents
+        $folders = @('licenses')
+        $folders | ForEach-Object {
+            New-Item -ItemType Directory -Path (Join-Path $path $_) -Force | Out-Null
+            Copy-Item -Path "./$($_)/*" -Destination (Join-Path $path $_) -Force -Recurse | Out-Null
+        }
+
+        # copy general files
+        $files = @('src/Pode.psm1', 'src/Pode.psd1', 'src/Pode.Internal.psm1', 'src/Pode.Internal.psd1', 'LICENSE.txt')
+        $files | ForEach-Object {
+            Copy-Item -Path "./$($_)" -Destination $path -Force | Out-Null
+        }
     }
 
-    # which route folders to we need? create them and copy their contents
-    $folders = @('licenses')
-    $folders | ForEach-Object {
-        New-Item -ItemType Directory -Path (Join-Path $path $_) -Force | Out-Null
-        Copy-Item -Path "./$($_)/*" -Destination (Join-Path $path $_) -Force -Recurse | Out-Null
-    }
 
-    # copy general files
-    $files = @('src/Pode.psm1', 'src/Pode.psd1', 'src/Pode.Internal.psm1', 'src/Pode.Internal.psd1', 'LICENSE.txt')
-    $files | ForEach-Object {
-        Copy-Item -Path "./$($_)" -Destination $path -Force | Out-Null
-    }
-}
-
-
-<#
+    <#
 # Testing
 #>
 
-# Synopsis: Run the tests
-Task TestNoBuild TestDeps, {
-    $p = (Get-Command Invoke-Pester)
-    if ($null -eq $p -or $p.Version -ine $Versions.Pester) {
-        Remove-Module Pester -Force -ErrorAction Ignore
-        Import-Module Pester -Force -RequiredVersion $Versions.Pester
+    # Synopsis: Run the tests
+    Task TestNoBuild TestDeps, {
+        $p = (Get-Command Invoke-Pester)
+        if ($null -eq $p -or $p.Version -ine $Versions.Pester) {
+            Remove-Module Pester -Force -ErrorAction Ignore
+            Import-Module Pester -Force -RequiredVersion $Versions.Pester
+        }
+
+        # for windows, output current netsh excluded ports
+        if (Test-PodeBuildIsWindows) {
+            netsh int ipv4 show excludedportrange protocol=tcp | Out-Default
+        }
+        if ($UICulture -ne ([System.Threading.Thread]::CurrentThread.CurrentUICulture) ) {
+            $originalUICulture = [System.Threading.Thread]::CurrentThread.CurrentUICulture
+            Write-Output "Original UICulture is $originalUICulture"
+            Write-Output "Set UICulture to $UICulture"
+            # set new UICulture
+            [System.Threading.Thread]::CurrentThread.CurrentUICulture = $UICulture
+        }
+        $Script:TestResultFile = "$($pwd)/TestResults.xml"
+
+        # get default from static property
+        $configuration = [PesterConfiguration]::Default
+        $configuration.run.path = @('./tests/unit', './tests/integration')
+        $configuration.run.PassThru = $true
+        $configuration.TestResult.OutputFormat = 'NUnitXml'
+        $configuration.Output.Verbosity = $PesterVerbosity
+        $configuration.TestResult.OutputPath = $Script:TestResultFile
+
+        # if run code coverage if enabled
+        if (Test-PodeBuildCanCodeCoverage) {
+            $srcFiles = (Get-ChildItem "$($pwd)/src/*.ps1" -Recurse -Force).FullName
+            $configuration.CodeCoverage.Enabled = $true
+            $configuration.CodeCoverage.Path = $srcFiles
+            $Script:TestStatus = Invoke-Pester -Configuration $configuration
+        }
+        else {
+            $Script:TestStatus = Invoke-Pester -Configuration $configuration
+        }
+        if ($originalUICulture) {
+            Write-Output "Restore UICulture to $originalUICulture"
+            # restore original UICulture
+            [System.Threading.Thread]::CurrentThread.CurrentUICulture = $originalUICulture
+        }
+    }, PushCodeCoverage, CheckFailedTests
+
+    # Synopsis: Run tests after a build
+    Task Test Build, TestNoBuild
+
+    # Synopsis: Check if any of the tests failed
+    Task CheckFailedTests {
+        if ($TestStatus.FailedCount -gt 0) {
+            throw "$($TestStatus.FailedCount) tests failed"
+        }
     }
 
-    # for windows, output current netsh excluded ports
-    if (Test-PodeBuildIsWindows) {
-        netsh int ipv4 show excludedportrange protocol=tcp | Out-Default
-    }
-    if ($UICulture -ne ([System.Threading.Thread]::CurrentThread.CurrentUICulture) ) {
-        $originalUICulture = [System.Threading.Thread]::CurrentThread.CurrentUICulture
-        Write-Output "Original UICulture is $originalUICulture"
-        Write-Output "Set UICulture to $UICulture"
-        # set new UICulture
-        [System.Threading.Thread]::CurrentThread.CurrentUICulture = $UICulture
-    }
-    $Script:TestResultFile = "$($pwd)/TestResults.xml"
+    # Synopsis: If AppyVeyor or GitHub, push code coverage stats
+    Task PushCodeCoverage -If (Test-PodeBuildCanCodeCoverage) {
+        try {
+            $service = Get-PodeBuildService
+            $branch = Get-PodeBuildBranch
 
-    # get default from static property
-    $configuration = [PesterConfiguration]::Default
-    $configuration.run.path = @('./tests/unit', './tests/integration')
-    $configuration.run.PassThru = $true
-    $configuration.TestResult.OutputFormat = 'NUnitXml'
-    $configuration.Output.Verbosity = $PesterVerbosity
-    $configuration.TestResult.OutputPath = $Script:TestResultFile
-
-    # if run code coverage if enabled
-    if (Test-PodeBuildCanCodeCoverage) {
-        $srcFiles = (Get-ChildItem "$($pwd)/src/*.ps1" -Recurse -Force).FullName
-        $configuration.CodeCoverage.Enabled = $true
-        $configuration.CodeCoverage.Path = $srcFiles
-        $Script:TestStatus = Invoke-Pester -Configuration $configuration
+            Write-Host "Pushing coverage for $($branch) from $($service)"
+            $coverage = New-CoverallsReport -Coverage $Script:TestStatus.CodeCoverage -ServiceName $service -BranchName $branch
+            Publish-CoverallsReport -Report $coverage -ApiToken $env:PODE_COVERALLS_TOKEN
+        }
+        catch {
+            $_.Exception | Out-Default
+        }
     }
-    else {
-        $Script:TestStatus = Invoke-Pester -Configuration $configuration
-    }
-    if ($originalUICulture) {
-        Write-Output "Restore UICulture to $originalUICulture"
-        # restore original UICulture
-        [System.Threading.Thread]::CurrentThread.CurrentUICulture = $originalUICulture
-    }
-}, PushCodeCoverage, CheckFailedTests
-
-# Synopsis: Run tests after a build
-Task Test Build, TestNoBuild
-
-# Synopsis: Check if any of the tests failed
-Task CheckFailedTests {
-    if ($TestStatus.FailedCount -gt 0) {
-        throw "$($TestStatus.FailedCount) tests failed"
-    }
-}
-
-# Synopsis: If AppyVeyor or GitHub, push code coverage stats
-Task PushCodeCoverage -If (Test-PodeBuildCanCodeCoverage) {
-    try {
-        $service = Get-PodeBuildService
-        $branch = Get-PodeBuildBranch
-
-        Write-Host "Pushing coverage for $($branch) from $($service)"
-        $coverage = New-CoverallsReport -Coverage $Script:TestStatus.CodeCoverage -ServiceName $service -BranchName $branch
-        Publish-CoverallsReport -Report $coverage -ApiToken $env:PODE_COVERALLS_TOKEN
-    }
-    catch {
-        $_.Exception | Out-Default
-    }
-}
 
 
-<#
+    <#
 # Docs
 #>
 
-# Synopsis: Run the documentation locally
-Task Docs DocsDeps, DocsHelpBuild, {
-    mkdocs serve --open
-}
+    # Synopsis: Run the documentation locally
+    Task Docs DocsDeps, DocsHelpBuild, {
+        mkdocs serve --open
+    }
 
-# Synopsis: Build the function help documentation
-Task DocsHelpBuild IndexSamples, DocsDeps, Build, {
-    # import the local module
-    Remove-Module Pode -Force -ErrorAction Ignore | Out-Null
-    Import-Module ./src/Pode.psm1 -Force | Out-Null
+    # Synopsis: Build the function help documentation
+    Task DocsHelpBuild IndexSamples, DocsDeps, Build, {
+        # import the local module
+        Remove-Module Pode -Force -ErrorAction Ignore | Out-Null
+        Import-Module ./src/Pode.psm1 -Force | Out-Null
 
-    # build the function docs
-    $path = './docs/Functions'
-    $map = @{}
+        # build the function docs
+        $path = './docs/Functions'
+        $map = @{}
 
     (Get-Module Pode).ExportedFunctions.Keys | ForEach-Object {
-        $type = [System.IO.Path]::GetFileNameWithoutExtension((Split-Path -Leaf -Path (Get-Command $_ -Module Pode).ScriptBlock.File))
-        New-MarkdownHelp -Command $_ -OutputFolder (Join-Path $path $type) -Force -Metadata @{ PodeType = $type } -AlphabeticParamsOrder | Out-Null
-        $map[$_] = $type
-    }
-
-    # update docs to bind links to unlinked functions
-    $path = Join-Path $pwd 'docs'
-    Get-ChildItem -Path $path -Recurse -Filter '*.md' | ForEach-Object {
-        $depth = ($_.FullName.Replace($path, [string]::Empty).trim('\/') -split '[\\/]').Length
-        $updated = $false
-
-        $content = (Get-Content -Path $_.FullName | ForEach-Object {
-                $line = $_
-
-                while ($line -imatch '\[`(?<name>[a-z]+\-pode[a-z]+)`\](?<char>([^(]|$))') {
-                    $updated = $true
-                    $name = $Matches['name']
-                    $char = $Matches['char']
-                    $line = ($line -ireplace "\[``$($name)``\]([^(]|$)", "[``$($name)``]($('../' * $depth)Functions/$($map[$name])/$($name))$($char)")
-                }
-
-                $line
-            })
-
-        if ($updated) {
-            $content | Out-File -FilePath $_.FullName -Force -Encoding ascii
+            $type = [System.IO.Path]::GetFileNameWithoutExtension((Split-Path -Leaf -Path (Get-Command $_ -Module Pode).ScriptBlock.File))
+            New-MarkdownHelp -Command $_ -OutputFolder (Join-Path $path $type) -Force -Metadata @{ PodeType = $type } -AlphabeticParamsOrder | Out-Null
+            $map[$_] = $type
         }
+
+        # update docs to bind links to unlinked functions
+        $path = Join-Path $pwd 'docs'
+        Get-ChildItem -Path $path -Recurse -Filter '*.md' | ForEach-Object {
+            $depth = ($_.FullName.Replace($path, [string]::Empty).trim('\/') -split '[\\/]').Length
+            $updated = $false
+
+            $content = (Get-Content -Path $_.FullName | ForEach-Object {
+                    $line = $_
+
+                    while ($line -imatch '\[`(?<name>[a-z]+\-pode[a-z]+)`\](?<char>([^(]|$))') {
+                        $updated = $true
+                        $name = $Matches['name']
+                        $char = $Matches['char']
+                        $line = ($line -ireplace "\[``$($name)``\]([^(]|$)", "[``$($name)``]($('../' * $depth)Functions/$($map[$name])/$($name))$($char)")
+                    }
+
+                    $line
+                })
+
+            if ($updated) {
+                $content | Out-File -FilePath $_.FullName -Force -Encoding ascii
+            }
+        }
+
+        # remove the module
+        Remove-Module Pode -Force -ErrorAction Ignore | Out-Null
     }
 
-    # remove the module
-    Remove-Module Pode -Force -ErrorAction Ignore | Out-Null
-}
-
-# Synopsis: Build the documentation
-Task DocsBuild DocsDeps, DocsHelpBuild, {
-    mkdocs build --quiet
-}
+    # Synopsis: Build the documentation
+    Task DocsBuild DocsDeps, DocsHelpBuild, {
+        mkdocs build --quiet
+    }
 
 
-<#
+    <#
 # Clean-up
 #>
 
-# Synopsis: Clean the build enviroment
-Task Clean  CleanPkg, CleanDeliverable, CleanLibs, CleanListener, CleanDocs
+    # Synopsis: Clean the build enviroment
+    Task Clean  CleanPkg, CleanDeliverable, CleanLibs, CleanListener, CleanDocs
 
-# Synopsis: Clean the Deliverable folder
-Task CleanDeliverable {
-    $path = './deliverable'
-    if (Test-Path -Path $path -PathType Container) {
-        Write-Host 'Removing ./deliverable folder'
-        Remove-Item -Path $path -Recurse -Force | Out-Null
-    }
-    Write-Host "Cleanup $path done"
-}
-
-# Synopsis: Clean the pkg directory
-Task CleanPkg {
-    $path = './pkg'
-    if ((Test-Path -Path $path -PathType Container )) {
-        Write-Host 'Removing ./pkg folder'
-        Remove-Item -Path $path -Recurse -Force | Out-Null
+    # Synopsis: Clean the Deliverable folder
+    Task CleanDeliverable {
+        $path = './deliverable'
+        if (Test-Path -Path $path -PathType Container) {
+            Write-Host 'Removing ./deliverable folder'
+            Remove-Item -Path $path -Recurse -Force | Out-Null
+        }
+        Write-Host "Cleanup $path done"
     }
 
-    if ((Test-Path -Path .\packers\choco\tools\ChocolateyInstall.ps1 -PathType Leaf )) {
-        Write-Host 'Removing .\packers\choco\tools\ChocolateyInstall.ps1'
-        Remove-Item -Path .\packers\choco\tools\ChocolateyInstall.ps1
+    # Synopsis: Clean the pkg directory
+    Task CleanPkg {
+        $path = './pkg'
+        if ((Test-Path -Path $path -PathType Container )) {
+            Write-Host 'Removing ./pkg folder'
+            Remove-Item -Path $path -Recurse -Force | Out-Null
+        }
+
+        if ((Test-Path -Path .\packers\choco\tools\ChocolateyInstall.ps1 -PathType Leaf )) {
+            Write-Host 'Removing .\packers\choco\tools\ChocolateyInstall.ps1'
+            Remove-Item -Path .\packers\choco\tools\ChocolateyInstall.ps1
+        }
+
+        if ((Test-Path -Path .\packers\choco\pode.nuspec -PathType Leaf )) {
+            Write-Host 'Removing .\packers\choco\pode.nuspec'
+            Remove-Item -Path .\packers\choco\pode.nuspec
+        }
+
+        Write-Host "Cleanup $path done"
     }
 
-    if ((Test-Path -Path .\packers\choco\pode.nuspec -PathType Leaf )) {
-        Write-Host 'Removing .\packers\choco\pode.nuspec'
-        Remove-Item -Path .\packers\choco\pode.nuspec
+    # Synopsis: Clean the libs folder
+    Task CleanLibs {
+        $path = './src/Libs'
+        if (Test-Path -Path $path -PathType Container) {
+            Write-Host "Removing $path  contents"
+            Remove-Item -Path $path -Recurse -Force | Out-Null
+        }
+
+        Write-Host "Cleanup $path done"
     }
 
-    Write-Host "Cleanup $path done"
-}
+    # Synopsis: Clean the Listener folder
+    Task CleanListener {
+        $path = './src/Listener/bin'
+        if (Test-Path -Path $path -PathType Container) {
+            Write-Host "Removing $path contents"
+            Remove-Item -Path $path -Recurse -Force | Out-Null
+        }
 
-# Synopsis: Clean the libs folder
-Task CleanLibs {
-    $path = './src/Libs'
-    if (Test-Path -Path $path -PathType Container) {
-        Write-Host "Removing $path  contents"
-        Remove-Item -Path $path -Recurse -Force | Out-Null
+        Write-Host "Cleanup $path done"
     }
 
-    Write-Host "Cleanup $path done"
-}
-
-# Synopsis: Clean the Listener folder
-Task CleanListener {
-    $path = './src/Listener/bin'
-    if (Test-Path -Path $path -PathType Container) {
-        Write-Host "Removing $path contents"
-        Remove-Item -Path $path -Recurse -Force | Out-Null
+    Task CleanDocs {
+        $path = './docs/Getting-Started/Samples.md'
+        if (Test-Path -Path $path -PathType Leaf) {
+            Write-Host "Removing $path"
+            Remove-Item -Path $path -Force | Out-Null
+        }
     }
-
-    Write-Host "Cleanup $path done"
-}
-
-Task CleanDocs {
-    $path = './docs/Getting-Started/Samples.md'
-    if (Test-Path -Path $path -PathType Leaf) {
-        Write-Host "Removing $path"
-        Remove-Item -Path $path -Force | Out-Null
-    }
-}
-<#
+    <#
 # Local module management
 #>
 
-# Synopsis: Install Pode Module locally
-Task Install-Module -If ($Version) Pack, {
-    $PSPaths = Split-PodeBuildPwshPath
+    # Synopsis: Install Pode Module locally
+    Task Install-Module -If ($Version) Pack, {
+        $PSPaths = Split-PodeBuildPwshPath
 
-    $dest = Join-Path -Path $PSPaths[0] -ChildPath 'Pode' -AdditionalChildPath "$Version"
-    if (Test-Path $dest) {
+        $dest = Join-Path -Path $PSPaths[0] -ChildPath 'Pode' -AdditionalChildPath "$Version"
+        if (Test-Path $dest) {
+            Remove-Item -Path $dest -Recurse -Force | Out-Null
+        }
+
+        # create the dest dir
+        New-Item -Path $dest -ItemType Directory -Force | Out-Null
+        $path = './pkg'
+
+        # copy over folders
+        $folders = @('Private', 'Public', 'Misc', 'Libs', 'licenses', 'Locales')
+        $folders | ForEach-Object {
+            Copy-Item -Path (Join-Path -Path $path -ChildPath $_) -Destination $dest -Force -Recurse | Out-Null
+        }
+
+        # copy over general files
+        $files = @('Pode.psm1', 'Pode.psd1', 'Pode.Internal.psm1', 'Pode.Internal.psd1', 'LICENSE.txt')
+        $files | ForEach-Object {
+            Copy-Item -Path (Join-Path -Path $path -ChildPath $_) -Destination $dest -Force | Out-Null
+        }
+
+        Write-Host "Deployed to $dest"
+    }
+
+    # Synopsis: Remove the Pode Module from the local registry
+    Task Remove-Module {
+        if (!$Version) {
+            throw 'Parameter -Version is required'
+        }
+
+        $PSPaths = Split-PodeBuildPwshPath
+
+        $dest = Join-Path -Path $PSPaths[0] -ChildPath 'Pode' -AdditionalChildPath "$Version"
+        if (!(Test-Path $dest)) {
+            Write-Warning "Directory $dest doesn't exist"
+        }
+
+        Write-Host "Deleting module from $dest"
         Remove-Item -Path $dest -Recurse -Force | Out-Null
     }
 
-    # create the dest dir
-    New-Item -Path $dest -ItemType Directory -Force | Out-Null
-    $path = './pkg'
 
-    # copy over folders
-    $folders = @('Private', 'Public', 'Misc', 'Libs', 'licenses', 'Locales')
-    $folders | ForEach-Object {
-        Copy-Item -Path (Join-Path -Path $path -ChildPath $_) -Destination $dest -Force -Recurse | Out-Null
-    }
-
-    # copy over general files
-    $files = @('Pode.psm1', 'Pode.psd1', 'Pode.Internal.psm1', 'Pode.Internal.psd1', 'LICENSE.txt')
-    $files | ForEach-Object {
-        Copy-Item -Path (Join-Path -Path $path -ChildPath $_) -Destination $dest -Force | Out-Null
-    }
-
-    Write-Host "Deployed to $dest"
-}
-
-# Synopsis: Remove the Pode Module from the local registry
-Task Remove-Module {
-    if (!$Version) {
-        throw 'Parameter -Version is required'
-    }
-
-    $PSPaths = Split-PodeBuildPwshPath
-
-    $dest = Join-Path -Path $PSPaths[0] -ChildPath 'Pode' -AdditionalChildPath "$Version"
-    if (!(Test-Path $dest)) {
-        Write-Warning "Directory $dest doesn't exist"
-    }
-
-    Write-Host "Deleting module from $dest"
-    Remove-Item -Path $dest -Recurse -Force | Out-Null
-}
-
-
-<#
+    <#
 # PowerShell setup
 #>
 
-# Synopsis: Setup the PowerShell environment
-Task SetupPowerShell {
-    # code for this step is altered versions of the code found here:
-    # - https://github.com/bjompen/UpdatePWSHAction/blob/main/UpgradePwsh.ps1
-    # - https://raw.githubusercontent.com/PowerShell/PowerShell/master/tools/install-powershell.ps1
+    # Synopsis: Setup the PowerShell environment
+    Task SetupPowerShell {
+        # code for this step is altered versions of the code found here:
+        # - https://github.com/bjompen/UpdatePWSHAction/blob/main/UpgradePwsh.ps1
+        # - https://raw.githubusercontent.com/PowerShell/PowerShell/master/tools/install-powershell.ps1
 
-    # fail if no version supplied
-    if ([string]::IsNullOrWhiteSpace($PowerShellVersion)) {
-        throw 'No PowerShell version supplied to set up'
-    }
+        # fail if no version supplied
+        if ([string]::IsNullOrWhiteSpace($PowerShellVersion)) {
+            throw 'No PowerShell version supplied to set up'
+        }
 
-    # is the version valid?
-    $tags = @('preview', 'lts', 'daily', 'stable')
-    if (($PowerShellVersion -inotin $tags) -and ($PowerShellVersion -inotmatch '^\d+\.\d+\.\d+(-\w+(\.\d+)?)?$')) {
-        throw "Invalid PowerShell version supplied: $($PowerShellVersion)"
-    }
+        # is the version valid?
+        $tags = @('preview', 'lts', 'daily', 'stable')
+        if (($PowerShellVersion -inotin $tags) -and ($PowerShellVersion -inotmatch '^\d+\.\d+\.\d+(-\w+(\.\d+)?)?$')) {
+            throw "Invalid PowerShell version supplied: $($PowerShellVersion)"
+        }
 
-    # tag version or literal version?
-    $isTagVersion = $PowerShellVersion -iin $tags
-    if ($isTagVersion) {
-        Write-Host "Release tag: $($PowerShellVersion)"
-        $PowerShellVersion = Convert-PodeBuildOSPwshTagToVersion
-    }
-    Write-Host "Release version: $($PowerShellVersion)"
+        # tag version or literal version?
+        $isTagVersion = $PowerShellVersion -iin $tags
+        if ($isTagVersion) {
+            Write-Host "Release tag: $($PowerShellVersion)"
+            $PowerShellVersion = Convert-PodeBuildOSPwshTagToVersion
+        }
+        Write-Host "Release version: $($PowerShellVersion)"
 
-    # base/prefix versions
-    $atoms = $PowerShellVersion -split '\-'
-    $baseVersion = $atoms[0]
+        # base/prefix versions
+        $atoms = $PowerShellVersion -split '\-'
+        $baseVersion = $atoms[0]
 
-    # do nothing if the current version is the version we're trying to set up
-    $currentVersion = Get-PodeBuildCurrentPwshVersion
-    Write-Host "Current PowerShell version: $($currentVersion)"
+        # do nothing if the current version is the version we're trying to set up
+        $currentVersion = Get-PodeBuildCurrentPwshVersion
+        Write-Host "Current PowerShell version: $($currentVersion)"
 
-    if ($baseVersion -ieq $currentVersion) {
-        Write-Host "PowerShell version $($PowerShellVersion) is already installed"
-        return
-    }
+        if ($baseVersion -ieq $currentVersion) {
+            Write-Host "PowerShell version $($PowerShellVersion) is already installed"
+            return
+        }
 
-    # build the package name
-    $arch = Get-PodeBuildOSPwshArchitecture
-    $os = Get-PodeBuildOSPwshName
+        # build the package name
+        $arch = Get-PodeBuildOSPwshArchitecture
+        $os = Get-PodeBuildOSPwshName
 
-    $packageName = (@{
-            win   = "PowerShell-$($PowerShellVersion)-$($os)-$($arch).zip"
-            linux = "powershell-$($PowerShellVersion)-$($os)-$($arch).tar.gz"
-            osx   = "powershell-$($PowerShellVersion)-$($os)-$($arch).tar.gz"
-        })[$os]
+        $packageName = (@{
+                win   = "PowerShell-$($PowerShellVersion)-$($os)-$($arch).zip"
+                linux = "powershell-$($PowerShellVersion)-$($os)-$($arch).tar.gz"
+                osx   = "powershell-$($PowerShellVersion)-$($os)-$($arch).tar.gz"
+            })[$os]
 
-    # build the URL
-    $urls = @{
-        Old = "https://pscoretestdata.blob.core.windows.net/v$($PowerShellVersion -replace '\.', '-')/$($packageName)"
-        New = "https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/install/v$($PowerShellVersion)/$($packageName)"
-    }
+        # build the URL
+        $urls = @{
+            Old = "https://pscoretestdata.blob.core.windows.net/v$($PowerShellVersion -replace '\.', '-')/$($packageName)"
+            New = "https://powershellinfraartifacts-gkhedzdeaghdezhr.z01.azurefd.net/install/v$($PowerShellVersion)/$($packageName)"
+        }
 
-    # download the package to a temp location
-    $outputFile = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath $packageName
-    $downloadParams = @{
-        Uri         = $urls.New
-        OutFile     = $outputFile
-        ErrorAction = 'Stop'
-    }
+        # download the package to a temp location
+        $outputFile = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath $packageName
+        $downloadParams = @{
+            Uri         = $urls.New
+            OutFile     = $outputFile
+            ErrorAction = 'Stop'
+        }
 
-    Write-Host "Output file: $($outputFile)"
+        Write-Host "Output file: $($outputFile)"
 
-    # retry the download 6 times, with a sleep of 10s between each attempt, and altering between old and new URLs
-    $counter = 0
-    $success = $false
+        # retry the download 6 times, with a sleep of 10s between each attempt, and altering between old and new URLs
+        $counter = 0
+        $success = $false
 
-    do {
-        try {
-            $counter++
-            Write-Host "Attempt $($counter) of 6"
+        do {
+            try {
+                $counter++
+                Write-Host "Attempt $($counter) of 6"
 
-            # use new URL for odd attempts, and old URL for even attempts
-            if ($counter % 2 -eq 0) {
-                $downloadParams.Uri = $urls.Old
+                # use new URL for odd attempts, and old URL for even attempts
+                if ($counter % 2 -eq 0) {
+                    $downloadParams.Uri = $urls.Old
+                }
+                else {
+                    $downloadParams.Uri = $urls.New
+                }
+
+                # download the package
+                Write-Host "Attempting download of $($packageName) from $($downloadParams.Uri)"
+                Invoke-WebRequest @downloadParams
+
+                $success = $true
+                Write-Host "Downloaded $($packageName) successfully"
             }
-            else {
-                $downloadParams.Uri = $urls.New
+            catch {
+                $success = $false
+                if ($counter -ge 6) {
+                    throw "Failed to download PowerShell package after 6 attempts. Error: $($_.Exception.Message)"
+                }
+
+                Start-Sleep -Seconds 5
+            }
+        } while (!$success)
+
+        # create target folder for package
+        $targetFolder = Join-Path -Path (Resolve-Path ~).Path -ChildPath ($packageName -ireplace '\.tar$')
+        if (!(Test-Path $targetFolder)) {
+            $null = New-Item -Path $targetFolder -ItemType Directory -Force
+        }
+
+        # extract the package
+        switch ($os) {
+            'win' {
+                Expand-Archive -Path $outputFile -DestinationPath $targetFolder -Force
             }
 
-            # download the package
-            Write-Host "Attempting download of $($packageName) from $($downloadParams.Uri)"
-            Invoke-WebRequest @downloadParams
-
-            $success = $true
-            Write-Host "Downloaded $($packageName) successfully"
-        }
-        catch {
-            $success = $false
-            if ($counter -ge 6) {
-                throw "Failed to download PowerShell package after 6 attempts. Error: $($_.Exception.Message)"
+            { $_ -iin 'linux', 'osx' } {
+                $null = tar -xzf $outputFile -C $targetFolder
             }
-
-            Start-Sleep -Seconds 5
-        }
-    } while (!$success)
-
-    # create target folder for package
-    $targetFolder = Join-Path -Path (Resolve-Path ~).Path -ChildPath ($packageName -ireplace '\.tar$')
-    if (!(Test-Path $targetFolder)) {
-        $null = New-Item -Path $targetFolder -ItemType Directory -Force
-    }
-
-    # extract the package
-    switch ($os) {
-        'win' {
-            Expand-Archive -Path $outputFile -DestinationPath $targetFolder -Force
         }
 
-        { $_ -iin 'linux', 'osx' } {
-            $null = tar -xzf $outputFile -C $targetFolder
+        # install the package
+        Write-Host "Installing PowerShell $($PowerShellVersion) to $($targetFolder)"
+        if (Test-PodeBuildOSWindows) {
+            Install-PodeBuildPwshWindows -Target $targetFolder
+        }
+        else {
+            Install-PodeBuildPwshUnix -Target $targetFolder
         }
     }
 
-    # install the package
-    Write-Host "Installing PowerShell $($PowerShellVersion) to $($targetFolder)"
-    if (Test-PodeBuildOSWindows) {
-        Install-PodeBuildPwshWindows -Target $targetFolder
-    }
-    else {
-        Install-PodeBuildPwshUnix -Target $targetFolder
-    }
-}
 
-
-<#
+    <#
 # Release Notes
 #>
 
-# Synopsis: Build the Release Notes
-task ReleaseNotes {
-    if ([string]::IsNullOrWhiteSpace($ReleaseNoteVersion)) {
-        Write-Host 'Please provide a ReleaseNoteVersion' -ForegroundColor Red
-        return
-    }
-
-    # get the PRs for the ReleaseNoteVersion
-    $prs = gh search prs --milestone $ReleaseNoteVersion --repo badgerati/pode --merged --limit 200 --json 'number,title,labels,author' | ConvertFrom-Json
-
-    # group PRs into categories, filtering out some internal PRs
-    $categories = [ordered]@{
-        Features      = @()
-        Enhancements  = @()
-        Bugs          = @()
-        Documentation = @()
-    }
-
-    $dependabot = @{}
-
-    foreach ($pr in $prs) {
-        if ($pr.labels.name -icontains 'superseded') {
-            continue
+    # Synopsis: Build the Release Notes
+    task ReleaseNotes {
+        if ([string]::IsNullOrWhiteSpace($ReleaseNoteVersion)) {
+            Write-Host 'Please provide a ReleaseNoteVersion' -ForegroundColor Red
+            return
         }
 
-        $label = ($pr.labels[0].name -split ' ')[0]
-        if ($label -iin @('new-release', 'internal-code')) {
-            continue
+        # get the PRs for the ReleaseNoteVersion
+        $prs = gh search prs --milestone $ReleaseNoteVersion --repo badgerati/pode --merged --limit 200 --json 'number,title,labels,author' | ConvertFrom-Json
+
+        # group PRs into categories, filtering out some internal PRs
+        $categories = [ordered]@{
+            Features      = @()
+            Enhancements  = @()
+            Bugs          = @()
+            Documentation = @()
         }
 
-        if ([string]::IsNullOrWhiteSpace($label)) {
-            $label = 'misc'
-        }
+        $dependabot = @{}
 
-        switch ($label.ToLowerInvariant()) {
-            'feature' { $label = 'Features' }
-            'enhancement' { $label = 'Enhancements' }
-            'bug' { $label = 'Bugs' }
-        }
-
-        if (!$categories.Contains($label)) {
-            $categories[$label] = @()
-        }
-
-        if ($pr.author.login -ilike '*dependabot*') {
-            if ($pr.title -imatch 'Bump (?<name>\S+) from (?<from>[0-9\.]+) to (?<to>[0-9\.]+)') {
-                if (!$dependabot.ContainsKey($Matches['name'])) {
-                    $dependabot[$Matches['name']] = @{
-                        Name   = $Matches['name']
-                        Number = $pr.number
-                        From   = [version]$Matches['from']
-                        To     = [version]$Matches['to']
-                    }
-                }
-                else {
-                    $item = $dependabot[$Matches['name']]
-                    if ([int]$pr.number -gt [int]$item.Number) {
-                        $item.Number = $pr.number
-                    }
-                    if ([version]$Matches['from'] -lt $item.From) {
-                        $item.From = [version]$Matches['from']
-                    }
-                    if ([version]$Matches['to'] -gt $item.To) {
-                        $item.To = [version]$Matches['to']
-                    }
-                }
-
+        foreach ($pr in $prs) {
+            if ($pr.labels.name -icontains 'superseded') {
                 continue
             }
-        }
 
-        $titles = @($pr.title).Trim()
-        if ($pr.title.Contains(';')) {
-            $titles = ($pr.title -split ';').Trim()
-        }
-
-        $author = $null
-        if (($pr.author.login -ine 'badgerati') -and ($pr.author.login -inotlike '*dependabot*')) {
-            $author = $pr.author.login
-        }
-
-        foreach ($title in $titles) {
-            $str = "* #$($pr.number): $($title -replace '`', "'")"
-            if (![string]::IsNullOrWhiteSpace($author)) {
-                $str += " (thanks @$($author)!)"
+            $label = ($pr.labels[0].name -split ' ')[0]
+            if ($label -iin @('new-release', 'internal-code')) {
+                continue
             }
 
-            if ($str -imatch '\s+(docs|documentation)\s+') {
-                $categories['Documentation'] += $str
+            if ([string]::IsNullOrWhiteSpace($label)) {
+                $label = 'misc'
             }
-            else {
-                $categories[$label] += $str
+
+            switch ($label.ToLowerInvariant()) {
+                'feature' { $label = 'Features' }
+                'enhancement' { $label = 'Enhancements' }
+                'bug' { $label = 'Bugs' }
+            }
+
+            if (!$categories.Contains($label)) {
+                $categories[$label] = @()
+            }
+
+            if ($pr.author.login -ilike '*dependabot*') {
+                if ($pr.title -imatch 'Bump (?<name>\S+) from (?<from>[0-9\.]+) to (?<to>[0-9\.]+)') {
+                    if (!$dependabot.ContainsKey($Matches['name'])) {
+                        $dependabot[$Matches['name']] = @{
+                            Name   = $Matches['name']
+                            Number = $pr.number
+                            From   = [version]$Matches['from']
+                            To     = [version]$Matches['to']
+                        }
+                    }
+                    else {
+                        $item = $dependabot[$Matches['name']]
+                        if ([int]$pr.number -gt [int]$item.Number) {
+                            $item.Number = $pr.number
+                        }
+                        if ([version]$Matches['from'] -lt $item.From) {
+                            $item.From = [version]$Matches['from']
+                        }
+                        if ([version]$Matches['to'] -gt $item.To) {
+                            $item.To = [version]$Matches['to']
+                        }
+                    }
+
+                    continue
+                }
+            }
+
+            $titles = @($pr.title).Trim()
+            if ($pr.title.Contains(';')) {
+                $titles = ($pr.title -split ';').Trim()
+            }
+
+            $author = $null
+            if (($pr.author.login -ine 'badgerati') -and ($pr.author.login -inotlike '*dependabot*')) {
+                $author = $pr.author.login
+            }
+
+            foreach ($title in $titles) {
+                $str = "* #$($pr.number): $($title -replace '`', "'")"
+                if (![string]::IsNullOrWhiteSpace($author)) {
+                    $str += " (thanks @$($author)!)"
+                }
+
+                if ($str -imatch '\s+(docs|documentation)\s+') {
+                    $categories['Documentation'] += $str
+                }
+                else {
+                    $categories[$label] += $str
+                }
             }
         }
-    }
 
-    # add dependabot aggregated PRs
-    if ($dependabot.Count -gt 0) {
-        $label = 'dependencies'
-        if (!$categories.Contains($label)) {
-            $categories[$label] = @()
+        # add dependabot aggregated PRs
+        if ($dependabot.Count -gt 0) {
+            $label = 'dependencies'
+            if (!$categories.Contains($label)) {
+                $categories[$label] = @()
+            }
+
+            foreach ($dep in $dependabot.Values) {
+                $categories[$label] += "* #$($dep.Number): Bump $($dep.Name) from $($dep.From) to $($dep.To)"
+            }
         }
 
-        foreach ($dep in $dependabot.Values) {
-            $categories[$label] += "* #$($dep.Number): Bump $($dep.Name) from $($dep.From) to $($dep.To)"
+        # output the release notes
+        Write-Host "# v$($ReleaseNoteVersion)`n"
+
+        $culture = (Get-Culture).TextInfo
+        foreach ($category in $categories.Keys) {
+            if ($categories[$category].Length -eq 0) {
+                continue
+            }
+
+            Write-Host "### $($culture.ToTitleCase($category))"
+            $categories[$category] | Sort-Object | ForEach-Object { Write-Host $_ }
+            Write-Host ''
         }
     }
-
-    # output the release notes
-    Write-Host "# v$($ReleaseNoteVersion)`n"
-
-    $culture = (Get-Culture).TextInfo
-    foreach ($category in $categories.Keys) {
-        if ($categories[$category].Length -eq 0) {
-            continue
-        }
-
-        Write-Host "### $($culture.ToTitleCase($category))"
-        $categories[$category] | Sort-Object | ForEach-Object { Write-Host $_ }
-        Write-Host ''
-    }
+}
+else {
+    Write-Host 'This script is intended to be run with Invoke-Build. Please use Invoke-Build to execute the tasks defined in this script.' -ForegroundColor Yellow
 }

--- a/pode.build.ps1
+++ b/pode.build.ps1
@@ -699,6 +699,19 @@ if (($null -ne $PSCmdlet.MyInvocation) -and ($PSCmdlet.MyInvocation.BoundParamet
         #   if (!(Test-PodeBuildCommand 'dotnet')) {
         #     Invoke-PodeBuildInstall $dotnet $SdkVersion
         #  }
+
+        if (Test-PodeBuildIsGitHub){
+            $sdkVersions = dotnet --list-sdks | ForEach-Object { $_.Split('[')[0].Trim() }
+            $majorVersions = $sdkVersions | ForEach-Object { ([version]$_).Major } | Sort-Object -Descending | Select-Object -Unique
+            $script:AvailableSdkVersion = Get-TargetFrameworkName  -Version $majorVersions
+
+            if ($majorVersions -lt (Get-TargetFramework -TargetFrameworks $SdkVersion)) {
+                Write-Error "The requested framework '$SdkVersion' is not available."
+                return
+            }
+            return
+        }
+
         try {
             $sdkVersions = dotnet --list-sdks | ForEach-Object { $_.Split('[')[0].Trim() }
         }

--- a/pode.build.ps1
+++ b/pode.build.ps1
@@ -700,21 +700,17 @@ if (($null -ne $PSCmdlet.MyInvocation) -and ($PSCmdlet.MyInvocation.BoundParamet
         #     Invoke-PodeBuildInstall $dotnet $SdkVersion
         #  }
 
-        if (Test-PodeBuildIsGitHub){
+  <#       if (Test-PodeBuildIsGitHub){
             $sdkVersions = dotnet --list-sdks | ForEach-Object { $_.Split('[')[0].Trim() }
-            dotnet --list-sdks
-            Write-Warning $sdkVersions
             $majorVersions = ($sdkVersions | ForEach-Object { ([version]$_).Major } | Sort-Object -Descending | Select-Object -Unique)[0]
-            Write-Warning "Majorversion=$majorVersions"
             $script:AvailableSdkVersion = Get-TargetFrameworkName  -Version $majorVersions
-  Write-Warning "AvailableSdkVersion=$AvailableSdkVersion"
             if ($majorVersions -lt (Get-TargetFramework -TargetFrameworks $SdkVersion)) {
                 Write-Error "The requested framework '$SdkVersion' is not available."
                 return
             }
             return
         }
-
+#>
         try {
             $sdkVersions = dotnet --list-sdks | ForEach-Object { $_.Split('[')[0].Trim() }
         }

--- a/pode.build.ps1
+++ b/pode.build.ps1
@@ -704,7 +704,7 @@ if (($null -ne $PSCmdlet.MyInvocation) -and ($PSCmdlet.MyInvocation.BoundParamet
             $sdkVersions = dotnet --list-sdks | ForEach-Object { $_.Split('[')[0].Trim() }
             dotnet --list-sdks
             Write-Warning $sdkVersions
-            $majorVersions = $sdkVersions | ForEach-Object { ([version]$_).Major } | Sort-Object -Descending | Select-Object -Unique
+            $majorVersions = ($sdkVersions | ForEach-Object { ([version]$_).Major } | Sort-Object -Descending | Select-Object -Unique)[0]
             Write-Warning "Majorversion=$majorVersions"
             $script:AvailableSdkVersion = Get-TargetFrameworkName  -Version $majorVersions
   Write-Warning "AvailableSdkVersion=$AvailableSdkVersion"
@@ -722,13 +722,13 @@ if (($null -ne $PSCmdlet.MyInvocation) -and ($PSCmdlet.MyInvocation.BoundParamet
             Invoke-PodeBuildInstall $dotnet $SdkVersion
             $sdkVersions = dotnet --list-sdks | ForEach-Object { $_.Split('[')[0].Trim() }
         }
-        $majorVersions = $sdkVersions | ForEach-Object { ([version]$_).Major } | Sort-Object -Descending | Select-Object -Unique
+        $majorVersions = ($sdkVersions | ForEach-Object { ([version]$_).Major } | Sort-Object -Descending | Select-Object -Unique)[0]
         $script:AvailableSdkVersion = Get-TargetFrameworkName  -Version $majorVersions
 
         if ($majorVersions -lt (Get-TargetFramework -TargetFrameworks $SdkVersion)) {
             Invoke-PodeBuildInstall $dotnet $SdkVersion
             $sdkVersions = dotnet --list-sdks | ForEach-Object { $_.Split('[')[0].Trim() }
-            $majorVersions = $sdkVersions | ForEach-Object { ([version]$_).Major } | Sort-Object -Descending | Select-Object -Unique
+            $majorVersions = ($sdkVersions | ForEach-Object { ([version]$_).Major } | Sort-Object -Descending | Select-Object -Unique)[0]
             $script:AvailableSdkVersion = Get-TargetFrameworkName  -Version $majorVersions
 
             if ($majorVersions -lt (Get-TargetFramework -TargetFrameworks $SdkVersion)) {

--- a/pode.build.ps1
+++ b/pode.build.ps1
@@ -703,7 +703,7 @@ if (($null -ne $PSCmdlet.MyInvocation) -and ($PSCmdlet.MyInvocation.BoundParamet
     }
 
     # Synopsis: Build the function help documentation
-    Task DocsHelpBuild IndexSamples, DocsDeps, {
+    Task DocsHelpBuild IndexSamples, DocsDeps, Build, {
         # import the local module
         Remove-Module Pode -Force -ErrorAction Ignore | Out-Null
         Import-Module ./src/Pode.psm1 -Force | Out-Null

--- a/pode.build.ps1
+++ b/pode.build.ps1
@@ -703,7 +703,7 @@ if (($null -ne $PSCmdlet.MyInvocation) -and ($PSCmdlet.MyInvocation.BoundParamet
     }
 
     # Synopsis: Build the function help documentation
-    Task DocsHelpBuild IndexSamples, DocsDeps, Build, {
+    Task DocsHelpBuild IndexSamples, DocsDeps, {
         # import the local module
         Remove-Module Pode -Force -ErrorAction Ignore | Out-Null
         Import-Module ./src/Pode.psm1 -Force | Out-Null

--- a/pode.build.ps1
+++ b/pode.build.ps1
@@ -702,6 +702,7 @@ if (($null -ne $PSCmdlet.MyInvocation) -and ($PSCmdlet.MyInvocation.BoundParamet
 
         if (Test-PodeBuildIsGitHub){
             $sdkVersions = dotnet --list-sdks | ForEach-Object { $_.Split('[')[0].Trim() }
+            dotnet --list-sdks 
             Write-Warning $sdkVersions
             $majorVersions = $sdkVersions | ForEach-Object { ([version]$_).Major } | Sort-Object -Descending | Select-Object -Unique
             $script:AvailableSdkVersion = Get-TargetFrameworkName  -Version $majorVersions

--- a/pode.build.ps1
+++ b/pode.build.ps1
@@ -302,7 +302,7 @@ function Get-PodeBuildPwshEOL {
     }
 }
 
- 
+
 
 function Test-PodeBuildOSWindows {
     return ($IsWindows -or
@@ -696,11 +696,16 @@ if (($null -ne $PSCmdlet.MyInvocation) -and ($PSCmdlet.MyInvocation.BoundParamet
             $dotnet = "dotnet-sdk-$SdkVersion"
         }
 
-        if (!(Test-PodeBuildCommand 'dotnet')) {
-            Invoke-PodeBuildInstall $dotnet $SdkVersion
+        #   if (!(Test-PodeBuildCommand 'dotnet')) {
+        #     Invoke-PodeBuildInstall $dotnet $SdkVersion
+        #  }
+        try {
+            $sdkVersions = dotnet --list-sdks | ForEach-Object { $_.Split('[')[0].Trim() }
         }
-
-        $sdkVersions = dotnet --list-sdks | ForEach-Object { $_.Split('[')[0].Trim() }
+        catch {
+            Invoke-PodeBuildInstall $dotnet $SdkVersion
+            $sdkVersions = dotnet --list-sdks | ForEach-Object { $_.Split('[')[0].Trim() }
+        }
         $majorVersions = $sdkVersions | ForEach-Object { ([version]$_).Major } | Sort-Object -Descending | Select-Object -Unique
         $script:AvailableSdkVersion = Get-TargetFrameworkName  -Version $majorVersions
 

--- a/pode.build.ps1
+++ b/pode.build.ps1
@@ -702,11 +702,12 @@ if (($null -ne $PSCmdlet.MyInvocation) -and ($PSCmdlet.MyInvocation.BoundParamet
 
         if (Test-PodeBuildIsGitHub){
             $sdkVersions = dotnet --list-sdks | ForEach-Object { $_.Split('[')[0].Trim() }
-            dotnet --list-sdks 
+            dotnet --list-sdks
             Write-Warning $sdkVersions
             $majorVersions = $sdkVersions | ForEach-Object { ([version]$_).Major } | Sort-Object -Descending | Select-Object -Unique
+            Write-Warning "Majorversion=$majorVersions"
             $script:AvailableSdkVersion = Get-TargetFrameworkName  -Version $majorVersions
-
+  Write-Warning "AvailableSdkVersion=$AvailableSdkVersion"
             if ($majorVersions -lt (Get-TargetFramework -TargetFrameworks $SdkVersion)) {
                 Write-Error "The requested framework '$SdkVersion' is not available."
                 return

--- a/pode.build.ps1
+++ b/pode.build.ps1
@@ -702,6 +702,7 @@ if (($null -ne $PSCmdlet.MyInvocation) -and ($PSCmdlet.MyInvocation.BoundParamet
 
         if (Test-PodeBuildIsGitHub){
             $sdkVersions = dotnet --list-sdks | ForEach-Object { $_.Split('[')[0].Trim() }
+            Write-Warning $sdkVersions
             $majorVersions = $sdkVersions | ForEach-Object { ([version]$_).Major } | Sort-Object -Descending | Select-Object -Unique
             $script:AvailableSdkVersion = Get-TargetFrameworkName  -Version $majorVersions
 

--- a/pode.build.ps1
+++ b/pode.build.ps1
@@ -845,7 +845,7 @@ function Invoke-PodeBuildDockerBuild {
     )
 
     # Build the Docker image with the specified tag and Dockerfile
-    docker build -t badgerati/pode:$tTag -f $File .
+    docker build -t badgerati/pode:$Tag -f $File .
     if (!$?) {
         throw "docker build failed for $($Tag)"
     }

--- a/src/Listener/Pode.csproj
+++ b/src/Listener/Pode.csproj
@@ -1,7 +1,35 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0;net9.0;</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <NoWarn>$(NoWarn);SYSLIB0001</NoWarn>
     <LangVersion>7.3</LangVersion>
+  </PropertyGroup>
+
+   <PropertyGroup Condition="'$(NETCoreSdkVersion)' >= '3.1'">
+    <TargetFrameworks>$(TargetFrameworks);netcoreapp3.1</TargetFrameworks>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(NETCoreSdkVersion)' >= '5.0'">
+    <TargetFrameworks>$(TargetFrameworks);net5.0</TargetFrameworks>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(NETCoreSdkVersion)' >= '6.0'">
+    <TargetFrameworks>$(TargetFrameworks);net6.0</TargetFrameworks>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(NETCoreSdkVersion)' >= '7.0'">
+    <TargetFrameworks>$(TargetFrameworks);net7.0</TargetFrameworks>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(NETCoreSdkVersion)' >= '8.0'">
+    <TargetFrameworks>$(TargetFrameworks);net8.0</TargetFrameworks>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(NETCoreSdkVersion)' >= '9.0'">
+    <TargetFrameworks>$(TargetFrameworks);net9.0</TargetFrameworks>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(NETCoreSdkVersion)' >= '10.0'">
+    <TargetFrameworks>$(TargetFrameworks);net10.0</TargetFrameworks>
   </PropertyGroup>
 </Project>

--- a/src/Listener/Pode.csproj
+++ b/src/Listener/Pode.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0;net9.0;</TargetFrameworks>
     <NoWarn>$(NoWarn);SYSLIB0001</NoWarn>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>


### PR DESCRIPTION
 **Description**:
This update improves the build process by dynamically selecting the appropriate .NET versions to deliver binaries, . By automatically excluding unsupported .NET versions, the `build.ps1` script now ensures that only maintained versions are targeted for binary generation.

### Key Changes:
- Removing redundant part of code 
 
  
 
 