### PR TITLE
Adds support for retrieving the IP address from the X-Forwarded-For header, for Access/Rate Limit rules

### DIFF
--- a/docs/Hosting/IIS.md
+++ b/docs/Hosting/IIS.md
@@ -509,6 +509,20 @@ This can be done using the following example:
 })
 ```
 
+## IIS Client IP
+
+If you're using Pode's Access or Rate limiting rules, or you just need the Client IP address of the request, then it's worth noting that the Remote Address will always be `localhost` - as IIS forwards the request to Pode running behind-the-scenes.
+
+You can get the originating client IP from the `X-Forwarded-For` header, which IIS does add to the request by default.
+
+For example, if you want to block requests from a certain subnet:
+
+```powershell
+Add-PodeLimitAccessRule -Name 'Example' -Action Deny -Component @(
+    New-PodeLimitIPComponent -IP '10.0.1.0/16' -Location 'XForwardedFor'
+)
+```
+
 ## Azure Web Apps
 
 To host your Pode server under IIS using Azure Web Apps, ensure the OS type is Windows and the framework is .NET Core 2.1/3.0.

--- a/docs/Hosting/IIS.md
+++ b/docs/Hosting/IIS.md
@@ -98,6 +98,18 @@ The first thing you'll need to do so IIS can host your server is, in the same di
 </configuration>
 ```
 
+### PowerShell Permissions
+
+Ensure IIS has access to the `pwsh.exe` processPath referenced in the `web.config` file above. If IIS doesn't have access, you'll see the `HTTP Error 502.5 - ANCM Out-Of-Process Startup Failure` error page.
+
+If IIS doesn't have access to the whole path, you can either:
+
+* Grant the user running your IIS application pool (or website) access to the path and `pwsh.exe`, or
+* Install a standalone version of the `pwsh.exe` from the [PowerShell GitHub](https://github.com/PowerShell/PowerShell/releases), and into a path IIS can access.
+
+!!! tip
+    If you installed PowerShell via the Microsoft Store, and the `pwsh.exe` is under the `WindowsApps` directory path, then IIS won't have access. Because this is WindowsApp, the recommended solution is to install a standalone `pwsh.exe` from the [PowerShell GitHub](https://github.com/PowerShell/PowerShell/releases), and use that path as the processPath in your `web.config`.
+
 ## IIS Setup
 
 With the `web.config` file in place, it's then time to setup the site in IIS. The first thing to do is open up the IIS Manager, then once open, follow the below steps to setup your site:
@@ -272,18 +284,18 @@ Start-PodeServer {
 
 If the required header is missing, then Pode responds with a 401. The retrieved user, like other authentication, is set on the [web event](../../Tutorials/WebEvent)'s `$WebEvent.Auth.User` property, and contains the same information as Pode's inbuilt Windows AD authenticator:
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| UserType | string | Specifies if the user is a Domain or Local user |
-| Identity | System.Security.Principal.WindowsIdentity | Returns the WindowsIdentity which can be used for Impersonation |
-| AuthenticationType | string | Value is fixed to LDAP |
-| DistinguishedName | string | The distinguished name of the user |
-| Username | string | The user's username (without domain) |
-| Name | string | The user's fullname |
-| Email | string | The user's email address |
-| FQDN | string | The FQDN of the AD server |
-| Domain | string | The domain part of the user's username |
-| Groups | string[] | All groups of which the the user is a member |
+| Name               | Type                                      | Description                                                     |
+| ------------------ | ----------------------------------------- | --------------------------------------------------------------- |
+| UserType           | string                                    | Specifies if the user is a Domain or Local user                 |
+| Identity           | System.Security.Principal.WindowsIdentity | Returns the WindowsIdentity which can be used for Impersonation |
+| AuthenticationType | string                                    | Value is fixed to LDAP                                          |
+| DistinguishedName  | string                                    | The distinguished name of the user                              |
+| Username           | string                                    | The user's username (without domain)                            |
+| Name               | string                                    | The user's fullname                                             |
+| Email              | string                                    | The user's email address                                        |
+| FQDN               | string                                    | The FQDN of the AD server                                       |
+| Domain             | string                                    | The domain part of the user's username                          |
+| Groups             | string[]                                  | All groups of which the the user is a member                    |
 
 !!! note
     If the authenticated user is a Local User, then the following properties will be empty: FQDN, Email, and DistinguishedName

--- a/docs/Tutorials/Middleware/Types/Limiters/Components.md
+++ b/docs/Tutorials/Middleware/Types/Limiters/Components.md
@@ -38,6 +38,22 @@ New-PodeLimitIPComponent -IP '10.0.1.0/16'
 New-PodeLimitIPComponent -IP '10.0.1.0/16' -Group
 ```
 
+By default, Pode will retrieve the IP address for the request from the Remote Address of the connecting socket. If you're using a proxy - such as a WAF, Load Balancer, or even IIS, then you can instead use the IP from the `X-Forwarded-For` header. The default IP used from the header will be the leftmost IP (typically the originating client IP), but you can also use either the rightmost IP (typically the IP of the last proxy), or all IPs.
+
+```powershell
+# use the leftmost IP in the X-Forwarded-For header
+New-PodeLimitIPComponent -IP '10.0.0.92' -Location 'XForwardedFor'
+
+# use the rightmost IP in the X-Forwarded-For header
+New-PodeLimitIPComponent -IP '10.0.0.92' -Location 'XForwardedFor' -XForwardedForType 'Rightmost'
+
+# check all of the IPs in the X-Forwarded-For header
+New-PodeLimitIPComponent -IP '10.0.0.92' -Location 'XForwardedFor' -XForwardedForType 'All'
+```
+
+!!! note
+    When using `-XForwardedForType 'All'`, at least 1 of the IPs must match an IP from the `-IP` parameter.
+
 ## Route
 
 A Route Component can be created via [`New-PodeLimitRouteComponent`](../../../../../Functions/Limit/New-PodeLimitRouteComponent). You can specify none, one, or more Route paths - if none are supplied, then the component will match every Route path. You can also use wildcard/regex to match multiple Routes.

--- a/examples/IIS-Example.ps1
+++ b/examples/IIS-Example.ps1
@@ -49,6 +49,10 @@ Start-PodeServer {
     New-PodeLoggingMethod -Terminal | Enable-PodeRequestLogging
     New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
 
+    # Add-PodeLimitAccessRule -Name 'DenyLocal' -Action Deny -Component @(
+    #     New-PodeLimitIPComponent -IP localhost -Location XForwardedFor
+    # )
+
     Add-PodeTask -Name 'Test' -ScriptBlock {
         Start-Sleep -Seconds 10
         'a message is never late, it arrives exactly when it means to' | Out-Default
@@ -56,7 +60,6 @@ Start-PodeServer {
 
     Add-PodeRoute -Method Get -Path '/' -ScriptBlock {
         Write-PodeJsonResponse -Value @{ Message = 'Hello' }
-        $WebEvent.Request | out-default
     }
 
     Add-PodeRoute -Method Get -Path '/run-task' -ScriptBlock {

--- a/examples/web.config
+++ b/examples/web.config
@@ -14,7 +14,7 @@
         <remove name="WebDAVModule" />
       </modules>
 
-      <aspNetCore processPath="pwsh.exe" arguments=".\iis-example.ps1" stdoutLogEnabled="true" stdoutLogFile=".\logs\stdout" hostingModel="OutOfProcess"/>
+      <aspNetCore processPath="pwsh.exe" arguments=".\IIS-Example.ps1" stdoutLogEnabled="true" stdoutLogFile=".\logs\stdout" hostingModel="OutOfProcess"/>
 
       <security>
         <authorization>

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -433,11 +433,28 @@ function Get-PodeIPAddress {
         $IP,
 
         [switch]
-        $DualMode
+        $DualMode,
+
+        [switch]
+        $ContainsPort
     )
 
+    # if we have a port, remove it
+    if ($ContainsPort) {
+        $ipRegex = Get-PodeHostIPRegex -Type IP
+        $portRegex = Get-PodePortRegex
+        $regex = "^$($ipRegex)(\:$($portRegex))?$"
+
+        if ($IP -imatch $regex) {
+            $IP = $Matches['host']
+        }
+        else {
+            $IP = ($IP -split ':')[0]
+        }
+    }
+
     # any address for IPv4 (or IPv6 for DualMode)
-    if ([string]::IsNullOrWhiteSpace($IP) -or ($IP -iin @('*', 'all'))) {
+    if ([string]::IsNullOrEmpty($IP) -or ($IP -iin @('*', 'all'))) {
         if ($DualMode) {
             return [System.Net.IPAddress]::IPv6Any
         }


### PR DESCRIPTION
### Description of the Change
Adds support to `New-PodeLimitIPComponent` so it can can retrieve the IP address from the `X-Forwarded-For` header - useful for IIS, or any other proxy you're site might be running behind.

You'll need to specify `-Location 'XForwardedFor'`, otherwise it'll use the Remote Address IP by default.

When using the XFF header, Pode will use the leftmost IP by default - typically the originating client IP. You can also specify the rightmost, or all IPs, if required.

### Related Issue
Resolves #1375 

### Examples
```powershell
Add-PodeLimitAccessRule -Name 'Example' -Action Deny -Component @(
    New-PodeLimitIPComponent -IP '10.0.1.0/16' -Location 'XForwardedFor'
)
```
