### PR TITLE
Adds support for retrying failed Task processes

### DIFF
--- a/examples/Tasks.ps1
+++ b/examples/Tasks.ps1
@@ -56,6 +56,14 @@ Start-PodeServer {
         "a $($value) is never late, it arrives exactly when it means to" | Out-Default
     }
 
+    Add-PodeTask -Name 'Intermittent' -MaxRetries 3 -AutoRetry -ScriptBlock {
+        if ($TaskEvent.Count -lt 2) {
+            throw "this task is intermittent (attempt $($TaskEvent.Count))"
+        }
+
+        'task completed' | Out-Default
+    }
+
     # create a new timer via a route
     Add-PodeRoute -Method Get -Path '/api/task/sync' -ScriptBlock {
         $result = Invoke-PodeTask -Name 'Test1' -Wait
@@ -73,4 +81,7 @@ Start-PodeServer {
         Write-PodeJsonResponse -Value @{ Result = 'jobs done' }
     }
 
+    Add-PodeRoute -Method Get -Path '/api/task/intermittent' -ScriptBlock {
+        Invoke-PodeTask -Name 'Intermittent'
+    }
 }

--- a/src/Pode.psd1
+++ b/src/Pode.psd1
@@ -211,8 +211,10 @@
         'Use-PodeTasks',
         'Close-PodeTask',
         'Test-PodeTaskCompleted',
+        'Test-PodeTaskFailed',
         'Wait-PodeTask',
         'Get-PodeTaskProcess',
+        'Restart-PodeTaskProcess',
 
         # middleware
         'Add-PodeMiddleware',

--- a/src/Private/Tasks.ps1
+++ b/src/Private/Tasks.ps1
@@ -7,27 +7,63 @@ function Start-PodeTaskHousekeeper {
         return
     }
 
-    Add-PodeTimer -Name '__pode_task_housekeeper__' -Interval 30 -ScriptBlock {
+    Add-PodeTimer -Name '__pode_task_housekeeper__' -Interval 20 -ScriptBlock {
         try {
+            # return if no task processes
             if ($PodeContext.Tasks.Processes.Count -eq 0) {
                 return
             }
 
+            # get the current time
             $now = [datetime]::UtcNow
 
+            # loop through each process
             foreach ($key in $PodeContext.Tasks.Processes.Keys.Clone()) {
                 try {
+                    # get the process and the task
                     $process = $PodeContext.Tasks.Processes[$key]
+                    $task = $PodeContext.Tasks.Items[$process.Task]
 
-                    # has it completed or expire? then dispose and remove
-                    if ((($null -ne $process.CompletedTime) -and ($process.CompletedTime.AddMinutes(1) -lt $now)) -or ($process.ExpireTime -lt $now)) {
+                    # if completed, and no completed time set, then set one and continue
+                    if ($process.Runspace.Handler.IsCompleted -and ($null -eq $process.CompletedTime)) {
+                        $process.CompletedTime = $now
+                        $process.State = 'Completed'
+                        continue
+                    }
+
+                    # if the process is completed, then close and remove
+                    if (($process.State -ieq 'Completed') -and ($process.CompletedTime.AddMinutes(1) -lt $now)) {
                         Close-PodeTaskInternal -Process $process
                         continue
                     }
 
-                    # if completed, and no completed time, set it
-                    if ($process.Runspace.Handler.IsCompleted -and ($null -eq $process.CompletedTime)) {
-                        $process.CompletedTime = $now
+                    # has the process failed?
+                    if ($process.State -ieq 'Failed') {
+                        # if we have hit the max retries, then close and remove
+                        if ($process.Retry.Count -ge $task.Retry.Max) {
+                            Close-PodeTaskInternal -Process $process
+                            continue
+                        }
+
+                        # if we aren't auto-retrying, then continue
+                        if (!$task.Retry.AutoRetry) {
+                            continue
+                        }
+
+                        # if the retry delay hasn't passed, then continue
+                        if (($null -eq $process.Retry.From) -or ($process.Retry.From -gt $now)) {
+                            continue
+                        }
+
+                        # restart the process
+                        Restart-PodeTaskInternal -ProcessId $process.ID
+                        continue
+                    }
+
+                    # if the process is running, and the expire time has passed, then close and remove
+                    if ($process.ExpireTime -lt $now) {
+                        Close-PodeTaskInternal -Process $process
+                        continue
                     }
                 }
                 catch {
@@ -47,19 +83,28 @@ function Close-PodeTaskInternal {
     param(
         [Parameter()]
         [hashtable]
-        $Process
+        $Process,
+
+        [switch]
+        $Keep
     )
 
+    # return if no process
     if ($null -eq $Process) {
         return
     }
 
+    # close the runspace
     Close-PodeDisposable -Disposable $Process.Runspace.Pipeline
     Close-PodeDisposable -Disposable $Process.Result
-    $null = $PodeContext.Tasks.Processes.Remove($Process.ID)
+
+    # remove the process
+    if (!$Keep) {
+        $null = $PodeContext.Tasks.Processes.Remove($Process.ID)
+    }
 }
 
-function Invoke-PodeInternalTask {
+function Invoke-PodeTaskInternal {
     param(
         [Parameter(Mandatory = $true)]
         [hashtable]
@@ -111,15 +156,21 @@ function Invoke-PodeInternalTask {
         $PodeContext.Tasks.Processes[$processId] = @{
             ID            = $processId
             Task          = $Task.Name
+            Parameters    = $parameters
             Runspace      = $null
             Result        = $result
             CreateTime    = $createTime
             StartTime     = $null
             CompletedTime = $null
             ExpireTime    = $expireTime
+            Exception     = $null
             Timeout       = @{
                 Value = $Timeout
                 From  = $TimeoutFrom
+            }
+            Retry         = @{
+                Count = 0
+                From  = $null
             }
             State         = 'Pending'
         }
@@ -133,6 +184,69 @@ function Invoke-PodeInternalTask {
 
         # return the task process
         return $PodeContext.Tasks.Processes[$processId]
+    }
+    catch {
+        $_ | Write-PodeErrorLog
+    }
+}
+
+function Restart-PodeTaskInternal {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]
+        $ProcessId
+    )
+
+    try {
+        # get the process, and return if not found or not failed
+        $process = $PodeContext.Tasks.Processes[$ProcessId]
+        if (($null -eq $process) -or ($process.State -ine 'Failed')) {
+            return
+        }
+
+        # get the task
+        $task = $PodeContext.Tasks.Items[$process.Task]
+
+        # dispose of the old runspace
+        Close-PodeTaskInternal -Process $process -Keep
+
+        # return if we have hit the max retries
+        if ($process.Retry.Count -ge $task.Retry.Max) {
+            return
+        }
+
+        # what is the expire time if using "create" timeout?
+        $expireTime = [datetime]::MaxValue
+        $createTime = [datetime]::UtcNow
+
+        if (($process.Timeout.From -ieq 'Create') -and ($process.Timeout.Value -ge 0)) {
+            $expireTime = $createTime.AddSeconds($process.Timeout.Value)
+        }
+
+        $process.CreateTime = $createTime
+        $process.ExpireTime = $expireTime
+        $process.StartTime = $null
+        $process.CompletedTime = $null
+
+        # reset the process result
+        $result = [System.Management.Automation.PSDataCollection[psobject]]::new()
+        $process.Result = $result
+
+        # reset the process state
+        $process.State = 'Pending'
+        $process.Exception = $null
+        $process.Retry.Count++
+        $process.Retry.From = $null
+
+        # start the task runspace
+        $scriptblock = Get-PodeTaskScriptBlock
+        $runspace = Add-PodeRunspace -Type Tasks -Name $process.Task -ScriptBlock $scriptblock -Parameters $process.Parameters -OutputStream $result -PassThru
+
+        # add runspace to process
+        $process.Runspace = $runspace
+
+        # return the task process
+        return $process
     }
     catch {
         $_ | Write-PodeErrorLog
@@ -171,6 +285,7 @@ function Get-PodeTaskScriptBlock {
                 Lockable  = $PodeContext.Threading.Lockables.Global
                 Sender    = $task
                 Timestamp = [DateTime]::UtcNow
+                Count     = $process.Retry.Count
                 Metadata  = @{}
             }
 
@@ -205,19 +320,23 @@ function Get-PodeTaskScriptBlock {
             # update the state
             if ($null -ne $process) {
                 $process.State = 'Failed'
+                $process.ExpireTime = $null
+                $process.Retry.From = [datetime]::UtcNow.AddMinutes($task.Retry.Delay)
+                $process.Exception = $_
             }
 
             # log the error
             $_ | Write-PodeErrorLog
         }
         finally {
+            $process.CompletedTime = [datetime]::UtcNow
             Reset-PodeRunspaceName
             Invoke-PodeGC
         }
     }
 }
 
-function Wait-PodeNetTaskInternal {
+function Wait-PodeTaskNetInternal {
     [CmdletBinding()]
     [OutputType([object])]
     param(
@@ -252,7 +371,7 @@ function Wait-PodeNetTaskInternal {
         $checkTask.Wait($PodeContext.Tokens.Cancellation.Token)
     }
 
-    # if the main task isnt complete, it timed out
+    # if the main task isn't complete, it timed out
     if (($null -ne $timeoutTask) -and (!$Task.IsCompleted)) {
         # "Task has timed out after $($Timeout)ms")
         throw [System.TimeoutException]::new($PodeLocale.taskTimedOutExceptionMessage -f $Timeout)
@@ -264,13 +383,13 @@ function Wait-PodeNetTaskInternal {
     }
 }
 
-function Wait-PodeTaskInternal {
+function Wait-PodeTaskProcessInternal {
     [CmdletBinding()]
     [OutputType([object])]
     param(
         [Parameter(Mandatory = $true)]
         [hashtable]
-        $Task,
+        $Process,
 
         [Parameter()]
         [int]
@@ -283,13 +402,13 @@ function Wait-PodeTaskInternal {
     }
 
     # wait for the pipeline to finish processing
-    $null = $Task.Runspace.Handler.AsyncWaitHandle.WaitOne($Timeout)
+    $null = $Process.Runspace.Handler.AsyncWaitHandle.WaitOne($Timeout)
 
     # get the current result
-    $result = $Task.Result.ReadAll()
+    $result = $Process.Result.ReadAll()
 
     # close the task
-    Close-PodeTask -Task $Task
+    Close-PodeTask -Process $Process
 
     # only return a value if the result has one
     if (($null -ne $result) -and ($result.Count -gt 0)) {

--- a/src/Public/Tasks.ps1
+++ b/src/Public/Tasks.ps1
@@ -1,33 +1,45 @@
 <#
 .SYNOPSIS
-    Adds a new Task.
+Adds a new Task.
 
 .DESCRIPTION
-    Adds a new Task, which can be asynchronously or synchronously invoked.
+Adds a new Task, which can be asynchronously or synchronously invoked.
 
 .PARAMETER Name
-    The Name of the Task.
+The Name of the Task.
 
 .PARAMETER ScriptBlock
-    The script for the Task.
+The script for the Task.
 
 .PARAMETER FilePath
-    A literal, or relative, path to a file containing a ScriptBlock for the Task's logic.
+A literal, or relative, path to a file containing a ScriptBlock for the Task's logic.
 
 .PARAMETER ArgumentList
-    A hashtable of arguments to supply to the Task's ScriptBlock.
+A hashtable of arguments to supply to the Task's ScriptBlock.
 
 .PARAMETER Timeout
-    A Timeout, in seconds, to abort running the Task process. (Default: -1 [never timeout])
+A Timeout, in seconds, to abort running the Task process. (Default: -1 [never timeout])
 
 .PARAMETER TimeoutFrom
-    Where to start the Timeout from, either 'Create', 'Start'. (Default: 'Create')
+Where to start the Timeout from, either 'Create', 'Start'. (Default: 'Create')
+
+.PARAMETER MaxRetries
+The maximum number of retries to attempt if the Task fails. (Default: 0)
+
+.PARAMETER RetryDelay
+The delay, in minutes, between automatically retrying failed task processes. (Default: 0)
+
+.PARAMETER AutoRetry
+If supplied, the Task will automatically retry processes if they fail.
 
 .EXAMPLE
-    Add-PodeTask -Name 'Example1' -ScriptBlock { Invoke-SomeLogic }
+Add-PodeTask -Name 'Example1' -ScriptBlock { Invoke-SomeLogic }
 
 .EXAMPLE
-    Add-PodeTask -Name 'Example1' -ScriptBlock { return Get-SomeObject }
+Add-PodeTask -Name 'Example1' -ScriptBlock { return Get-SomeObject }
+
+.EXAMPLE
+Add-PodeTask -Name 'Example1' -ScriptBlock { return Get-SomeObject } -MaxRetries 3 -RetryDelay 5 -AutoRetry
 #>
 function Add-PodeTask {
     [CmdletBinding(DefaultParameterSetName = 'Script')]
@@ -55,8 +67,22 @@ function Add-PodeTask {
         [Parameter()]
         [ValidateSet('Create', 'Start')]
         [string]
-        $TimeoutFrom = 'Create'
+        $TimeoutFrom = 'Create',
+
+        [Parameter()]
+        [ValidateRange(0, [int]::MaxValue)]
+        [int]
+        $MaxRetries = 0,
+
+        [Parameter()]
+        [ValidateRange(0, [int]::MaxValue)]
+        [int]
+        $RetryDelay = 0,
+
+        [switch]
+        $AutoRetry
     )
+
     # ensure the task doesn't already exist
     if ($PodeContext.Tasks.Items.ContainsKey($Name)) {
         # [Task] Task already defined
@@ -84,6 +110,11 @@ function Add-PodeTask {
         Timeout        = @{
             Value = $Timeout
             From  = $TimeoutFrom
+        }
+        Retry          = @{
+            Max       = $MaxRetries
+            Delay     = $RetryDelay
+            AutoRetry = $AutoRetry.IsPresent
         }
     }
 }
@@ -140,7 +171,7 @@ Invoke a Task.
 
 .DESCRIPTION
 Invoke a Task either asynchronously or synchronously, with support for returning values.
-The function returns the Task process onbject which was triggered.
+The function returns the Task process object which was triggered.
 
 .PARAMETER Name
 The Name of the Task.
@@ -192,6 +223,7 @@ function Invoke-PodeTask {
         [switch]
         $Wait
     )
+
     process {
         # ensure the task exists
         if (!$PodeContext.Tasks.Items.ContainsKey($Name)) {
@@ -200,11 +232,11 @@ function Invoke-PodeTask {
         }
 
         # run task logic
-        $task = Invoke-PodeInternalTask -Task $PodeContext.Tasks.Items[$Name] -ArgumentList $ArgumentList -Timeout $Timeout -TimeoutFrom $TimeoutFrom
+        $task = Invoke-PodeTaskInternal -Task $PodeContext.Tasks.Items[$Name] -ArgumentList $ArgumentList -Timeout $Timeout -TimeoutFrom $TimeoutFrom
 
         # wait, and return result?
         if ($Wait) {
-            return (Wait-PodeTask -Task $task -Timeout $Timeout)
+            return (Wait-PodeTask -Process $task -Timeout $Timeout)
         }
 
         # return task
@@ -232,6 +264,7 @@ function Remove-PodeTask {
         [string]
         $Name
     )
+
     process {
         $null = $PodeContext.Tasks.Items.Remove($Name)
     }
@@ -289,6 +322,7 @@ function Edit-PodeTask {
         [hashtable]
         $ArgumentList
     )
+
     process {
         # ensure the task exists
         if (!$PodeContext.Tasks.Items.ContainsKey($Name)) {
@@ -390,7 +424,7 @@ Close and dispose of a Task.
 .DESCRIPTION
 Close and dispose of a Task, even if still running.
 
-.PARAMETER Task
+.PARAMETER Process
 The Task to be closed.
 
 .EXAMPLE
@@ -400,22 +434,24 @@ function Close-PodeTask {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true)]
+        [Alias('Task')]
         [hashtable]
-        $Task
+        $Process
     )
+
     process {
-        Close-PodeTaskInternal -Process $Task
+        Close-PodeTaskInternal -Process $Process
     }
 }
 
 <#
 .SYNOPSIS
-Test if a running Task process has completed.
+Test if a running Task process has completed (including failed).
 
 .DESCRIPTION
-Test if a running Task process has completed.
+Test if a running Task process has completed (including failed).
 
-.PARAMETER Task
+.PARAMETER Process
 The Task process to be check. The process returned by either Invoke-PodeTask or Get-PodeTaskProcess.
 
 .EXAMPLE
@@ -426,11 +462,43 @@ function Test-PodeTaskCompleted {
     [OutputType([bool])]
     param(
         [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true)]
+        [Alias('Task')]
         [hashtable]
-        $Task
+        $Process
     )
+
     process {
-        return [bool]$Task.Runspace.Handler.IsCompleted
+        return ([bool]$Process.Runspace.Handler.IsCompleted) -or
+            ($Process.State -ieq 'Completed') -or
+            ($Process.State -ieq 'Failed')
+    }
+}
+
+<#
+.SYNOPSIS
+Test if a running Task process has failed.
+
+.DESCRIPTION
+Test if a running Task process has failed.
+
+.PARAMETER Process
+The Task process to be check. The process returned by either Invoke-PodeTask or Get-PodeTaskProcess.
+
+.EXAMPLE
+Invoke-PodeTask -Name 'Example1' | Test-PodeTaskFailed
+#>
+function Test-PodeTaskFailed {
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true)]
+        [Alias('Task')]
+        [hashtable]
+        $Process
+    )
+
+    process {
+        return ($Process.State -ieq 'Failed')
     }
 }
 
@@ -441,7 +509,7 @@ Waits for a Task process to finish, and returns a result if there is one.
 .DESCRIPTION
 Waits for a Task process to finish, and returns a result if there is one.
 
-.PARAMETER Task
+.PARAMETER Process
 The Task process to wait on. The process returned by either Invoke-PodeTask or Get-PodeTaskProcess.
 
 .PARAMETER Timeout
@@ -458,12 +526,14 @@ function Wait-PodeTask {
     [OutputType([object])]
     param(
         [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true)]
-        $Task,
+        [Alias('Task')]
+        $Process,
 
         [Parameter()]
         [int]
         $Timeout = -1
     )
+
     begin {
         $pipelineItemCount = 0
     }
@@ -476,12 +546,13 @@ function Wait-PodeTask {
         if ($pipelineItemCount -gt 1) {
             throw ($PodeLocale.fnDoesNotAcceptArrayAsPipelineInputExceptionMessage -f $($MyInvocation.MyCommand.Name))
         }
-        if ($Task -is [System.Threading.Tasks.Task]) {
-            return (Wait-PodeNetTaskInternal -Task $Task -Timeout $Timeout)
+
+        if ($Process -is [System.Threading.Tasks.Task]) {
+            return (Wait-PodeTaskNetInternal -Task $Process -Timeout $Timeout)
         }
 
-        if ($Task -is [hashtable]) {
-            return (Wait-PodeTaskInternal -Task $Task -Timeout $Timeout)
+        if ($Process -is [hashtable]) {
+            return (Wait-PodeTaskProcessInternal -Process $Process -Timeout $Timeout)
         }
 
         # Task type is invalid, expected either [System.Threading.Tasks.Task] or [hashtable]
@@ -575,4 +646,56 @@ function Get-PodeTaskProcess {
 
     # return processes
     return $processes
+}
+
+<#
+.SYNOPSIS
+Restart a Task process which has failed.
+
+.DESCRIPTION
+Restart a Task process which has failed.
+
+.PARAMETER Process
+The Task process to be restarted. The process returned by either Invoke-PodeTask or Get-PodeTaskProcess.
+
+.PARAMETER Timeout
+A Timeout, in seconds, to abort running the Task process. (Default: -1 [never timeout])
+
+.PARAMETER Wait
+If supplied, Pode will wait until the Task process has finished
+
+.EXAMPLE
+$task = Invoke-PodeTask -Name 'Example1' -Wait
+if (Test-PodeTaskFailed -Process $task) {
+    Restart-PodeTaskProcess -Process $task
+}
+
+.EXAMPLE
+Get-PodeTaskProcess -State 'Failed' | ForEach-Object { Restart-PodeTaskProcess -Process $_ }
+#>
+function Restart-PodeTaskProcess {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true)]
+        [Alias('Task')]
+        [hashtable]
+        $Process,
+
+        [Parameter()]
+        [int]
+        $Timeout = -1,
+
+        [switch]
+        $Wait
+    )
+
+    process {
+        $task = Restart-PodeTaskInternal -ProcessId $Process.ID
+
+        if ($Wait) {
+            return (Wait-PodeTask -Process $task -Timeout $Timeout)
+        }
+
+        return $task
+    }
 }


### PR DESCRIPTION
### Description of the Change
Adds support for being able to either automatically, or manually, retry failed Task processes.

* `Add-PodeTask` has new `-MaxRetries`, `-RetryDelay`, and `-AutoRetry` parameters. These allow saying how many times to retry a process (default: 0), how many minutes between each retry (default: 0), and where Pode should auto-retry for you.
* A new `Restart-PodeTaskProcess` function, for retrying failed Task processes. Can be used when `-AutoRetry` above is not supplied.

### Related Issue
Resolves #1405 

### Examples
```powershell
# auto-retry up to 3 times, at approx. 1 minute intervals
Add-PodeTask -Name 'Example' -MaxRetries 3 -RetryDelay 1 -AutoRetry -ScriptBlock {
    # do some work
    return $user
}
```

```powershell
# allow the task to be retried up to 3 times
Add-PodeTask -Name 'Example' -MaxRetries 3 -ScriptBlock {
    # do some work
    return $user
}

# route to get failed processes, and retry them
Add-PodeRoute -Method Get -Path '/retry-tasks' -ScriptBlock {
    Get-PodeTaskProcess -State Failed | Foreach-Object {
        Restart-PodeTaskProcess -Process $_
    }
}
```