### PR TITLE
Fix typo for the "screen-wake-lock" Permission-Policy parameter

### DIFF
--- a/src/Private/Security.ps1
+++ b/src/Private/Security.ps1
@@ -711,7 +711,7 @@ function Set-PodeSecurityPermissionsPolicyInternal {
         Protect-PodePermissionsPolicyKeyword -Name 'unoptimized-images' -Value $Params.UnoptimisedImages -Append:$Append
         Protect-PodePermissionsPolicyKeyword -Name 'unsized-media' -Value $Params.UnsizedMedia -Append:$Append
         Protect-PodePermissionsPolicyKeyword -Name 'usb' -Value $Params.Usb -Append:$Append
-        Protect-PodePermissionsPolicyKeyword -Name 'screen-wake-lock' -Value $Params.ScreenWakeLake -Append:$Append
+        Protect-PodePermissionsPolicyKeyword -Name 'screen-wake-lock' -Value $Params.ScreenWakeLock -Append:$Append
         Protect-PodePermissionsPolicyKeyword -Name 'web-share' -Value $Params.WebShare -Append:$Append
         Protect-PodePermissionsPolicyKeyword -Name 'xr-spatial-tracking' -Value $Params.XrSpatialTracking -Append:$Append
     )

--- a/src/Public/Security.ps1
+++ b/src/Public/Security.ps1
@@ -757,8 +757,8 @@ The values to use for the UnsizedMedia portion of the header.
 .PARAMETER Usb
 The values to use for the Usb portion of the header.
 
-.PARAMETER ScreenWakeLake
-The values to use for the ScreenWakeLake portion of the header.
+.PARAMETER ScreenWakeLock
+The values to use for the ScreenWakeLock portion of the header.
 
 .PARAMETER WebShare
 The values to use for the WebShare portion of the header.
@@ -881,7 +881,7 @@ function Set-PodeSecurityPermissionsPolicy {
 
         [Parameter()]
         [string[]]
-        $ScreenWakeLake,
+        $ScreenWakeLock,
 
         [Parameter()]
         [string[]]
@@ -983,8 +983,8 @@ The values to add for the UnsizedMedia portion of the header.
 .PARAMETER Usb
 The values to add for the Usb portion of the header.
 
-.PARAMETER ScreenWakeLake
-The values to add for the ScreenWakeLake portion of the header.
+.PARAMETER ScreenWakeLock
+The values to add for the ScreenWakeLock portion of the header.
 
 .PARAMETER WebShare
 The values to add for the WebShare portion of the header.
@@ -1108,7 +1108,7 @@ function Add-PodeSecurityPermissionsPolicy {
 
         [Parameter()]
         [string[]]
-        $ScreenWakeLake,
+        $ScreenWakeLock,
 
         [Parameter()]
         [string[]]


### PR DESCRIPTION
### Description of the Change
Fix typo for the "screen-wake-lock" Permission-Policy parameter, should be `ScreenWakeLock` but it currently `ScreenWakeLake`.
