### PR TITLE
Set initial runspace location to be the Server Root path

### DIFF
--- a/src/Private/Runspaces.ps1
+++ b/src/Private/Runspaces.ps1
@@ -39,7 +39,6 @@
         # Your script code here
     }
 #>
-
 function Add-PodeRunspace {
     param(
         [Parameter(Mandatory = $true)]
@@ -75,10 +74,13 @@ function Add-PodeRunspace {
     try {
         # Define the script block to open the runspace and set its state.
         $openRunspaceScript = {
-            param($Type, $Name, $NoProfile)
+            param([string]$Type, [string]$Name, [bool]$NoProfile)
             try {
                 # Set the runspace name.
                 Set-PodeCurrentRunspaceName -Name $Name
+
+                # Set runspace location to server root
+                Set-Location $PodeContext.Server.Root
 
                 if (!$NoProfile) {
                     # Import necessary internal Pode modules for the runspace.
@@ -110,13 +112,11 @@ function Add-PodeRunspace {
 
         # Add the script block and parameters to the pipeline.
         $null = $ps.AddScript($openRunspaceScript)
-        $null = $ps.AddParameters(
-            @{
-                'Type'      = $Type
-                'Name'      = "Pode_$($Type)_$($Name)_$((++$PodeContext.RunspacePools[$Type].LastId))" # create the name and increment the last Id for the type
-                'NoProfile' = $NoProfile.IsPresent
-            }
-        )
+        $null = $ps.AddParameters(@{
+                Type      = $Type
+                Name      = "Pode_$($Type)_$($Name)_$((++$PodeContext.RunspacePools[$Type].LastId))" # create the name and increment the last Id for the type
+                NoProfile = $NoProfile.IsPresent
+            })
 
         # Add the main script block to the pipeline.
         $null = $ps.AddScript($ScriptBlock)
@@ -352,5 +352,5 @@ function Reset-PodeRunspaceName {
     }
 
     # Update the runspace name with the required format
-    $currentRunspace.Name = "_$($currentRunspace.Name -replace '^(Pode_[^_]+_).+?(_\d+)$', '${1}idle${2}')" 
+    $currentRunspace.Name = "_$($currentRunspace.Name -replace '^(Pode_[^_]+_).+?(_\d+)$', '${1}idle${2}')"
 }

--- a/src/Private/Timers.ps1
+++ b/src/Private/Timers.ps1
@@ -123,6 +123,9 @@ function Invoke-PodeInternalTimer {
 
         # invoke timer
         Invoke-PodeScriptBlock -ScriptBlock $Timer.Script.GetNewClosure() -Arguments $_args -UsingVariables $Timer.UsingVariables -Scoped -Splat -NoNewClosure
+
+        # reset runspace location
+        Set-Location $PodeContext.Server.Root
     }
     catch {
         $_ | Write-PodeErrorLog


### PR DESCRIPTION
### Description of the Change
When runspaces are created, set their initial location to be the server root. If the path is ever changed via Set-Location in Tasks, this will reset the location back to server root.

### Related Issue
Resolves #1455 