### PR TITLE
Fixes an issue with loading static content paths which contain wildcard characters

### DIFF
--- a/examples/assets/[metadata].json
+++ b/examples/assets/[metadata].json
@@ -1,0 +1,3 @@
+{
+    "name": "example"
+}

--- a/examples/public/[brackets].txt
+++ b/examples/public/[brackets].txt
@@ -1,0 +1,1 @@
+Brackets test file

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -118,8 +118,15 @@ function Get-PodeFileContent {
     param(
         [Parameter(Mandatory = $true)]
         [string]
-        $Path
+        $Path,
+
+        [switch]
+        $NoEscape
     )
+
+    if (!$NoEscape) {
+        $Path = [WildcardPattern]::Escape($Path)
+    }
 
     return (Get-Content -Path $Path -Raw -Encoding utf8)
 }
@@ -1799,7 +1806,6 @@ function Test-PodePath {
         catch {
             $statusCode = 400
         }
-
     }
 
     if ($statusCode -eq 200) {
@@ -2497,7 +2503,6 @@ function Get-PodeRelativePath {
 
         [switch]
         $TestPath
-
     )
 
     # if the path is relative, join to root if flagged
@@ -2517,7 +2522,8 @@ function Get-PodeRelativePath {
 
     # if flagged, test the path and throw error if it doesn't exist
     if ($TestPath -and !(Test-PodePath $Path -NoStatus)) {
-        throw ($PodeLocale.pathNotExistExceptionMessage -f (Protect-PodeValue -Value $Path -Default $_rawPath))#"The path does not exist: $(Protect-PodeValue -Value $Path -Default $_rawPath)"
+        # "The path does not exist: $(Protect-PodeValue -Value $Path -Default $_rawPath)"
+        throw ($PodeLocale.pathNotExistExceptionMessage -f (Protect-PodeValue -Value $Path -Default $_rawPath))
     }
 
     return $Path

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -124,11 +124,25 @@ function Get-PodeFileContent {
         $NoEscape
     )
 
-    if (!$NoEscape) {
-        $Path = [WildcardPattern]::Escape($Path)
+    $Path = Protect-PodePath -Path $Path -NoEscape:$NoEscape
+    return (Get-Content -Path $Path -Raw -Encoding utf8)
+}
+
+function Protect-PodePath {
+    param(
+        [Parameter()]
+        [string]
+        $Path,
+
+        [switch]
+        $NoEscape
+    )
+
+    if ($NoEscape -or [string]::IsNullOrEmpty($Path)) {
+        return $Path
     }
 
-    return (Get-Content -Path $Path -Raw -Encoding utf8)
+    return [WildcardPattern]::Escape($Path)
 }
 
 function Get-PodeType {

--- a/src/Private/Responses.ps1
+++ b/src/Private/Responses.ps1
@@ -166,9 +166,7 @@ function Write-PodeFileResponseInternal {
     )
 
     # escape the path
-    if (!$NoEscape) {
-        $Path = [WildcardPattern]::Escape($Path)
-    }
+    $Path = Protect-PodePath -Path $Path -NoEscape:$NoEscape
 
     # Attempt to retrieve information about the path
     $pathInfo = Test-PodePath -Path $Path -Force -ReturnItem -FailOnDirectory:(!$FileBrowser)
@@ -274,9 +272,7 @@ function Write-PodeDirectoryResponseInternal {
     )
 
     # escape the path
-    if (!$NoEscape) {
-        $Path = [WildcardPattern]::Escape($Path)
-    }
+    $Path = Protect-PodePath -Path $Path -NoEscape:$NoEscape
 
     # Attempt to retrieve information about the path
     if ($WebEvent.Path -eq '/') {
@@ -452,9 +448,7 @@ function Write-PodeAttachmentResponseInternal {
     )
 
     # escape the path
-    if (!$NoEscape) {
-        $Path = [WildcardPattern]::Escape($Path)
-    }
+    $Path = Protect-PodePath -Path $Path -NoEscape:$NoEscape
 
     # Attempt to retrieve information about the path
     $pathInfo = Test-PodePath -Path $Path -Force -ReturnItem -FailOnDirectory:(!$FileBrowser)

--- a/src/Private/Responses.ps1
+++ b/src/Private/Responses.ps1
@@ -113,6 +113,9 @@ The HTTP status code to accompany the response. Defaults to 200 (OK).
 .PARAMETER Cache
 A switch to indicate whether the response should include HTTP caching headers. Applies only to static content.
 
+.PARAMETER NoEscape
+If supplied, the path will not be escaped. This is useful for paths that contain expected wildcards, or are already escaped.
+
 .EXAMPLE
 Write-PodeFileResponseInternal -Path 'index.pode' -Data @{ Title = 'Home Page' } -ContentType 'text/html'
 
@@ -129,7 +132,6 @@ None. The function writes directly to the HTTP response stream.
 .NOTES
 This is an internal function and may change in future releases of Pode.
 #>
-
 function Write-PodeFileResponseInternal {
     [CmdletBinding()]
     param (
@@ -157,8 +159,16 @@ function Write-PodeFileResponseInternal {
         $Cache,
 
         [switch]
-        $FileBrowser
+        $FileBrowser,
+
+        [switch]
+        $NoEscape
     )
+
+    # escape the path
+    if (!$NoEscape) {
+        $Path = [WildcardPattern]::Escape($Path)
+    }
 
     # Attempt to retrieve information about the path
     $pathInfo = Test-PodePath -Path $Path -Force -ReturnItem -FailOnDirectory:(!$FileBrowser)
@@ -238,6 +248,8 @@ serves the file directly.
 .PARAMETER Path
 The relative path to the directory that should be displayed. This path is resolved and used to generate a list of contents.
 
+.PARAMETER NoEscape
+If supplied, the path will not be escaped. This is useful for paths that contain expected wildcards, or are already escaped.
 
 .EXAMPLE
 # resolve for relative path
@@ -255,9 +267,18 @@ function Write-PodeDirectoryResponseInternal {
         [Parameter(Mandatory = $true)]
         [ValidateNotNull()]
         [string]
-        $Path
+        $Path,
+
+        [switch]
+        $NoEscape
     )
 
+    # escape the path
+    if (!$NoEscape) {
+        $Path = [WildcardPattern]::Escape($Path)
+    }
+
+    # Attempt to retrieve information about the path
     if ($WebEvent.Path -eq '/') {
         $leaf = '/'
         $rootPath = '/'
@@ -268,9 +289,9 @@ function Write-PodeDirectoryResponseInternal {
         $rootPath = $WebEvent.Path -ireplace "$($leaf)$", ''
     }
 
-    # Determine if the server is running in Windows mode or is running a varsion that support Linux
+    # Determine if the server is running in Windows mode or is running a version that support Linux
     # https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.management/get-childitem?view=powershell-7.4#example-10-output-for-non-windows-operating-systems
-    $windowsMode = ((Test-PodeIsWindows) -or ($PSVersionTable.PSVersion -lt [version]'7.1.0') )
+    $windowsMode = ((Test-PodeIsWindows) -or ($PSVersionTable.PSVersion -lt [version]'7.1.0'))
 
     # Construct the HTML content for the file browser view
     $htmlContent = [System.Text.StringBuilder]::new()
@@ -281,6 +302,7 @@ function Write-PodeDirectoryResponseInternal {
                 [uri]::EscapeDataString($atom)
             }
         })
+
     if ([string]::IsNullOrWhiteSpace($atoms)) {
         $baseLink = ''
     }
@@ -320,6 +342,7 @@ function Write-PodeDirectoryResponseInternal {
         $htmlContent.Append($ParentLink)
         $htmlContent.AppendLine("'>..</a></td> </tr>")
     }
+
     # Retrieve the child items of the specified directory
     $child = Get-ChildItem -Path $Path -Force
     foreach ($item in $child) {
@@ -369,9 +392,9 @@ function Write-PodeDirectoryResponseInternal {
     }
 
     $podeRoot = Get-PodeModuleMiscPath
-    # Write the response
-    Write-PodeFileResponseInternal -Path ([System.IO.Path]::Combine($podeRoot, 'default-file-browsing.html.pode')) -Data $Data
 
+    # Write the response
+    Write-PodeFileResponseInternal -Path ([System.IO.Path]::Combine($podeRoot, 'default-file-browsing.html.pode')) -Data $Data -NoEscape
 }
 
 
@@ -391,6 +414,9 @@ The MIME type of the file being served. This is validated against a pattern to e
 
 .PARAMETER FileBrowser
 A switch parameter that, when present, enables directory browsing. If the path points to a directory and this parameter is enabled, the function will list the directory's contents instead of returning a 404 error.
+
+.PARAMETER NoEscape
+If supplied, the path will not be escaped. This is useful for paths that contain expected wildcards, or are already escaped.
 
 .EXAMPLE
 Write-PodeAttachmentResponseInternal -Path './files/document.pdf' -ContentType 'application/pdf'
@@ -419,9 +445,16 @@ function Write-PodeAttachmentResponseInternal {
 
         [Parameter()]
         [switch]
-        $FileBrowser
+        $FileBrowser,
 
+        [switch]
+        $NoEscape
     )
+
+    # escape the path
+    if (!$NoEscape) {
+        $Path = [WildcardPattern]::Escape($Path)
+    }
 
     # Attempt to retrieve information about the path
     $pathInfo = Test-PodePath -Path $Path -Force -ReturnItem -FailOnDirectory:(!$FileBrowser)

--- a/src/Private/Routes.ps1
+++ b/src/Private/Routes.ps1
@@ -113,9 +113,7 @@ function Find-PodePublicRoute {
     }
 
     # escape characters in the path
-    if (!$NoEscape) {
-        $Path = [WildcardPattern]::Escape($Path)
-    }
+    $Path = Protect-PodePath -Path $Path -NoEscape:$NoEscape
 
     # use the public static directory (but only if path is a file, and a public dir is present)
     if (Test-PodePathIsFile $Path) {
@@ -185,9 +183,7 @@ function Find-PodeStaticRoute {
     )
 
     # escape characters in the path
-    if (!$NoEscape) {
-        $Path = [WildcardPattern]::Escape($Path)
-    }
+    $Path = Protect-PodePath -Path $Path -NoEscape:$NoEscape
 
     # attempt to get a static route for the path
     $found = Find-PodeRoute -Method 'static' -Path $Path -EndpointName $EndpointName

--- a/src/Private/Routes.ps1
+++ b/src/Private/Routes.ps1
@@ -98,15 +98,23 @@ function Find-PodePublicRoute {
     param(
         [Parameter(Mandatory = $true)]
         [string]
-        $Path
+        $Path,
+
+        [switch]
+        $NoEscape
     )
 
     $source = $null
     $publicPath = $PodeContext.Server.InbuiltDrives['public']
 
-    # reutrn null if there is no public directory
+    # return null if there is no public directory
     if ([string]::IsNullOrWhiteSpace($publicPath)) {
         return $source
+    }
+
+    # escape characters in the path
+    if (!$NoEscape) {
+        $Path = [WildcardPattern]::Escape($Path)
     }
 
     # use the public static directory (but only if path is a file, and a public dir is present)
@@ -138,6 +146,9 @@ Optional. Specifies the name of the endpoint to which the route may belong. If n
 .PARAMETER CheckPublic
 A switch parameter. If specified, the function also checks for the route in public routes as a fallback option.
 
+.PARAMETER NoEscape
+If supplied, the path will not be escaped. This is useful for paths that contain expected wildcards, or are already escaped.
+
 .EXAMPLE
 $staticRoute = Find-PodeStaticRoute -Path '/images/logo.png' -CheckPublic
 
@@ -167,33 +178,36 @@ function Find-PodeStaticRoute {
         $EndpointName,
 
         [switch]
-        $CheckPublic
+        $CheckPublic,
+
+        [switch]
+        $NoEscape
     )
+
+    # escape characters in the path
+    if (!$NoEscape) {
+        $Path = [WildcardPattern]::Escape($Path)
+    }
 
     # attempt to get a static route for the path
     $found = Find-PodeRoute -Method 'static' -Path $Path -EndpointName $EndpointName
-    $download = ([bool]$found.Download)
+    $download = [bool]$found.Download
     $source = $null
     $isDefault = $false
-    $redirectToDefault = ([bool]$found.RedirectToDefault)
+    $redirectToDefault = [bool]$found.RedirectToDefault
 
     # if we have a defined static route, use that
     if ($null -ne $found) {
         # see if we have a file
         $file = [string]::Empty
+        $matchingPath = "$($found.Path.Replace('*', '.+?'))$"
 
-        if ($found.KleeneStar) {
-            $matchingPath = "$($found.Path -ireplace '.\*', '.+?')$"
-        }
-        else {
-            $matchingPath = "$($found.Path)$"
-        }
         if ($Path -imatch $matchingPath) {
             $file = (Protect-PodeValue -Value $Matches['file'] -Default ([string]::Empty))
         }
 
+        # if $file doesn't exist return $null
         $fileInfo = Get-Item -Path ([System.IO.Path]::Combine($found.Source, $file)) -Force -ErrorAction Ignore
-        #if $file doesn't exist return $null
         if ($null -eq $fileInfo) {
             return $null
         }
@@ -209,8 +223,8 @@ function Find-PodeStaticRoute {
                 }
             }
         }
-        $source = [System.IO.Path]::Combine($found.Source, $file)
 
+        $source = [System.IO.Path]::Combine($found.Source, $file)
     }
 
     # check public, if flagged
@@ -228,12 +242,7 @@ function Find-PodeStaticRoute {
     }
 
     # return the route details
-    if ($redirectToDefault -and $isDefault) {
-        $redirectToDefault = $true
-    }
-    else {
-        $redirectToDefault = $false
-    }
+    $redirectToDefault = $redirectToDefault -and $isDefault
 
     return @{
         Content = @{
@@ -368,7 +377,7 @@ function Get-PodeRouteByUrl {
     return $null
 }
 
- 
+
 <#
 .SYNOPSIS
     Updates a Pode route path to ensure proper formatting.

--- a/src/Public/Responses.ps1
+++ b/src/Public/Responses.ps1
@@ -23,6 +23,9 @@ Optional EndpointName that the static route was creating under.
 .PARAMETER FileBrowser
 If the path is a folder, instead of returning 404, will return A browsable content of the directory.
 
+.PARAMETER NoEscape
+If supplied, the path will not be escaped. This is useful for paths that contain expected wildcards, or are already escaped.
+
 .EXAMPLE
 Set-PodeResponseAttachment -Path 'downloads/installer.exe'
 
@@ -37,6 +40,12 @@ Set-PodeResponseAttachment -Path './data.txt' -ContentType 'application/json'
 
 .EXAMPLE
 Set-PodeResponseAttachment -Path '/assets/data.txt' -EndpointName 'Example'
+
+.EXAMPLE
+Set-PodeResponseAttachment -Path './[metadata].json'
+
+.EXAMPLE
+Set-PodeResponseAttachment -Path './`[metadata`].json' -NoEscape
 #>
 
 function Set-PodeResponseAttachment {
@@ -55,8 +64,10 @@ function Set-PodeResponseAttachment {
         $EndpointName,
 
         [switch]
-        $FileBrowser
+        $FileBrowser,
 
+        [switch]
+        $NoEscape
     )
     begin {
         $pipelineItemCount = 0
@@ -76,8 +87,13 @@ function Set-PodeResponseAttachment {
             return
         }
 
+        # escape the path if needed
+        if (!$NoEscape) {
+            $Path = [WildcardPattern]::Escape($Path)
+        }
+
         # only attach files from public/static-route directories when path is relative
-        $route = (Find-PodeStaticRoute -Path $Path -CheckPublic -EndpointName $EndpointName)
+        $route = (Find-PodeStaticRoute -Path $Path -CheckPublic -EndpointName $EndpointName -NoEscape)
         if ($route) {
             $_path = $route.Content.Source
         }
@@ -86,7 +102,7 @@ function Set-PodeResponseAttachment {
         }
 
         #call internal Attachment function
-        Write-PodeAttachmentResponseInternal -Path $_path -ContentType $ContentType -FileBrowser:$fileBrowser
+        Write-PodeAttachmentResponseInternal -Path $_path -ContentType $ContentType -FileBrowser:$fileBrowser -NoEscape
     }
 }
 
@@ -187,7 +203,7 @@ function Write-PodeTextResponse {
             return
         }
 
-        # if the response stream isn't writable or already sent, return
+        # if the response stream isn't writeable or already sent, return
         $res = $WebEvent.Response
         if (($null -eq $res) -or ($WebEvent.Streamed -and (($null -eq $res.OutputStream) -or !$res.OutputStream.CanWrite -or $res.Sent))) {
             return
@@ -339,6 +355,9 @@ Should the file's content be cached by browsers, or not?
 .PARAMETER FileBrowser
 If the path is a folder, instead of returning 404, will return A browsable content of the directory.
 
+.PARAMETER NoEscape
+If supplied, the path will not be escaped. This is useful for paths that contain expected wildcards, or are already escaped.
+
 .EXAMPLE
 Write-PodeFileResponse -Path 'C:/Files/Stuff.txt'
 
@@ -356,6 +375,12 @@ Write-PodeFileResponse -Path 'C:/Files/Stuff.txt' -StatusCode 201
 
 .EXAMPLE
 Write-PodeFileResponse -Path 'C:/Files/' -FileBrowser
+
+.EXAMPLE
+Set-PodeResponseAttachment -Path './[metadata].json'
+
+.EXAMPLE
+Set-PodeResponseAttachment -Path './`[metadata`].json' -NoEscape
 #>
 function Write-PodeFileResponse {
     [CmdletBinding()]
@@ -384,8 +409,12 @@ function Write-PodeFileResponse {
         $Cache,
 
         [switch]
-        $FileBrowser
+        $FileBrowser,
+
+        [switch]
+        $NoEscape
     )
+
     begin {
         $pipelineItemCount = 0
     }
@@ -398,11 +427,25 @@ function Write-PodeFileResponse {
         if ($pipelineItemCount -gt 1) {
             throw ($PodeLocale.fnDoesNotAcceptArrayAsPipelineInputExceptionMessage -f $($MyInvocation.MyCommand.Name))
         }
+
+        # escape the path if needed
+        if (!$NoEscape) {
+            $Path = [WildcardPattern]::Escape($Path)
+        }
+
         # resolve for relative path
         $RelativePath = Get-PodeRelativePath -Path $Path -JoinRoot
 
-        Write-PodeFileResponseInternal -Path $RelativePath -Data $Data -ContentType $ContentType -MaxAge $MaxAge `
-            -StatusCode $StatusCode -Cache:$Cache -FileBrowser:$FileBrowser
+        # call internal File function
+        Write-PodeFileResponseInternal `
+            -Path $RelativePath `
+            -Data $Data `
+            -ContentType $ContentType `
+            -MaxAge $MaxAge `
+            -StatusCode $StatusCode `
+            -Cache:$Cache `
+            -FileBrowser:$FileBrowser `
+            -NoEscape
     }
 }
 
@@ -419,6 +462,9 @@ serves the file directly.
 .PARAMETER Path
 The path to the directory that should be displayed. This path is resolved and used to generate a list of contents.
 
+.PARAMETER NoEscape
+If supplied, the path will not be escaped. This is useful for paths that contain expected wildcards, or are already escaped.
+
 .EXAMPLE
 Write-PodeDirectoryResponse -Path './static'
 
@@ -430,7 +476,10 @@ function Write-PodeDirectoryResponse {
         [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true)]
         [ValidateNotNull()]
         [string]
-        $Path
+        $Path,
+
+        [switch]
+        $NoEscape
     )
 
     begin {
@@ -446,11 +495,16 @@ function Write-PodeDirectoryResponse {
             throw ($PodeLocale.fnDoesNotAcceptArrayAsPipelineInputExceptionMessage -f $($MyInvocation.MyCommand.Name))
         }
 
+        # escape the path if needed
+        if (!$NoEscape) {
+            $Path = [WildcardPattern]::Escape($Path)
+        }
+
         # resolve for relative path
         $RelativePath = Get-PodeRelativePath -Path $Path -JoinRoot
 
         if (Test-Path -Path $RelativePath -PathType Container) {
-            Write-PodeDirectoryResponseInternal -Path $RelativePath
+            Write-PodeDirectoryResponseInternal -Path $RelativePath -NoEscape
         }
         else {
             Set-PodeResponseStatus -Code 404
@@ -474,6 +528,9 @@ The path to a CSV file.
 .PARAMETER StatusCode
 The status code to set against the response.
 
+.PARAMETER NoEscape
+If supplied, the path will not be escaped. This is useful for paths that contain expected wildcards, or are already escaped.
+
 .EXAMPLE
 Write-PodeCsvResponse -Value "Name`nRick"
 
@@ -482,6 +539,12 @@ Write-PodeCsvResponse -Value @{ Name = 'Rick' }
 
 .EXAMPLE
 Write-PodeCsvResponse -Path 'E:/Files/Names.csv'
+
+.EXAMPLE
+Set-PodeResponseAttachment -Path './[metadata].csv'
+
+.EXAMPLE
+Set-PodeResponseAttachment -Path './`[metadata`].csv' -NoEscape
 #>
 function Write-PodeCsvResponse {
     [CmdletBinding(DefaultParameterSetName = 'Value')]
@@ -495,7 +558,11 @@ function Write-PodeCsvResponse {
 
         [Parameter()]
         [int]
-        $StatusCode = 200
+        $StatusCode = 200,
+
+        [Parameter(ParameterSetName = 'File')]
+        [switch]
+        $NoEscape
     )
 
     begin {
@@ -512,7 +579,7 @@ function Write-PodeCsvResponse {
         switch ($PSCmdlet.ParameterSetName.ToLowerInvariant()) {
             'file' {
                 if (Test-PodePath $Path) {
-                    $Value = Get-PodeFileContent -Path $Path
+                    $Value = Get-PodeFileContent -Path $Path -NoEscape:$NoEscape
                 }
             }
 
@@ -560,6 +627,9 @@ The path to a HTML file.
 .PARAMETER StatusCode
 The status code to set against the response.
 
+.PARAMETER NoEscape
+If supplied, the path will not be escaped. This is useful for paths that contain expected wildcards, or are already escaped.
+
 .EXAMPLE
 Write-PodeHtmlResponse -Value "Raw HTML can be placed here"
 
@@ -568,6 +638,12 @@ Write-PodeHtmlResponse -Value @{ Message = 'Hello, all!' }
 
 .EXAMPLE
 Write-PodeHtmlResponse -Path 'E:/Site/About.html'
+
+.EXAMPLE
+Set-PodeResponseAttachment -Path './[metadata].html'
+
+.EXAMPLE
+Set-PodeResponseAttachment -Path './`[metadata`].html' -NoEscape
 #>
 function Write-PodeHtmlResponse {
     [CmdletBinding(DefaultParameterSetName = 'Value')]
@@ -581,7 +657,11 @@ function Write-PodeHtmlResponse {
 
         [Parameter()]
         [int]
-        $StatusCode = 200
+        $StatusCode = 200,
+
+        [Parameter(ParameterSetName = 'File')]
+        [switch]
+        $NoEscape
     )
 
     begin {
@@ -598,7 +678,7 @@ function Write-PodeHtmlResponse {
         switch ($PSCmdlet.ParameterSetName.ToLowerInvariant()) {
             'file' {
                 if (Test-PodePath $Path) {
-                    $Value = Get-PodeFileContent -Path $Path
+                    $Value = Get-PodeFileContent -Path $Path -NoEscape:$NoEscape
                 }
             }
 
@@ -641,11 +721,20 @@ The status code to set against the response.
 .PARAMETER AsHtml
 If supplied, the Markdown will be converted to HTML. (This is only supported in PS7+)
 
+.PARAMETER NoEscape
+If supplied, the path will not be escaped. This is useful for paths that contain expected wildcards, or are already escaped.
+
 .EXAMPLE
 Write-PodeMarkdownResponse -Value '# Hello, world!' -AsHtml
 
 .EXAMPLE
 Write-PodeMarkdownResponse -Path 'E:/Site/About.md'
+
+.EXAMPLE
+Set-PodeResponseAttachment -Path './[metadata].md'
+
+.EXAMPLE
+Set-PodeResponseAttachment -Path './`[metadata`].md' -NoEscape
 #>
 function Write-PodeMarkdownResponse {
     [CmdletBinding(DefaultParameterSetName = 'Value')]
@@ -662,7 +751,11 @@ function Write-PodeMarkdownResponse {
         $StatusCode = 200,
 
         [switch]
-        $AsHtml
+        $AsHtml,
+
+        [Parameter(ParameterSetName = 'File')]
+        [switch]
+        $NoEscape
     )
     begin {
         $pipelineItemCount = 0
@@ -679,7 +772,7 @@ function Write-PodeMarkdownResponse {
         switch ($PSCmdlet.ParameterSetName.ToLowerInvariant()) {
             'file' {
                 if (Test-PodePath $Path) {
-                    $Value = Get-PodeFileContent -Path $Path
+                    $Value = Get-PodeFileContent -Path $Path -NoEscape:$NoEscape
                 }
             }
         }
@@ -727,6 +820,9 @@ The status code to set against the response.
 .PARAMETER NoCompress
 The JSON document is not compressed (Human readable form)
 
+.PARAMETER NoEscape
+If supplied, the path will not be escaped. This is useful for paths that contain expected wildcards, or are already escaped.
+
 .EXAMPLE
 Write-PodeJsonResponse -Value '{"name": "Rick"}'
 
@@ -735,6 +831,12 @@ Write-PodeJsonResponse -Value @{ Name = 'Rick' } -StatusCode 201
 
 .EXAMPLE
 Write-PodeJsonResponse -Path 'E:/Files/Names.json'
+
+.EXAMPLE
+Set-PodeResponseAttachment -Path './[metadata].json'
+
+.EXAMPLE
+Set-PodeResponseAttachment -Path './`[metadata`].json' -NoEscape
 #>
 function Write-PodeJsonResponse {
     [CmdletBinding(DefaultParameterSetName = 'Value')]
@@ -764,9 +866,13 @@ function Write-PodeJsonResponse {
 
         [Parameter(ParameterSetName = 'Value')]
         [switch]
-        $NoCompress
+        $NoCompress,
 
+        [Parameter(ParameterSetName = 'File')]
+        [switch]
+        $NoEscape
     )
+
     begin {
         $pipelineValue = @()
     }
@@ -781,7 +887,7 @@ function Write-PodeJsonResponse {
         switch ($PSCmdlet.ParameterSetName.ToLowerInvariant()) {
             'file' {
                 if (Test-PodePath $Path) {
-                    $Value = Get-PodeFileContent -Path $Path
+                    $Value = Get-PodeFileContent -Path $Path -NoEscape:$NoEscape
                 }
                 if ([string]::IsNullOrWhiteSpace($Value)) {
                     $Value = '{}'
@@ -830,6 +936,9 @@ The Depth to generate the XML document - the larger this value the worse perform
 .PARAMETER StatusCode
 The status code to set against the response.
 
+.PARAMETER NoEscape
+If supplied, the path will not be escaped. This is useful for paths that contain expected wildcards, or are already escaped.
+
 .EXAMPLE
 Write-PodeXmlResponse -Value '<root><name>Rick</name></root>'
 
@@ -859,6 +968,11 @@ Write-PodeXmlResponse -Value $users
 .EXAMPLE
 Write-PodeXmlResponse -Path 'E:/Files/Names.xml'
 
+.EXAMPLE
+Set-PodeResponseAttachment -Path './[metadata].xml'
+
+.EXAMPLE
+Set-PodeResponseAttachment -Path './`[metadata`].xml' -NoEscape
 #>
 function Write-PodeXmlResponse {
     [CmdletBinding(DefaultParameterSetName = 'Value')]
@@ -884,8 +998,13 @@ function Write-PodeXmlResponse {
 
         [Parameter()]
         [int]
-        $StatusCode = 200
+        $StatusCode = 200,
+
+        [Parameter(ParameterSetName = 'File')]
+        [switch]
+        $NoEscape
     )
+
     begin {
         $pipelineValue = @()
     }
@@ -901,7 +1020,7 @@ function Write-PodeXmlResponse {
         switch ($PSCmdlet.ParameterSetName.ToLowerInvariant()) {
             'file' {
                 if (Test-PodePath $Path) {
-                    $Value = Get-PodeFileContent -Path $Path
+                    $Value = Get-PodeFileContent -Path $Path -NoEscape:$NoEscape
                 }
             }
 
@@ -947,6 +1066,9 @@ The Depth to generate the YAML document - the larger this value the worse perfor
 .PARAMETER StatusCode
 The status code to set against the response.
 
+.PARAMETER NoEscape
+If supplied, the path will not be escaped. This is useful for paths that contain expected wildcards, or are already escaped.
+
 .EXAMPLE
 Write-PodeYamlResponse -Value 'name: "Rick"'
 
@@ -955,6 +1077,12 @@ Write-PodeYamlResponse -Value @{ Name = 'Rick' } -StatusCode 201
 
 .EXAMPLE
 Write-PodeYamlResponse -Path 'E:/Files/Names.yaml'
+
+.EXAMPLE
+Set-PodeResponseAttachment -Path './[metadata].yaml'
+
+.EXAMPLE
+Set-PodeResponseAttachment -Path './`[metadata`].yaml' -NoEscape
 #>
 function Write-PodeYamlResponse {
     [CmdletBinding(DefaultParameterSetName = 'Value')]
@@ -981,7 +1109,11 @@ function Write-PodeYamlResponse {
 
         [Parameter()]
         [int]
-        $StatusCode = 200
+        $StatusCode = 200,
+
+        [Parameter(ParameterSetName = 'File')]
+        [switch]
+        $NoEscape
     )
 
     begin {
@@ -999,7 +1131,7 @@ function Write-PodeYamlResponse {
         switch ($PSCmdlet.ParameterSetName.ToLowerInvariant()) {
             'file' {
                 if (Test-PodePath $Path) {
-                    $Value = Get-PodeFileContent -Path $Path
+                    $Value = Get-PodeFileContent -Path $Path -NoEscape:$NoEscape
                 }
             }
 
@@ -1046,6 +1178,9 @@ If supplied, a custom views folder will be used.
 .PARAMETER FlashMessages
 Automatically supply all Flash messages in the current session to the View.
 
+.PARAMETER NoEscape
+If supplied, the path will not be escaped. This is useful for paths that contain expected wildcards, or are already escaped.
+
 .EXAMPLE
 Write-PodeViewResponse -Path 'index'
 
@@ -1075,8 +1210,13 @@ function Write-PodeViewResponse {
         $Folder,
 
         [switch]
-        $FlashMessages
+        $FlashMessages,
+
+        [Parameter(ParameterSetName = 'File')]
+        [switch]
+        $NoEscape
     )
+
     begin {
         $pipelineItemCount = 0
     }
@@ -1124,6 +1264,11 @@ function Write-PodeViewResponse {
         }
 
         $Path = [System.IO.Path]::Combine($viewFolder, $Path)
+
+        # escape the path if needed
+        if (!$NoEscape) {
+            $Path = [WildcardPattern]::Escape($Path)
+        }
 
         # test the file path, and set status accordingly
         if (!(Test-PodePath $Path)) {
@@ -1656,6 +1801,9 @@ Any dynamic data to supply to a dynamic partial View.
 .PARAMETER Folder
 If supplied, a custom views folder will be used.
 
+.PARAMETER NoEscape
+If supplied, the path will not be escaped. This is useful for paths that contain expected wildcards, or are already escaped.
+
 .EXAMPLE
 Use-PodePartialView -Path 'shared/footer'
 #>
@@ -1672,8 +1820,13 @@ function Use-PodePartialView {
 
         [Parameter()]
         [string]
-        $Folder
+        $Folder,
+
+        [Parameter(ParameterSetName = 'File')]
+        [switch]
+        $NoEscape
     )
+
     begin {
         $pipelineItemCount = 0
     }
@@ -1703,6 +1856,11 @@ function Use-PodePartialView {
         }
 
         $Path = [System.IO.Path]::Combine($viewFolder, $Path)
+
+        # escape the path if needed
+        if (!$NoEscape) {
+            $Path = [WildcardPattern]::Escape($Path)
+        }
 
         # test the file path, and set status accordingly
         if (!(Test-PodePath $Path -NoStatus)) {

--- a/src/Public/Responses.ps1
+++ b/src/Public/Responses.ps1
@@ -88,9 +88,7 @@ function Set-PodeResponseAttachment {
         }
 
         # escape the path if needed
-        if (!$NoEscape) {
-            $Path = [WildcardPattern]::Escape($Path)
-        }
+        $Path = Protect-PodePath -Path $Path -NoEscape:$NoEscape
 
         # only attach files from public/static-route directories when path is relative
         $route = (Find-PodeStaticRoute -Path $Path -CheckPublic -EndpointName $EndpointName -NoEscape)
@@ -429,9 +427,7 @@ function Write-PodeFileResponse {
         }
 
         # escape the path if needed
-        if (!$NoEscape) {
-            $Path = [WildcardPattern]::Escape($Path)
-        }
+        $Path = Protect-PodePath -Path $Path -NoEscape:$NoEscape
 
         # resolve for relative path
         $RelativePath = Get-PodeRelativePath -Path $Path -JoinRoot
@@ -496,9 +492,7 @@ function Write-PodeDirectoryResponse {
         }
 
         # escape the path if needed
-        if (!$NoEscape) {
-            $Path = [WildcardPattern]::Escape($Path)
-        }
+        $Path = Protect-PodePath -Path $Path -NoEscape:$NoEscape
 
         # resolve for relative path
         $RelativePath = Get-PodeRelativePath -Path $Path -JoinRoot
@@ -1266,9 +1260,7 @@ function Write-PodeViewResponse {
         $Path = [System.IO.Path]::Combine($viewFolder, $Path)
 
         # escape the path if needed
-        if (!$NoEscape) {
-            $Path = [WildcardPattern]::Escape($Path)
-        }
+        $Path = Protect-PodePath -Path $Path -NoEscape:$NoEscape
 
         # test the file path, and set status accordingly
         if (!(Test-PodePath $Path)) {
@@ -1858,9 +1850,7 @@ function Use-PodePartialView {
         $Path = [System.IO.Path]::Combine($viewFolder, $Path)
 
         # escape the path if needed
-        if (!$NoEscape) {
-            $Path = [WildcardPattern]::Escape($Path)
-        }
+        $Path = Protect-PodePath -Path $Path -NoEscape:$NoEscape
 
         # test the file path, and set status accordingly
         if (!(Test-PodePath $Path -NoStatus)) {

--- a/src/Public/Routes.ps1
+++ b/src/Public/Routes.ps1
@@ -830,7 +830,7 @@ function Add-PodeStaticRoute {
 
         $options = @{
             Name = $Authentication
-            Anon = $AllowAnon
+            Anon = $AllowAnon.IsPresent
         }
 
         $Middleware = (@(Get-PodeAuthMiddlewareScript | New-PodeMiddleware -ArgumentList $options) + $Middleware)
@@ -842,19 +842,15 @@ function Add-PodeStaticRoute {
     # workout a default transfer encoding for the route
     $TransferEncoding = Find-PodeRouteTransferEncoding -Path $Path -TransferEncoding $TransferEncoding
 
-    #The path use KleeneStar(Asterisk)
-    $KleeneStar = $OrigPath.Contains('*')
-
     # add the route(s)
     Write-Verbose "Adding Route: [$($Method)] $($Path)"
     $newRoutes = @(foreach ($_endpoint in $endpoints) {
             @{
                 Source            = $Source
                 Path              = $Path
-                KleeneStar        = $KleeneStar
                 Method            = $Method
                 Defaults          = $Defaults
-                RedirectToDefault = $RedirectToDefault
+                RedirectToDefault = $RedirectToDefault.IsPresent
                 Middleware        = $Middleware
                 Authentication    = $Authentication
                 Access            = $Access
@@ -873,7 +869,7 @@ function Add-PodeStaticRoute {
                 ContentType       = $ContentType
                 TransferEncoding  = $TransferEncoding
                 ErrorType         = $ErrorContentType
-                Download          = $DownloadOnly
+                Download          = $DownloadOnly.IsPresent
                 IsStatic          = $true
                 FileBrowser       = $FileBrowser.isPresent
                 OpenApi           = @{

--- a/tests/unit/Helpers.Tests.ps1
+++ b/tests/unit/Helpers.Tests.ps1
@@ -1587,9 +1587,6 @@ Describe 'New-PodeCron' {
     }
 }
 
-
-
-
 Describe 'ConvertTo-PodeYaml Tests' {
     BeforeAll {
         $PodeContext = @{
@@ -1743,5 +1740,15 @@ Describe 'ConvertTo-PodeYamlInternal Tests' {
             $result = ConvertTo-PodeYamlInternal -InputObject $null
             $result | Should -Be ''
         }
+    }
+}
+
+Describe 'Protect-PodePath' {
+    It 'Escapes a path' {
+        Protect-PodePath -Path '/assets/[brackets].txt' | Should -Be '/assets/`[brackets`].txt'
+    }
+
+    It "Doesn't escape a path" {
+        Protect-PodePath -Path '/assets/[brackets].txt' -NoEscape | Should -Be '/assets/[brackets].txt'
     }
 }


### PR DESCRIPTION
### Description of the Change
Fixes an issue with loading static content paths which contain wildcard characters. When loading singular files, Pode will now auto-escape wildcard characters like `*` and `[` in paths.

At times, this escaping might not be required so a new `-NoEscape` switch has been added onto the relevant functions.

Escaping is done via `[WildcardPattern]::Escape()`

### Related Issue
Resolves #1500 

### Examples
```powershell
# the following path will now work, and be escaped accordingly
Set-PodeResponseAttachment -Path './[metadata].json'

# if the path is already escaped, -NoEscape can be used
Set-PodeResponseAttachment -Path './`[metadata`].json' -NoEscape
```
