### PR TITLE
fix net10 build: comparison with string and int that worked until now

### DIFF
--- a/pode.build.ps1
+++ b/pode.build.ps1
@@ -465,7 +465,7 @@ function Invoke-PodeBuildDotnetBuild {
         $majorVersions = $sdkVersions | ForEach-Object { ([version]$_).Major } | Sort-Object -Descending | Select-Object -Unique
     }
     else {
-        $majorVersions = $sdkVersions.Where( { ([version]$_).Major -ge (Get-PodeBuildTargetFramework -TargetFrameworks $AvailableSdkVersion) } ) | Sort-Object -Descending | Select-Object -Unique
+        $majorVersions = $sdkVersions.Where( { ([version]$_).Major -ge (Get-PodeBuildTargetFramework -TargetFrameworks $AvailableSdkVersion) } ) | ForEach-Object { ([version]$_).Major } | Sort-Object -Descending | Select-Object -Unique
     }
     # Map target frameworks to minimum SDK versions
 


### PR DESCRIPTION
### Description of the Change
Building on net10 failed because the build script tried comparing the major version `"10"` (a string) with `9` (an integer). I haven't checked how string/int comparisons work exactly, but `"9" -ge 9` is `True`, but `"10" -ge 9` is `False`. The script would wrongly find that net10 isn't able to build for _any_ version of the framework and fail.

This patch just converts it to an integer.

Using:
- Debian 13, amd64
- dotnet 10.0.100 (via MS apt repo)