### PR TITLE
Bumps Pester to v5.7.1

### DIFF
--- a/pode.build.ps1
+++ b/pode.build.ps1
@@ -114,7 +114,7 @@ param(
 
 # Dependency Versions
 $Versions = @{
-    Pester      = '5.6.1'
+    Pester      = '5.7.1'
     MkDocs      = '1.6.1'
     PSCoveralls = '1.0.0'
     DotNet      = $SdkVersion


### PR DESCRIPTION
### Description of the Change
Bumps the version of Pester to v5.7.1