### PR TITLE
Fix OpenAPI Route Parameter Handling in Pode

### DIFF
--- a/src/Public/Routes.ps1
+++ b/src/Public/Routes.ps1
@@ -452,8 +452,8 @@ function Add-PodeRoute {
             })
 
 
-        if ($PodeContext.Server.OpenAPI.Routes -notcontains $OpenApiPath ) {
-            $PodeContext.Server.OpenAPI.Routes += $OpenApiPath
+        if ($PodeContext.Server.OpenAPI.Routes -notcontains $Path ) {
+            $PodeContext.Server.OpenAPI.Routes += $Path
         }
 
 

--- a/tests/integration/specs/OpenApi-TuttiFrutti_3.0.3.json
+++ b/tests/integration/specs/OpenApi-TuttiFrutti_3.0.3.json
@@ -1,1457 +1,2886 @@
 {
-    "openapi": "3.0.3",
-    "info": {
-        "license": {
-            "name": "Apache 2.0",
-            "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
-        },
-        "title": "Swagger Petstore - OpenAPI 3.0",
-        "version": "1.0.17",
-        "description": "This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about Swagger at [http://swagger.io](http://swagger.io).\r\nIn the third iteration of the pet store, we've switched to the design first approach!\r\nYou can now help us improve the API whether it's by making changes to the definition itself or to the code.\r\nThat way, with time, we can improve the API in general, and expose some of the new features in OAS3.\r\n\r\nSome useful links:\r\n- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)\r\n- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)",
-        "termsOfService": "http://swagger.io/terms/",
-        "contact": {
-            "name": "API Support",
-            "email": "apiteam@swagger.io"
-        }
+  "openapi": "3.0.3",
+  "info": {
+    "license": {
+      "name": "Apache 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "externalDocs": {
+    "title": "Swagger Petstore - OpenAPI 3.0",
+    "version": "1.0.17",
+    "description": "This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about Swagger at [http://swagger.io](http://swagger.io).\nIn the third iteration of the pet store, we've switched to the design first approach!\nYou can now help us improve the API whether it's by making changes to the definition itself or to the code.\nThat way, with time, we can improve the API in general, and expose some of the new features in OAS3.\n\nSome useful links:\n- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)\n- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)",
+    "termsOfService": "http://swagger.io/terms/",
+    "contact": {
+      "name": "API Support",
+      "email": "apiteam@swagger.io"
+    }
+  },
+  "externalDocs": {
+    "description": "Find out more about Swagger",
+    "url": "http://swagger.io"
+  },
+  "servers": [
+    {
+      "url": "/api/v3",
+      "description": "default endpoint"
+    }
+  ],
+  "tags": [
+    {
+      "name": "user",
+      "description": "Operations about user",
+      "externalDocs": {
         "description": "Find out more about Swagger",
         "url": "http://swagger.io"
+      }
     },
-    "servers": [
-        {
-            "url": "/api/v3",
-            "description": "default endpoint"
-        }
-    ],
-    "tags": [
-        {
-            "name": "user",
-            "description": "Operations about user",
-            "externalDocs": {
-                "description": "Find out more about Swagger",
-                "url": "http://swagger.io"
-            }
-        },
-        {
-            "name": "store",
-            "description": "Access to Petstore orders",
-            "externalDocs": {
-                "description": "Find out more about Swagger",
-                "url": "http://swagger.io"
-            }
-        },
-        {
-            "name": "pet",
-            "description": "Everything about your Pets",
-            "externalDocs": {
-                "description": "Find out more about Swagger",
-                "url": "http://swagger.io"
-            }
-        }
-    ],
-    "paths": {
-        "/pet": {
-            "post": {
-                "tags": [
-                    "pet"
-                ],
-                "summary": "Add a new pet to the store",
-                "description": "Add a new pet to the store",
-                "operationId": "addPet",
-                "requestBody": {
-                    "$ref": "#/components/requestBodies/PetBodySchema"
-                },
-                "security": [
-                    {
-                        "Login-OAuth2": [
-                            "write"
-                        ]
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Pet"
-                                }
-                            },
-                            "application/xml": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Pet"
-                                }
-                            }
-                        }
-                    },
-                    "405": {
-                        "description": "Validation exception",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "properties": {
-                                        "result": {
-                                            "type": "string"
-                                        },
-                                        "message": {
-                                            "type": "string"
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "put": {
-                "tags": [
-                    "pet"
-                ],
-                "summary": "Update an existing pet",
-                "description": "Update an existing pet by Id",
-                "operationId": "updatePet",
-                "requestBody": {
-                    "$ref": "#/components/requestBodies/PetBodySchema"
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Pet"
-                                }
-                            },
-                            "application/xml": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Pet"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Invalid ID supplied"
-                    },
-                    "404": {
-                        "description": "Pet not found"
-                    },
-                    "405": {
-                        "description": "Validation exception",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "properties": {
-                                        "result": {
-                                            "type": "string"
-                                        },
-                                        "message": {
-                                            "type": "string"
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/petcallback": {
-            "post": {
-                "tags": [
-                    "pet"
-                ],
-                "summary": "Add a new pet to the store",
-                "description": "Add a new pet to the store",
-                "operationId": "addPetcallback",
-                "requestBody": {
-                    "$ref": "#/components/requestBodies/PetBodySchema"
-                },
-                "callbacks": {
-                    "test": {
-                        "'{$request.body#/id}'": {
-                            "post": {
-                                "requestBody": {
-                                    "content": {
-                                        "\"*/*\"": {
-                                            "schema": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                },
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful operation",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "type": "array",
-                                                    "items": {
-                                                        "$ref": "#/components/schemas/Pet"
-                                                    }
-                                                }
-                                            },
-                                            "application/xml": {
-                                                "schema": {
-                                                    "type": "array",
-                                                    "items": {
-                                                        "$ref": "#/components/schemas/Pet"
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    },
-                                    "400": {
-                                        "description": "Invalid ID supplied"
-                                    },
-                                    "404": {
-                                        "description": "Pet not found"
-                                    },
-                                    "default": {
-                                        "description": "Something is wrong"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "Login-OAuth2": [
-                            "write"
-                        ]
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Pet"
-                                }
-                            },
-                            "application/xml": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Pet"
-                                }
-                            }
-                        }
-                    },
-                    "405": {
-                        "description": "Validation exception",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "properties": {
-                                        "result": {
-                                            "type": "string"
-                                        },
-                                        "message": {
-                                            "type": "string"
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/petcallbackReference": {
-            "post": {
-                "tags": [
-                    "pet"
-                ],
-                "summary": "Add a new pet to the store",
-                "description": "Add a new pet to the store",
-                "operationId": "petcallbackReference",
-                "requestBody": {
-                    "$ref": "#/components/requestBodies/PetBodySchema"
-                },
-                "callbacks": {
-                    "test1": {
-                        "$ref": "#/components/callbacks/test"
-                    }
-                },
-                "security": [
-                    {
-                        "Login-OAuth2": [
-                            "write"
-                        ]
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Pet"
-                                }
-                            },
-                            "application/xml": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Pet"
-                                }
-                            }
-                        }
-                    },
-                    "405": {
-                        "description": "Validation exception",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "properties": {
-                                        "result": {
-                                            "type": "string"
-                                        },
-                                        "message": {
-                                            "type": "string"
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/pet/findByStatus": {
-            "get": {
-                "tags": [
-                    "pet"
-                ],
-                "summary": "Finds Pets by status",
-                "description": "Multiple status values can be provided with comma separated strings",
-                "operationId": "findPetsByStatus",
-                "parameters": [
-                    {
-                        "description": "Status values that need to be considered for filter",
-                        "schema": {
-                            "type": "string",
-                            "default": "available",
-                            "enum": [
-                                "available",
-                                "pending",
-                                "sold"
-                            ]
-                        },
-                        "name": "status",
-                        "in": "query"
-                    }
-                ],
-                "security": [
-                    {},
-                    {
-                        "Login-OAuth2": [
-                            "read"
-                        ]
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Pet"
-                                    }
-                                }
-                            },
-                            "application/xml": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Pet"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Invalid status value"
-                    }
-                }
-            }
-        },
-        "/pet/findByTag": {
-            "get": {
-                "tags": [
-                    "pet"
-                ],
-                "summary": "Finds Pets by tags",
-                "description": "Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.",
-                "operationId": "findPetsByTags",
-                "parameters": [
-                    {
-                        "explode": true,
-                        "description": "Tags to filter by",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        },
-                        "name": "tag",
-                        "in": "query"
-                    }
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    },
-                    {
-                        "Login-OAuth2": [
-                            "read"
-                        ]
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Pet"
-                                }
-                            },
-                            "application/xml": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Pet"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Invalid status value"
-                    },
-                    "default": {
-                        "description": "Unexpected error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ErrorModel"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/store/inventory": {
-            "get": {
-                "tags": [
-                    "store"
-                ],
-                "summary": "Returns pet inventories by status",
-                "description": "Returns a map of status codes to quantities",
-                "operationId": "getInventory",
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "properties": {
-                                        "none": {
-                                            "type": "string"
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/store/order": {
-            "post": {
-                "deprecated": true,
-                "tags": [
-                    "store"
-                ],
-                "summary": "Place an order for a pet",
-                "description": "Place a new order in the store",
-                "operationId": "placeOrder",
-                "requestBody": {
-                    "content": {
-                        "application/xml": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Order"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Order"
-                            }
-                        },
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Order"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Order"
-                                }
-                            },
-                            "application/xml": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Order"
-                                }
-                            }
-                        }
-                    },
-                    "405": {
-                        "description": "Invalid Input"
-                    }
-                }
-            }
-        },
-        "/user": {
-            "post": {
-                "tags": [
-                    "user"
-                ],
-                "summary": "Create user.",
-                "description": "This can only be done by the logged in user.",
-                "operationId": "createUser",
-                "requestBody": {
-                    "content": {
-                        "application/xml": {
-                            "schema": {
-                                "$ref": "#/components/schemas/User"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/User"
-                            }
-                        },
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/User"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "$ref": "#/components/responses/UserOpSuccess"
-                    },
-                    "405": {
-                        "description": "Invalid Input",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "properties": {
-                                        "result": {
-                                            "type": "string"
-                                        },
-                                        "message": {
-                                            "type": "string"
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/user/createWithList": {
-            "post": {
-                "tags": [
-                    "user"
-                ],
-                "summary": "Creates list of users with given input array.",
-                "description": "Creates list of users with given input array.",
-                "operationId": "createUsersWithListInput",
-                "requestBody": {
-                    "content": {
-                        "application/xml": {
-                            "schema": {
-                                "$ref": "#/components/schemas/User"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/User"
-                            }
-                        },
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/User"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "$ref": "#/components/responses/UserOpSuccess"
-                    },
-                    "405": {
-                        "description": "Invalid Input"
-                    }
-                }
-            }
-        },
-        "/user/login": {
-            "get": {
-                "tags": [
-                    "user"
-                ],
-                "summary": "Logs user into the system.",
-                "description": "Logs user into the system.",
-                "operationId": "loginUser",
-                "parameters": [
-                    {
-                        "description": "The user name for login",
-                        "schema": {
-                            "type": "string"
-                        },
-                        "name": "username",
-                        "in": "query"
-                    },
-                    {
-                        "description": "The password for login in clear text",
-                        "schema": {
-                            "type": "string",
-                            "format": "password"
-                        },
-                        "name": "password",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "headers": {
-                            "X-Rate-Limit": {
-                                "$ref": "#/components/headers/X-Rate-Limit"
-                            },
-                            "X-Expires-After": {
-                                "$ref": "#/components/headers/X-Expires-After"
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "application/xml": {
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Invalid username/password supplied"
-                    }
-                }
-            }
-        },
-        "/user/logout": {
-            "get": {
-                "tags": [
-                    "user"
-                ],
-                "summary": "Logs out current logged in user session.",
-                "description": "Logs out current logged in user session.",
-                "operationId": "logoutUser",
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    }
-                }
-            }
-        },
-        "/stores/order/{orderId}": {
-            "get": {
-                "tags": [
-                    "store"
-                ],
-                "summary": "Find purchase order by ID",
-                "description": "For valid response try integer IDs with value <= 5 or > 10. Other values will generate exceptions.",
-                "operationId": "getOrderExternalById",
-                "parameters": [
-                    {
-                        "description": "ID of order that needs to be fetched",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64"
-                        },
-                        "name": "orderId",
-                        "in": "path"
-                    }
-                ],
-                "servers": [
-                    {
-                        "url": "http://ext.server.com/api/v12",
-                        "description": "ext test server"
-                    },
-                    {
-                        "url": "http://ext13.server.com/api/v12",
-                        "description": "ext test server 13"
-                    },
-                    {
-                        "url": "http://ext14.server.com/api/v12",
-                        "description": "ext test server 14"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "content": {
-                            "application/xml": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Order"
-                                }
-                            },
-                            "application/x-www-form-urlencoded": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Order"
-                                }
-                            },
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Order"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Invalid ID supplied"
-                    },
-                    "404": {
-                        "description": "Order not found"
-                    }
-                }
-            }
-        }
+    {
+      "name": "store",
+      "description": "Access to Petstore orders",
+      "externalDocs": {
+        "description": "Find out more about Swagger",
+        "url": "http://swagger.io"
+      }
     },
-    "components": {
-        "schemas": {
-            "Address": {
-                "type": "object",
-                "description": "Shipping Address",
-                "xml": {
-                    "name": "address"
-                },
-                "properties": {
-                    "street": {
-                        "type": "string",
-                        "example": "437 Lytton"
-                    },
-                    "city": {
-                        "type": "string",
-                        "example": "Palo Alto"
-                    },
-                    "state": {
-                        "type": "string",
-                        "example": "CA"
-                    },
-                    "zip": {
-                        "type": "string",
-                        "example": "94031"
-                    }
-                },
-                "required": [
-                    "street",
-                    "city",
-                    "state",
-                    "zip"
-                ]
+    {
+      "name": "pet",
+      "description": "Everything about your Pets",
+      "externalDocs": {
+        "description": "Find out more about Swagger",
+        "url": "http://swagger.io"
+      }
+    }
+  ],
+  "paths": {
+    "/private/pat/{petId}": {
+      "post": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Updates a pet in the store with form data",
+        "parameters": [
+          {
+            "name": "petId",
+            "schema": {
+              "type": "string"
             },
-            "Order": {
-                "type": "object",
-                "xml": {
-                    "name": "order"
-                },
-                "properties": {
-                    "id": {
-                        "type": "integer",
-                        "readOnly": true,
-                        "example": 10,
-                        "format": "int64"
-                    },
-                    "petId": {
-                        "type": "integer",
-                        "example": 198772,
-                        "format": "int64"
-                    },
-                    "quantity": {
-                        "type": "integer",
-                        "example": 7,
-                        "format": "int32"
-                    },
-                    "shipDate": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "status": {
-                        "type": "string",
-                        "description": "Order Status",
-                        "example": "approved",
-                        "enum": [
-                            "placed",
-                            "approved",
-                            "delivered"
-                        ]
-                    },
-                    "complete": {
-                        "type": "boolean"
-                    },
-                    "Address": {
-                        "$ref": "#/components/schemas/Address"
-                    }
-                },
-                "additionalProperties": {
-                    "type": "string"
+            "description": "ID of pet that needs to be updated",
+            "required": true,
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              },
+              "examples": {
+                "user": {
+                  "summary": "User Example",
+                  "externalValue": "http://foo.bar/examples/user-example.json"
                 }
+              }
             },
-            "Category": {
-                "type": "object",
-                "xml": {
-                    "name": "category"
-                },
-                "properties": {
-                    "id": {
-                        "type": "integer",
-                        "example": 1,
-                        "format": "int64"
-                    },
-                    "name": {
-                        "type": "string",
-                        "example": "Dogs"
-                    }
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              },
+              "examples": {
+                "user": {
+                  "summary": "User Example in XML",
+                  "externalValue": "http://foo.bar/examples/user-example.xml"
                 }
+              }
             },
-            "User": {
-                "type": "object",
-                "xml": {
-                    "name": "user"
-                },
-                "properties": {
-                    "id": {
-                        "type": "integer",
-                        "readOnly": true,
-                        "example": 1,
-                        "format": "int64"
-                    },
-                    "username": {
-                        "type": "string",
-                        "example": "theUser"
-                    },
-                    "firstName": {
-                        "type": "string",
-                        "example": "John"
-                    },
-                    "lastName": {
-                        "type": "string",
-                        "example": "James"
-                    },
-                    "email": {
-                        "type": "string",
-                        "example": "john@email.com",
-                        "format": "email"
-                    },
-                    "password": {
-                        "type": "string",
-                        "example": "12345",
-                        "format": "password"
-                    },
-                    "phone": {
-                        "type": "string",
-                        "example": "12345"
-                    },
-                    "userStatus": {
-                        "type": "integer",
-                        "description": "User Status",
-                        "example": 1,
-                        "format": "int32"
-                    }
-                },
-                "required": [
-                    "username",
-                    "password"
-                ]
-            },
-            "aaaaa": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/Address"
-                    },
-                    {
-                        "$ref": "#/components/schemas/User"
-                    }
-                ]
-            },
-            "Tag": {
-                "type": "object",
-                "xml": {
-                    "name": "tag"
-                },
-                "properties": {
-                    "id": {
-                        "type": "integer",
-                        "format": "int64"
-                    },
-                    "name": {
-                        "type": "string"
-                    }
+            "text/plain": {
+              "examples": {
+                "user": {
+                  "summary": "User Example in Plain text",
+                  "externalValue": "http://foo.bar/examples/user-example.txt"
                 }
+              }
             },
-            "Pet": {
-                "type": "object",
-                "xml": {
-                    "name": "pet"
-                },
-                "properties": {
-                    "id": {
-                        "type": "integer",
-                        "readOnly": true,
-                        "example": [
-                            10,
-                            2,
-                            4
-                        ],
-                        "format": "int64"
-                    },
-                    "name": {
-                        "type": "string",
-                        "example": "doggie"
-                    },
-                    "category": {
-                        "$ref": "#/components/schemas/Category"
-                    },
-                    "petType": {
-                        "type": "string",
-                        "example": "dog"
-                    },
-                    "photoUrls": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "tags": {
-                        "$ref": "#/components/schemas/Tag"
-                    },
-                    "status": {
-                        "type": "string",
-                        "description": "pet status in the store",
-                        "enum": [
-                            "available",
-                            "pending",
-                            "sold"
-                        ]
-                    }
-                },
-                "required": [
-                    "name",
-                    "petType"
-                ]
-            },
-            "NewCat": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/Pet"
-                    },
-                    {
-                        "type": "object",
-                        "properties": {
-                            "huntingSkill": {
-                                "type": "string",
-                                "description": "The measured skill for hunting",
-                                "enum": [
-                                    "clueless",
-                                    "lazy",
-                                    "adventurous",
-                                    "aggressive"
-                                ]
-                            }
-                        }
-                    }
-                ]
-            },
-            "XmlPrefixAndNamespace": {
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "integer",
-                        "xml": {
-                            "attribute": true
-                        },
-                        "format": "int32"
-                    },
-                    "name": {
-                        "type": "string",
-                        "xml": {
-                            "namespace": "http://example.com/schema/sample",
-                            "prefix": "sample"
-                        }
-                    }
+            "\"*/*\"": {
+              "examples": {
+                "user": {
+                  "summary": "User example in other forma",
+                  "externalValue": "http://foo.bar/examples/user-example.whatever"
                 }
-            },
-            "animals": {
-                "type": "array",
-                "items": {
-                    "type": "string",
-                    "xml": {
-                        "name": "animal"
-                    }
-                }
-            },
-            "AnimalsNoAliens": {
-                "type": "array",
-                "xml": {
-                    "name": "aliens"
-                },
-                "items": {
-                    "type": "string",
-                    "xml": {
-                        "name": "animal"
-                    }
-                }
-            },
-            "WrappedAnimals": {
-                "type": "array",
-                "xml": {
-                    "wrapped": true
-                },
-                "items": {
-                    "type": "string"
-                }
-            },
-            "WrappedAnimal": {
-                "type": "array",
-                "xml": {
-                    "wrapped": true
-                },
-                "items": {
-                    "type": "string",
-                    "xml": {
-                        "name": "animal"
-                    }
-                }
-            },
-            "WrappedAliens": {
-                "type": "array",
-                "xml": {
-                    "name": "aliens",
-                    "wrapped": true
-                },
-                "items": {
-                    "type": "string",
-                    "xml": {
-                        "name": "animal"
-                    }
-                }
-            },
-            "WrappedAliensWithItems": {
-                "type": "array",
-                "xml": {
-                    "name": "aliens",
-                    "wrapped": true
-                },
-                "items": {
-                    "type": "string"
-                }
-            },
-            "StructPart": {
-                "type": "object",
-                "properties": {
-                    "name": {
-                        "type": "string"
-                    },
-                    "type": {
-                        "type": "string"
-                    },
-                    "children": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/StructPart"
-                        }
-                    }
-                }
-            },
-            "Pet2": {
-                "type": "object",
-                "properties": {
-                    "name": {
-                        "type": "string"
-                    },
-                    "petType": {
-                        "type": "string"
-                    }
-                },
-                "discriminator": {
-                    "propertyName": "petType"
-                }
-            },
-            "Cat2": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/Pet2"
-                    },
-                    {
-                        "type": "object",
-                        "properties": {
-                            "huntingSkill": {
-                                "type": "string",
-                                "description": "The measured skill for hunting",
-                                "default": "lazy",
-                                "enum": [
-                                    "clueless",
-                                    "lazy",
-                                    "adventurous",
-                                    "aggressive"
-                                ]
-                            }
-                        },
-                        "required": [
-                            "huntingSkill"
-                        ]
-                    }
-                ],
-                "description": "A representation of a cat. Note that Cat will be used as the discriminator value."
-            },
-            "Dog2": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/Pet2"
-                    },
-                    {
-                        "type": "object",
-                        "properties": {
-                            "packSize": {
-                                "type": "integer",
-                                "description": "the size of the pack the dog is from",
-                                "minimum": 0,
-                                "format": "int32"
-                            }
-                        },
-                        "required": [
-                            "packSize"
-                        ]
-                    }
-                ],
-                "description": "A representation of a dog. Note that Dog will be used as the discriminator value."
-            },
-            "ExtendedErrorModel": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/Pet"
-                    },
-                    {
-                        "type": "object",
-                        "properties": {
-                            "rootCause": {
-                                "type": "string"
-                            }
-                        },
-                        "required": [
-                            "rootCause"
-                        ]
-                    }
-                ]
-            },
-            "Cat": {
-                "type": "object",
-                "description": "Type of cat",
-                "properties": {
-                    "breed": {
-                        "type": "string",
-                        "description": "Type of Breed",
-                        "enum": [
-                            "Abyssinian",
-                            "Balinese-Javanese",
-                            "Burmese",
-                            "British Shorthair"
-                        ]
-                    }
-                },
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/Pet"
-                    },
-                    {
-                        "type": "object",
-                        "properties": {
-                            "huntingSkill": {
-                                "type": "string",
-                                "description": "The measured skill for hunting",
-                                "enum": [
-                                    "clueless",
-                                    "lazy",
-                                    "adventurous",
-                                    "aggressive"
-                                ]
-                            }
-                        }
-                    }
-                ]
-            },
-            "Dog": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/Pet"
-                    },
-                    {
-                        "type": "object",
-                        "properties": {
-                            "breed": {
-                                "type": "string",
-                                "description": "Type of Breed",
-                                "enum": [
-                                    "Dingo",
-                                    "Husky",
-                                    "Retriever",
-                                    "Shepherd"
-                                ]
-                            },
-                            "bark": {
-                                "type": "boolean"
-                            }
-                        }
-                    }
-                ]
-            },
-            "Pets": {
-                "oneOf": [
-                    {
-                        "$ref": "#/components/schemas/Cat"
-                    },
-                    {
-                        "$ref": "#/components/schemas/Dog"
-                    }
-                ],
-                "discriminator": {
-                    "propertyName": "petType"
-                }
-            },
-            "ApiResponse": {
-                "type": "object",
-                "xml": {
-                    "name": "##default"
-                },
-                "properties": {
-                    "code": {
-                        "type": "integer",
-                        "format": "int32"
-                    },
-                    "type": {
-                        "type": "string",
-                        "example": "doggie"
-                    },
-                    "message": {
-                        "type": "string"
-                    }
-                }
-            },
-            "ErrorModel": {
-                "type": "object",
-                "properties": {
-                    "message": {
-                        "type": "string"
-                    },
-                    "code": {
-                        "type": "integer",
-                        "format": "int32"
-                    }
-                }
+              }
             }
+          },
+          "description": "user to add to the system"
         },
         "responses": {
-            "UserOpSuccess": {
-                "description": "Successful operation",
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/User"
-                        }
-                    },
-                    "application/xml": {
-                        "schema": {
-                            "$ref": "#/components/schemas/User"
-                        }
-                    }
-                }
+          "200": {
+            "description": "Pet updated.",
+            "content": {
+              "application/json": {},
+              "application/xml": {}
             }
-        },
-        "parameters": {
-            "PetIdParam": {
-                "description": "ID of the pet",
-                "required": true,
-                "schema": {
-                    "type": "integer",
-                    "format": "int64"
-                },
-                "name": "petId",
-                "in": "path"
+          },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": {
+              "application/json": {},
+              "application/xml": {}
             }
-        },
-        "examples": {
-            "frog-example": {
-                "summary": "An example of a frog with a cat's name",
-                "value": {
-                    "name": "Jaguar",
-                    "gender": "Male",
-                    "color": "Lion",
-                    "breed": "Mantella Baroni",
-                    "petType": "Panthera"
-                }
-            }
-        },
-        "requestBodies": {
-            "PetBodySchema": {
-                "content": {
-                    "application/xml": {
-                        "schema": {
-                            "$ref": "#/components/schemas/Pets"
-                        }
-                    },
-                    "application/x-www-form-urlencoded": {
-                        "schema": {
-                            "$ref": "#/components/schemas/Pets"
-                        }
-                    },
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/Pets"
-                        }
-                    }
-                },
-                "required": true,
-                "description": "Pet in the store"
-            }
-        },
-        "headers": {
-            "X-Rate-Limit": {
-                "schema": {
-                    "type": "integer",
-                    "format": "int32"
-                }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Updates a pet in the store with form data",
+        "parameters": [
+          {
+            "name": "petId",
+            "schema": {
+              "type": "string"
             },
-            "X-Expires-After": {
-                "schema": {
-                    "type": "string",
-                    "format": "date-time"
+            "description": "ID of pet that needs to be updated",
+            "required": true,
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              },
+              "examples": {
+                "user": {
+                  "summary": "User Example",
+                  "externalValue": "http://foo.bar/examples/user-example.json"
                 }
+              }
+            },
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              },
+              "examples": {
+                "user": {
+                  "summary": "User Example in XML",
+                  "externalValue": "http://foo.bar/examples/user-example.xml"
+                }
+              }
+            },
+            "text/plain": {
+              "examples": {
+                "user": {
+                  "summary": "User Example in Plain text",
+                  "externalValue": "http://foo.bar/examples/user-example.txt"
+                }
+              }
+            },
+            "\"*/*\"": {
+              "examples": {
+                "user": {
+                  "summary": "User example in other forma",
+                  "externalValue": "http://foo.bar/examples/user-example.whatever"
+                }
+              }
             }
+          },
+          "description": "user to add to the system"
         },
-        "links": {
-            "address": {
-                "operationId": "getUserByName",
-                "parameters": {
-                    "username": "$request.path.username"
-                }
+        "responses": {
+          "200": {
+            "description": "Pet updated.",
+            "content": {
+              "application/json": {},
+              "application/xml": {}
             }
+          },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": {
+              "application/json": {},
+              "application/xml": {}
+            }
+          }
+        }
+      }
+    },
+    "/private/paet/{petId}": {
+      "put": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Updates a pet in the store with form data",
+        "operationId": "updatepaet",
+        "parameters": [
+          {
+            "name": "petId",
+            "examples": {
+              "user": {
+                "summary": "User Example",
+                "value": "http://foo.bar/examples/user-example.json"
+              },
+              "user1": {
+                "summary": "User Example in XML",
+                "value": "http://foo.bar/examples/user-example.xml"
+              },
+              "user2": {
+                "summary": "User Example in Plain text",
+                "value": "http://foo.bar/examples/user-example.txt"
+              },
+              "user3": {
+                "summary": "User example in other forma",
+                "value": "http://foo.bar/examples/user-example.whatever"
+              }
+            },
+            "description": "ID of pet that needs to be updated",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "Updated name of the pet"
+                  },
+                  "status": {
+                    "type": "string",
+                    "description": "Updated status of the pet"
+                  }
+                },
+                "required": [
+                  "status"
+                ]
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Pet updated.",
+            "content": {
+              "application/json": {},
+              "application/xml": {}
+            }
+          },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": {
+              "application/json": {},
+              "application/xml": {}
+            }
+          }
+        }
+      }
+    },
+    "/private/paet2/{petId}": {
+      "put": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Updates a pet in the store with form data",
+        "operationId": "updatepaet2",
+        "parameters": [
+          {
+            "name": "petId",
+            "schema": {
+              "type": "string"
+            },
+            "description": "ID of pet that needs to be updated",
+            "required": true,
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "text/plain": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "description": "user to add to the system"
+        },
+        "responses": {
+          "200": {
+            "description": "Pet updated.",
+            "content": {
+              "application/json": {},
+              "application/xml": {}
+            }
+          },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": {
+              "application/json": {},
+              "application/xml": {}
+            }
+          }
+        }
+      }
+    },
+    "/private/paet3/{petId}": {
+      "put": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Updates a pet in the store with form data",
+        "operationId": "updatepaet3",
+        "parameters": [
+          {
+            "name": "petId",
+            "schema": {
+              "type": "string"
+            },
+            "description": "ID of pet that needs to be updated",
+            "required": true,
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NewCat"
+              },
+              "examples": {
+                "cat": {
+                  "summary": "An example of a cat",
+                  "value": {
+                    "color": "White",
+                    "name": "Fluffy",
+                    "gender": "male",
+                    "breed": "Persian",
+                    "petType": "Cat"
+                  }
+                },
+                "dog": {
+                  "summary": "An example of a dog with a cat's name",
+                  "value": {
+                    "color": "Black",
+                    "name": "Puma",
+                    "gender": "Female",
+                    "breed": "Mixed",
+                    "petType": "Dog"
+                  }
+                },
+                "frog-example": {
+                  "$ref": "#/components/examples/frog-example"
+                }
+              }
+            }
+          },
+          "description": "user to add to the system"
+        },
+        "responses": {
+          "200": {
+            "description": "Pet updated.",
+            "content": {
+              "application/json": {},
+              "application/xml": {}
+            }
+          },
+          "4XX": {
+            "description": "Method Not Allowed",
+            "content": {
+              "application/json": {},
+              "application/xml": {}
+            }
+          }
+        }
+      }
+    },
+    "/private/paet4/{petId}": {
+      "put": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Updates a pet in the store with form data",
+        "operationId": "updatepaet4",
+        "parameters": [
+          {
+            "name": "petId",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "ID of pet that needs to be updated",
+            "required": true,
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Pet"
+              },
+              "examples": {
+                "cat": {
+                  "summary": "An example of a cat",
+                  "value": {
+                    "color": "White",
+                    "name": "Fluffy",
+                    "gender": "male",
+                    "breed": "Persian",
+                    "petType": "Cat"
+                  }
+                },
+                "dog": {
+                  "summary": "An example of a dog with a cat's name",
+                  "value": {
+                    "color": "Black",
+                    "name": "Puma",
+                    "gender": "Female",
+                    "breed": "Mixed",
+                    "petType": "Dog"
+                  }
+                },
+                "frog-example": {
+                  "$ref": "#/components/examples/frog-example"
+                }
+              }
+            }
+          },
+          "description": "user to add to the system"
+        },
+        "responses": {
+          "200": {
+            "description": "Pet updated.",
+            "content": {
+              "application/json": {},
+              "application/xml": {}
+            }
+          },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": {
+              "application/json": {},
+              "application/xml": {}
+            }
+          }
+        }
+      }
+    },
+    "/pet": {
+      "post": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Add a new pet to the store",
+        "description": "Add a new pet to the store",
+        "operationId": "addPet",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/PetBodySchema"
+        },
+        "security": [
+          {
+            "Login-OAuth2": [
+              "write"
+            ]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Validation exception",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "result": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Update an existing pet",
+        "description": "Update an existing pet by Id",
+        "operationId": "updatePet",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/PetBodySchema"
+        },
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Pet not found"
+          },
+          "405": {
+            "description": "Validation exception",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "result": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/petcallback": {
+      "post": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Add a new pet to the store",
+        "description": "Add a new pet to the store",
+        "operationId": "addPetcallback",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/PetBodySchema"
         },
         "callbacks": {
-            "test": {
-                "'{$request.body#/id}'": {
-                    "post": {
-                        "requestBody": {
-                            "content": {
-                                "\"*/*\"": {
-                                    "schema": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "responses": {
-                            "200": {
-                                "description": "Successful operation",
-                                "content": {
-                                    "application/json": {
-                                        "schema": {
-                                            "type": "array",
-                                            "items": {
-                                                "$ref": "#/components/schemas/Pet"
-                                            }
-                                        }
-                                    },
-                                    "application/xml": {
-                                        "schema": {
-                                            "type": "array",
-                                            "items": {
-                                                "$ref": "#/components/schemas/Pet"
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            "400": {
-                                "description": "Invalid ID supplied"
-                            },
-                            "404": {
-                                "description": "Pet not found"
-                            },
-                            "default": {
-                                "description": "Something is wrong"
-                            }
-                        }
+          "test": {
+            "'{$request.body#/id}'": {
+              "post": {
+                "requestBody": {
+                  "content": {
+                    "\"*/*\"": {
+                      "schema": {
+                        "type": "string"
+                      }
                     }
+                  }
+                },
+                "responses": {
+                  "200": {
+                    "description": "Successful operation",
+                    "content": {
+                      "application/json": {
+                        "schema": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/Pet"
+                          }
+                        }
+                      },
+                      "application/xml": {
+                        "schema": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/Pet"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "400": {
+                    "description": "Invalid ID supplied"
+                  },
+                  "404": {
+                    "description": "Pet not found"
+                  },
+                  "default": {
+                    "description": "Something is wrong"
+                  }
                 }
+              }
             }
+          }
         },
-        "securitySchemes": {
-            "LoginApiKey": {
-                "type": "apiKey",
-                "in": "header",
-                "name": "X-API-KEY"
-            },
-            "Login": {
-                "type": "http",
-                "scheme": "basic"
-            },
-            "Jwt": {
-                "type": "http",
-                "scheme": "bearer"
-            },
-            "api_key": {
-                "type": "apiKey",
-                "in": "header",
-                "name": "api_key"
-            },
-            "Login-OAuth2": {
-                "type": "oauth2",
-                "flows": {
-                    "authorizationCode": {
-                        "tokenUrl": "http://example.org/api/oauth/token",
-                        "authorizationUrl": "http://example.org/api/oauth/dialog",
-                        "scopes": {
-                            "read": "Grant read-only access to all your data except for the account and user info",
-                            "write": "Grant write-only access to all your data except for the account and user info"
-                        }
-                    }
+        "security": [
+          {
+            "Login-OAuth2": [
+              "write"
+            ]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
                 }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
             }
+          },
+          "405": {
+            "description": "Validation exception",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "result": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
         }
+      }
+    },
+    "/petcallbackReference": {
+      "post": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Add a new pet to the store",
+        "description": "Add a new pet to the store",
+        "operationId": "petcallbackReference",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/PetBodySchema"
+        },
+        "callbacks": {
+          "test1": {
+            "$ref": "#/components/callbacks/test"
+          }
+        },
+        "security": [
+          {
+            "Login-OAuth2": [
+              "write"
+            ]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Validation exception",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "result": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pet/findByStatus": {
+      "get": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Finds Pets by status",
+        "description": "Multiple status values can be provided with comma separated strings",
+        "operationId": "findPetsByStatus",
+        "parameters": [
+          {
+            "name": "status",
+            "schema": {
+              "type": "string",
+              "default": "available",
+              "enum": [
+                "available",
+                "pending",
+                "sold"
+              ]
+            },
+            "description": "Status values that need to be considered for filter",
+            "in": "query"
+          }
+        ],
+        "security": [
+          {},
+          {
+            "Login-OAuth2": [
+              "read"
+            ]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Pet"
+                  }
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Pet"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid status value"
+          }
+        }
+      }
+    },
+    "/pet/findByTag": {
+      "get": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Finds Pets by tags",
+        "description": "Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.",
+        "operationId": "findPetsByTags",
+        "parameters": [
+          {
+            "name": "tag",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "description": "Tags to filter by",
+            "explode": true,
+            "in": "query"
+          }
+        ],
+        "security": [
+          {
+            "api_key": []
+          },
+          {
+            "Login-OAuth2": [
+              "read"
+            ]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid status value"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pet/{petId}": {
+      "get": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Find pet by ID",
+        "description": "Returns a single pet.",
+        "operationId": "getPetById",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PetIdParam"
+          }
+        ],
+        "security": [
+          {
+            "Login-OAuth2": [
+              "read"
+            ]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Pet not found"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Updates a pet in the store",
+        "description": "Updates a pet in the store with form data",
+        "operationId": "updatePetWithForm",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PetIdParam"
+          },
+          {
+            "name": "name",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Name of pet that needs to be updated",
+            "in": "query"
+          },
+          {
+            "name": "status",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Status of pet that needs to be updated",
+            "in": "query"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "properties": {
+                  "file": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "format": "binary"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Login-OAuth2": [
+              "write"
+            ]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful operation"
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "405": {
+            "description": "Invalid Input"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Deletes a pet",
+        "description": "Deletes a pet.",
+        "operationId": "deletePet",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PetIdParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful operation"
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Pet not found"
+          }
+        }
+      }
+    },
+    "/pet2/{petId}": {
+      "post": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Updates a pet in the store",
+        "description": "Updates a pet in the store with form data",
+        "operationId": "updatePet2WithForm",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PetIdParam"
+          },
+          {
+            "name": "name",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Name of pet that needs to be updated",
+            "in": "query"
+          },
+          {
+            "name": "status",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Status of pet that needs to be updated",
+            "in": "query"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "address": {
+                    "type": "object",
+                    "properties": {}
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Login-OAuth2": [
+              "write"
+            ]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful operation"
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "405": {
+            "description": "Invalid Input"
+          }
+        }
+      }
+    },
+    "/pet3/{petId}": {
+      "post": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Updates a pet in the store",
+        "description": "Updates a pet in the store with form data",
+        "operationId": "updatePet3WithForm",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PetIdParam"
+          },
+          {
+            "name": "name",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Name of pet that needs to be updated",
+            "in": "query"
+          },
+          {
+            "name": "status",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Status of pet that needs to be updated",
+            "in": "query"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "address": {
+                    "type": "object",
+                    "properties": {}
+                  },
+                  "children": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "addresses": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/Address"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Login-OAuth2": [
+              "write"
+            ]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful operation"
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "405": {
+            "description": "Invalid Input"
+          }
+        }
+      }
+    },
+    "/pet4/{petId}": {
+      "post": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Updates a pet in the store",
+        "description": "Updates a pet in the store with form data",
+        "operationId": "updatePet4WithForm",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PetIdParam"
+          },
+          {
+            "name": "name",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Name of pet that needs to be updated",
+            "in": "query"
+          },
+          {
+            "name": "status",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Status of pet that needs to be updated",
+            "in": "query"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "address": {
+                    "type": "object",
+                    "properties": {}
+                  },
+                  "historyMetadata": {
+                    "type": "object",
+                    "description": "metadata in XML format",
+                    "properties": {}
+                  },
+                  "profileImage": {
+                    "type": "string",
+                    "format": "binary"
+                  }
+                }
+              },
+              "encoding": {
+                "historyMetadata": {
+                  "contentType": "application/xml; charset=utf-8"
+                },
+                "profileImage": {
+                  "contentType": "image/png, image/jpeg",
+                  "headers": {
+                    "X-Rate-Limit-Limit": {
+                      "description": "The number of allowed requests in the current period",
+                      "schema": {
+                        "type": "integer",
+                        "default": 3,
+                        "enum": [
+                          1,
+                          2,
+                          3
+                        ],
+                        "maximum": 3
+                      }
+                    },
+                    "X-Rate-Limit-Reset": {
+                      "description": "The number of seconds left in the current period",
+                      "schema": {
+                        "type": "integer",
+                        "minimum": 2
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Login-OAuth2": [
+              "write"
+            ]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A simple string response",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "405": {
+            "description": "Invalid Input"
+          }
+        }
+      }
+    },
+    "/pet/{petId}/uploadImage2": {
+      "post": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Uploads an image",
+        "description": "Updates a pet in the store with a new image",
+        "operationId": "uploadFile2",
+        "parameters": [
+          {
+            "name": "petId",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "description": "ID of pet that needs to be updated",
+            "required": true,
+            "in": "path"
+          },
+          {
+            "name": "additionalMetadata",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Additional Metadata",
+            "in": "query"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "image": {
+                    "type": "string",
+                    "format": "binary"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "A simple string response",
+            "headers": {
+              "X-Rate-Limit-Limit": {
+                "description": "The number of allowed requests in the current period",
+                "schema": {
+                  "type": "integer"
+                }
+              },
+              "X-Rate-Limit-Remaining": {
+                "description": "The number of remaining requests in the current period",
+                "schema": {
+                  "type": "integer"
+                }
+              },
+              "X-Rate-Limit-Reset": {
+                "description": "The number of seconds left in the current period",
+                "schema": {
+                  "type": "integer",
+                  "maximum": 3
+                }
+              }
+            },
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "example": "whoa!"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pet/{petId}/uploadmultiImage": {
+      "post": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Uploads an image",
+        "description": "Updates a pet in the store with a new image",
+        "operationId": "uploadFilemulti",
+        "parameters": [
+          {
+            "name": "petId",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "description": "ID of pet that needs to be updated",
+            "required": true,
+            "in": "path"
+          },
+          {
+            "name": "additionalMetadata",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Additional Metadata",
+            "in": "query"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "orderId": {
+                    "type": "integer"
+                  },
+                  "image": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "405": {
+            "description": "Invalid Input"
+          }
+        }
+      }
+    },
+    "/pet/{petId}/uploadImageOctet": {
+      "post": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Uploads an image",
+        "description": "Updates a pet in the store with a new image",
+        "operationId": "uploadFileOctet",
+        "parameters": [
+          {
+            "name": "petId",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "description": "ID of pet that needs to be updated",
+            "required": true,
+            "in": "path"
+          },
+          {
+            "name": "additionalMetadata",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Additional Metadata",
+            "in": "query"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/octet-stream": {
+              "schema": {}
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "405": {
+            "description": "Invalid Input"
+          }
+        }
+      }
+    },
+    "/store/inventory": {
+      "get": {
+        "tags": [
+          "store"
+        ],
+        "summary": "Returns pet inventories by status",
+        "description": "Returns a map of status codes to quantities",
+        "operationId": "getInventory",
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "none": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/store/order": {
+      "post": {
+        "deprecated": true,
+        "tags": [
+          "store"
+        ],
+        "summary": "Place an order for a pet",
+        "description": "Place a new order in the store",
+        "operationId": "placeOrder",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Order"
+              }
+            },
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/Order"
+              }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Order"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Invalid Input"
+          }
+        }
+      }
+    },
+    "/store/order/{orderId}": {
+      "get": {
+        "tags": [
+          "store"
+        ],
+        "summary": "Find purchase order by ID",
+        "description": "For valid response try integer IDs with value <= 5 or > 10. Other values will generate exceptions.",
+        "operationId": "getOrderById",
+        "parameters": [
+          {
+            "name": "orderId",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "description": "ID of order that needs to be fetched",
+            "required": true,
+            "in": "path"
+          }
+        ],
+        "servers": [
+          {
+            "description": "ext test server",
+            "url": "http://ext.server.com/api/v12"
+          },
+          {
+            "description": "ext test server 13",
+            "url": "http://ext13.server.com/api/v12"
+          },
+          {
+            "description": "ext test server 14",
+            "url": "http://ext14.server.com/api/v12"
+          },
+          {
+            "url": "/api/v3",
+            "description": "default endpoint"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              },
+              "application/x-www-form-urlencoded": {
+                "schema": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Order not found"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "store"
+        ],
+        "summary": "Delete purchase order by ID",
+        "description": "For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors.",
+        "operationId": "deleteOrder",
+        "parameters": [
+          {
+            "name": "orderId",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "description": " ID of the order that needs to be deleted",
+            "required": true,
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful operation"
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Order not found"
+          }
+        }
+      }
+    },
+    "/user": {
+      "post": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Create user.",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "createUser",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              }
+            },
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/UserOpSuccess"
+          },
+          "405": {
+            "description": "Invalid Input",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "result": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/user/createWithList": {
+      "post": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Creates list of users with given input array.",
+        "description": "Creates list of users with given input array.",
+        "operationId": "createUsersWithListInput",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              }
+            },
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/UserOpSuccess"
+          },
+          "405": {
+            "description": "Invalid Input"
+          }
+        }
+      }
+    },
+    "/user/login": {
+      "get": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Logs user into the system.",
+        "description": "Logs user into the system.",
+        "operationId": "loginUser",
+        "parameters": [
+          {
+            "name": "username",
+            "schema": {
+              "type": "string"
+            },
+            "description": "The user name for login",
+            "in": "query"
+          },
+          {
+            "name": "password",
+            "schema": {
+              "type": "string",
+              "format": "password"
+            },
+            "description": "The password for login in clear text",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "headers": {
+              "X-Rate-Limit": {
+                "$ref": "#/components/headers/X-Rate-Limit"
+              },
+              "X-Expires-After": {
+                "$ref": "#/components/headers/X-Expires-After"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid username/password supplied"
+          }
+        }
+      }
+    },
+    "/user/logout": {
+      "get": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Logs out current logged in user session.",
+        "description": "Logs out current logged in user session.",
+        "operationId": "logoutUser",
+        "responses": {
+          "200": {
+            "description": "Successful operation"
+          }
+        }
+      }
+    },
+    "/user/{username}": {
+      "get": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Get user by user name",
+        "description": "Get user by user name.",
+        "operationId": "getUserByName",
+        "parameters": [
+          {
+            "name": "username",
+            "schema": {
+              "type": "string"
+            },
+            "description": "The name that needs to be fetched. Use user1 for testing.",
+            "required": true,
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/UserOpSuccess"
+          },
+          "400": {
+            "description": "Invalid username supplied"
+          },
+          "404": {
+            "description": "User not found"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Update user",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "updateUser",
+        "parameters": [
+          {
+            "name": "username",
+            "schema": {
+              "type": "string"
+            },
+            "description": " name that need to be updated.",
+            "required": true,
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              }
+            },
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/UserOpSuccess"
+          },
+          "400": {
+            "description": "Invalid username supplied"
+          },
+          "404": {
+            "description": "User not found"
+          },
+          "405": {
+            "description": "Invalid Input"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Delete user",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "deleteUser",
+        "parameters": [
+          {
+            "name": "username",
+            "schema": {
+              "type": "string"
+            },
+            "description": "The name that needs to be deleted.",
+            "required": true,
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful operation"
+          },
+          "400": {
+            "description": "Invalid username supplied"
+          },
+          "404": {
+            "description": "User not found"
+          }
+        }
+      }
+    },
+    "/user_1/{username}": {
+      "put": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Update user",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "updateUser_1",
+        "parameters": [
+          {
+            "name": "username",
+            "schema": {
+              "type": "string"
+            },
+            "description": " name that need to be updated.",
+            "required": true,
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/StructPart"
+              }
+            },
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/StructPart"
+              }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/StructPart"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/UserOpSuccess"
+          },
+          "400": {
+            "description": "Invalid username supplied"
+          },
+          "404": {
+            "description": "User not found"
+          },
+          "405": {
+            "description": "Invalid Input"
+          }
+        }
+      }
+    },
+    "/userLink/{username}": {
+      "put": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Update user",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "updateUserLink",
+        "parameters": [
+          {
+            "name": "username",
+            "schema": {
+              "type": "string"
+            },
+            "description": " name that need to be updated.",
+            "required": true,
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              }
+            },
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            },
+            "links": {
+              "address": {
+                "operationId": "getUserByName",
+                "parameters": {
+                  "username": "$request.path.username"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid username supplied"
+          },
+          "404": {
+            "description": "User not found"
+          },
+          "405": {
+            "description": "Invalid Input"
+          }
+        }
+      }
+    },
+    "/userLinkByRef/{username}": {
+      "put": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Update user",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "updateUserLinkByRef",
+        "parameters": [
+          {
+            "name": "username",
+            "schema": {
+              "type": "string"
+            },
+            "description": " name that need to be updated.",
+            "required": true,
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              }
+            },
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            },
+            "links": {
+              "address2": {
+                "$ref": "#/components/links/address"
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid username supplied"
+          },
+          "404": {
+            "description": "User not found"
+          },
+          "405": {
+            "description": "Invalid Input"
+          }
+        }
+      }
+    },
+    "/stores/order/{orderId}": {
+      "get": {
+        "tags": [
+          "store"
+        ],
+        "summary": "Find purchase order by ID",
+        "description": "For valid response try integer IDs with value <= 5 or > 10. Other values will generate exceptions.",
+        "operationId": "getOrderExternalById",
+        "parameters": [
+          {
+            "name": "orderId",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "description": "ID of order that needs to be fetched",
+            "required": true,
+            "in": "path"
+          }
+        ],
+        "servers": [
+          {
+            "description": "ext test server",
+            "url": "http://ext.server.com/api/v12"
+          },
+          {
+            "description": "ext test server 13",
+            "url": "http://ext13.server.com/api/v12"
+          },
+          {
+            "description": "ext test server 14",
+            "url": "http://ext14.server.com/api/v12"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              },
+              "application/x-www-form-urlencoded": {
+                "schema": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Order not found"
+          }
+        }
+      }
     }
+  },
+  "components": {
+    "schemas": {
+      "Address": {
+        "type": "object",
+        "description": "Shipping Address",
+        "xml": {
+          "name": "address"
+        },
+        "properties": {
+          "street": {
+            "type": "string",
+            "example": "437 Lytton"
+          },
+          "city": {
+            "type": "string",
+            "example": "Palo Alto"
+          },
+          "state": {
+            "type": "string",
+            "example": "CA"
+          },
+          "zip": {
+            "type": "string",
+            "example": "94031"
+          }
+        },
+        "required": [
+          "street",
+          "city",
+          "state",
+          "zip"
+        ]
+      },
+      "Order": {
+        "type": "object",
+        "xml": {
+          "name": "order"
+        },
+        "properties": {
+          "id": {
+            "type": "integer",
+            "readOnly": true,
+            "example": 10,
+            "format": "int64"
+          },
+          "petId": {
+            "type": "integer",
+            "example": 198772,
+            "format": "int64"
+          },
+          "quantity": {
+            "type": "integer",
+            "example": 7,
+            "format": "int32"
+          },
+          "shipDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "status": {
+            "type": "string",
+            "description": "Order Status",
+            "example": "approved",
+            "enum": [
+              "placed",
+              "approved",
+              "delivered"
+            ]
+          },
+          "complete": {
+            "type": "boolean"
+          },
+          "Address": {
+            "$ref": "#/components/schemas/Address"
+          }
+        },
+        "additionalProperties": {
+          "type": "string"
+        }
+      },
+      "Category": {
+        "type": "object",
+        "xml": {
+          "name": "category"
+        },
+        "properties": {
+          "id": {
+            "type": "integer",
+            "example": 1,
+            "format": "int64"
+          },
+          "name": {
+            "type": "string",
+            "example": "Dogs"
+          }
+        }
+      },
+      "User": {
+        "type": "object",
+        "xml": {
+          "name": "user"
+        },
+        "properties": {
+          "id": {
+            "type": "integer",
+            "readOnly": true,
+            "example": 1,
+            "format": "int64"
+          },
+          "username": {
+            "type": "string",
+            "example": "theUser"
+          },
+          "firstName": {
+            "type": "string",
+            "example": "John"
+          },
+          "lastName": {
+            "type": "string",
+            "example": "James"
+          },
+          "email": {
+            "type": "string",
+            "example": "john@email.com",
+            "format": "email"
+          },
+          "password": {
+            "type": "string",
+            "example": "12345",
+            "format": "password"
+          },
+          "phone": {
+            "type": "string",
+            "example": "12345"
+          },
+          "userStatus": {
+            "type": "integer",
+            "description": "User Status",
+            "example": 1,
+            "format": "int32"
+          }
+        },
+        "required": [
+          "username",
+          "password"
+        ]
+      },
+      "aaaaa": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Address"
+          },
+          {
+            "$ref": "#/components/schemas/User"
+          }
+        ]
+      },
+      "Tag": {
+        "type": "object",
+        "xml": {
+          "name": "tag"
+        },
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "Pet": {
+        "type": "object",
+        "xml": {
+          "name": "pet"
+        },
+        "properties": {
+          "id": {
+            "type": "integer",
+            "readOnly": true,
+            "example": [
+              10,
+              2,
+              4
+            ],
+            "format": "int64"
+          },
+          "name": {
+            "type": "string",
+            "example": "doggie"
+          },
+          "category": {
+            "$ref": "#/components/schemas/Category"
+          },
+          "petType": {
+            "type": "string",
+            "example": "dog"
+          },
+          "photoUrls": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "tags": {
+            "$ref": "#/components/schemas/Tag"
+          },
+          "status": {
+            "type": "string",
+            "description": "pet status in the store",
+            "enum": [
+              "available",
+              "pending",
+              "sold"
+            ]
+          }
+        },
+        "required": [
+          "name",
+          "petType"
+        ]
+      },
+      "NewCat": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Pet"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "huntingSkill": {
+                "type": "string",
+                "description": "The measured skill for hunting",
+                "enum": [
+                  "clueless",
+                  "lazy",
+                  "adventurous",
+                  "aggressive"
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "XmlPrefixAndNamespace": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "xml": {
+              "attribute": true
+            },
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "xml": {
+              "namespace": "http://example.com/schema/sample",
+              "prefix": "sample"
+            }
+          }
+        }
+      },
+      "animals": {
+        "type": "array",
+        "items": {
+          "type": "string",
+          "xml": {
+            "name": "animal"
+          }
+        }
+      },
+      "AnimalsNoAliens": {
+        "type": "array",
+        "xml": {
+          "name": "aliens"
+        },
+        "items": {
+          "type": "string",
+          "xml": {
+            "name": "animal"
+          }
+        }
+      },
+      "WrappedAnimals": {
+        "type": "array",
+        "xml": {
+          "wrapped": true
+        },
+        "items": {
+          "type": "string"
+        }
+      },
+      "WrappedAnimal": {
+        "type": "array",
+        "xml": {
+          "wrapped": true
+        },
+        "items": {
+          "type": "string",
+          "xml": {
+            "name": "animal"
+          }
+        }
+      },
+      "WrappedAliens": {
+        "type": "array",
+        "xml": {
+          "name": "aliens",
+          "wrapped": true
+        },
+        "items": {
+          "type": "string",
+          "xml": {
+            "name": "animal"
+          }
+        }
+      },
+      "WrappedAliensWithItems": {
+        "type": "array",
+        "xml": {
+          "name": "aliens",
+          "wrapped": true
+        },
+        "items": {
+          "type": "string"
+        }
+      },
+      "StructPart": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "children": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/StructPart"
+            }
+          }
+        }
+      },
+      "Pet2": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "petType": {
+            "type": "string"
+          }
+        },
+        "discriminator": {
+          "propertyName": "petType"
+        }
+      },
+      "Cat2": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Pet2"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "huntingSkill": {
+                "type": "string",
+                "description": "The measured skill for hunting",
+                "default": "lazy",
+                "enum": [
+                  "clueless",
+                  "lazy",
+                  "adventurous",
+                  "aggressive"
+                ]
+              }
+            },
+            "required": [
+              "huntingSkill"
+            ]
+          }
+        ],
+        "description": "A representation of a cat. Note that Cat will be used as the discriminator value."
+      },
+      "Dog2": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Pet2"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "packSize": {
+                "type": "integer",
+                "description": "the size of the pack the dog is from",
+                "minimum": 0,
+                "format": "int32"
+              }
+            },
+            "required": [
+              "packSize"
+            ]
+          }
+        ],
+        "description": "A representation of a dog. Note that Dog will be used as the discriminator value."
+      },
+      "ExtendedErrorModel": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Pet"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "rootCause": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "rootCause"
+            ]
+          }
+        ]
+      },
+      "Cat": {
+        "type": "object",
+        "description": "Type of cat",
+        "properties": {
+          "breed": {
+            "type": "string",
+            "description": "Type of Breed",
+            "enum": [
+              "Abyssinian",
+              "Balinese-Javanese",
+              "Burmese",
+              "British Shorthair"
+            ]
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Pet"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "huntingSkill": {
+                "type": "string",
+                "description": "The measured skill for hunting",
+                "enum": [
+                  "clueless",
+                  "lazy",
+                  "adventurous",
+                  "aggressive"
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "Dog": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Pet"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "breed": {
+                "type": "string",
+                "description": "Type of Breed",
+                "enum": [
+                  "Dingo",
+                  "Husky",
+                  "Retriever",
+                  "Shepherd"
+                ]
+              },
+              "bark": {
+                "type": "boolean"
+              }
+            }
+          }
+        ]
+      },
+      "Pets": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/Cat"
+          },
+          {
+            "$ref": "#/components/schemas/Dog"
+          }
+        ],
+        "discriminator": {
+          "propertyName": "petType"
+        }
+      },
+      "ApiResponse": {
+        "type": "object",
+        "xml": {
+          "name": "##default"
+        },
+        "properties": {
+          "code": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "type": {
+            "type": "string",
+            "example": "doggie"
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      },
+      "ErrorModel": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string"
+          },
+          "code": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      }
+    },
+    "responses": {
+      "UserOpSuccess": {
+        "description": "Successful operation",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/User"
+            }
+          },
+          "application/xml": {
+            "schema": {
+              "$ref": "#/components/schemas/User"
+            }
+          }
+        }
+      }
+    },
+    "parameters": {
+      "PetIdParam": {
+        "name": "petId",
+        "schema": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "description": "ID of the pet",
+        "required": true,
+        "in": "path"
+      }
+    },
+    "examples": {
+      "frog-example": {
+        "summary": "An example of a frog with a cat's name",
+        "value": {
+          "color": "Lion",
+          "name": "Jaguar",
+          "gender": "Male",
+          "breed": "Mantella Baroni",
+          "petType": "Panthera"
+        }
+      }
+    },
+    "requestBodies": {
+      "PetBodySchema": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Pets"
+            }
+          },
+          "application/xml": {
+            "schema": {
+              "$ref": "#/components/schemas/Pets"
+            }
+          },
+          "application/x-www-form-urlencoded": {
+            "schema": {
+              "$ref": "#/components/schemas/Pets"
+            }
+          }
+        },
+        "required": true,
+        "description": "Pet in the store"
+      }
+    },
+    "headers": {
+      "X-Rate-Limit": {
+        "schema": {
+          "type": "integer",
+          "format": "int32"
+        }
+      },
+      "X-Expires-After": {
+        "schema": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "links": {
+      "address": {
+        "operationId": "getUserByName",
+        "parameters": {
+          "username": "$request.path.username"
+        }
+      }
+    },
+    "callbacks": {
+      "test": {
+        "'{$request.body#/id}'": {
+          "post": {
+            "requestBody": {
+              "content": {
+                "\"*/*\"": {
+                  "schema": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "responses": {
+              "200": {
+                "description": "Successful operation",
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Pet"
+                      }
+                    }
+                  },
+                  "application/xml": {
+                    "schema": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Pet"
+                      }
+                    }
+                  }
+                }
+              },
+              "400": {
+                "description": "Invalid ID supplied"
+              },
+              "404": {
+                "description": "Pet not found"
+              },
+              "default": {
+                "description": "Something is wrong"
+              }
+            }
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "Jwt": {
+        "type": "http",
+        "scheme": "bearer"
+      },
+      "Login": {
+        "type": "http",
+        "scheme": "basic"
+      },
+      "Login-OAuth2": {
+        "type": "oauth2",
+        "flows": {
+          "authorizationCode": {
+            "tokenUrl": "http://example.org/api/oauth/token",
+            "authorizationUrl": "http://example.org/api/oauth/dialog",
+            "scopes": {
+              "read": "Grant read-only access to all your data except for the account and user info",
+              "write": "Grant write-only access to all your data except for the account and user info"
+            }
+          }
+        }
+      },
+      "LoginApiKey": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-API-KEY"
+      },
+      "api_key": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "api_key"
+      }
+    }
+  }
 }

--- a/tests/integration/specs/OpenApi-TuttiFrutti_3.1.0.json
+++ b/tests/integration/specs/OpenApi-TuttiFrutti_3.1.0.json
@@ -1,1735 +1,2780 @@
 {
-    "openapi": "3.1.0",
-    "jsonSchemaDialect": "https://spec.openapis.org/oas/3.1/dialect/base",
-    "info": {
-        "license": {
-            "name": "Apache 2.0",
-            "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
-        },
-        "title": "Swagger Petstore - OpenAPI 3.1",
-        "version": "1.0.17",
-        "description": "This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about Swagger at [http://swagger.io](http://swagger.io).\r\nIn the third iteration of the pet store, we've switched to the design first approach!\r\nYou can now help us improve the API whether it's by making changes to the definition itself or to the code.\r\nThat way, with time, we can improve the API in general, and expose some of the new features in OAS3.\r\n\r\nSome useful links:\r\n- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)\r\n- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)",
-        "termsOfService": "http://swagger.io/terms/",
-        "contact": {
-            "name": "API Support",
-            "email": "apiteam@swagger.io"
-        }
+  "openapi": "3.1.0",
+  "jsonSchemaDialect": "https://spec.openapis.org/oas/3.1/dialect/base",
+  "info": {
+    "license": {
+      "name": "Apache 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "externalDocs": {
+    "title": "Swagger Petstore - OpenAPI 3.1",
+    "version": "1.0.17",
+    "description": "This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about Swagger at [http://swagger.io](http://swagger.io).\nIn the third iteration of the pet store, we've switched to the design first approach!\nYou can now help us improve the API whether it's by making changes to the definition itself or to the code.\nThat way, with time, we can improve the API in general, and expose some of the new features in OAS3.\n\nSome useful links:\n- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)\n- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)",
+    "termsOfService": "http://swagger.io/terms/",
+    "contact": {
+      "name": "API Support",
+      "email": "apiteam@swagger.io"
+    }
+  },
+  "externalDocs": {
+    "description": "Find out more about Swagger",
+    "url": "http://swagger.io"
+  },
+  "servers": [
+    {
+      "url": "/api/v3",
+      "description": "default endpoint"
+    }
+  ],
+  "tags": [
+    {
+      "name": "user",
+      "description": "Operations about user",
+      "externalDocs": {
         "description": "Find out more about Swagger",
         "url": "http://swagger.io"
+      }
     },
-    "servers": [
-        {
-            "url": "/api/v3",
-            "description": "default endpoint"
-        }
-    ],
-    "tags": [
-        {
-            "name": "user",
-            "description": "Operations about user",
-            "externalDocs": {
-                "description": "Find out more about Swagger",
-                "url": "http://swagger.io"
-            }
-        },
-        {
-            "name": "store",
-            "description": "Access to Petstore orders",
-            "externalDocs": {
-                "description": "Find out more about Swagger",
-                "url": "http://swagger.io"
-            }
-        },
-        {
-            "name": "pet",
-            "description": "Everything about your Pets",
-            "externalDocs": {
-                "description": "Find out more about Swagger",
-                "url": "http://swagger.io"
-            }
-        }
-    ],
-    "paths": {
-        "/pet": {
-            "post": {
-                "tags": [
-                    "pet"
-                ],
-                "summary": "Add a new pet to the store",
-                "description": "Add a new pet to the store",
-                "operationId": "addPet",
-                "requestBody": {
-                    "$ref": "#/components/requestBodies/PetBodySchema"
-                },
-                "security": [
-                    {
-                        "Login-OAuth2": [
-                            "write"
-                        ]
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Pet"
-                                }
-                            },
-                            "application/xml": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Pet"
-                                }
-                            }
-                        }
-                    },
-                    "405": {
-                        "description": "Validation exception",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": [
-                                        "object"
-                                    ],
-                                    "properties": {
-                                        "result": {
-                                            "type": [
-                                                "string"
-                                            ]
-                                        },
-                                        "message": {
-                                            "type": [
-                                                "string"
-                                            ]
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "put": {
-                "tags": [
-                    "pet"
-                ],
-                "summary": "Update an existing pet",
-                "description": "Update an existing pet by Id",
-                "operationId": "updatePet",
-                "requestBody": {
-                    "$ref": "#/components/requestBodies/PetBodySchema"
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Pet"
-                                }
-                            },
-                            "application/xml": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Pet"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Invalid ID supplied"
-                    },
-                    "404": {
-                        "description": "Pet not found"
-                    },
-                    "405": {
-                        "description": "Validation exception",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": [
-                                        "object"
-                                    ],
-                                    "properties": {
-                                        "result": {
-                                            "type": [
-                                                "string"
-                                            ]
-                                        },
-                                        "message": {
-                                            "type": [
-                                                "string"
-                                            ]
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/petcallback": {
-            "post": {
-                "tags": [
-                    "pet"
-                ],
-                "summary": "Add a new pet to the store",
-                "description": "Add a new pet to the store",
-                "operationId": "addPetcallback",
-                "requestBody": {
-                    "$ref": "#/components/requestBodies/PetBodySchema"
-                },
-                "callbacks": {
-                    "test": {
-                        "'{$request.body#/id}'": {
-                            "post": {
-                                "requestBody": {
-                                    "content": {
-                                        "\"*/*\"": {
-                                            "schema": {
-                                                "type": [
-                                                    "string"
-                                                ]
-                                            }
-                                        }
-                                    }
-                                },
-                                "responses": {
-                                    "200": {
-                                        "description": "Successful operation",
-                                        "content": {
-                                            "application/json": {
-                                                "schema": {
-                                                    "type": "array",
-                                                    "items": {
-                                                        "$ref": "#/components/schemas/Pet"
-                                                    }
-                                                }
-                                            },
-                                            "application/xml": {
-                                                "schema": {
-                                                    "type": "array",
-                                                    "items": {
-                                                        "$ref": "#/components/schemas/Pet"
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    },
-                                    "400": {
-                                        "description": "Invalid ID supplied"
-                                    },
-                                    "404": {
-                                        "description": "Pet not found"
-                                    },
-                                    "default": {
-                                        "description": "Something is wrong"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "Login-OAuth2": [
-                            "write"
-                        ]
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Pet"
-                                }
-                            },
-                            "application/xml": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Pet"
-                                }
-                            }
-                        }
-                    },
-                    "405": {
-                        "description": "Validation exception",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": [
-                                        "object"
-                                    ],
-                                    "properties": {
-                                        "result": {
-                                            "type": [
-                                                "string"
-                                            ]
-                                        },
-                                        "message": {
-                                            "type": [
-                                                "string"
-                                            ]
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/petcallbackReference": {
-            "post": {
-                "tags": [
-                    "pet"
-                ],
-                "summary": "Add a new pet to the store",
-                "description": "Add a new pet to the store",
-                "operationId": "petcallbackReference",
-                "requestBody": {
-                    "$ref": "#/components/requestBodies/PetBodySchema"
-                },
-                "callbacks": {
-                    "test1": {
-                        "$ref": "#/components/callbacks/test"
-                    }
-                },
-                "security": [
-                    {
-                        "Login-OAuth2": [
-                            "write"
-                        ]
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Pet"
-                                }
-                            },
-                            "application/xml": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Pet"
-                                }
-                            }
-                        }
-                    },
-                    "405": {
-                        "description": "Validation exception",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": [
-                                        "object"
-                                    ],
-                                    "properties": {
-                                        "result": {
-                                            "type": [
-                                                "string"
-                                            ]
-                                        },
-                                        "message": {
-                                            "type": [
-                                                "string"
-                                            ]
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/pet/findByStatus": {
-            "get": {
-                "tags": [
-                    "pet"
-                ],
-                "summary": "Finds Pets by status",
-                "description": "Multiple status values can be provided with comma separated strings",
-                "operationId": "findPetsByStatus",
-                "parameters": [
-                    {
-                        "description": "Status values that need to be considered for filter",
-                        "schema": {
-                            "type": "string",
-                            "default": "available",
-                            "enum": [
-                                "available",
-                                "pending",
-                                "sold"
-                            ]
-                        },
-                        "name": "status",
-                        "in": "query"
-                    }
-                ],
-                "security": [
-                    {},
-                    {
-                        "Login-OAuth2": [
-                            "read"
-                        ]
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Pet"
-                                    }
-                                }
-                            },
-                            "application/xml": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Pet"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Invalid status value"
-                    }
-                }
-            }
-        },
-        "/pet/findByTag": {
-            "get": {
-                "tags": [
-                    "pet"
-                ],
-                "summary": "Finds Pets by tags",
-                "description": "Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.",
-                "operationId": "findPetsByTags",
-                "parameters": [
-                    {
-                        "explode": true,
-                        "description": "Tags to filter by",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        },
-                        "name": "tag",
-                        "in": "query"
-                    }
-                ],
-                "security": [
-                    {
-                        "api_key": []
-                    },
-                    {
-                        "Login-OAuth2": [
-                            "read"
-                        ]
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Pet"
-                                }
-                            },
-                            "application/xml": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Pet"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Invalid status value"
-                    },
-                    "default": {
-                        "description": "Unexpected error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ErrorModel"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/store/inventory": {
-            "get": {
-                "tags": [
-                    "store"
-                ],
-                "summary": "Returns pet inventories by status",
-                "description": "Returns a map of status codes to quantities",
-                "operationId": "getInventory",
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": [
-                                        "object"
-                                    ],
-                                    "properties": {
-                                        "none": {
-                                            "type": [
-                                                "string"
-                                            ]
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/store/order": {
-            "post": {
-                "deprecated": true,
-                "tags": [
-                    "store"
-                ],
-                "summary": "Place an order for a pet",
-                "description": "Place a new order in the store",
-                "operationId": "placeOrder",
-                "requestBody": {
-                    "content": {
-                        "application/xml": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Order"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Order"
-                            }
-                        },
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Order"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Order"
-                                }
-                            },
-                            "application/xml": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Order"
-                                }
-                            }
-                        }
-                    },
-                    "405": {
-                        "description": "Invalid Input"
-                    }
-                }
-            }
-        },
-        "/user": {
-            "post": {
-                "tags": [
-                    "user"
-                ],
-                "summary": "Create user.",
-                "description": "This can only be done by the logged in user.",
-                "operationId": "createUser",
-                "requestBody": {
-                    "content": {
-                        "application/xml": {
-                            "schema": {
-                                "$ref": "#/components/schemas/User"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/User"
-                            }
-                        },
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/User"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "$ref": "#/components/responses/UserOpSuccess"
-                    },
-                    "405": {
-                        "description": "Invalid Input",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": [
-                                        "object"
-                                    ],
-                                    "properties": {
-                                        "result": {
-                                            "type": [
-                                                "string"
-                                            ]
-                                        },
-                                        "message": {
-                                            "type": [
-                                                "string"
-                                            ]
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/user/createWithList": {
-            "post": {
-                "tags": [
-                    "user"
-                ],
-                "summary": "Creates list of users with given input array.",
-                "description": "Creates list of users with given input array.",
-                "operationId": "createUsersWithListInput",
-                "requestBody": {
-                    "content": {
-                        "application/xml": {
-                            "schema": {
-                                "$ref": "#/components/schemas/User"
-                            }
-                        },
-                        "application/x-www-form-urlencoded": {
-                            "schema": {
-                                "$ref": "#/components/schemas/User"
-                            }
-                        },
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/User"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "$ref": "#/components/responses/UserOpSuccess"
-                    },
-                    "405": {
-                        "description": "Invalid Input"
-                    }
-                }
-            }
-        },
-        "/user/login": {
-            "get": {
-                "tags": [
-                    "user"
-                ],
-                "summary": "Logs user into the system.",
-                "description": "Logs user into the system.",
-                "operationId": "loginUser",
-                "parameters": [
-                    {
-                        "description": "The user name for login",
-                        "schema": {
-                            "type": "string"
-                        },
-                        "name": "username",
-                        "in": "query"
-                    },
-                    {
-                        "description": "The password for login in clear text",
-                        "schema": {
-                            "type": "string",
-                            "format": "password"
-                        },
-                        "name": "password",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "headers": {
-                            "X-Rate-Limit": {
-                                "$ref": "#/components/headers/X-Rate-Limit"
-                            },
-                            "X-Expires-After": {
-                                "$ref": "#/components/headers/X-Expires-After"
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "application/xml": {
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Invalid username/password supplied"
-                    }
-                }
-            }
-        },
-        "/user/logout": {
-            "get": {
-                "tags": [
-                    "user"
-                ],
-                "summary": "Logs out current logged in user session.",
-                "description": "Logs out current logged in user session.",
-                "operationId": "logoutUser",
-                "responses": {
-                    "200": {
-                        "description": "Successful operation"
-                    }
-                }
-            }
-        },
-        "/stores/order/{orderId}": {
-            "get": {
-                "tags": [
-                    "store"
-                ],
-                "summary": "Find purchase order by ID",
-                "description": "For valid response try integer IDs with value <= 5 or > 10. Other values will generate exceptions.",
-                "operationId": "getOrderExternalById",
-                "parameters": [
-                    {
-                        "description": "ID of order that needs to be fetched",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64"
-                        },
-                        "name": "orderId",
-                        "in": "path"
-                    }
-                ],
-                "servers": [
-                    {
-                        "url": "http://ext.server.com/api/v12",
-                        "description": "ext test server"
-                    },
-                    {
-                        "url": "http://ext13.server.com/api/v12",
-                        "description": "ext test server 13"
-                    },
-                    {
-                        "url": "http://ext14.server.com/api/v12",
-                        "description": "ext test server 14"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful operation",
-                        "content": {
-                            "application/xml": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Order"
-                                }
-                            },
-                            "application/x-www-form-urlencoded": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Order"
-                                }
-                            },
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Order"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Invalid ID supplied"
-                    },
-                    "404": {
-                        "description": "Order not found"
-                    }
-                }
-            }
-        }
+    {
+      "name": "store",
+      "description": "Access to Petstore orders",
+      "externalDocs": {
+        "description": "Find out more about Swagger",
+        "url": "http://swagger.io"
+      }
     },
-    "webhooks": {
-        "newPet": {
-            "post": {
-                "description": "Information about a new pet in the system",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Pets"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "Return a 200 status to indicate that the data was received successfully"
-                    }
+    {
+      "name": "pet",
+      "description": "Everything about your Pets",
+      "externalDocs": {
+        "description": "Find out more about Swagger",
+        "url": "http://swagger.io"
+      }
+    }
+  ],
+  "paths": {
+    "/pet": {
+      "post": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Add a new pet to the store",
+        "description": "Add a new pet to the store",
+        "operationId": "addPet",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/PetBodySchema"
+        },
+        "security": [
+          {
+            "Login-OAuth2": [
+              "write"
+            ]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
                 }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
             }
-        }
-    },
-    "components": {
-        "schemas": {
-            "Address": {
-                "type": [
+          },
+          "405": {
+            "description": "Validation exception",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": [
                     "object"
-                ],
-                "description": "Shipping Address",
-                "xml": {
-                    "name": "address"
-                },
-                "properties": {
-                    "street": {
-                        "type": [
-                            "string"
-                        ],
-                        "examples": [
-                            "437 Lytton"
-                        ]
-                    },
-                    "city": {
-                        "type": [
-                            "string"
-                        ],
-                        "examples": [
-                            "Palo Alto"
-                        ]
-                    },
-                    "state": {
-                        "type": [
-                            "string"
-                        ],
-                        "examples": [
-                            "CA"
-                        ]
-                    },
-                    "zip": {
-                        "type": [
-                            "string"
-                        ],
-                        "examples": [
-                            "94031"
-                        ]
-                    }
-                },
-                "required": [
-                    "street",
-                    "city",
-                    "state",
-                    "zip"
-                ]
-            },
-            "Order": {
-                "type": [
-                    "object"
-                ],
-                "xml": {
-                    "name": "order"
-                },
-                "properties": {
-                    "id": {
-                        "type": [
-                            "integer"
-                        ],
-                        "readOnly": true,
-                        "examples": [
-                            10
-                        ],
-                        "format": "int64"
-                    },
-                    "petId": {
-                        "type": [
-                            "integer"
-                        ],
-                        "examples": [
-                            198772
-                        ],
-                        "format": "int64"
-                    },
-                    "quantity": {
-                        "type": [
-                            "integer"
-                        ],
-                        "examples": [
-                            7
-                        ],
-                        "format": "int32"
-                    },
-                    "shipDate": {
-                        "type": [
-                            "string"
-                        ],
-                        "format": "date-time"
-                    },
-                    "status": {
-                        "type": [
-                            "string"
-                        ],
-                        "description": "Order Status",
-                        "examples": [
-                            "approved"
-                        ],
-                        "enum": [
-                            "placed",
-                            "approved",
-                            "delivered"
-                        ]
-                    },
-                    "complete": {
-                        "type": [
-                            "boolean"
-                        ]
-                    },
-                    "Address": {
-                        "$ref": "#/components/schemas/Address"
-                    }
-                },
-                "additionalProperties": {
-                    "type": [
+                  ],
+                  "properties": {
+                    "result": {
+                      "type": [
                         "string"
-                    ]
-                }
-            },
-            "Category": {
-                "type": [
-                    "object"
-                ],
-                "xml": {
-                    "name": "category"
-                },
-                "properties": {
-                    "id": {
-                        "type": [
-                            "integer"
-                        ],
-                        "examples": [
-                            1
-                        ],
-                        "format": "int64"
-                    },
-                    "name": {
-                        "type": [
-                            "string"
-                        ],
-                        "examples": [
-                            "Dogs"
-                        ]
-                    }
-                }
-            },
-            "User": {
-                "type": [
-                    "object"
-                ],
-                "xml": {
-                    "name": "user"
-                },
-                "properties": {
-                    "id": {
-                        "type": [
-                            "integer"
-                        ],
-                        "readOnly": true,
-                        "examples": [
-                            1
-                        ],
-                        "format": "int64"
-                    },
-                    "username": {
-                        "type": [
-                            "string"
-                        ],
-                        "examples": [
-                            "theUser"
-                        ]
-                    },
-                    "firstName": {
-                        "type": [
-                            "string"
-                        ],
-                        "examples": [
-                            "John"
-                        ]
-                    },
-                    "lastName": {
-                        "type": [
-                            "string"
-                        ],
-                        "examples": [
-                            "James"
-                        ]
-                    },
-                    "email": {
-                        "type": [
-                            "string"
-                        ],
-                        "examples": [
-                            "john@email.com"
-                        ],
-                        "format": "email"
-                    },
-                    "password": {
-                        "type": [
-                            "string"
-                        ],
-                        "examples": [
-                            "12345"
-                        ],
-                        "format": "password"
-                    },
-                    "phone": {
-                        "type": [
-                            "string"
-                        ],
-                        "examples": [
-                            "12345"
-                        ]
-                    },
-                    "userStatus": {
-                        "type": [
-                            "integer"
-                        ],
-                        "description": "User Status",
-                        "examples": [
-                            1
-                        ],
-                        "format": "int32"
-                    }
-                },
-                "required": [
-                    "username",
-                    "password"
-                ]
-            },
-            "aaaaa": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/Address"
-                    },
-                    {
-                        "$ref": "#/components/schemas/User"
-                    }
-                ]
-            },
-            "Tag": {
-                "type": [
-                    "object"
-                ],
-                "xml": {
-                    "name": "tag"
-                },
-                "properties": {
-                    "id": {
-                        "type": [
-                            "integer"
-                        ],
-                        "format": "int64"
-                    },
-                    "name": {
-                        "type": [
-                            "string"
-                        ]
-                    }
-                }
-            },
-            "Pet": {
-                "type": [
-                    "object"
-                ],
-                "xml": {
-                    "name": "pet"
-                },
-                "properties": {
-                    "id": {
-                        "type": [
-                            "integer"
-                        ],
-                        "readOnly": true,
-                        "examples": [
-                            10,
-                            2,
-                            4
-                        ],
-                        "format": "int64"
-                    },
-                    "name": {
-                        "type": [
-                            "string"
-                        ],
-                        "examples": [
-                            "doggie"
-                        ]
-                    },
-                    "category": {
-                        "$ref": "#/components/schemas/Category"
-                    },
-                    "petType": {
-                        "type": [
-                            "string"
-                        ],
-                        "examples": [
-                            "dog"
-                        ]
-                    },
-                    "photoUrls": {
-                        "type": "array",
-                        "items": {
-                            "type": [
-                                "string"
-                            ]
-                        }
-                    },
-                    "tags": {
-                        "$ref": "#/components/schemas/Tag"
-                    },
-                    "status": {
-                        "type": [
-                            "string"
-                        ],
-                        "description": "pet status in the store",
-                        "enum": [
-                            "available",
-                            "pending",
-                            "sold"
-                        ]
-                    }
-                },
-                "required": [
-                    "name",
-                    "petType"
-                ]
-            },
-            "NewCat": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/Pet"
-                    },
-                    {
-                        "type": [
-                            "object"
-                        ],
-                        "properties": {
-                            "huntingSkill": {
-                                "type": [
-                                    "string"
-                                ],
-                                "description": "The measured skill for hunting",
-                                "enum": [
-                                    "clueless",
-                                    "lazy",
-                                    "adventurous",
-                                    "aggressive"
-                                ]
-                            }
-                        }
-                    }
-                ]
-            },
-            "XmlPrefixAndNamespace": {
-                "type": [
-                    "object"
-                ],
-                "properties": {
-                    "id": {
-                        "type": [
-                            "integer"
-                        ],
-                        "xml": {
-                            "attribute": true
-                        },
-                        "format": "int32"
-                    },
-                    "name": {
-                        "type": [
-                            "string"
-                        ],
-                        "xml": {
-                            "namespace": "http://example.com/schema/sample",
-                            "prefix": "sample"
-                        }
-                    }
-                }
-            },
-            "animals": {
-                "type": "array",
-                "items": {
-                    "type": [
-                        "string"
-                    ],
-                    "xml": {
-                        "name": "animal"
-                    }
-                }
-            },
-            "AnimalsNoAliens": {
-                "type": "array",
-                "xml": {
-                    "name": "aliens"
-                },
-                "items": {
-                    "type": [
-                        "string"
-                    ],
-                    "xml": {
-                        "name": "animal"
-                    }
-                }
-            },
-            "WrappedAnimals": {
-                "type": "array",
-                "xml": {
-                    "wrapped": true
-                },
-                "items": {
-                    "type": [
-                        "string"
-                    ]
-                }
-            },
-            "WrappedAnimal": {
-                "type": "array",
-                "xml": {
-                    "wrapped": true
-                },
-                "items": {
-                    "type": [
-                        "string"
-                    ],
-                    "xml": {
-                        "name": "animal"
-                    }
-                }
-            },
-            "WrappedAliens": {
-                "type": "array",
-                "xml": {
-                    "name": "aliens",
-                    "wrapped": true
-                },
-                "items": {
-                    "type": [
-                        "string"
-                    ],
-                    "xml": {
-                        "name": "animal"
-                    }
-                }
-            },
-            "WrappedAliensWithItems": {
-                "type": "array",
-                "xml": {
-                    "name": "aliens",
-                    "wrapped": true
-                },
-                "items": {
-                    "type": [
-                        "string"
-                    ]
-                }
-            },
-            "StructPart": {
-                "type": [
-                    "object"
-                ],
-                "properties": {
-                    "name": {
-                        "type": [
-                            "string"
-                        ]
-                    },
-                    "type": {
-                        "type": [
-                            "string"
-                        ]
-                    },
-                    "children": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/StructPart"
-                        }
-                    }
-                }
-            },
-            "Pet2": {
-                "type": [
-                    "object"
-                ],
-                "properties": {
-                    "name": {
-                        "type": [
-                            "string"
-                        ]
-                    },
-                    "petType": {
-                        "type": [
-                            "string"
-                        ]
-                    }
-                },
-                "discriminator": {
-                    "propertyName": "petType"
-                }
-            },
-            "Cat2": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/Pet2"
-                    },
-                    {
-                        "type": "object",
-                        "properties": {
-                            "huntingSkill": {
-                                "type": [
-                                    "string"
-                                ],
-                                "description": "The measured skill for hunting",
-                                "default": "lazy",
-                                "enum": [
-                                    "clueless",
-                                    "lazy",
-                                    "adventurous",
-                                    "aggressive"
-                                ]
-                            }
-                        },
-                        "required": [
-                            "huntingSkill"
-                        ]
-                    }
-                ],
-                "description": "A representation of a cat. Note that Cat will be used as the discriminator value."
-            },
-            "Dog2": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/Pet2"
-                    },
-                    {
-                        "type": "object",
-                        "properties": {
-                            "packSize": {
-                                "type": [
-                                    "integer"
-                                ],
-                                "description": "the size of the pack the dog is from",
-                                "minimum": 0,
-                                "format": "int32"
-                            }
-                        },
-                        "required": [
-                            "packSize"
-                        ]
-                    }
-                ],
-                "description": "A representation of a dog. Note that Dog will be used as the discriminator value."
-            },
-            "ExtendedErrorModel": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/Pet"
-                    },
-                    {
-                        "type": "object",
-                        "properties": {
-                            "rootCause": {
-                                "type": [
-                                    "string"
-                                ]
-                            }
-                        },
-                        "required": [
-                            "rootCause"
-                        ]
-                    }
-                ]
-            },
-            "Cat": {
-                "type": [
-                    "object"
-                ],
-                "description": "Type of cat",
-                "properties": {
-                    "breed": {
-                        "type": [
-                            "string"
-                        ],
-                        "description": "Type of Breed",
-                        "enum": [
-                            "Abyssinian",
-                            "Balinese-Javanese",
-                            "Burmese",
-                            "British Shorthair"
-                        ]
-                    }
-                },
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/Pet"
-                    },
-                    {
-                        "type": "object",
-                        "properties": {
-                            "huntingSkill": {
-                                "type": [
-                                    "string"
-                                ],
-                                "description": "The measured skill for hunting",
-                                "enum": [
-                                    "clueless",
-                                    "lazy",
-                                    "adventurous",
-                                    "aggressive"
-                                ]
-                            }
-                        }
-                    }
-                ]
-            },
-            "Dog": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/Pet"
-                    },
-                    {
-                        "type": [
-                            "object"
-                        ],
-                        "properties": {
-                            "breed": {
-                                "type": [
-                                    "string"
-                                ],
-                                "description": "Type of Breed",
-                                "enum": [
-                                    "Dingo",
-                                    "Husky",
-                                    "Retriever",
-                                    "Shepherd"
-                                ]
-                            },
-                            "bark": {
-                                "type": [
-                                    "boolean"
-                                ]
-                            }
-                        }
-                    }
-                ]
-            },
-            "Pets": {
-                "oneOf": [
-                    {
-                        "$ref": "#/components/schemas/Cat"
-                    },
-                    {
-                        "$ref": "#/components/schemas/Dog"
-                    }
-                ],
-                "discriminator": {
-                    "propertyName": "petType"
-                }
-            },
-            "ApiResponse": {
-                "type": [
-                    "object"
-                ],
-                "xml": {
-                    "name": "##default"
-                },
-                "properties": {
-                    "code": {
-                        "type": [
-                            "integer"
-                        ],
-                        "format": "int32"
-                    },
-                    "type": {
-                        "type": [
-                            "string"
-                        ],
-                        "examples": [
-                            "doggie"
-                        ]
+                      ]
                     },
                     "message": {
-                        "type": [
-                            "string"
-                        ]
+                      "type": [
+                        "string"
+                      ]
                     }
+                  }
                 }
-            },
-            "ErrorModel": {
-                "type": [
-                    "object"
-                ],
-                "properties": {
-                    "message": {
-                        "type": [
-                            "string"
-                        ]
-                    },
-                    "code": {
-                        "type": [
-                            "integer"
-                        ],
-                        "format": "int32"
-                    }
-                }
+              }
             }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Update an existing pet",
+        "description": "Update an existing pet by Id",
+        "operationId": "updatePet",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/PetBodySchema"
         },
         "responses": {
-            "UserOpSuccess": {
-                "description": "Successful operation",
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/User"
-                        }
-                    },
-                    "application/xml": {
-                        "schema": {
-                            "$ref": "#/components/schemas/User"
-                        }
-                    }
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
                 }
-            }
-        },
-        "parameters": {
-            "PetIdParam": {
-                "description": "ID of the pet",
-                "required": true,
+              },
+              "application/xml": {
                 "schema": {
-                    "type": "integer",
-                    "format": "int64"
-                },
-                "name": "petId",
-                "in": "path"
-            }
-        },
-        "requestBodies": {
-            "PetBodySchema": {
-                "content": {
-                    "application/xml": {
-                        "schema": {
-                            "$ref": "#/components/schemas/Pets"
-                        }
-                    },
-                    "application/x-www-form-urlencoded": {
-                        "schema": {
-                            "$ref": "#/components/schemas/Pets"
-                        }
-                    },
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/Pets"
-                        }
-                    }
-                },
-                "required": true,
-                "description": "Pet in the store"
-            }
-        },
-        "headers": {
-            "X-Rate-Limit": {
-                "schema": {
-                    "type": [
-                        "integer"
-                    ],
-                    "format": "int32"
+                  "$ref": "#/components/schemas/Pet"
                 }
-            },
-            "X-Expires-After": {
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Pet not found"
+          },
+          "405": {
+            "description": "Validation exception",
+            "content": {
+              "application/json": {
                 "schema": {
-                    "type": [
+                  "type": [
+                    "object"
+                  ],
+                  "properties": {
+                    "result": {
+                      "type": [
                         "string"
-                    ],
-                    "format": "date-time"
+                      ]
+                    },
+                    "message": {
+                      "type": [
+                        "string"
+                      ]
+                    }
+                  }
                 }
+              }
             }
-        },
-        "links": {
-            "address": {
-                "operationId": "getUserByName",
-                "parameters": {
-                    "username": "$request.path.username"
-                }
-            }
+          }
+        }
+      }
+    },
+    "/petcallback": {
+      "post": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Add a new pet to the store",
+        "description": "Add a new pet to the store",
+        "operationId": "addPetcallback",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/PetBodySchema"
         },
         "callbacks": {
-            "test": {
-                "'{$request.body#/id}'": {
-                    "post": {
-                        "requestBody": {
-                            "content": {
-                                "\"*/*\"": {
-                                    "schema": {
-                                        "type": [
-                                            "string"
-                                        ]
-                                    }
-                                }
-                            }
-                        },
-                        "responses": {
-                            "200": {
-                                "description": "Successful operation",
-                                "content": {
-                                    "application/json": {
-                                        "schema": {
-                                            "type": "array",
-                                            "items": {
-                                                "$ref": "#/components/schemas/Pet"
-                                            }
-                                        }
-                                    },
-                                    "application/xml": {
-                                        "schema": {
-                                            "type": "array",
-                                            "items": {
-                                                "$ref": "#/components/schemas/Pet"
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            "400": {
-                                "description": "Invalid ID supplied"
-                            },
-                            "404": {
-                                "description": "Pet not found"
-                            },
-                            "default": {
-                                "description": "Something is wrong"
-                            }
-                        }
+          "test": {
+            "'{$request.body#/id}'": {
+              "post": {
+                "requestBody": {
+                  "content": {
+                    "\"*/*\"": {
+                      "schema": {
+                        "type": [
+                          "string"
+                        ]
+                      }
                     }
+                  }
+                },
+                "responses": {
+                  "200": {
+                    "description": "Successful operation",
+                    "content": {
+                      "application/json": {
+                        "schema": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/Pet"
+                          }
+                        }
+                      },
+                      "application/xml": {
+                        "schema": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/Pet"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "400": {
+                    "description": "Invalid ID supplied"
+                  },
+                  "404": {
+                    "description": "Pet not found"
+                  },
+                  "default": {
+                    "description": "Something is wrong"
+                  }
                 }
+              }
             }
+          }
         },
-        "pathItems": {
-            "GetPetByIdWithRef": {
-                "get": {
-                    "tags": [
-                        "pet"
-                    ],
-                    "summary": "Find pet by ID",
-                    "description": "Returns a single pet.",
-                    "operationId": "getPetByIdWithRef",
-                    "parameters": [
-                        {
-                            "description": "ID of pet to return",
-                            "required": true,
-                            "schema": {
-                                "type": "integer",
-                                "format": "int64"
-                            },
-                            "name": "petId",
-                            "in": "path"
-                        }
-                    ],
-                    "responses": {
-                        "200": {
-                            "description": "Successful operation",
-                            "content": {
-                                "application/json": {
-                                    "schema": {
-                                        "$ref": "#/components/schemas/Pet"
-                                    }
-                                },
-                                "application/xml": {
-                                    "schema": {
-                                        "$ref": "#/components/schemas/Pet"
-                                    }
-                                }
-                            }
-                        },
-                        "400": {
-                            "description": "Invalid ID supplied"
-                        },
-                        "404": {
-                            "description": "Pet not found"
-                        },
-                        "415": {
-                            "description": "Unsupported Media Type"
-                        }
-                    }
+        "security": [
+          {
+            "Login-OAuth2": [
+              "write"
+            ]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
                 }
-            }
-        },
-        "securitySchemes": {
-            "LoginApiKey": {
-                "type": "apiKey",
-                "in": "header",
-                "name": "X-API-KEY"
-            },
-            "Login": {
-                "type": "http",
-                "scheme": "basic"
-            },
-            "Jwt": {
-                "type": "http",
-                "scheme": "bearer"
-            },
-            "api_key": {
-                "type": "apiKey",
-                "in": "header",
-                "name": "api_key"
-            },
-            "Login-OAuth2": {
-                "type": "oauth2",
-                "flows": {
-                    "authorizationCode": {
-                        "tokenUrl": "http://example.org/api/oauth/token",
-                        "authorizationUrl": "http://example.org/api/oauth/dialog",
-                        "scopes": {
-                            "read": "Grant read-only access to all your data except for the account and user info",
-                            "write": "Grant write-only access to all your data except for the account and user info"
-                        }
-                    }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
                 }
+              }
             }
+          },
+          "405": {
+            "description": "Validation exception",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": [
+                    "object"
+                  ],
+                  "properties": {
+                    "result": {
+                      "type": [
+                        "string"
+                      ]
+                    },
+                    "message": {
+                      "type": [
+                        "string"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
         }
+      }
+    },
+    "/petcallbackReference": {
+      "post": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Add a new pet to the store",
+        "description": "Add a new pet to the store",
+        "operationId": "petcallbackReference",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/PetBodySchema"
+        },
+        "callbacks": {
+          "test1": {
+            "$ref": "#/components/callbacks/test"
+          }
+        },
+        "security": [
+          {
+            "Login-OAuth2": [
+              "write"
+            ]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Validation exception",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": [
+                    "object"
+                  ],
+                  "properties": {
+                    "result": {
+                      "type": [
+                        "string"
+                      ]
+                    },
+                    "message": {
+                      "type": [
+                        "string"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pet/findByStatus": {
+      "get": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Finds Pets by status",
+        "description": "Multiple status values can be provided with comma separated strings",
+        "operationId": "findPetsByStatus",
+        "parameters": [
+          {
+            "name": "status",
+            "schema": {
+              "type": "string",
+              "default": "available",
+              "enum": [
+                "available",
+                "pending",
+                "sold"
+              ]
+            },
+            "description": "Status values that need to be considered for filter",
+            "in": "query"
+          }
+        ],
+        "security": [
+          {},
+          {
+            "Login-OAuth2": [
+              "read"
+            ]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Pet"
+                  }
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Pet"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid status value"
+          }
+        }
+      }
+    },
+    "/pet/findByTag": {
+      "get": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Finds Pets by tags",
+        "description": "Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.",
+        "operationId": "findPetsByTags",
+        "parameters": [
+          {
+            "name": "tag",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "description": "Tags to filter by",
+            "explode": true,
+            "in": "query"
+          }
+        ],
+        "security": [
+          {
+            "api_key": []
+          },
+          {
+            "Login-OAuth2": [
+              "read"
+            ]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid status value"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pet/{petId}": {
+      "get": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Find pet by ID",
+        "description": "Returns a single pet.",
+        "operationId": "getPetById",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PetIdParam"
+          }
+        ],
+        "security": [
+          {
+            "Login-OAuth2": [
+              "read"
+            ]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Pet not found"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Updates a pet in the store",
+        "description": "Updates a pet in the store with form data",
+        "operationId": "updatePetWithForm",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PetIdParam"
+          },
+          {
+            "name": "name",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Name of pet that needs to be updated",
+            "in": "query"
+          },
+          {
+            "name": "status",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Status of pet that needs to be updated",
+            "in": "query"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "properties": {
+                  "file": {
+                    "type": "array",
+                    "items": {
+                      "type": [
+                        "string"
+                      ],
+                      "format": "binary"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Login-OAuth2": [
+              "write"
+            ]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful operation"
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "405": {
+            "description": "Invalid Input"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Deletes a pet",
+        "description": "Deletes a pet.",
+        "operationId": "deletePet",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PetIdParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful operation"
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Pet not found"
+          }
+        }
+      }
+    },
+    "/pet2/{petId}": {
+      "post": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Updates a pet in the store",
+        "description": "Updates a pet in the store with form data",
+        "operationId": "updatePet2WithForm",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PetIdParam"
+          },
+          {
+            "name": "name",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Name of pet that needs to be updated",
+            "in": "query"
+          },
+          {
+            "name": "status",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Status of pet that needs to be updated",
+            "in": "query"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": [
+                  "object"
+                ],
+                "properties": {
+                  "id": {
+                    "type": [
+                      "string"
+                    ],
+                    "format": "uuid"
+                  },
+                  "address": {
+                    "type": [
+                      "object"
+                    ],
+                    "properties": {}
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Login-OAuth2": [
+              "write"
+            ]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful operation"
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "405": {
+            "description": "Invalid Input"
+          }
+        }
+      }
+    },
+    "/pet3/{petId}": {
+      "post": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Updates a pet in the store",
+        "description": "Updates a pet in the store with form data",
+        "operationId": "updatePet3WithForm",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PetIdParam"
+          },
+          {
+            "name": "name",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Name of pet that needs to be updated",
+            "in": "query"
+          },
+          {
+            "name": "status",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Status of pet that needs to be updated",
+            "in": "query"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": [
+                  "object"
+                ],
+                "properties": {
+                  "id": {
+                    "type": [
+                      "string"
+                    ],
+                    "format": "uuid"
+                  },
+                  "address": {
+                    "type": [
+                      "object"
+                    ],
+                    "properties": {}
+                  },
+                  "children": {
+                    "type": "array",
+                    "items": {
+                      "type": [
+                        "string"
+                      ]
+                    }
+                  },
+                  "addresses": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/Address"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Login-OAuth2": [
+              "write"
+            ]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful operation"
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "405": {
+            "description": "Invalid Input"
+          }
+        }
+      }
+    },
+    "/pet4/{petId}": {
+      "post": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Updates a pet in the store",
+        "description": "Updates a pet in the store with form data",
+        "operationId": "updatePet4WithForm",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PetIdParam"
+          },
+          {
+            "name": "name",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Name of pet that needs to be updated",
+            "in": "query"
+          },
+          {
+            "name": "status",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Status of pet that needs to be updated",
+            "in": "query"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": [
+                  "object"
+                ],
+                "properties": {
+                  "id": {
+                    "type": [
+                      "string"
+                    ],
+                    "format": "uuid"
+                  },
+                  "address": {
+                    "type": [
+                      "object"
+                    ],
+                    "properties": {}
+                  },
+                  "historyMetadata": {
+                    "type": [
+                      "object"
+                    ],
+                    "description": "metadata in XML format",
+                    "properties": {}
+                  },
+                  "profileImage": {
+                    "type": [
+                      "string"
+                    ],
+                    "format": "binary"
+                  }
+                }
+              },
+              "encoding": {
+                "historyMetadata": {
+                  "contentType": "application/xml; charset=utf-8"
+                },
+                "profileImage": {
+                  "contentType": "image/png, image/jpeg",
+                  "headers": {
+                    "X-Rate-Limit-Limit": {
+                      "description": "The number of allowed requests in the current period",
+                      "schema": {
+                        "type": "integer",
+                        "default": 3,
+                        "enum": [
+                          1,
+                          2,
+                          3
+                        ],
+                        "maximum": 3
+                      }
+                    },
+                    "X-Rate-Limit-Reset": {
+                      "description": "The number of seconds left in the current period",
+                      "schema": {
+                        "type": "integer",
+                        "minimum": 2
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Login-OAuth2": [
+              "write"
+            ]
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A simple string response",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": [
+                    "string"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "405": {
+            "description": "Invalid Input"
+          }
+        }
+      }
+    },
+    "/pet/{petId}/uploadImage2": {
+      "post": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Uploads an image",
+        "description": "Updates a pet in the store with a new image",
+        "operationId": "uploadFile2",
+        "parameters": [
+          {
+            "name": "petId",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "description": "ID of pet that needs to be updated",
+            "required": true,
+            "in": "path"
+          },
+          {
+            "name": "additionalMetadata",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Additional Metadata",
+            "in": "query"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": [
+                  "object"
+                ],
+                "properties": {
+                  "image": {
+                    "type": [
+                      "string"
+                    ],
+                    "format": "binary"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "A simple string response",
+            "headers": {
+              "X-Rate-Limit-Limit": {
+                "description": "The number of allowed requests in the current period",
+                "schema": {
+                  "type": "integer"
+                }
+              },
+              "X-Rate-Limit-Remaining": {
+                "description": "The number of remaining requests in the current period",
+                "schema": {
+                  "type": "integer"
+                }
+              },
+              "X-Rate-Limit-Reset": {
+                "description": "The number of seconds left in the current period",
+                "schema": {
+                  "type": "integer",
+                  "maximum": 3
+                }
+              }
+            },
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": [
+                    "string"
+                  ],
+                  "examples": [
+                    "whoa!"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pet/{petId}/uploadmultiImage": {
+      "post": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Uploads an image",
+        "description": "Updates a pet in the store with a new image",
+        "operationId": "uploadFilemulti",
+        "parameters": [
+          {
+            "name": "petId",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "description": "ID of pet that needs to be updated",
+            "required": true,
+            "in": "path"
+          },
+          {
+            "name": "additionalMetadata",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Additional Metadata",
+            "in": "query"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": [
+                  "object"
+                ],
+                "properties": {
+                  "orderId": {
+                    "type": [
+                      "integer"
+                    ]
+                  },
+                  "image": {
+                    "type": [
+                      "string"
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "405": {
+            "description": "Invalid Input"
+          }
+        }
+      }
+    },
+    "/pet/{petId}/uploadImageOctet": {
+      "post": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Uploads an image",
+        "description": "Updates a pet in the store with a new image",
+        "operationId": "uploadFileOctet",
+        "parameters": [
+          {
+            "name": "petId",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "description": "ID of pet that needs to be updated",
+            "required": true,
+            "in": "path"
+          },
+          {
+            "name": "additionalMetadata",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Additional Metadata",
+            "in": "query"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/octet-stream": {
+              "schema": {}
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "405": {
+            "description": "Invalid Input"
+          }
+        }
+      }
+    },
+    "/store/inventory": {
+      "get": {
+        "tags": [
+          "store"
+        ],
+        "summary": "Returns pet inventories by status",
+        "description": "Returns a map of status codes to quantities",
+        "operationId": "getInventory",
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": [
+                    "object"
+                  ],
+                  "properties": {
+                    "none": {
+                      "type": [
+                        "string"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/store/order": {
+      "post": {
+        "deprecated": true,
+        "tags": [
+          "store"
+        ],
+        "summary": "Place an order for a pet",
+        "description": "Place a new order in the store",
+        "operationId": "placeOrder",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Order"
+              }
+            },
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/Order"
+              }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Order"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Invalid Input"
+          }
+        }
+      }
+    },
+    "/store/order/{orderId}": {
+      "get": {
+        "tags": [
+          "store"
+        ],
+        "summary": "Find purchase order by ID",
+        "description": "For valid response try integer IDs with value <= 5 or > 10. Other values will generate exceptions.",
+        "operationId": "getOrderById",
+        "parameters": [
+          {
+            "name": "orderId",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "description": "ID of order that needs to be fetched",
+            "required": true,
+            "in": "path"
+          }
+        ],
+        "servers": [
+          {
+            "description": "ext test server",
+            "url": "http://ext.server.com/api/v12"
+          },
+          {
+            "description": "ext test server 13",
+            "url": "http://ext13.server.com/api/v12"
+          },
+          {
+            "description": "ext test server 14",
+            "url": "http://ext14.server.com/api/v12"
+          },
+          {
+            "url": "/api/v3",
+            "description": "default endpoint"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              },
+              "application/x-www-form-urlencoded": {
+                "schema": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Order not found"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "store"
+        ],
+        "summary": "Delete purchase order by ID",
+        "description": "For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors.",
+        "operationId": "deleteOrder",
+        "parameters": [
+          {
+            "name": "orderId",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "description": " ID of the order that needs to be deleted",
+            "required": true,
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful operation"
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Order not found"
+          }
+        }
+      }
+    },
+    "/user": {
+      "post": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Create user.",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "createUser",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              }
+            },
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/UserOpSuccess"
+          },
+          "405": {
+            "description": "Invalid Input",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": [
+                    "object"
+                  ],
+                  "properties": {
+                    "result": {
+                      "type": [
+                        "string"
+                      ]
+                    },
+                    "message": {
+                      "type": [
+                        "string"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/user/createWithList": {
+      "post": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Creates list of users with given input array.",
+        "description": "Creates list of users with given input array.",
+        "operationId": "createUsersWithListInput",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              }
+            },
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/UserOpSuccess"
+          },
+          "405": {
+            "description": "Invalid Input"
+          }
+        }
+      }
+    },
+    "/user/login": {
+      "get": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Logs user into the system.",
+        "description": "Logs user into the system.",
+        "operationId": "loginUser",
+        "parameters": [
+          {
+            "name": "username",
+            "schema": {
+              "type": "string"
+            },
+            "description": "The user name for login",
+            "in": "query"
+          },
+          {
+            "name": "password",
+            "schema": {
+              "type": "string",
+              "format": "password"
+            },
+            "description": "The password for login in clear text",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "headers": {
+              "X-Rate-Limit": {
+                "$ref": "#/components/headers/X-Rate-Limit"
+              },
+              "X-Expires-After": {
+                "$ref": "#/components/headers/X-Expires-After"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid username/password supplied"
+          }
+        }
+      }
+    },
+    "/user/logout": {
+      "get": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Logs out current logged in user session.",
+        "description": "Logs out current logged in user session.",
+        "operationId": "logoutUser",
+        "responses": {
+          "200": {
+            "description": "Successful operation"
+          }
+        }
+      }
+    },
+    "/user/{username}": {
+      "get": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Get user by user name",
+        "description": "Get user by user name.",
+        "operationId": "getUserByName",
+        "parameters": [
+          {
+            "name": "username",
+            "schema": {
+              "type": "string"
+            },
+            "description": "The name that needs to be fetched. Use user1 for testing.",
+            "required": true,
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/UserOpSuccess"
+          },
+          "400": {
+            "description": "Invalid username supplied"
+          },
+          "404": {
+            "description": "User not found"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Update user",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "updateUser",
+        "parameters": [
+          {
+            "name": "username",
+            "schema": {
+              "type": "string"
+            },
+            "description": " name that need to be updated.",
+            "required": true,
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              }
+            },
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/UserOpSuccess"
+          },
+          "400": {
+            "description": "Invalid username supplied"
+          },
+          "404": {
+            "description": "User not found"
+          },
+          "405": {
+            "description": "Invalid Input"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Delete user",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "deleteUser",
+        "parameters": [
+          {
+            "name": "username",
+            "schema": {
+              "type": "string"
+            },
+            "description": "The name that needs to be deleted.",
+            "required": true,
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful operation"
+          },
+          "400": {
+            "description": "Invalid username supplied"
+          },
+          "404": {
+            "description": "User not found"
+          }
+        }
+      }
+    },
+    "/user_1/{username}": {
+      "put": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Update user",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "updateUser_1",
+        "parameters": [
+          {
+            "name": "username",
+            "schema": {
+              "type": "string"
+            },
+            "description": " name that need to be updated.",
+            "required": true,
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/StructPart"
+              }
+            },
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/StructPart"
+              }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/StructPart"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/UserOpSuccess"
+          },
+          "400": {
+            "description": "Invalid username supplied"
+          },
+          "404": {
+            "description": "User not found"
+          },
+          "405": {
+            "description": "Invalid Input"
+          }
+        }
+      }
+    },
+    "/userLink/{username}": {
+      "put": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Update user",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "updateUserLink",
+        "parameters": [
+          {
+            "name": "username",
+            "schema": {
+              "type": "string"
+            },
+            "description": " name that need to be updated.",
+            "required": true,
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              }
+            },
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            },
+            "links": {
+              "address": {
+                "operationId": "getUserByName",
+                "parameters": {
+                  "username": "$request.path.username"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid username supplied"
+          },
+          "404": {
+            "description": "User not found"
+          },
+          "405": {
+            "description": "Invalid Input"
+          }
+        }
+      }
+    },
+    "/userLinkByRef/{username}": {
+      "put": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Update user",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "updateUserLinkByRef",
+        "parameters": [
+          {
+            "name": "username",
+            "schema": {
+              "type": "string"
+            },
+            "description": " name that need to be updated.",
+            "required": true,
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              }
+            },
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            },
+            "links": {
+              "address2": {
+                "$ref": "#/components/links/address"
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid username supplied"
+          },
+          "404": {
+            "description": "User not found"
+          },
+          "405": {
+            "description": "Invalid Input"
+          }
+        }
+      }
+    },
+    "/stores/order/{orderId}": {
+      "get": {
+        "tags": [
+          "store"
+        ],
+        "summary": "Find purchase order by ID",
+        "description": "For valid response try integer IDs with value <= 5 or > 10. Other values will generate exceptions.",
+        "operationId": "getOrderExternalById",
+        "parameters": [
+          {
+            "name": "orderId",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "description": "ID of order that needs to be fetched",
+            "required": true,
+            "in": "path"
+          }
+        ],
+        "servers": [
+          {
+            "description": "ext test server",
+            "url": "http://ext.server.com/api/v12"
+          },
+          {
+            "description": "ext test server 13",
+            "url": "http://ext13.server.com/api/v12"
+          },
+          {
+            "description": "ext test server 14",
+            "url": "http://ext14.server.com/api/v12"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              },
+              "application/x-www-form-urlencoded": {
+                "schema": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Order not found"
+          }
+        }
+      }
     }
+  },
+  "webhooks": {
+    "newPet": {
+      "post": {
+        "description": "Information about a new pet in the system",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Pets"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Return a 200 status to indicate that the data was received successfully"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Address": {
+        "type": [
+          "object"
+        ],
+        "description": "Shipping Address",
+        "xml": {
+          "name": "address"
+        },
+        "properties": {
+          "street": {
+            "type": [
+              "string"
+            ],
+            "examples": [
+              "437 Lytton"
+            ]
+          },
+          "city": {
+            "type": [
+              "string"
+            ],
+            "examples": [
+              "Palo Alto"
+            ]
+          },
+          "state": {
+            "type": [
+              "string"
+            ],
+            "examples": [
+              "CA"
+            ]
+          },
+          "zip": {
+            "type": [
+              "string"
+            ],
+            "examples": [
+              "94031"
+            ]
+          }
+        },
+        "required": [
+          "street",
+          "city",
+          "state",
+          "zip"
+        ]
+      },
+      "Order": {
+        "type": [
+          "object"
+        ],
+        "xml": {
+          "name": "order"
+        },
+        "properties": {
+          "id": {
+            "type": [
+              "integer"
+            ],
+            "readOnly": true,
+            "examples": [
+              10
+            ],
+            "format": "int64"
+          },
+          "petId": {
+            "type": [
+              "integer"
+            ],
+            "examples": [
+              198772
+            ],
+            "format": "int64"
+          },
+          "quantity": {
+            "type": [
+              "integer"
+            ],
+            "examples": [
+              7
+            ],
+            "format": "int32"
+          },
+          "shipDate": {
+            "type": [
+              "string"
+            ],
+            "format": "date-time"
+          },
+          "status": {
+            "type": [
+              "string"
+            ],
+            "description": "Order Status",
+            "examples": [
+              "approved"
+            ],
+            "enum": [
+              "placed",
+              "approved",
+              "delivered"
+            ]
+          },
+          "complete": {
+            "type": [
+              "boolean"
+            ]
+          },
+          "Address": {
+            "$ref": "#/components/schemas/Address"
+          }
+        },
+        "additionalProperties": {
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "Category": {
+        "type": [
+          "object"
+        ],
+        "xml": {
+          "name": "category"
+        },
+        "properties": {
+          "id": {
+            "type": [
+              "integer"
+            ],
+            "examples": [
+              1
+            ],
+            "format": "int64"
+          },
+          "name": {
+            "type": [
+              "string"
+            ],
+            "examples": [
+              "Dogs"
+            ]
+          }
+        }
+      },
+      "User": {
+        "type": [
+          "object"
+        ],
+        "xml": {
+          "name": "user"
+        },
+        "properties": {
+          "id": {
+            "type": [
+              "integer"
+            ],
+            "readOnly": true,
+            "examples": [
+              1
+            ],
+            "format": "int64"
+          },
+          "username": {
+            "type": [
+              "string"
+            ],
+            "examples": [
+              "theUser"
+            ]
+          },
+          "firstName": {
+            "type": [
+              "string"
+            ],
+            "examples": [
+              "John"
+            ]
+          },
+          "lastName": {
+            "type": [
+              "string"
+            ],
+            "examples": [
+              "James"
+            ]
+          },
+          "email": {
+            "type": [
+              "string"
+            ],
+            "examples": [
+              "john@email.com"
+            ],
+            "format": "email"
+          },
+          "password": {
+            "type": [
+              "string"
+            ],
+            "examples": [
+              "12345"
+            ],
+            "format": "password"
+          },
+          "phone": {
+            "type": [
+              "string"
+            ],
+            "examples": [
+              "12345"
+            ]
+          },
+          "userStatus": {
+            "type": [
+              "integer"
+            ],
+            "description": "User Status",
+            "examples": [
+              1
+            ],
+            "format": "int32"
+          }
+        },
+        "required": [
+          "username",
+          "password"
+        ]
+      },
+      "aaaaa": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Address"
+          },
+          {
+            "$ref": "#/components/schemas/User"
+          }
+        ]
+      },
+      "Tag": {
+        "type": [
+          "object"
+        ],
+        "xml": {
+          "name": "tag"
+        },
+        "properties": {
+          "id": {
+            "type": [
+              "integer"
+            ],
+            "format": "int64"
+          },
+          "name": {
+            "type": [
+              "string"
+            ]
+          }
+        }
+      },
+      "Pet": {
+        "type": [
+          "object"
+        ],
+        "xml": {
+          "name": "pet"
+        },
+        "properties": {
+          "id": {
+            "type": [
+              "integer"
+            ],
+            "readOnly": true,
+            "examples": [
+              10,
+              2,
+              4
+            ],
+            "format": "int64"
+          },
+          "name": {
+            "type": [
+              "string"
+            ],
+            "examples": [
+              "doggie"
+            ]
+          },
+          "category": {
+            "$ref": "#/components/schemas/Category"
+          },
+          "petType": {
+            "type": [
+              "string"
+            ],
+            "examples": [
+              "dog"
+            ]
+          },
+          "photoUrls": {
+            "type": "array",
+            "items": {
+              "type": [
+                "string"
+              ]
+            }
+          },
+          "tags": {
+            "$ref": "#/components/schemas/Tag"
+          },
+          "status": {
+            "type": [
+              "string"
+            ],
+            "description": "pet status in the store",
+            "enum": [
+              "available",
+              "pending",
+              "sold"
+            ]
+          }
+        },
+        "required": [
+          "name",
+          "petType"
+        ]
+      },
+      "NewCat": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Pet"
+          },
+          {
+            "type": [
+              "object"
+            ],
+            "properties": {
+              "huntingSkill": {
+                "type": [
+                  "string"
+                ],
+                "description": "The measured skill for hunting",
+                "enum": [
+                  "clueless",
+                  "lazy",
+                  "adventurous",
+                  "aggressive"
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "XmlPrefixAndNamespace": {
+        "type": [
+          "object"
+        ],
+        "properties": {
+          "id": {
+            "type": [
+              "integer"
+            ],
+            "xml": {
+              "attribute": true
+            },
+            "format": "int32"
+          },
+          "name": {
+            "type": [
+              "string"
+            ],
+            "xml": {
+              "namespace": "http://example.com/schema/sample",
+              "prefix": "sample"
+            }
+          }
+        }
+      },
+      "animals": {
+        "type": "array",
+        "items": {
+          "type": [
+            "string"
+          ],
+          "xml": {
+            "name": "animal"
+          }
+        }
+      },
+      "AnimalsNoAliens": {
+        "type": "array",
+        "xml": {
+          "name": "aliens"
+        },
+        "items": {
+          "type": [
+            "string"
+          ],
+          "xml": {
+            "name": "animal"
+          }
+        }
+      },
+      "WrappedAnimals": {
+        "type": "array",
+        "xml": {
+          "wrapped": true
+        },
+        "items": {
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "WrappedAnimal": {
+        "type": "array",
+        "xml": {
+          "wrapped": true
+        },
+        "items": {
+          "type": [
+            "string"
+          ],
+          "xml": {
+            "name": "animal"
+          }
+        }
+      },
+      "WrappedAliens": {
+        "type": "array",
+        "xml": {
+          "name": "aliens",
+          "wrapped": true
+        },
+        "items": {
+          "type": [
+            "string"
+          ],
+          "xml": {
+            "name": "animal"
+          }
+        }
+      },
+      "WrappedAliensWithItems": {
+        "type": "array",
+        "xml": {
+          "name": "aliens",
+          "wrapped": true
+        },
+        "items": {
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "StructPart": {
+        "type": [
+          "object"
+        ],
+        "properties": {
+          "name": {
+            "type": [
+              "string"
+            ]
+          },
+          "type": {
+            "type": [
+              "string"
+            ]
+          },
+          "children": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/StructPart"
+            }
+          }
+        }
+      },
+      "Pet2": {
+        "type": [
+          "object"
+        ],
+        "properties": {
+          "name": {
+            "type": [
+              "string"
+            ]
+          },
+          "petType": {
+            "type": [
+              "string"
+            ]
+          }
+        },
+        "discriminator": {
+          "propertyName": "petType"
+        }
+      },
+      "Cat2": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Pet2"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "huntingSkill": {
+                "type": [
+                  "string"
+                ],
+                "description": "The measured skill for hunting",
+                "default": "lazy",
+                "enum": [
+                  "clueless",
+                  "lazy",
+                  "adventurous",
+                  "aggressive"
+                ]
+              }
+            },
+            "required": [
+              "huntingSkill"
+            ]
+          }
+        ],
+        "description": "A representation of a cat. Note that Cat will be used as the discriminator value."
+      },
+      "Dog2": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Pet2"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "packSize": {
+                "type": [
+                  "integer"
+                ],
+                "description": "the size of the pack the dog is from",
+                "minimum": 0,
+                "format": "int32"
+              }
+            },
+            "required": [
+              "packSize"
+            ]
+          }
+        ],
+        "description": "A representation of a dog. Note that Dog will be used as the discriminator value."
+      },
+      "ExtendedErrorModel": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Pet"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "rootCause": {
+                "type": [
+                  "string"
+                ]
+              }
+            },
+            "required": [
+              "rootCause"
+            ]
+          }
+        ]
+      },
+      "Cat": {
+        "type": [
+          "object"
+        ],
+        "description": "Type of cat",
+        "properties": {
+          "breed": {
+            "type": [
+              "string"
+            ],
+            "description": "Type of Breed",
+            "enum": [
+              "Abyssinian",
+              "Balinese-Javanese",
+              "Burmese",
+              "British Shorthair"
+            ]
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Pet"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "huntingSkill": {
+                "type": [
+                  "string"
+                ],
+                "description": "The measured skill for hunting",
+                "enum": [
+                  "clueless",
+                  "lazy",
+                  "adventurous",
+                  "aggressive"
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "Dog": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Pet"
+          },
+          {
+            "type": [
+              "object"
+            ],
+            "properties": {
+              "breed": {
+                "type": [
+                  "string"
+                ],
+                "description": "Type of Breed",
+                "enum": [
+                  "Dingo",
+                  "Husky",
+                  "Retriever",
+                  "Shepherd"
+                ]
+              },
+              "bark": {
+                "type": [
+                  "boolean"
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "Pets": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/Cat"
+          },
+          {
+            "$ref": "#/components/schemas/Dog"
+          }
+        ],
+        "discriminator": {
+          "propertyName": "petType"
+        }
+      },
+      "ApiResponse": {
+        "type": [
+          "object"
+        ],
+        "xml": {
+          "name": "##default"
+        },
+        "properties": {
+          "code": {
+            "type": [
+              "integer"
+            ],
+            "format": "int32"
+          },
+          "type": {
+            "type": [
+              "string"
+            ],
+            "examples": [
+              "doggie"
+            ]
+          },
+          "message": {
+            "type": [
+              "string"
+            ]
+          }
+        }
+      },
+      "ErrorModel": {
+        "type": [
+          "object"
+        ],
+        "properties": {
+          "message": {
+            "type": [
+              "string"
+            ]
+          },
+          "code": {
+            "type": [
+              "integer"
+            ],
+            "format": "int32"
+          }
+        }
+      }
+    },
+    "responses": {
+      "UserOpSuccess": {
+        "description": "Successful operation",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/User"
+            }
+          },
+          "application/xml": {
+            "schema": {
+              "$ref": "#/components/schemas/User"
+            }
+          }
+        }
+      }
+    },
+    "parameters": {
+      "PetIdParam": {
+        "name": "petId",
+        "schema": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "description": "ID of the pet",
+        "required": true,
+        "in": "path"
+      }
+    },
+    "requestBodies": {
+      "PetBodySchema": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Pets"
+            }
+          },
+          "application/xml": {
+            "schema": {
+              "$ref": "#/components/schemas/Pets"
+            }
+          },
+          "application/x-www-form-urlencoded": {
+            "schema": {
+              "$ref": "#/components/schemas/Pets"
+            }
+          }
+        },
+        "required": true,
+        "description": "Pet in the store"
+      }
+    },
+    "headers": {
+      "X-Rate-Limit": {
+        "schema": {
+          "type": [
+            "integer"
+          ],
+          "format": "int32"
+        }
+      },
+      "X-Expires-After": {
+        "schema": {
+          "type": [
+            "string"
+          ],
+          "format": "date-time"
+        }
+      }
+    },
+    "links": {
+      "address": {
+        "operationId": "getUserByName",
+        "parameters": {
+          "username": "$request.path.username"
+        }
+      }
+    },
+    "callbacks": {
+      "test": {
+        "'{$request.body#/id}'": {
+          "post": {
+            "requestBody": {
+              "content": {
+                "\"*/*\"": {
+                  "schema": {
+                    "type": [
+                      "string"
+                    ]
+                  }
+                }
+              }
+            },
+            "responses": {
+              "200": {
+                "description": "Successful operation",
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Pet"
+                      }
+                    }
+                  },
+                  "application/xml": {
+                    "schema": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Pet"
+                      }
+                    }
+                  }
+                }
+              },
+              "400": {
+                "description": "Invalid ID supplied"
+              },
+              "404": {
+                "description": "Pet not found"
+              },
+              "default": {
+                "description": "Something is wrong"
+              }
+            }
+          }
+        }
+      }
+    },
+    "pathItems": {
+      "GetPetByIdWithRef": {
+        "get": {
+          "tags": [
+            "pet"
+          ],
+          "summary": "Find pet by ID",
+          "description": "Returns a single pet.",
+          "operationId": "getPetByIdWithRef",
+          "parameters": [
+            {
+              "name": "petId",
+              "schema": {
+                "type": "integer",
+                "format": "int64"
+              },
+              "description": "ID of pet to return",
+              "required": true,
+              "in": "path"
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Successful operation",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Pet"
+                  }
+                },
+                "application/xml": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Pet"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Invalid ID supplied"
+            },
+            "404": {
+              "description": "Pet not found"
+            },
+            "415": {
+              "description": "Unsupported Media Type"
+            }
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "Jwt": {
+        "type": "http",
+        "scheme": "bearer"
+      },
+      "Login": {
+        "type": "http",
+        "scheme": "basic"
+      },
+      "Login-OAuth2": {
+        "type": "oauth2",
+        "flows": {
+          "authorizationCode": {
+            "tokenUrl": "http://example.org/api/oauth/token",
+            "authorizationUrl": "http://example.org/api/oauth/dialog",
+            "scopes": {
+              "read": "Grant read-only access to all your data except for the account and user info",
+              "write": "Grant write-only access to all your data except for the account and user info"
+            }
+          }
+        }
+      },
+      "LoginApiKey": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-API-KEY"
+      },
+      "api_key": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "api_key"
+      }
+    }
+  }
 }


### PR DESCRIPTION
**Description:**
This pull request addresses issue [#1450](https://github.com/Badgerati/Pode/issues/1450), where routes containing parameters (e.g., `/api/users/:userId`) were not correctly added to the OpenAPI Routes list in Pode. This fix adjusts the code to properly recognize and add parameterized routes, ensuring they appear in the generated OpenAPI documentation.

**Fix Details:**
The modification was made in `public/Route.ps1` at line 455.

**Original Code:**
```powershell
if ($PodeContext.Server.OpenAPI.Routes -notcontains $OpenApiPath ) {
    $PodeContext.Server.OpenAPI.Routes += $OpenApiPath
}
```

**Updated Code:**
```powershell
if ($PodeContext.Server.OpenAPI.Routes -notcontains $Path ) {
    $PodeContext.Server.OpenAPI.Routes += $Path
}
```

**Issue and Solution Explanation:**
The previous implementation checked and added the `$OpenApiPath` variable, which did not correctly account for routes with parameters, such as `/api/users/:userId`. By updating the condition to check and add `$Path` instead of `$OpenApiPath`, parameterized routes are now accurately identified and included in the `Routes` collection within Pode’s OpenAPI configuration.

**Testing and Validation:**
- Verified that OpenAPI documentation includes parameterized routes as expected.
- Confirmed that non-parameterized routes are unaffected by the change.
 