### PR TITLE
Extend datetime format for more detail

### DIFF
--- a/src/Private/Logging.ps1
+++ b/src/Private/Logging.ps1
@@ -182,7 +182,7 @@ function Get-PodeLoggingInbuiltType {
 
                 # build the exception details
                 $row = @(
-                    "Date: $($item.Date.ToString('yyyy-MM-dd HH:mm:ss'))",
+                    "Date: $($item.Date.ToString('yyyy-MM-dd HH:mm:ss.fffK'))",
                     "Level: $($item.Level)",
                     "ThreadId: $($item.ThreadId)",
                     "Server: $($item.Server)",
@@ -316,7 +316,7 @@ function Write-PodeRequestLog {
             Size              = '-'
         }
     }
-    
+
     # set size if >0
     if ($Response.ContentLength64 -gt 0) {
         $item.Response.Size = $Response.ContentLength64


### PR DESCRIPTION
This PR adds in milliseconds and timezone for event logging. A lot of the time, multiple commands can happen within the same second, so this gives more insight to the order of events.