### PR TITLE
Adds .gitattributes to standardise line-endings to CRLF for PowerShell/Markdown files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+*.ps1 text eol=crlf
+*.psm1 text eol=crlf
+*.psd1 text eol=crlf
+*.md text eol=crlf


### PR DESCRIPTION
### Description of the Change
Adds .gitattributes to standardise line-endings to CRLF for PowerShell/Markdown files
