### PR TITLE
Fixes for `Suspend-PodeServer`, `Resume-PodeServer`, and Endpoint Data Handling  

### DIFF
--- a/src/Private/Console.ps1
+++ b/src/Private/Console.ps1
@@ -944,10 +944,6 @@ function Get-PodeConsoleKey {
     The `Invoke-PodeConsoleAction` function uses a hashtable to define and centralize key mappings,
     allowing for easier updates and a cleaner implementation.
 
-.PARAMETER serverState
-    The current state of the Pode server, retrieved using Get-PodeServerState,
-    which determines whether actions like suspend, disable, or restart can be executed.
-
 .NOTES
     This function is part of Pode's internal utilities and may change in future releases.
 
@@ -957,11 +953,10 @@ function Get-PodeConsoleKey {
     Processes the next key press or cancellation token to execute the corresponding server action.
 #>
 function Invoke-PodeConsoleAction {
-    param(
-        [Parameter(Mandatory = $true)]
-        [Pode.PodeServerState]
-        $ServerState
-    )
+
+    # Retrieve the current state of the server (e.g., Running, Suspended).
+    $serverState = Get-PodeServerState
+
     # Get the next key press if console input is enabled
     $Key = Get-PodeConsoleKey
     if ($null -ne $key) {
@@ -1427,7 +1422,7 @@ function Test-PodeHasConsole {
         return ([Pode.NativeMethods]::IsTerminal($handleTypeMap.Input) -and `
                 [Pode.NativeMethods]::IsTerminal($handleTypeMap.Output) -and `
                 [Pode.NativeMethods]::IsTerminal($handleTypeMap.Error)
-        )  
+        )
     }
     return $false
 }

--- a/src/Private/Server.ps1
+++ b/src/Private/Server.ps1
@@ -183,16 +183,18 @@ function Start-PodeInternalServer {
             }
         }
 
-        # Trigger the start
-        Close-PodeCancellationTokenRequest -Type Start
 
         # set the start time of the server (start and after restart)
         $PodeContext.Metrics.Server.StartTime = [datetime]::UtcNow
 
+        # Trigger the start
+        Close-PodeCancellationTokenRequest -Type Start
+
+        Show-PodeConsoleInfo
+
         # run running event hooks
         Invoke-PodeEvent -Type Running
 
-        Show-PodeConsoleInfo
 
     }
     catch {

--- a/src/Public/Core.ps1
+++ b/src/Public/Core.ps1
@@ -302,21 +302,18 @@ function Start-PodeServer {
 
             # Sit in a loop waiting for server termination/cancellation or a restart request.
             while (!(Test-PodeCancellationTokenRequest -Type Terminate)) {
-                # Retrieve the current state of the server (e.g., Running, Suspended).
-                $serverState = Get-PodeServerState
 
                 # If console input is not disabled, invoke any actions based on console commands.
                 if (!$PodeContext.Server.Console.DisableConsoleInput) {
-                    Invoke-PodeConsoleAction -ServerState $serverState
+                    Invoke-PodeConsoleAction
                 }
 
                 # Resolve cancellation token requests (e.g., Restart, Enable/Disable, Suspend/Resume).
-                Resolve-PodeCancellationToken -ServerState $serverState
+                Resolve-PodeCancellationToken
 
                 # Pause for 1 second before re-checking the state and processing the next action.
                 Start-Sleep -Seconds 1
             }
-
 
             if ($PodeContext.Server.IsIIS -and $PodeContext.Server.IIS.Shutdown) {
                 # (IIS Shutdown)


### PR DESCRIPTION
## Summary  
This pull request resolves issues with `Suspend-PodeServer` and `Resume-PodeServer` not correctly handling server state transitions. Additionally, it fixes a problem where endpoints were receiving data before the Pode start event.  

## Related Issues  
- Fixes #1476  
- Fixes #1477  

## Changes  
- Fixed `Suspend-PodeServer` and `Resume-PodeServer` to ensure proper server suspension and resumption.  
- Resolved an issue where endpoints were processing incoming requests before the Pode start event was triggered.  

## Impact  
These fixes ensure that:  
- `Suspend-PodeServer` and `Resume-PodeServer` function as expected.  
- Endpoints do not receive data before Pode has fully started, preventing potential race conditions.  

## Testing  
- Verified that `Suspend-PodeServer` and `Resume-PodeServer` properly pause and resume the server.  
- Confirmed that endpoints no longer process data before the Pode start event completes.  
 