### PR TITLE
Fix crash during server restart, by clearing existing limit rules

### DIFF
--- a/src/Private/Server.ps1
+++ b/src/Private/Server.ps1
@@ -288,6 +288,7 @@ function Restart-PodeInternalServer {
 
         # clear openapi
         $PodeContext.Server.OpenAPI = Initialize-PodeOpenApiTable -DefaultDefinitionTag $PodeContext.Server.Configuration.Web.OpenApi.DefaultDefinitionTag
+
         # clear the sockets
         $PodeContext.Server.Signals.Enabled = $false
         $PodeContext.Server.Signals.Listener = $null
@@ -335,6 +336,12 @@ function Restart-PodeInternalServer {
         # clear up output
         $PodeContext.Server.Output.Variables.Clear()
 
+        # clear up limit rules
+        $PodeContext.Server.Limits.Rate.Rules.Clear()
+        $PodeContext.Server.Limits.Rate.RuleOrder = @()
+        $PodeContext.Server.Limits.Access.Rules.Clear()
+        $PodeContext.Server.Limits.Access.RuleOrder = @()
+
         # reset type if smtp/tcp
         $PodeContext.Server.Types = @()
 
@@ -342,7 +349,7 @@ function Restart-PodeInternalServer {
         Reset-PodeCancellationToken -Type Cancellation, Restart, Suspend, Resume, Terminate, Disable
 
         # if the configuration is enable reload it
-        if ( $PodeContext.Server.Configuration.Enabled) {
+        if ($PodeContext.Server.Configuration.Enabled) {
             # reload the configuration
             $PodeContext.Server.Configuration = Open-PodeConfiguration -Context $PodeContext -ConfigFile $PodeContext.Server.Configuration.ConfigFile
         }

--- a/tests/unit/Server.Tests.ps1
+++ b/tests/unit/Server.Tests.ps1
@@ -229,7 +229,16 @@ Describe 'Restart-PodeInternalServer' {
                         Resume  = 30  # timeout in seconds
                     }
                 }
-
+                Limits          = @{
+                    Rate   = @{
+                        Rules     = [ordered]@{}
+                        RuleOrder = @()
+                    }
+                    Access = @{
+                        Rules     = [ordered]@{}
+                        RuleOrder = @()
+                    }
+                }
             }
             Metrics   = @{
                 Server = @{


### PR DESCRIPTION
### Description of the Change
During a server restart, when using `Add-PodeLimitAccessRule` or `Add-PodeLimitRateRule`, existing rules weren't being cleared up to the server would crash with the following error:

```
An access limit rule with the name 'Nessus' already exists.
At C:\Program Files\WindowsPowerShell\Modules\Pode\2.12.0\Public\Limit.ps1:467 char:9
+         throw ($PodeLocale.accessLimitRuleAlreadyExistsExceptionMessa ...
+         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : OperationStopped: (An access limit...already exists.:String) [], RuntimeException
    + FullyQualifiedErrorId : An access limit rule with the name 'Nessus' already exists.
```

This PR fixes this, and clears-up existing limit rules.
