### PR TITLE
Fixes AzureAD link in Authentication Overview page

### DIFF
--- a/docs/Tutorials/Authentication/Overview.md
+++ b/docs/Tutorials/Authentication/Overview.md
@@ -16,7 +16,7 @@ The [`New-PodeAuthScheme`](../../../Functions/Authentication/New-PodeAuthScheme)
 The following schemes are supported:
 
 * [API Key](../Methods/ApiKey)
-* [Azure AD](../Methods/AzureAD)
+* [Azure AD](../Inbuilt/AzureAD)
 * [Basic](../Methods/Basic)
 * [Bearer](../Methods/Bearer)
 * [Client Certificate](../Methods/ClientCertificate)


### PR DESCRIPTION
### Description of the Change
Fixes an incorrect link in the Authentication docs for AzureAD

### Related Issue
Resolves #1516 