### PR TITLE
Add NuGet packages to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,10 @@ updates:
       interval: "daily"
     labels:
       - "packaging :package:"
+
+  - package-ecosystem: "nuget"
+    directory: "/src/Listener"
+    schedule:
+      interval: "daily"
+    labels:
+      - "packaging :package:"


### PR DESCRIPTION
### Description of the Change
Add the NuGet packaging ecosystem to Dependabot, so it can scan for new versions of NuGet packages - for example, Kerberos.NET.