### PR TITLE
Fix: Prevent Early Invocation of Write-PodeErrorLog in Console Setup

### DIFF
--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -53,7 +53,10 @@ function New-PodeContext {
         $IgnoreServerConfig,
 
         [string]
-        $ConfigFile
+        $ConfigFile,
+
+        [switch]
+        $Daemon
     )
 
     # set a random server name if one not supplied
@@ -290,8 +293,8 @@ function New-PodeContext {
     # is the server running under Heroku?
     $ctx.Server.IsHeroku = (!$isServerless -and (!(Test-PodeIsEmpty $env:PORT)) -and (!(Test-PodeIsEmpty $env:DYNO)))
 
-    # Check if the current session is running in a console-like environment
-    if (Test-PodeHasConsole) {
+    # Check if the current session is running in a console-like environment and it's not marked as Daemon
+    if (Test-PodeHasConsole -and ! $Daemon) {
         try {
             if (! (Test-PodeIsISEHost)) {
                 # If the session is not configured for quiet mode, modify console behavior
@@ -311,14 +314,12 @@ function New-PodeContext {
             }
         }
         catch {
-            $_ | Write-PodeErrorLog
             # Console support is partial , configure the context for non-console behavior
             $ctx.Server.Console.DisableTermination = $true  # Prevent termination
             $ctx.Server.Console.DisableConsoleInput = $true # Disable console input
             $ctx.Server.Console.Quiet = $true               # Silence the console
             $ctx.Server.Console.ShowDivider = $false        # Disable divider display
         }
-
     }
     else {
         # If not running in a console-like environment, configure the context for non-console behavior

--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -294,7 +294,7 @@ function New-PodeContext {
     $ctx.Server.IsHeroku = (!$isServerless -and (!(Test-PodeIsEmpty $env:PORT)) -and (!(Test-PodeIsEmpty $env:DYNO)))
 
     # Check if the current session is running in a console-like environment and it's not marked as Daemon
-    if (Test-PodeHasConsole -and ! $Daemon) {
+    if ((Test-PodeHasConsole) -and ! $Daemon) {
         try {
             if (! (Test-PodeIsISEHost)) {
                 # If the session is not configured for quiet mode, modify console behavior

--- a/src/Public/Core.ps1
+++ b/src/Public/Core.ps1
@@ -268,6 +268,7 @@ function Start-PodeServer {
                 EnableBreakpoints    = $EnableBreakpoints
                 IgnoreServerConfig   = $IgnoreServerConfig
                 ConfigFile           = $ConfigFile
+                Daemon               = $Daemon
             }
 
 


### PR DESCRIPTION
## **Issue Description**
This pull request implements #1514

Currently, Pode attempts to invoke `Write-PodeErrorLog` inside a `catch` block during console setup:

```powershell
catch {
    $_ | Write-PodeErrorLog
    $ctx.Server.Console.DisableTermination = $true
    $ctx.Server.Console.DisableConsoleInput = $true
    $ctx.Server.Console.Quiet = $true
    $ctx.Server.Console.ShowDivider = $false
}
```

However, this occurs **before** the logging subsystem is fully initialized, leading to potential issues with the new logging features introduced in #1387

## **Proposed Fix**
- Added a check to ensure the session is running in a console-like environment **and** is **not** marked as a daemon before proceeding.
- Removed the invocation of `Write-PodeErrorLog` from this section to avoid premature logging.

### **Updated Code**
```powershell
# Check if the current session is running in a console-like environment and it's not marked as Daemon
if (Test-PodeHasConsole -and ! $Daemon) {
    try {
        if (! (Test-PodeIsISEHost)) {
            if (!$ctx.Server.Console.Quiet) {
                [System.Console]::CursorVisible = $false

                if ($ctx.Server.Console.ShowDivider) {
                    [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
                }
            }
            if (Test-PodeIsConsoleHost) {
                [Console]::TreatControlCAsInput = $true
            }
        }
    }
    catch {
        $ctx.Server.Console.DisableTermination = $true
        $ctx.Server.Console.DisableConsoleInput = $true
        $ctx.Server.Console.Quiet = $true
        $ctx.Server.Console.ShowDivider = $false
    }
}
```

## **Justification**
- Implements #1514 
- Ensures Pode does not attempt to write to logs before the logging subsystem is available.
- Preserves expected console behavior while handling errors gracefully.
- Avoids potential conflicts with new logging features.

## **Testing**
- Verified that Pode initializes correctly without triggering premature logging errors.
- Confirmed that the console behavior remains consistent after an exception.

