### PR TITLE
Ensure Consistent Enum Key Usage for Pode Events

### DIFF
--- a/src/Private/Events.ps1
+++ b/src/Private/Events.ps1
@@ -6,12 +6,12 @@ function Invoke-PodeEvent {
     )
 
     # do nothing if no events
-    if (($null -eq $PodeContext.Server.Events) -or ($PodeContext.Server.Events[$Type].Count -eq 0)) {
+    if (($null -eq $PodeContext.Server.Events) -or ($PodeContext.Server.Events[$Type.ToString()].Count -eq 0)) {
         return
     }
 
     # invoke each event's scriptblock
-    foreach ($evt in $PodeContext.Server.Events[$Type].Values) {
+    foreach ($evt in $PodeContext.Server.Events[$Type.ToString()].Values) {
         if (($null -eq $evt) -or ($null -eq $evt.ScriptBlock)) {
             continue
         }

--- a/src/Public/Events.ps1
+++ b/src/Public/Events.ps1
@@ -49,7 +49,7 @@ function Register-PodeEvent {
     $ScriptBlock, $usingVars = Convert-PodeScopedVariables -ScriptBlock $ScriptBlock -PSSession $PSCmdlet.SessionState
 
     # add event
-    $PodeContext.Server.Events[$Type][$Name] = @{
+    $PodeContext.Server.Events[$Type.ToString()][$Name] = @{
         Name           = $Name
         ScriptBlock    = $ScriptBlock
         UsingVariables = $usingVars
@@ -91,7 +91,7 @@ function Unregister-PodeEvent {
     }
 
     # remove event
-    $null = $PodeContext.Server.Events[$Type].Remove($Name)
+    $null = $PodeContext.Server.Events[$Type.ToString()].Remove($Name)
 }
 
 <#
@@ -122,7 +122,7 @@ function Test-PodeEvent {
         $Name
     )
 
-    return $PodeContext.Server.Events[$Type].Contains($Name)
+    return $PodeContext.Server.Events[$Type.ToString()].Contains($Name)
 }
 
 <#
@@ -153,7 +153,7 @@ function Get-PodeEvent {
         $Name
     )
 
-    return $PodeContext.Server.Events[$Type][$Name]
+    return $PodeContext.Server.Events[$Type.ToString()][$Name]
 }
 
 <#
@@ -177,7 +177,7 @@ function Clear-PodeEvent {
         $Type
     )
 
-    $null = $PodeContext.Server.Events[$Type].Clear()
+    $null = $PodeContext.Server.Events[$Type.ToString()].Clear()
 }
 
 <#


### PR DESCRIPTION
This PR fixes an issue where `Pode.PodeServerEventType` was being used directly as a hashtable key in `$PodeContext.Server.Events`. Since PowerShell hashtable keys are expected to be strings, this inconsistency could cause lookup failures when retrieving or managing events.  

### **Key Highlights:**  
- **Ensured consistency** by converting `Pode.PodeServerEventType` values to strings (`$Type.ToString()`) before using them as keys.  
- **Fixed potential issues** when unregistering, testing, or retrieving events due to enum-object mismatch.  
- **Updated the following functions:**  
  - `Register-PodeEvent`  
  - `Unregister-PodeEvent`  
  - `Test-PodeEvent`  
  - `Get-PodeEvent`  
  - `Clear-PodeEvent`  

 
```powershell
# Example of the fix in action:
Register-PodeEvent -Type Start -Name 'Event1' -ScriptBlock { }
Unregister-PodeEvent -Type Start -Name 'Event1'  # Now works consistently
```
 
 Fix: https://github.com/Badgerati/Pode/issues/1497