### PR TITLE
Fix buffer reuse issue in WebSockets

### DIFF
--- a/docs/Tutorials/WebSockets/Endpoints.md
+++ b/docs/Tutorials/WebSockets/Endpoints.md
@@ -3,7 +3,12 @@
 Pode has support for creating WebSocket endpoints, for server-to-client and/or client-to-server communications. WebSockets allow you to broadcast messages directly from your server to connected clients. This allows you to get real-time continuous updates on the frontend without having to constantly refresh the page, or by using async javascript.
 
 !!! note
-    The maximum size for WebSocket payloads in Pode is **32KB**. If a message exceeds this size, the connection may be closed or the message may not be delivered correctly.
+    The maximum size for WebSocket payloads in Pode depends on the version of PowerShell being used:
+
+    - For **PowerShell ≤ 6.0**, the maximum payload size is **32KB**.
+    - For **PowerShell ≥ 7.0**, the maximum payload size is **16KB**.
+
+    If a message exceeds these limits, the connection may be closed or the message may not be delivered correctly.
 
 ## Server Side
 

--- a/docs/Tutorials/WebSockets/Endpoints.md
+++ b/docs/Tutorials/WebSockets/Endpoints.md
@@ -2,6 +2,9 @@
 
 Pode has support for creating WebSocket endpoints, for server-to-client and/or client-to-server communications. WebSockets allow you to broadcast messages directly from your server to connected clients. This allows you to get real-time continuous updates on the frontend without having to constantly refresh the page, or by using async javascript.
 
+!!! note
+    The maximum size for WebSocket payloads in Pode is **32KB**. If a message exceeds this size, the connection may be closed or the message may not be delivered correctly.
+
 ## Server Side
 
 ### Listening

--- a/src/Listener/PodeRequest.cs
+++ b/src/Listener/PodeRequest.cs
@@ -231,8 +231,9 @@ namespace Pode
         /// <summary>
         /// Provides access to a buffer. The buffer is allocated only when first requested,
         /// saving memory if it is never needed.
+        /// This property is virtual to allow derived classes to override the buffer allocation behavior.
         /// </summary>
-        protected byte[] Buffer
+        protected virtual byte[] Buffer
         {
             get
             {
@@ -243,13 +244,6 @@ namespace Pode
                 return _buffer;
             }
         }
-
-        /// <summary>
-        /// This virtual method returns a buffer to be used during the receive operation.
-        /// Derived classes can override this to customize buffer allocation behavior.
-        /// By default, it returns the lazily allocated Buffer property.
-        /// </summary>
-        protected virtual byte[] GetBuffer() => Buffer;
 
         /// <summary>
         /// Receives data from the input stream and processes it.
@@ -266,7 +260,7 @@ namespace Pode
                 }
 
                 Error = null;
-                var localBuffer = GetBuffer();
+                var localBuffer = Buffer;
                 using (BufferStream = new MemoryStream())
                 {
                     var close = true;
@@ -364,7 +358,7 @@ namespace Pode
             }
 
             // Read data from the input stream until the check bytes are found
-             var localBuffer = GetBuffer();
+             var localBuffer = Buffer;
             using (var bufferStream = new MemoryStream())
             {
                 while (true)

--- a/src/Listener/PodeRequest.cs
+++ b/src/Listener/PodeRequest.cs
@@ -232,7 +232,7 @@ namespace Pode
         /// Provides access to a buffer. The buffer is allocated only when first requested,
         /// saving memory if it is never needed.
         /// </summary>
-        protected virtual byte[] Buffer
+        protected byte[] Buffer
         {
             get
             {

--- a/src/Listener/PodeRequest.cs
+++ b/src/Listener/PodeRequest.cs
@@ -60,10 +60,10 @@ namespace Pode
 
         // A fixed buffer used to temporarily store data read from the input stream.
         // This buffer is readonly to prevent reassignment and reduce memory allocations.
-        private readonly byte[] Buffer;
+        private byte[] _buffer;
 
         private MemoryStream BufferStream;
-        private const int BufferSize = 16384;
+        protected const int BufferSize = 16384;
 
         /// <summary>
         /// Initializes a new instance of the PodeRequest class.
@@ -83,7 +83,6 @@ namespace Pode
             Protocols = podeSocket.Protocols;
             Context = context;
             State = PodeStreamState.New;
-            Buffer = new byte[BufferSize]; // Allocate buffer once
         }
 
         /// <summary>
@@ -230,6 +229,29 @@ namespace Pode
         }
 
         /// <summary>
+        /// Provides access to a buffer. The buffer is allocated only when first requested,
+        /// saving memory if it is never needed.
+        /// </summary>
+        protected virtual byte[] Buffer
+        {
+            get
+            {
+                if (_buffer == null)
+                {
+                    _buffer = new byte[BufferSize];
+                }
+                return _buffer;
+            }
+        }
+
+        /// <summary>
+        /// This virtual method returns a buffer to be used during the receive operation.
+        /// Derived classes can override this to customize buffer allocation behavior.
+        /// By default, it returns the lazily allocated Buffer property.
+        /// </summary>
+        protected virtual byte[] GetBuffer() => Buffer;
+
+        /// <summary>
         /// Receives data from the input stream and processes it.
         /// </summary>
         /// <param name="cancellationToken">Token to monitor for cancellation requests.</param>
@@ -244,7 +266,7 @@ namespace Pode
                 }
 
                 Error = null;
-
+                var localBuffer = GetBuffer();
                 using (BufferStream = new MemoryStream())
                 {
                     var close = true;
@@ -261,9 +283,9 @@ namespace Pode
                         {
                             // Read data from the input stream
 #if NETCOREAPP2_1_OR_GREATER
-                            read = await InputStream.ReadAsync(Buffer.AsMemory(0, BufferSize), cancellationToken).ConfigureAwait(false);
+                            read = await InputStream.ReadAsync(localBuffer.AsMemory(0, BufferSize), cancellationToken).ConfigureAwait(false);
 #else
-                            read = await InputStream.ReadAsync(Buffer, 0, BufferSize, cancellationToken).ConfigureAwait(false);
+                            read = await InputStream.ReadAsync(localBuffer, 0, BufferSize, cancellationToken).ConfigureAwait(false);
 #endif
                         }
                         catch (Exception ex) when (ex is IOException || ex is ObjectDisposedException)
@@ -277,9 +299,9 @@ namespace Pode
                         }
 
 #if NETCOREAPP2_1_OR_GREATER
-                        await BufferStream.WriteAsync(Buffer.AsMemory(0, read), cancellationToken).ConfigureAwait(false);
+                        await BufferStream.WriteAsync(localBuffer.AsMemory(0, read), cancellationToken).ConfigureAwait(false);
 #else
-                        await BufferStream.WriteAsync(Buffer, 0, read, cancellationToken).ConfigureAwait(false);
+                        await BufferStream.WriteAsync(localBuffer, 0, read, cancellationToken).ConfigureAwait(false);
 #endif
 
                         // Validate and parse the data if available
@@ -342,31 +364,31 @@ namespace Pode
             }
 
             // Read data from the input stream until the check bytes are found
-            var buffer = new byte[BufferSize];
+             var localBuffer = GetBuffer();
             using (var bufferStream = new MemoryStream())
             {
                 while (true)
                 {
 #if NETCOREAPP2_1_OR_GREATER
                     // Read data from the input stream
-                    var read = await InputStream.ReadAsync(buffer.AsMemory(0, BufferSize), cancellationToken).ConfigureAwait(false);
+                    var read = await InputStream.ReadAsync(localBuffer.AsMemory(0, BufferSize), cancellationToken).ConfigureAwait(false);
                     if (read <= 0)
                     {
                         break;
                     }
 
                     // Write the data to the buffer stream
-                    await bufferStream.WriteAsync(buffer.AsMemory(0, read), cancellationToken).ConfigureAwait(false);
+                    await bufferStream.WriteAsync(localBuffer.AsMemory(0, read), cancellationToken).ConfigureAwait(false);
 #else
                     // Read data from the input stream
-                    var read = await InputStream.ReadAsync(buffer, 0, BufferSize, cancellationToken).ConfigureAwait(false);
+                    var read = await InputStream.ReadAsync(localBuffer, 0, BufferSize, cancellationToken).ConfigureAwait(false);
                     if (read <= 0)
                     {
                         break;
                     }
 
                     // Write the data to the buffer stream
-                    await bufferStream.WriteAsync(buffer, 0, read, cancellationToken).ConfigureAwait(false);
+                    await bufferStream.WriteAsync(localBuffer, 0, read, cancellationToken).ConfigureAwait(false);
 #endif
                     // Validate the input data
                     if (Socket.Available > 0 || !ValidateInputInternal(bufferStream.ToArray(), checkBytes))

--- a/src/Listener/PodeServerSignal.cs
+++ b/src/Listener/PodeServerSignal.cs
@@ -2,14 +2,45 @@ using System;
 
 namespace Pode
 {
+    /// <summary>
+    /// Represents a server signal used by Pode that includes signal details and associated listener management.
+    /// </summary>
     public class PodeServerSignal : IDisposable
     {
+        private bool _disposed = false;
+
+        /// <summary>
+        /// Gets the value of the server signal.
+        /// </summary>
         public string Value { get; private set; }
+
+        /// <summary>
+        /// Gets the path associated with the signal.
+        /// </summary>
         public string Path { get; private set; }
+
+        /// <summary>
+        /// Gets the client identifier that originated the signal.
+        /// </summary>
         public string ClientId { get; private set; }
+
+        /// <summary>
+        /// Gets the timestamp when the signal was created (in UTC).
+        /// </summary>
         public DateTime Timestamp { get; private set; }
+
+        /// <summary>
+        /// Gets the listener associated with processing the signal.
+        /// </summary>
         public PodeListener Listener { get; private set; }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PodeServerSignal"/> class.
+        /// </summary>
+        /// <param name="value">The value representing the signal.</param>
+        /// <param name="path">The path associated with the signal request.</param>
+        /// <param name="clientId">The unique identifier of the client.</param>
+        /// <param name="listener">The listener managing the server signal.</param>
         public PodeServerSignal(string value, string path, string clientId, PodeListener listener)
         {
             Value = value;
@@ -19,9 +50,38 @@ namespace Pode
             Listener = listener;
         }
 
+        /// <summary>
+        /// Releases the unmanaged and optionally managed resources used by the <see cref="PodeServerSignal"/> instance.
+        /// </summary>
+        /// <param name="disposing">
+        /// If set to <c>true</c>, both managed and unmanaged resources are disposed; if <c>false</c>, only unmanaged resources are disposed.
+        /// </param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                if (disposing)
+                {
+                    // Dispose managed resources.
+                    Listener?.RemoveProcessingServerSignal(this);
+                }
+                // Clean up unmanaged resources here if there are any.
+
+                _disposed = true;
+            }
+        }
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        /// <remarks>
+        /// This method calls <see cref="Dispose(bool)"/> with <c>true</c> and suppresses the finalization
+        /// of the object, preventing any derived class finalizers from running unnecessarily.
+        /// </remarks>
         public void Dispose()
         {
-            Listener.RemoveProcessingServerSignal(this);
+            Dispose(true);
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/Listener/PodeSignalRequest.cs
+++ b/src/Listener/PodeSignalRequest.cs
@@ -5,107 +5,171 @@ using System.Threading.Tasks;
 
 namespace Pode
 {
+    /// <summary>
+    /// Represents a WebSocket signal request. Inherits from PodeRequest to leverage the base connection
+    /// and stream handling, and implements WebSocket-specific logic like frame parsing, op-code handling,
+    /// and resource cleanup.
+    /// </summary>
     public class PodeSignalRequest : PodeRequest
     {
+        // The WebSocket operation code extracted from the incoming frame.
         public PodeWsOpCode OpCode { get; private set; }
+
+        // The decoded message body as a string.
         public string Body { get; private set; }
+
+        // The raw data received (entire WebSocket frame).
         public byte[] RawBody { get; private set; }
+
+        // The signal object associated with this request.
         public PodeSignal Signal { get; private set; }
+
+        // The URL constructed from the original HTTP request.
         public Uri Url { get; private set; }
+
+        // The Host header from the original HTTP request.
         public string Host { get; private set; }
+
+        // Total length of the content/body.
         public int ContentLength { get; private set; }
 
+        // Private field to hold the WebSocket close status.
         private WebSocketCloseStatus _closeStatus = WebSocketCloseStatus.Empty;
+
+        // Public property exposing the close status.
         public WebSocketCloseStatus CloseStatus
         {
             get => _closeStatus;
         }
 
+        // Private field to hold the close description.
         private string _closeDescription = string.Empty;
+
+        // Public property exposing the close description.
         public string CloseDescription
         {
             get => _closeDescription;
         }
 
+        // Indicates whether the connection should be closed immediately.
+        // For WebSocket, this is true if the received op-code is 'Close'.
         public override bool CloseImmediately
         {
             get => OpCode == PodeWsOpCode.Close;
         }
 
+        // Determines if the request is processable.
+        // It excludes control frames (Ping/Pong) and ensures that a non-empty body exists.
         public override bool IsProcessable
         {
             get => !CloseImmediately && OpCode != PodeWsOpCode.Pong && OpCode != PodeWsOpCode.Ping && !string.IsNullOrEmpty(Body);
         }
 
+        /// <summary>
+        /// Constructs a new PodeSignalRequest from an existing HTTP request and an associated signal.
+        /// Sets up the connection as a WebSocket request, preserving the original host and URL details.
+        /// </summary>
+        /// <param name="request">The original HTTP request.</param>
+        /// <param name="signal">The associated PodeSignal.</param>
         public PodeSignalRequest(PodeHttpRequest request, PodeSignal signal)
-            : base(request)
+            : base(request) // Copy base request properties from the HTTP request.
         {
             Signal = signal;
             IsKeepAlive = true;
-            Type = PodeProtocolType.Ws;
+            Type = PodeProtocolType.Ws; // Set protocol type to WebSocket.
 
+            // Determine the protocol prefix based on SSL usage.
             var _proto = IsSsl ? "wss" : "ws";
             Host = request.Host;
+            // Build the WebSocket URL from the original request's authority and path/query.
             Url = new Uri($"{_proto}://{request.Url.Authority}{request.Url.PathAndQuery}");
         }
 
+        /// <summary>
+        /// Creates a new client signal object from this request.
+        /// This allows further processing of the signal within the Pode framework.
+        /// </summary>
+        /// <returns>A new PodeClientSignal instance.</returns>
         public PodeClientSignal NewClientSignal()
         {
             return new PodeClientSignal(Signal, Body, Context.Listener);
         }
 
+        /// <summary>
+        /// Overrides the base GetBuffer() method to always return a new buffer.
+        /// This ensures that every time a buffer is needed for parsing a WebSocket frame,
+        /// a fresh array is allocated, avoiding any residual data from previous operations.
+        /// Although this introduces a small allocation overhead, it ensures data integrity
+        /// for WebSocket communication.
+        /// </summary>
+        protected override byte[] GetBuffer() => new byte[BufferSize];
+
+        /// <summary>
+        /// Parses the raw WebSocket frame bytes.
+        /// This method extracts the frame's operation code, decodes the payload using the masking key,
+        /// and handles control frames (e.g., Close, Ping) accordingly.
+        /// </summary>
+        /// <param name="bytes">The raw bytes of the WebSocket frame.</param>
+        /// <param name="cancellationToken">Cancellation token to cancel the operation if needed.</param>
+        /// <returns>True if parsing is successful.</returns>
         protected override async Task<bool> Parse(byte[] bytes, CancellationToken cancellationToken)
         {
-            // get the length and op-code
+            // Calculate the payload length; the second byte includes a mask bit (subtract 128)
             var dataLength = bytes[1] - 128;
+            // Extract the operation code from the first byte (lower 4 bits)
             OpCode = (PodeWsOpCode)(bytes[0] & 0b00001111);
             var offset = 0;
 
-            // set the offset relevant to the data's length
+            // Determine the proper offset based on the payload length format.
             if (dataLength < 126)
             {
                 offset = 2;
             }
             else if (dataLength == 126)
             {
+                // For payload lengths equal to 126, the actual length is stored in the next 2 bytes.
                 dataLength = BitConverter.ToInt16(new byte[] { bytes[3], bytes[2] }, 0);
                 offset = 4;
             }
             else
             {
+                // For payload lengths greater than 126, the length is stored in the next 8 bytes.
                 dataLength = (int)BitConverter.ToInt64(new byte[] { bytes[9], bytes[8], bytes[7], bytes[6], bytes[5], bytes[4], bytes[3], bytes[2] }, 0);
                 offset = 10;
             }
 
-            // read in the mask
+            // Read the 4-byte masking key.
             var mask = new byte[] { bytes[offset], bytes[offset + 1], bytes[offset + 2], bytes[offset + 3] };
             offset += 4;
 
-            // build the decoded message
+            // Decode the message by applying the mask to each byte of the payload.
             var decoded = new byte[dataLength];
             for (var i = 0; i < dataLength; ++i)
             {
                 decoded[i] = (byte)(bytes[offset + i] ^ mask[i % 4]);
             }
 
-            // set the raw/body
+            // Store the raw frame and set the content length.
             RawBody = bytes;
             ContentLength = RawBody.Length;
+            // Convert the decoded bytes to a string message.
             Body = Encoding.GetString(decoded);
 
-            // determine action based on code
+            // Process the frame based on its operation code.
             switch (OpCode)
             {
-                // get the close status and description
+                // For a Close frame, extract the close status and description.
                 case PodeWsOpCode.Close:
                     _closeStatus = WebSocketCloseStatus.Empty;
                     _closeDescription = string.Empty;
 
                     if (dataLength >= 2)
                     {
+                        // Reverse the first two bytes to correctly interpret the close code.
                         Array.Reverse(decoded, 0, 2);
                         var code = (int)BitConverter.ToUInt16(decoded, 0);
 
+                        // Validate and assign the close status.
                         _closeStatus = Enum.IsDefined(typeof(WebSocketCloseStatus), code)
                             ? (WebSocketCloseStatus)code
                             : WebSocketCloseStatus.Empty;
@@ -113,12 +177,13 @@ namespace Pode
                         var descCount = dataLength - 2;
                         if (descCount > 0)
                         {
+                            // Extract the close description text, if available.
                             _closeDescription = Encoding.GetString(decoded, 2, descCount);
                         }
                     }
                     break;
 
-                // send back a pong
+                // For a Ping frame, send back a Pong frame.
                 case PodeWsOpCode.Ping:
                     await Context.Response.WriteFrame(string.Empty, PodeWsOpCode.Pong).ConfigureAwait(false);
                     break;
@@ -128,28 +193,28 @@ namespace Pode
         }
 
         /// <summary>
-        /// Dispose managed and unmanaged resources.
+        /// Disposes of managed and unmanaged resources used by the PodeSignalRequest.
+        /// In addition to base cleanup, it sends a WebSocket Close frame and removes the client signal.
         /// </summary>
-        /// <param name="disposing">Indicates if the method is called explicitly or by garbage collection.</param>
+        /// <param name="disposing">Indicates whether the method is called explicitly or by the garbage collector.</param>
         protected override void Dispose(bool disposing)
         {
             if (IsDisposed) return;
-            
+
             if (disposing)
             {
-                // Send close frame
+                // Log a message indicating the WebSocket is being closed.
                 PodeHelpers.WriteErrorMessage($"Closing Websocket", Context.Listener, PodeLoggingLevel.Verbose, Context);
 
-                // Wait for the close frame to be sent
+                // Send a Close frame to the client and wait for the operation to complete.
                 Context.Response.WriteFrame(string.Empty, PodeWsOpCode.Close).Wait();
 
-                // Remove the client signal
+                // Remove the associated client signal from the listener's collection.
                 Context.Listener.Signals.Remove(Signal.ClientId);
             }
 
-            // Call the base Dispose to clean up other resources
+            // Call the base class Dispose to clean up other resources.
             base.Dispose(disposing);
         }
-
     }
 }

--- a/src/Listener/PodeSignalRequest.cs
+++ b/src/Listener/PodeSignalRequest.cs
@@ -94,7 +94,7 @@ namespace Pode
         {
             return new PodeClientSignal(Signal, Body, Context.Listener);
         }
-
+        
         /// <summary>
         /// Overrides the base GetBuffer() method to always return a new buffer.
         /// This ensures that every time a buffer is needed for parsing a WebSocket frame,
@@ -102,8 +102,14 @@ namespace Pode
         /// Although this introduces a small allocation overhead, it ensures data integrity
         /// for WebSocket communication.
         /// </summary>
-        protected override byte[] GetBuffer() => new byte[BufferSize];
-
+        // protected override byte[] GetBuffer() => new byte[BufferSize];
+        protected override byte[] Buffer
+        {
+            get
+            {
+                return new byte[BufferSize];
+            }
+        }
         /// <summary>
         /// Parses the raw WebSocket frame bytes.
         /// This method extracts the frame's operation code, decodes the payload using the masking key,

--- a/tests/integration/WebSocket.Tests.ps1
+++ b/tests/integration/WebSocket.Tests.ps1
@@ -1,0 +1,92 @@
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
+param()
+
+Describe 'WebSocket' {
+
+    BeforeAll {
+        $Port = 8080
+        $Endpoint = "http://localhost:$($Port)"
+
+        Start-Job -Name 'Pode' -ErrorAction Stop -ScriptBlock {
+            Import-Module -Name "$($using:PSScriptRoot)\..\..\src\Pode.psm1"
+
+            Start-PodeServer -RootPath $using:PSScriptRoot -Quiet -ScriptBlock {
+                # listen
+                Add-PodeEndpoint -Address localhost -Port $using:Port -Protocol Http
+                Add-PodeEndpoint -Address localhost -Port $using:Port -Protocol Ws
+
+                New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+                Add-PodeRoute -Method Get -Path '/close' -ScriptBlock {
+                    Close-PodeServer
+                }
+
+                # set view engine to pode renderer
+                Set-PodeViewEngine -Type Html
+
+                # GET request for web page
+                Add-PodeRoute -Method Get -Path '/' -ScriptBlock {
+                    Write-PodeViewResponse -Path 'websockets'
+                }
+
+                # SIGNAL route, to return current date
+                Add-PodeSignalRoute -Path '/' -ScriptBlock {
+                    $msg = $SignalEvent.Data.Message
+
+                    if ($msg -ieq '[date]') {
+                        $msg = [datetime]::Now.ToString()
+                    }
+
+                    Send-PodeSignal -Value @{ message = $msg }
+                }
+            }
+        }
+
+        Start-Sleep -Seconds 10
+    }
+
+    AfterAll {
+        Receive-Job -Name 'Pode' | Out-Default
+        Invoke-RestMethod -Uri "$($Endpoint)/close" -Method Get | Out-Null
+        Get-Job -Name 'Pode' | Remove-Job -Force
+    }
+
+
+    It 'sends and receives a WebSocket signal with current date' {
+        # Create a new WebSocket client
+        $client = [System.Net.WebSockets.ClientWebSocket]::new()
+        $wsUri = "ws://localhost:$Port/"
+
+        # Connect to the WebSocket endpoint
+        $client.ConnectAsync([uri]$wsUri, [Threading.CancellationToken]::None).Wait()
+        $client.State | Should -Be 'Open'
+
+        # Prepare a JSON message that the server will interpret to return the current date/time
+        $jsonMessage = '{"message": "[date]"}'
+        $sendBuffer = [System.Text.Encoding]::UTF8.GetBytes($jsonMessage)
+        $sendSegment = [System.ArraySegment[byte]]::new($sendBuffer)
+
+        # Send the JSON message
+        $client.SendAsync($sendSegment, [System.Net.WebSockets.WebSocketMessageType]::Text, $true, [Threading.CancellationToken]::None).Wait()
+
+        # Wait briefly to allow the response to be processed
+        Start-Sleep -Seconds 1
+
+        # Prepare a buffer to receive the response
+        $receiveBuffer = [byte[]]::new(1024)
+        $receiveSegment = [System.ArraySegment[byte]]::new($receiveBuffer, 0, $receiveBuffer.Length)
+
+        # Receive a message from the server
+        $receiveResult = $client.ReceiveAsync($receiveSegment, [Threading.CancellationToken]::None).Result
+        $receivedText = [System.Text.Encoding]::UTF8.GetString($receiveBuffer, 0, $receiveResult.Count)
+
+        # Convert the JSON response to a PowerShell object
+        $response = $receivedText | ConvertFrom-Json
+
+        # Cleanly close the WebSocket connection
+        $client.CloseAsync([System.Net.WebSockets.WebSocketCloseStatus]::NormalClosure, "Closing", [Threading.CancellationToken]::None).Wait()
+
+        # Verify that the returned message appears to be a date (for example, by matching a date pattern).
+        # Adjust the regex as needed based on your date format.
+        $response.message | Should -Match '\d{1,2}\/\d{1,2}\/\d{4}'
+    }
+}

--- a/tests/integration/WebSocket.Tests.ps1
+++ b/tests/integration/WebSocket.Tests.ps1
@@ -90,7 +90,7 @@ Describe 'WebSocket' {
         $response.message | Should -Match '\d{1,2}\/\d{1,2}\/\d{4}'
     }
 
-    It 'handles sending and receiving Max default size (32KB)' {
+    It 'handles sending and receiving Max default size (16KB for 5.1 and 32KB for 7.0 or greater)' {
         $client = [System.Net.WebSockets.ClientWebSocket]::new()
         $wsUri = "ws://localhost:$Port/"
 
@@ -98,7 +98,7 @@ Describe 'WebSocket' {
         $client.State | Should -Be 'Open'
 
         # Generate a large message (~3MB)
-        $largeMessage = ('a' * ((32KB) - 16))
+        $largeMessage = if($PSVersionTable.PSEdition -eq 'Desktop') { ('a' * ((16KB) - 32))} else { ('a' * ((32KB) - 16)) }
         $jsonMessage = ('{"message": "' + $largeMessage + '"}')
         $sendBuffer = [System.Text.Encoding]::UTF8.GetBytes($jsonMessage)
         $sendSegment = [System.ArraySegment[byte]]::new($sendBuffer)


### PR DESCRIPTION
**Description:**  
This pull request addresses issue [[#1527]](https://github.com/Badgerati/Pode/issues/1527)  by modifying the way buffers are managed in PodeSignalRequest. The problem was that the base class, PodeRequest, uses a readonly, preallocated buffer that cannot be reinitialized. This caused issues for WebSocket signals (handled by PodeSignalRequest) where a fresh buffer is needed per Receive call.

**Changes Introduced:**

1. **Lazy Buffer Initialization in PodeRequest:**  
   - Removed the immediate allocation of the buffer from the constructor.
   - Introduced lazy initialization of the buffer using a private backing field with a property:
     ```csharp
     private byte[] _buffer;
     protected virtual byte[] Buffer
     {
         get
         {
             if (_buffer == null)
             {
                 _buffer = new byte[BufferSize];
             }
             return _buffer;
         }
     }
     ```
   - Added a virtual method `GetBuffer()` that returns the buffer. By default, it returns the lazily initialized, single preallocated buffer:
     ```csharp
     protected virtual byte[] GetBuffer() => Buffer;
     ```

2. **Override in PodeSignalRequest:**  
   - In PodeSignalRequest, override `GetBuffer()` to return a new byte array for each Receive call:
     ```csharp
     protected override byte[] GetBuffer() => new byte[BufferSize];
     ```
   This ensures that every WebSocket signal request gets a fresh buffer, avoiding any leftover data from previous operations.

3. **Integration Test:**  
   - Added a Pester integration test that creates a WebSocket client to send a JSON signal and asserts that the returned message (e.g. a date string) is correctly received. This test mimics the client behavior from our JS code and ensures that the buffer management in PodeSignalRequest is working correctly.

**Impact:**  
- These changes improve memory management by only allocating the shared buffer when necessary for most requests.
- For WebSocket signals, a new buffer is used on each receive call, ensuring data integrity.
- The modifications are backward-compatible for other request types (e.g., HTTP requests) that benefit from reusing the preallocated buffer.

**Testing:**  
- Verified the changes locally using the provided Pester integration test.
- The WebSocket client test successfully sends a signal and receives the correct response without any buffer contamination issues.

 