### PR TITLE
Re-use existing FileInfo objects for reading/writing byte streams; Removes redundant MemoryStream which doubled memory-use when writing to Responses

### DIFF
--- a/docs/Tutorials/Endpoints/Favicon.md
+++ b/docs/Tutorials/Endpoints/Favicon.md
@@ -6,8 +6,6 @@ Pode allows you to customize favicons served from HTTP/HTTPS endpoints using a s
 
 Favicons are the small icons displayed in browser tabs, bookmarks, and other UI elements. Pode supports using favicons in the standard ICO format, as well as other common web image formats such as PNG or SVG (depending on browser support).
 
----
-
 ## Managing Favicons
 
 Pode provides the following functions to manage favicons:
@@ -18,8 +16,6 @@ Pode provides the following functions to manage favicons:
 - `Test-PodeFavicon`: Checks whether a favicon is configured on one or more endpoints.
 
 These functions support targeting specific endpoints by name, or applying changes globally to all endpoints. You can also limit operations to only endpoints marked as default using the `-DefaultEndpoint` switch.
-
----
 
 ## Supported Formats
 
@@ -33,23 +29,15 @@ Other formats like `.jpg` or `.gif` may work but are not recommended due to lack
 
 For further details on favicon formats and specifications, refer to the [Favicon specification]([https://en.wikipedia.org/wiki/Favicon](https://en.wikipedia.org/wiki/Favicon)) and [RFC 5988]([https://datatracker.ietf.org/doc/html/rfc5988](https://datatracker.ietf.org/doc/html/rfc5988)).
 
----
-
 ## Recommended Sizes
 
 Favicons should include multiple resolutions for optimal display across different devices. Recommended sizes include:
 
 - **16x16** : Used in browser tabs, bookmarks, and address bars.
-
 - **32x32** : Used in browser tabs on higher-resolution displays.
-
 - **48x48** : Used by some older browsers and web applications.
-
 - **64x64** : Generally not used by browsers but can be helpful for scalability in web apps.
-
 - **256x256** : Mainly for **Windows app icons** (not typically used as a favicon in browsers).
-
----
 
 ## Usage Examples
 
@@ -103,8 +91,6 @@ Get-PodeFavicon
 ```powershell
 Test-PodeFavicon -DefaultEndpoint
 ```
-
----
 
 ## Notes
 

--- a/src/Listener/PodeHelpers.cs
+++ b/src/Listener/PodeHelpers.cs
@@ -308,26 +308,5 @@ namespace Pode
                     return stream;
             }
         }
-
-        public static byte[] ReadAllBytes(string path)
-        {
-            return ReadAllBytes(new FileInfo(path));
-        }
-
-        public static byte[] ReadAllBytes(FileSystemInfo file)
-        {
-            if (!(file is FileInfo fileInfo) || !fileInfo.Exists)
-            {
-                throw new FileNotFoundException($"File not found: {file.FullName}");
-            }
-
-            using (var stream = fileInfo.OpenRead())
-            {
-                using (var reader = new BinaryReader(stream))
-                {
-                    return reader.ReadBytes((int)stream.Length);
-                }
-            }
-        }
     }
 }

--- a/src/Listener/PodeHelpers.cs
+++ b/src/Listener/PodeHelpers.cs
@@ -308,5 +308,26 @@ namespace Pode
                     return stream;
             }
         }
+
+        public static byte[] ReadAllBytes(string path)
+        {
+            return ReadAllBytes(new FileInfo(path));
+        }
+
+        public static byte[] ReadAllBytes(FileSystemInfo file)
+        {
+            if (!(file is FileInfo fileInfo) || !fileInfo.Exists)
+            {
+                throw new FileNotFoundException($"File not found: {file.FullName}");
+            }
+
+            using (var stream = fileInfo.OpenRead())
+            {
+                using (var reader = new BinaryReader(stream))
+                {
+                    return reader.ReadBytes((int)stream.Length);
+                }
+            }
+        }
     }
 }

--- a/src/Listener/PodeResponse.cs
+++ b/src/Listener/PodeResponse.cs
@@ -366,6 +366,7 @@ namespace Pode
             await Write(Encoding.GetBytes($"{message}{PodeHelpers.NEW_LINE}"), flush).ConfigureAwait(false);
         }
 
+        // write a byte array to the actual client stream
         public async Task Write(byte[] buffer, bool flush = false)
         {
             if (Request.IsDisposed || !Request.InputStream.CanWrite)
@@ -396,6 +397,30 @@ namespace Pode
             {
                 PodeHelpers.WriteException(ex, Context.Listener);
                 throw;
+            }
+        }
+
+        public void WriteFile(string path)
+        {
+            WriteFile(new FileInfo(path));
+        }
+
+        public void WriteFile(FileSystemInfo file)
+        {
+            if (IsDisposed)
+            {
+                return;
+            }
+
+            if (!(file is FileInfo fileInfo) || !fileInfo.Exists)
+            {
+                throw new FileNotFoundException($"File not found: {file.FullName}");
+            }
+
+            ContentLength64 = fileInfo.Length;
+            using (var fileStream = fileInfo.OpenRead())
+            {
+                fileStream.CopyTo(OutputStream);
             }
         }
 

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -4086,13 +4086,3 @@ function Get-PodeImageContentType {
     # If none of the above formats match, return a generic binary type
     return 'application/octet-stream'
 }
-
-function Read-PodeFileContent {
-    param(
-        [Parameter()]
-        [System.IO.FileInfo]
-        $FileInfo
-    )
-
-    return ([PodeHelpers]::ReadAllBytes($FileInfo))
-}

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -60,7 +60,7 @@ function Get-PodeViewEngineType {
     $type = $PodeContext.Server.ViewEngine.Type
 
     $ext = Get-PodeFileExtension -Path $Path -TrimPeriod
-    if (![string]::IsNullOrWhiteSpace($ext) -and ($ext -ine $PodeContext.Server.ViewEngine.Extension)) {
+    if (![string]::IsNullOrEmpty($ext) -and ($ext -ine $PodeContext.Server.ViewEngine.Extension)) {
         $type = $ext
     }
 
@@ -68,18 +68,28 @@ function Get-PodeViewEngineType {
 }
 
 function Get-PodeFileContentUsingViewEngine {
+    [CmdletBinding(DefaultParameterSetName = 'Path')]
     param(
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true, ParameterSetName = 'Path')]
         [string]
         $Path,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'FileInfo')]
+        [System.IO.FileSystemInfo]
+        $FileInfo,
 
         [Parameter()]
         [hashtable]
         $Data
     )
 
+    # if we have no file info, get the file info from the path
+    if ($null -eq $FileInfo) {
+        $FileInfo = Get-Item -Path $Path -Force -ErrorAction Stop
+    }
+
     # work out the engine to use when parsing the file
-    $engine = Get-PodeViewEngineType -Path $Path
+    $engine = Get-PodeViewEngineType -Path $FileInfo.FullName
 
     # setup the content
     $content = [string]::Empty
@@ -87,23 +97,23 @@ function Get-PodeFileContentUsingViewEngine {
     # run the relevant engine logic
     switch ($engine.ToLowerInvariant()) {
         'html' {
-            $content = Get-Content -Path $Path -Raw -Encoding utf8
+            $content = [System.IO.File]::ReadAllText($FileInfo.FullName, [System.Text.Encoding]::UTF8)
         }
 
         'md' {
-            $content = Get-Content -Path $Path -Raw -Encoding utf8
+            $content = [System.IO.File]::ReadAllText($FileInfo.FullName, [System.Text.Encoding]::UTF8)
         }
 
         'pode' {
-            $content = Get-Content -Path $Path -Raw -Encoding utf8
+            $content = [System.IO.File]::ReadAllText($FileInfo.FullName, [System.Text.Encoding]::UTF8)
             $content = ConvertFrom-PodeFile -Content $content -Data $Data
         }
 
         default {
             if ($null -ne $PodeContext.Server.ViewEngine.ScriptBlock) {
-                $_args = @($Path)
+                $_args = @($FileInfo.FullName)
                 if (($null -ne $Data) -and ($Data.Count -gt 0)) {
-                    $_args = @($Path, $Data)
+                    $_args = @($FileInfo.FullName, $Data)
                 }
 
                 $content = (Invoke-PodeScriptBlock -ScriptBlock $PodeContext.Server.ViewEngine.ScriptBlock -Arguments $_args -UsingVariables $PodeContext.Server.ViewEngine.UsingVariables -Return -Splat)
@@ -1823,20 +1833,21 @@ function Test-PodePath {
     }
 
     if ($statusCode -eq 200) {
-        if ($ReturnItem.IsPresent) {
-            return  $item
+        if ($ReturnItem) {
+            return $item
         }
         return $true
     }
 
     # if we failed to get the file, report back the status code and/or return true/false
-    if (!$NoStatus.IsPresent) {
+    if (!$NoStatus) {
         Set-PodeResponseStatus -Code $statusCode
     }
 
-    if ($ReturnItem.IsPresent) {
-        return  $null
+    if ($ReturnItem) {
+        return $null
     }
+
     return $false
 }
 
@@ -1850,15 +1861,15 @@ function Test-PodePathIsFile {
         $FailOnWildcard
     )
 
-    if ([string]::IsNullOrWhiteSpace($Path)) {
+    if ([string]::IsNullOrEmpty($Path)) {
         return $false
     }
 
-    if ($FailOnWildcard -and (Test-PodePathIsWildcard $Path)) {
+    if ($FailOnWildcard -and (Test-PodePathIsWildcard -Path $Path)) {
         return $false
     }
 
-    return (![string]::IsNullOrWhiteSpace([System.IO.Path]::GetExtension($Path)))
+    return (![string]::IsNullOrEmpty([System.IO.Path]::GetExtension($Path)))
 }
 
 function Test-PodePathIsWildcard {
@@ -1868,7 +1879,7 @@ function Test-PodePathIsWildcard {
         $Path
     )
 
-    if ([string]::IsNullOrWhiteSpace($Path)) {
+    if ([string]::IsNullOrEmpty($Path)) {
         return $false
     }
 
@@ -4074,4 +4085,14 @@ function Get-PodeImageContentType {
 
     # If none of the above formats match, return a generic binary type
     return 'application/octet-stream'
+}
+
+function Read-PodeFileContent {
+    param(
+        [Parameter()]
+        [System.IO.FileInfo]
+        $FileInfo
+    )
+
+    return ([PodeHelpers]::ReadAllBytes($FileInfo))
 }

--- a/src/Private/Mappers.ps1
+++ b/src/Private/Mappers.ps1
@@ -8,7 +8,7 @@ function Get-PodeContentType {
         $DefaultIsNull
     )
 
-    if ([string]::IsNullOrWhiteSpace($Extension)) {
+    if ([string]::IsNullOrEmpty($Extension)) {
         $Extension = [string]::Empty
     }
 

--- a/src/Private/Middleware.ps1
+++ b/src/Private/Middleware.ps1
@@ -197,8 +197,8 @@ function Get-PodePublicMiddleware {
     param()
     return (Get-PodeInbuiltMiddleware -Name '__pode_mw_static_content__' -ScriptBlock {
             # only find public static content here
-            $path = Find-PodePublicRoute -Path $WebEvent.Path
-            if ([string]::IsNullOrWhiteSpace($path)) {
+            $pubRoute = Find-PodePublicRoute -Path $WebEvent.Path
+            if ($null -eq $pubRoute) {
                 return $true
             }
 
@@ -206,7 +206,7 @@ function Get-PodePublicMiddleware {
             $cachable = Test-PodeRouteValidForCaching -Path $WebEvent.Path
 
             # write the file to the response
-            Write-PodeFileResponse -Path $path -MaxAge $PodeContext.Server.Web.Static.Cache.MaxAge -Cache:$cachable
+            Write-PodeFileResponse -FileInfo $pubRoute.FileInfo -MaxAge $PodeContext.Server.Web.Static.Cache.MaxAge -Cache:$cachable
 
             # public static content found, stop
             return $false
@@ -266,7 +266,7 @@ function Get-PodeRouteValidateMiddleware {
                     return $false
                 }
 
-                # otheriwse, it's a 404
+                # otherwise, it's a 404
                 Set-PodeResponseStatus -Code 404
                 return $false
             }
@@ -287,12 +287,12 @@ function Get-PodeRouteValidateMiddleware {
             $WebEvent.Route = $route
 
             # override the content type from the route if it's not empty
-            if (![string]::IsNullOrWhiteSpace($route.ContentType)) {
+            if (![string]::IsNullOrEmpty($route.ContentType)) {
                 $WebEvent.ContentType = $route.ContentType
             }
 
             # override the transfer encoding from the route if it's not empty
-            if (![string]::IsNullOrWhiteSpace($route.TransferEncoding)) {
+            if (![string]::IsNullOrEmpty($route.TransferEncoding)) {
                 $WebEvent.TransferEncoding = $route.TransferEncoding
             }
 
@@ -395,7 +395,7 @@ function Initialize-PodeIISMiddleware {
     }
 
     # fail if no iis token - because there should be!
-    if ([string]::IsNullOrWhiteSpace($PodeContext.Server.IIS.Token)) {
+    if ([string]::IsNullOrEmpty($PodeContext.Server.IIS.Token)) {
         # IIS ASPNETCORE_TOKEN is missing
         throw ($PodeLocale.iisAspnetcoreTokenMissingExceptionMessage)
     }

--- a/src/Private/PodeServer.ps1
+++ b/src/Private/PodeServer.ps1
@@ -248,7 +248,7 @@ function Start-PodeWebServer {
                                         if ($null -ne $WebEvent.StaticContent) {
                                             $fileBrowser = $WebEvent.Route.FileBrowser
                                             if ($WebEvent.StaticContent.IsDownload) {
-                                                Write-PodeAttachmentResponseInternal -Path $WebEvent.StaticContent.Source -FileBrowser:$fileBrowser
+                                                Write-PodeAttachmentResponseInternal -FileInfo $WebEvent.StaticContent.FileInfo -FileBrowser:$fileBrowser
                                             }
                                             elseif ($WebEvent.StaticContent.RedirectToDefault) {
                                                 $file = [System.IO.Path]::GetFileName($WebEvent.StaticContent.Source)
@@ -256,13 +256,11 @@ function Start-PodeWebServer {
                                             }
                                             else {
                                                 $cachable = $WebEvent.StaticContent.IsCachable
-                                                Write-PodeFileResponseInternal -Path $WebEvent.StaticContent.Source -MaxAge $PodeContext.Server.Web.Static.Cache.MaxAge `
-                                                    -Cache:$cachable -FileBrowser:$fileBrowser
+                                                Write-PodeFileResponseInternal -FileInfo $WebEvent.StaticContent.FileInfo -MaxAge $PodeContext.Server.Web.Static.Cache.MaxAge -Cache:$cachable -FileBrowser:$fileBrowser
                                             }
                                         }
                                         elseif ($null -ne $WebEvent.Route.Logic) {
-                                            $null = Invoke-PodeScriptBlock -ScriptBlock $WebEvent.Route.Logic -Arguments $WebEvent.Route.Arguments `
-                                                -UsingVariables $WebEvent.Route.UsingVariables -Scoped -Splat
+                                            $null = Invoke-PodeScriptBlock -ScriptBlock $WebEvent.Route.Logic -Arguments $WebEvent.Route.Arguments -UsingVariables $WebEvent.Route.UsingVariables -Scoped -Splat
                                         }
                                     }
                                 }

--- a/src/Private/Responses.ps1
+++ b/src/Private/Responses.ps1
@@ -213,7 +213,7 @@ function Write-PodeFileResponseInternal {
     # this is a static file
     try {
         # load the file content
-        $content = Read-PodeFileContent -FileInfo $FileInfo
+        $content = [System.IO.File]::ReadAllBytes($FileInfo.FullName)
 
         # Determine and set the content type for static files
         $ContentType = Protect-PodeValue -Value $ContentType -Default (Get-PodeContentType -Extension $mainExt)
@@ -497,7 +497,7 @@ function Write-PodeAttachmentResponseInternal {
 
     # if serverless, get the content raw and return
     if (!$WebEvent.Streamed) {
-        $WebEvent.Response.Body = Read-PodeFileContent -FileInfo $FileInfo
+        $WebEvent.Response.Body = [System.IO.File]::ReadAllBytes($FileInfo.FullName)
         return
     }
 

--- a/src/Private/Serverless.ps1
+++ b/src/Private/Serverless.ps1
@@ -87,7 +87,7 @@ function Start-PodeAzFuncServer {
                     if ($null -ne $WebEvent.StaticContent) {
                         $fileBrowser = $WebEvent.Route.FileBrowser
                         if ($WebEvent.StaticContent.IsDownload) {
-                            Write-PodeAttachmentResponseInternal -Path $WebEvent.StaticContent.Source -FileBrowser:$fileBrowser
+                            Write-PodeAttachmentResponseInternal -FileInfo $WebEvent.StaticContent.FileInfo -FileBrowser:$fileBrowser
                         }
                         elseif ($WebEvent.StaticContent.RedirectToDefault) {
                             $file = [System.IO.Path]::GetFileName($WebEvent.StaticContent.Source)
@@ -95,7 +95,7 @@ function Start-PodeAzFuncServer {
                         }
                         else {
                             $cachable = $WebEvent.StaticContent.IsCachable
-                            Write-PodeFileResponseInternal -Path $WebEvent.StaticContent.Source -MaxAge $PodeContext.Server.Web.Static.Cache.MaxAge -Cache:$cachable -FileBrowser:$fileBrowser
+                            Write-PodeFileResponseInternal -FileInfo $WebEvent.StaticContent.FileInfo -MaxAge $PodeContext.Server.Web.Static.Cache.MaxAge -Cache:$cachable -FileBrowser:$fileBrowser
                         }
                     }
                     else {
@@ -207,7 +207,7 @@ function Start-PodeAwsLambdaServer {
                     if ($null -ne $WebEvent.StaticContent) {
                         $fileBrowser = $WebEvent.Route.FileBrowser
                         if ($WebEvent.StaticContent.IsDownload) {
-                            Write-PodeAttachmentResponseInternal -Path $WebEvent.StaticContent.Source -FileBrowser:$fileBrowser
+                            Write-PodeAttachmentResponseInternal -FileInfo $WebEvent.StaticContent.FileInfo -FileBrowser:$fileBrowser
                         }
                         elseif ($WebEvent.StaticContent.RedirectToDefault) {
                             $file = [System.IO.Path]::GetFileName($WebEvent.StaticContent.Source)
@@ -215,8 +215,7 @@ function Start-PodeAwsLambdaServer {
                         }
                         else {
                             $cachable = $WebEvent.StaticContent.IsCachable
-                            Write-PodeFileResponseInternal -Path $WebEvent.StaticContent.Source -MaxAge $PodeContext.Server.Web.Static.Cache.MaxAge `
-                                -Cache:$cachable -FileBrowser:$fileBrowser
+                            Write-PodeFileResponseInternal -FileInfo $WebEvent.StaticContent.FileInfo -MaxAge $PodeContext.Server.Web.Static.Cache.MaxAge -Cache:$cachable -FileBrowser:$fileBrowser
                         }
                     }
                     else {

--- a/src/Public/Routes.ps1
+++ b/src/Public/Routes.ps1
@@ -871,7 +871,7 @@ function Add-PodeStaticRoute {
                 ErrorType         = $ErrorContentType
                 Download          = $DownloadOnly.IsPresent
                 IsStatic          = $true
-                FileBrowser       = $FileBrowser.isPresent
+                FileBrowser       = $FileBrowser.IsPresent
                 OpenApi           = @{
                     Path           = $OpenApiPath
                     Responses      = @{}

--- a/tests/unit/Middleware.Tests.ps1
+++ b/tests/unit/Middleware.Tests.ps1
@@ -675,7 +675,7 @@ Describe 'Get-PodePublicMiddleware' {
             }
         }
 
-        Mock Find-PodePublicRoute { return '/' }
+        Mock Find-PodePublicRoute { return @{ Source = '/'; FileInfo = [System.IO.FileInfo]::new($pwd) } }
         Mock Write-PodeFileResponse { }
 
         $WebEvent = @{
@@ -702,7 +702,7 @@ Describe 'Get-PodePublicMiddleware' {
             }
         }
 
-        Mock Find-PodePublicRoute { return '/' }
+        Mock Find-PodePublicRoute { return @{ Source = '/'; FileInfo = [System.IO.FileInfo]::new($pwd) } }
         Mock Write-PodeFileResponse { }
 
         $WebEvent = @{
@@ -730,7 +730,7 @@ Describe 'Get-PodePublicMiddleware' {
             }
         }
 
-        Mock Find-PodePublicRoute { return '/' }
+        Mock Find-PodePublicRoute { return @{ Source = '/'; FileInfo = [System.IO.FileInfo]::new($pwd) } }
         Mock Write-PodeFileResponse { }
 
         $WebEvent = @{
@@ -758,7 +758,7 @@ Describe 'Get-PodePublicMiddleware' {
             }
         }
 
-        Mock Find-PodePublicRoute { return '/' }
+        Mock Find-PodePublicRoute { return @{ Source = '/'; FileInfo = [System.IO.FileInfo]::new($pwd) } }
         Mock Write-PodeFileResponse { }
 
         $WebEvent = @{
@@ -785,7 +785,7 @@ Describe 'Get-PodePublicMiddleware' {
             }
         }
 
-        Mock Find-PodePublicRoute { return '/' }
+        Mock Find-PodePublicRoute { return @{ Source = '/'; FileInfo = [System.IO.FileInfo]::new($pwd) } }
         Mock Write-PodeFileResponse { }
 
         $WebEvent = @{

--- a/tests/unit/Responses.Tests.ps1
+++ b/tests/unit/Responses.Tests.ps1
@@ -557,9 +557,9 @@ Describe 'Write-PodeAttachmentResponseInternal Tests' {
         Mock Get-PodeContentType { return 'application/octet-stream' }
         Mock Find-PodePublicRoute {}
         Mock Get-Item {
-            return [System.IO.FileInfo]::new('myfile.txt')
+            return [System.IO.FileInfo]::new($Path)
         }
-        Mock Read-PodeFileContent { return [System.Text.Encoding]::UTF8.GetBytes('Test file content') }
+        # Mock Read-PodeFileContent { return [System.Text.Encoding]::UTF8.GetBytes('Test file content') }
         Mock Set-PodeHeader {}
     }
 
@@ -570,15 +570,15 @@ Describe 'Write-PodeAttachmentResponseInternal Tests' {
     It 'Sets response status to 404 if file does not exist' {
         Mock Get-Item { return $null } -Verifiable
 
-        Write-PodeAttachmentResponseInternal -Path 'nonexistent.txt' -ContentType 'text/plain' | Should -BeNullOrEmpty
+        Write-PodeAttachmentResponseInternal -Path (Join-Path $pwd 'non-existent.txt') -ContentType 'text/plain' | Should -BeNullOrEmpty
         Should -Invoke Set-PodeResponseStatus -Times 1 -Scope It -ParameterFilter { $Code -eq 404 }
     }
 
     It 'Sets correct content type and downloads file' {
-        Write-PodeAttachmentResponseInternal -Path 'existing.txt' -ContentType 'text/plain'
+        Write-PodeAttachmentResponseInternal -Path (Join-Path $src 'Pode.psm1') -ContentType 'text/plain'
 
         Should -Invoke Set-PodeHeader -Times 1 -Scope It -ParameterFilter {
-            $Name -eq 'Content-Disposition' -and $Value -like '*filename=myfile.txt'
+            $Name -eq 'Content-Disposition' -and $Value -like '*filename=Pode.psm1'
         }
         Should -Invoke Get-PodeContentType -Times 0 -Scope It # ContentType is provided, so it should not attempt to get it
     }
@@ -589,7 +589,7 @@ Describe 'Write-PodeAttachmentResponseInternal Tests' {
             $dir | Add-Member -Name 'PSIsContainer' -Value $true -MemberType NoteProperty -PassThru
         }
 
-        Write-PodeAttachmentResponseInternal -Path 'mydirectory' -FileBrowser
+        Write-PodeAttachmentResponseInternal -Path $pwd -FileBrowser
         Should -Invoke Write-PodeDirectoryResponseInternal -Times 1 -Scope It
     }
 

--- a/tests/unit/Responses.Tests.ps1
+++ b/tests/unit/Responses.Tests.ps1
@@ -7,6 +7,10 @@ BeforeAll {
     Get-ChildItem "$($src)/*.ps1" -Recurse | Resolve-Path | ForEach-Object { . $_ }
     Import-LocalizedData -BindingVariable PodeLocale -BaseDirectory (Join-Path -Path $src -ChildPath 'Locales') -FileName 'Pode'
 
+    # Import Pode Assembly
+    $helperPath = (Split-Path -Parent -Path $path) -ireplace 'unit', 'shared'
+    . "$helperPath/TestHelper.ps1"
+    Import-PodeAssembly -SrcPath $src
 }
 
 Describe 'Set-PodeResponseStatus' {
@@ -431,7 +435,7 @@ Describe 'Write-PodeFileResponse' {
 
 
     It 'Loads the contents of a dynamic file' {
-        Mock Test-PodePath { return @{ PSIsContainer = $false ; extension = '.pode' } }
+        Mock Test-PodePath { return [System.IO.FileInfo]::new((Join-Path $src '../examples/views/simple.pode')) }
         Mock Get-PodeRelativePath { return $Path }
         Mock Get-PodeFileContentUsingViewEngine { return 'file contents' }
         Mock Write-PodeTextResponse { return $Value }
@@ -443,8 +447,7 @@ Describe 'Write-PodeFileResponse' {
     }
 
     It 'Loads the contents of a static file' {
-
-        Mock Test-PodePath { return @{ PSIsContainer = $false ; extension = '.pode' } }
+        Mock Test-PodePath { return [System.IO.FileInfo]::new((Join-Path $src '../examples/views/simple.pode')) }
         Mock Get-PodeRelativePath { return $Path }
         Mock Get-Content { return 'file contents' }
         Mock Get-PodeFileContentUsingViewEngine { return 'file contents' }
@@ -468,20 +471,17 @@ Describe 'Use-PodePartialView' {
     }
 
     It 'Throws an error for a path that does not exist' {
-        Mock Test-PodePath { return $false }
+        Mock Test-PodePath { return $null }
         { Use-PodePartialView -Path 'sub-view.pode' } | Should -Throw -ExpectedMessage ($PodeLocale.viewsPathDoesNotExistExceptionMessage -f '*' ) # The Views path does not exist: sub-view.pode'
     }
 
-
-
-
     It 'Returns file contents, and appends view engine' {
-        Mock Test-PodePath { return $true }
+        Mock Test-PodePath { return [System.IO.FileInfo]::new('./sub-view.pode') }
         Use-PodePartialView -Path 'sub-view' | Should -Be 'file contents'
     }
 
     It 'Returns file contents' {
-        Mock Test-PodePath { return $true }
+        Mock Test-PodePath { return [System.IO.FileInfo]::new('./sub-view.pode') }
         Use-PodePartialView -Path 'sub-view.pode' | Should -Be 'file contents'
     }
 }
@@ -557,18 +557,14 @@ Describe 'Write-PodeAttachmentResponseInternal Tests' {
         Mock Get-PodeContentType { return 'application/octet-stream' }
         Mock Find-PodePublicRoute {}
         Mock Get-Item {
-            return @{
-                PSIsContainer = $false
-                Name          = 'myfile.txt'
-                Extension     = '.txt'
-                OpenRead      = { [System.IO.MemoryStream]::new([System.Text.Encoding]::UTF8.GetBytes('Test file content')) }
-            }
+            return [System.IO.FileInfo]::new('myfile.txt')
         }
+        Mock Read-PodeFileContent { return [System.Text.Encoding]::UTF8.GetBytes('Test file content') }
         Mock Set-PodeHeader {}
-
     }
+
     BeforeEach {
-        $WebEvent = @{Response = @{} }
+        $WebEvent = @{ Response = @{} }
     }
 
     It 'Sets response status to 404 if file does not exist' {
@@ -589,14 +585,11 @@ Describe 'Write-PodeAttachmentResponseInternal Tests' {
 
     It 'Returns directory listing if FileBrowser is present and path is a directory' {
         Mock Get-Item {
-            return @{
-                PSIsContainer = $true
-                Name          = 'mydirectory'
-            }
+            $dir = [System.IO.FileInfo]::new($pwd)
+            $dir | Add-Member -Name 'PSIsContainer' -Value $true -MemberType NoteProperty -PassThru
         }
 
         Write-PodeAttachmentResponseInternal -Path 'mydirectory' -FileBrowser
-
         Should -Invoke Write-PodeDirectoryResponseInternal -Times 1 -Scope It
     }
 


### PR DESCRIPTION
This is primarily for static/public routes and files, but during a request flow for these we use `Get-Item` and `Get-Content` several times - given the PowerShell and PSDrive overheads this does make reading file contents and writing them slower. This PR makes it so that we instead re-use the FileInfo object returned by the first `Get-Item`, to avoid PS overhead, and so that we can use .NET directly for reading file byte contents.

Also, I've remove a redundant MemoryStream in `Write-PodeTextResponse` which actually double the memory-use when writing back to the Response stream. We can instead just write the bytes directly to the Response stream.

Both of these changes should speed to read/write performance, and reduce memory usage when writing to the Response steam.