### PR TITLE
Improved Compatibility for `Write-PodeHostDivider` on Older Windows Versions

### DIFF
--- a/src/Private/Console.ps1
+++ b/src/Private/Console.ps1
@@ -459,7 +459,7 @@ function Write-PodeHostDivider {
         }
         # Determine the divider style based on PowerShell version and encoding support
         $dividerChar = if ( $IsLinux -or $IsMacOS -or ( $PSVersionTable.PSVersion.Major -ge 7 -and
-        ((Test-PodeIsWindows -and [Environment]::OSVersion.Version.Major -ge 10)))) {
+        (((Test-PodeIsWindows) -and ([Environment]::OSVersion.Version.Major -ge 10))))) {
             '━' * $PodeContext.Server.Console.DividerLength  # Repeat the UTF-8 '━' (heavy horizontal line) character
         }
         else {

--- a/src/Private/Console.ps1
+++ b/src/Private/Console.ps1
@@ -454,7 +454,8 @@ function Write-PodeHostDivider {
             $dividerColor = [System.ConsoleColor]::Yellow
         }
         # Determine the divider style based on PowerShell version and encoding support
-        $dividerChar = if ($PSVersionTable.PSVersion.Major -ge 6 ) {
+        $dividerChar = if ( $IsLinux -or $IsMacOS -or ( $PSVersionTable.PSVersion.Major -ge 7 -and
+        ((Test-PodeIsWindows -and [Environment]::OSVersion.Version.Major -ge 10)))) {
             '━' * $PodeContext.Server.Console.DividerLength  # Repeat the '━' character
         }
         else {

--- a/src/Private/Console.ps1
+++ b/src/Private/Console.ps1
@@ -411,35 +411,39 @@ function Write-PodeKeyBinding {
     Write-PodeHost "$("Ctrl-$k".PadRight(8)): " -ForegroundColor $ForegroundColor -NoNewLine -Force:$Force
 }
 
-
 <#
 .SYNOPSIS
-Writes a visual divider line to the console.
+    Writes a visual divider line to the console.
 
 .DESCRIPTION
-The `Write-PodeHostDivider` function outputs a horizontal divider line to the console.
-For modern environments (PowerShell 6 and above or UTF-8 capable consoles),
-it uses the `━` character repeated to form the divider. For older environments
-like PowerShell 5.1, it falls back to the `-` character for compatibility.
+    The `Write-PodeHostDivider` function outputs a horizontal divider line to the console
+    to enhance readability. It dynamically selects the appropriate divider character based
+    on the operating system, PowerShell version, and console encoding capabilities.
+
+    For modern environments (Linux, macOS, or PowerShell 7+ on Windows 10+), it uses the
+    UTF-8 heavy horizontal line (`━`) for a visually enhanced appearance. For older
+    environments, such as PowerShell 5.1 or Windows versions without proper UTF-8 support,
+    it falls back to using the ASCII dash (`-`) to ensure compatibility.
 
 .PARAMETER Force
-Forces the output to display the divider even if certain conditions are not met.
-
-.PARAMETER ForegroundColor
-Specifies the foreground color of the divider.
+    Forces the output to display the divider even if the default console settings do not
+    require it.
 
 .EXAMPLE
-Write-PodeHostDivider
+    Write-PodeHostDivider
 
-Writes a divider to the console using the appropriate characters for the environment.
+    Writes a divider to the console using the appropriate character set based on the
+    current environment.
 
 .EXAMPLE
-Write-PodeHostDivider -Force $true
+    Write-PodeHostDivider -Force $true
 
-Writes a divider to the console even if conditions for displaying it are not met.
+    Forces the divider to be displayed, regardless of console settings.
 
 .NOTES
-This function dynamically adapts to the PowerShell version and console encoding, ensuring compatibility across different environments.
+    - This function automatically adapts to different platforms and versions.
+    - UTF-8 support varies by PowerShell version and Windows OS version.
+    - The ASCII fallback ensures compatibility with legacy environments.
 #>
 function Write-PodeHostDivider {
     param (
@@ -456,10 +460,10 @@ function Write-PodeHostDivider {
         # Determine the divider style based on PowerShell version and encoding support
         $dividerChar = if ( $IsLinux -or $IsMacOS -or ( $PSVersionTable.PSVersion.Major -ge 7 -and
         ((Test-PodeIsWindows -and [Environment]::OSVersion.Version.Major -ge 10)))) {
-            '━' * $PodeContext.Server.Console.DividerLength  # Repeat the '━' character
+            '━' * $PodeContext.Server.Console.DividerLength  # Repeat the UTF-8 '━' (heavy horizontal line) character
         }
         else {
-            '-' * $PodeContext.Server.Console.DividerLength # Repeat the '-' as a fallback
+            '-' * $PodeContext.Server.Console.DividerLength # Repeat the ASCII '-' as a fallback
         }
 
         # Write the divider with the chosen style


### PR DESCRIPTION
This update enhances the `Write-PodeHostDivider` function by improving compatibility with older versions of Windows that do not fully support UTF-8 characters.  

**Key Highlights:**  
- Now checks for `$IsLinux` and `$IsMacOS` to ensure UTF-8 divider compatibility across platforms.  
- Adds a condition for Windows: UTF-8 characters are used only if running PowerShell 7+ on Windows 10 or later.  
- Ensures consistent rendering of dividers across different environments.  

**Check out the pull request and give your feedback:** [Link]  

```powershell
function Write-PodeHostDivider {
    param (
        [bool]$Force = $false
    )

    if ($PodeContext.Server.Console.ShowDivider) {
        if ($null -ne $PodeContext.Server.Console.Colors.Divider) {
            $dividerColor = $PodeContext.Server.Console.Colors.Divider
        }
        else {
            $dividerColor = [System.ConsoleColor]::Yellow
        }
        # Determine the divider style based on PowerShell version and encoding support
        $dividerChar = if ( $IsLinux -or $IsMacOS -or ( $PSVersionTable.PSVersion.Major -ge 7 -and
        ((Test-PodeIsWindows -and [Environment]::OSVersion.Version.Major -ge 10)))) {
            '━' * $PodeContext.Server.Console.DividerLength  # Repeat the UTF-8 '━' (heavy horizontal line) character
        }
        else {
            '-' * $PodeContext.Server.Console.DividerLength # Repeat the ASCII '-' as a fallback
        }

        # Write the divider with the chosen style
        Write-PodeHost $dividerChar -ForegroundColor $dividerColor -Force:$Force
    }
    else {
        Write-PodeHost
    }
}
```

Fix: #1519