### PR TITLE
Add initial support for creating and hosting MCP Tools; Add initial support for creating JSON Schema definitions 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ pkg/
 deliverable/
 .vs/
 yarn.lock
+.vscode/mcp.json
 
 # Code Runner
 tempCodeRunnerFile.ps1

--- a/docs/Tutorials/Misc/JsonSchema.md
+++ b/docs/Tutorials/Misc/JsonSchema.md
@@ -317,7 +317,7 @@ $def = Merge-PodeJsonSchema -Type 'AllOf' -Definition @(
         @{
             type      = 'string'
             minLength = 5
-        }
+        },
         @{
             type      = 'string'
             maxLength = 10
@@ -344,7 +344,7 @@ $def = Merge-PodeJsonSchema -Type 'AnyOf' -Definition @(
         @{
             type      = 'string'
             maxLength = 5
-        }
+        },
         @{
             type    = 'integer'
             minimum = 0
@@ -371,7 +371,7 @@ $def = Merge-PodeJsonSchema -Type 'OneOf' -Definition @(
         @{
             type       = 'integer'
             multipleOf = 5
-        }
+        },
         @{
             type       = 'integer'
             multipleOf = 3

--- a/docs/Tutorials/Misc/JsonSchema.md
+++ b/docs/Tutorials/Misc/JsonSchema.md
@@ -2,7 +2,7 @@
 
 You can construct hashtable representations of JSON Schema objects in Pode, which follows the specification [outlined here](https://json-schema.org/specification).
 
-The hashtable objects can then be converted to JSON later, using `ConvertTo-Json` - or [`Write-PodeJsonResponse`].
+The hashtable objects can then be converted to JSON later, using `ConvertTo-Json` - or [`Write-PodeJsonResponse`](../../../Functions/Responses/Write-PodeJsonResponse).
 
 ## Types
 
@@ -18,7 +18,7 @@ The following types are supported:
 
 ### Null
 
-To construct a simple `null` object type definition use [`New-PodeJsonSchemaNull`]:
+To construct a simple `null` object type definition use [`New-PodeJsonSchemaNull`](../../../Functions/JsonSchema/New-PodeJsonSchemaNull):
 
 ```powershell
 $def = New-PodeJsonSchemaNull
@@ -32,7 +32,7 @@ $def = New-PodeJsonSchemaNull
 
 ### Boolean
 
-To construct a simple `boolean` object type definition use [`New-PodeJsonSchemaBoolean`]:
+To construct a simple `boolean` object type definition use [`New-PodeJsonSchemaBoolean`](../../../Functions/JsonSchema/New-PodeJsonSchemaBoolean):
 
 ```powershell
 $def = New-PodeJsonSchemaBoolean
@@ -57,7 +57,7 @@ $def = New-PodeJsonSchemaBoolean -Constant $true
 
 ### Integer
 
-To construct a simple `integer` object type definition use [`New-PodeJsonSchemaInteger`]:
+To construct a simple `integer` object type definition use [`New-PodeJsonSchemaInteger`](../../../Functions/JsonSchema/New-PodeJsonSchemaInteger):
 
 ```powershell
 $def = New-PodeJsonSchemaInteger
@@ -107,7 +107,7 @@ $def = New-PodeJsonSchemaInteger -Enum 1, 2, 4, 8, 16
 
 ### Number
 
-To construct a simple `number` object type definition use [`New-PodeJsonSchemaNumber`]:
+To construct a simple `number` object type definition use [`New-PodeJsonSchemaNumber`](../../../Functions/JsonSchema/New-PodeJsonSchemaNumber):
 
 ```powershell
 $def = New-PodeJsonSchemaNumber
@@ -157,7 +157,7 @@ $def = New-PodeJsonSchemaNumber -Enum 1, 2, 4, 8, 16
 
 ### String
 
-To construct a simple `string` object type definition use [`New-PodeJsonSchemaString`]:
+To construct a simple `string` object type definition use [`New-PodeJsonSchemaString`](../../../Functions/JsonSchema/New-PodeJsonSchemaString):
 
 ```powershell
 $def = New-PodeJsonSchemaString
@@ -258,7 +258,7 @@ $def = New-PodeJsonSchemaArray -Unique -MaxItems 2 -Item (
 
 ### Object
 
-An `object` uses the definitions above for Null, Boolean, Integer, Number, String and/or Array (or Object again) to define its own properties. However, instead of using the definitions directly, you need to first create a property definition using [`New-PodeJsonSchemaProperty`] - this allows you to explicitly name a definition, and specify if it's required.
+An `object` uses the definitions above for Null, Boolean, Integer, Number, String and/or Array (or Object again) to define its own properties. However, instead of using the definitions directly, you need to first create a property definition using [`New-PodeJsonSchemaProperty`](../../../Functions/JsonSchema/New-PodeJsonSchemaProperty) - this allows you to explicitly name a definition, and specify if it's required.
 
 A basic `object`, which can accept any properties, looks as follows:
 

--- a/docs/Tutorials/Misc/JsonSchema.md
+++ b/docs/Tutorials/Misc/JsonSchema.md
@@ -1,0 +1,402 @@
+# JSON Schema
+
+You can construct hashtable representations of JSON Schema objects in Pode, which follows the specification [outlined here](https://json-schema.org/specification).
+
+The hashtable objects can then be converted to JSON later, using `ConvertTo-Json` - or [`Write-PodeJsonResponse`].
+
+## Types
+
+The following types are supported:
+
+* Null
+* Boolean
+* Integer
+* Number
+* String
+* Array
+* Object
+
+### Null
+
+To construct a simple `null` object type definition use [`New-PodeJsonSchemaNull`]:
+
+```powershell
+$def = New-PodeJsonSchemaNull
+
+# return:
+
+@{
+    type = 'null'
+}
+```
+
+### Boolean
+
+To construct a simple `boolean` object type definition use [`New-PodeJsonSchemaBoolean`]:
+
+```powershell
+$def = New-PodeJsonSchemaBoolean
+
+# returns:
+@{
+    type = 'boolean'
+}
+```
+
+**An boolean with constant value:**
+
+```powershell
+$def = New-PodeJsonSchemaBoolean -Constant $true
+
+# returns:
+@{
+    type  = 'boolean'
+    const = $true
+}
+```
+
+### Integer
+
+To construct a simple `integer` object type definition use [`New-PodeJsonSchemaInteger`]:
+
+```powershell
+$def = New-PodeJsonSchemaInteger
+
+# returns:
+@{
+    type = 'integer'
+}
+```
+
+**An integer with constant value:**
+
+```powershell
+$def = New-PodeJsonSchemaInteger -Constant 42
+
+# returns:
+@{
+    type = 'integer'
+    const = 42
+}
+```
+
+**An integer with minimum and maximum:**
+
+```powershell
+$def = New-PodeJsonSchemaInteger -Minimum 0 -Maximum 100
+
+# returns:
+@{
+    type    = 'integer'
+    minimum = 0
+    maximum = 100
+}
+```
+
+**An integer with predefined values:**
+
+```powershell
+$def = New-PodeJsonSchemaInteger -Enum 1, 2, 4, 8, 16
+
+# returns:
+@{
+    type = 'integer'
+    enum = @(1, 2, 4, 8, 16)
+}
+```
+
+### Number
+
+To construct a simple `number` object type definition use [`New-PodeJsonSchemaNumber`]:
+
+```powershell
+$def = New-PodeJsonSchemaNumber
+
+# returns:
+@{
+    type = 'number'
+}
+```
+
+**A number with constant value:**
+
+```powershell
+$def = New-PodeJsonSchemaNumber -Constant 42
+
+# returns:
+@{
+    type = 'number'
+    const = 42
+}
+```
+
+**A number with minimum and maximum:**
+
+```powershell
+$def = New-PodeJsonSchemaNumber -Minimum 0 -Maximum 100
+
+# returns:
+@{
+    type    = 'number'
+    minimum = 0
+    maximum = 100
+}
+```
+
+**A number with predefined values:**
+
+```powershell
+$def = New-PodeJsonSchemaNumber -Enum 1, 2, 4, 8, 16
+
+# returns:
+@{
+    type = 'number'
+    enum = @(1, 2, 4, 8, 16)
+}
+```
+
+### String
+
+To construct a simple `string` object type definition use [`New-PodeJsonSchemaString`]:
+
+```powershell
+$def = New-PodeJsonSchemaString
+
+# returns:
+@{
+    type = 'string'
+}
+```
+
+**A string with constant value:**
+
+```powershell
+$def = New-PodeJsonSchemaString -Constant 'Hello, there'
+
+# returns:
+@{
+    type = 'string'
+    const = 'Hello, there'
+}
+```
+
+**A string with minimum and maximum length:**
+
+```powershell
+$def = New-PodeJsonSchemaString -MinLength 5 -MaxLength 20
+
+# returns:
+@{
+    type      = 'string'
+    minLength = 5
+    maxLength = 20
+}
+```
+
+**A string with predefined values:**
+
+```powershell
+$def = New-PodeJsonSchemaString -Enum 'Red', 'Blue', 'Green'
+
+# returns:
+@{
+    type = 'string'
+    enum = @('Red', 'Blue', 'Green')
+}
+```
+
+### Array
+
+An `array` takes one of the Null, Boolean, Integer, Number, or String definitions above to define its own items:
+
+```powershell
+# definition for an array of strings
+$def = New-PodeJsonSchemaArray -Item (New-PodeJsonSchemaString)
+
+# returns:
+@{
+    type  = 'array'
+    items = @{
+        type = 'string'
+    }
+}
+```
+
+**An array with minimum and maximum items:**
+
+```powershell
+$def = New-PodeJsonSchemaArray -MinItems 1 -MaxItems 5 -Item (New-PodeJsonSchemaString)
+
+# returns:
+@{
+    type     = 'array'
+    minItems = 1
+    maxItems = 5
+    items    = @{
+        type = 'string'
+    }
+}
+```
+
+**An array with unique items only:**
+```powershell
+$def = New-PodeJsonSchemaArray -Unique -MaxItems 2 -Item (
+    New-PodeJsonSchemaString -Enum 'Red', 'Green', 'Blue', 'Yellow'
+)
+
+# returns:
+@{
+    type        = 'array'
+    maxItems    = 2
+    uniqueItems = $true
+    items       = @{
+        type = 'string'
+        enum = @('Red', 'Green', 'Blue', 'Yellow')
+    }
+}
+```
+
+### Object
+
+An `object` uses the definitions above for Null, Boolean, Integer, Number, String and/or Array (or Object again) to define its own properties. However, instead of using the definitions directly, you need to first create a property definition using [`New-PodeJsonSchemaProperty`] - this allows you to explicitly name a definition, and specify if it's required.
+
+A basic `object`, which can accept any properties, looks as follows:
+
+```powershell
+$def = New-PodeJsonSchemaObject
+
+# returns:
+@{
+    type = 'object'
+}
+```
+
+An `object` with two properties to define a person, `name` of which is required:
+
+```powershell
+$def = New-PodeJsonSchemaObject -Property @(
+    (New-PodeJsonSchemaProperty -Name 'name' -Definition (New-PodeJsonSchemaString) -Required),
+    (New-PodeJsonSchemaProperty -Name 'age' -Definition (New-PodeJsonSchemaInteger -Minimum 0))
+)
+
+# returns:
+@{
+    type       = 'object'
+    required   = @('name')
+    properties = @{
+        name = @{
+            type = 'string'
+        }
+        age = @{
+            type    = 'integer'
+            minimum = 0
+        }
+    }
+}
+```
+
+## Merging
+
+You can merge multiple JSON Schema type definitions together, using either `allOf`, `anyOf`, `oneOf`, or `not` to create more complex type definitions.
+
+### All Of
+
+A merged type definition using `allOf` specifies that the value must match all of the defined schema of the type definitions supplied.
+
+For example, the following describes a type that has to be a `string` with minimum length of 5, and a maximum length of 10:
+
+```powershell
+$def = Merge-PodeJsonSchema -Type 'AllOf' -Definition @(
+    (New-PodeJsonSchemaString -MinLength 5),
+    (New-PodeJsonSchemaString -MaxLength 10)
+)
+
+# returns:
+@{
+    allOf = @(
+        @{
+            type      = 'string'
+            minLength = 5
+        }
+        @{
+            type      = 'string'
+            maxLength = 10
+        }
+    )
+}
+```
+
+### Any Of
+
+A merged type definition using `anyOf` specifies that the value must match any of the defined schema of the type definitions supplied.
+
+For example, the following describes a type that has to be either a `string` with maximum length of 5, or an `integer` with minimum value of 0:
+
+```powershell
+$def = Merge-PodeJsonSchema -Type 'AnyOf' -Definition @(
+    (New-PodeJsonSchemaString -MaxLength 5),
+    (New-PodeJsonSchemaInteger -Minimum 0)
+)
+
+# returns:
+@{
+    anyOf = @(
+        @{
+            type      = 'string'
+            maxLength = 5
+        }
+        @{
+            type    = 'integer'
+            minimum = 0
+        }
+    )
+}
+```
+
+### One Of
+
+A merged type definition using `oneOf` specifies that the value must match exactly one of the defined schema of the type definitions supplied.
+
+For example, the following describes a type that has to be either an `integer` that's a multiple of 5 or a multiple of 3 - but it cannot be both:
+
+```powershell
+$def = Merge-PodeJsonSchema -Type 'OneOf' -Definition @(
+    (New-PodeJsonSchemaInteger -MultipleOf 5),
+    (New-PodeJsonSchemaInteger -MultipleOf 3)
+)
+
+# returns:
+@{
+    oneOf = @(
+        @{
+            type       = 'integer'
+            multipleOf = 5
+        }
+        @{
+            type       = 'integer'
+            multipleOf = 3
+        }
+    )
+}
+```
+
+### Not
+
+A merged type definition using `not` specifies that the value must not match the defined schema of the type definitions supplied.
+
+For example, the following describes a type that cannot be a `string`:
+
+```powershell
+$def = Merge-PodeJsonSchema -Type 'Not' -Definition @(
+    (New-PodeJsonSchemaString)
+)
+
+# returns:
+@{
+    not = @(
+        @{
+            type = 'string'
+        }
+    )
+}
+```

--- a/docs/Tutorials/Misc/MCP.md
+++ b/docs/Tutorials/Misc/MCP.md
@@ -11,7 +11,7 @@ There is support for the tools to have, or not have, parameters; you can also de
 
 Tools are bundled into Groups, which lets you create a Tool and add it into one or more Groups - for example, you could have a `Default` Group where all Tools are added, or you could have a `ReadOnly` and `Admin` Groups to separate Tools.
 
-To create a Group use [`Add-PodeMcpGroup`] with a Name and optional Description:
+To create a Group use [`Add-PodeMcpGroup`](../../../Functions/MCP/Add-PodeMcpGroup) with a Name and optional Description:
 
 ```powershell
 Add-PodeMcpGroup -Name 'Default'
@@ -21,7 +21,7 @@ Add-PodeMcpGroup -Name 'Admin' -Description 'Admin only Tools for management of 
 
 ## Tools
 
-An MCP Tool is simply just a ScriptBlock, with a Name and Description, and then added to the server using [`Add-PodeMcpTool`] - you also need to supply one or more Groups to assign the Tool into.
+An MCP Tool is simply just a ScriptBlock, with a Name and Description, and then added to the server using [`Add-PodeMcpTool`](../../../Functions/MCP/Add-PodeMcpTool) - you also need to supply one or more Groups to assign the Tool into.
 
 If the supplied ScriptBlock has no parameters, there's nothing more for you to do. However, if your ScriptBlock does have parameters then you'll need to define and describe them - you can use `-AutoSchema` for simple parameter, or the [JSON Schema](../JsonSchema) functions for advanced definitions.
 
@@ -40,7 +40,7 @@ Once added to your MCP server, you can ask `What services are on this machine?` 
 
 ### AutoSchema
 
-When creating a Tool which accepts parameters there is the option to have Pode automatically generate the JSON Schema, to do this you should supply `-AutoSchema` to [`Add-PodeMcpTool`].
+When creating a Tool which accepts parameters there is the option to have Pode automatically generate the JSON Schema, to do this you should supply `-AutoSchema` to [`Add-PodeMcpTool`](../../../Functions/MCP/Add-PodeMcpTool).
 
 !!! important
     Only simple types are supported: string, int, long, double, float, and bool (including arrays of these types).
@@ -93,7 +93,7 @@ Once added to your MCP server, you can ask `What services are running on this ma
 
 Unlike the above automatically generated schema, there is also the option to manually define the schema yourself using [JSON Schema](../JsonSchema).
 
-To do this you'll need to supply `-PassThru` to [`Add-PodeMcpTool`], and pipe the result into [`Add-PodeMcpToolProperty`] and describe the parameters - chaining the [`Add-PodeMcpToolProperty`] calls for each ScriptBlock parameter you need to define.
+To do this you'll need to supply `-PassThru` to [`Add-PodeMcpTool`](../../../Functions/MCP/Add-PodeMcpTool), and pipe the result into [`Add-PodeMcpToolProperty`](../../../Functions/MCP/Add-PodeMcpToolProperty) and describe the parameters - chaining the [`Add-PodeMcpToolProperty`](../../../Functions/MCP/Add-PodeMcpToolProperty) calls for each ScriptBlock parameter you need to define.
 
 For example, building slightly on the above AutoSchema example, the following Tool will test if a specific Windows Service is present and in the specified State - but the schema is built manually. It is highly recommended to supply `-Description` to the JSON Schema functions, to help the MCP server further understand the parameters:
 
@@ -131,7 +131,7 @@ Once added to your MCP server, you can ask `Is the WinRM service running on this
 
 ## Response Types
 
-In the above Tool examples you'll have likely spotted the Tools return [`New-PodeMcpTextContent`]. This is because MCP tools should respond with one or more of the following types: text, image, and audio - each of which are represented by:
+In the above Tool examples you'll have likely spotted the Tools return [`New-PodeMcpTextContent`](../../../Functions/MCP/New-PodeMcpTextContent). This is because MCP tools should respond with one or more of the following types: text, image, and audio - each of which are represented by:
 
 * [`New-PodeMcpTextContent`]
 * [`New-PodeMcpImageContent`]
@@ -143,9 +143,9 @@ These functions are mandatory to return from Tool ScriptBlocks, so Pode can appr
 
 To actually host the created Tools, and let an MCP server list/invoke them, you need to configure Routing within Pode.
 
-This can be done via the usual [`Add-PodeRoute`], and then within its ScriptBlock you call [`Resolve-PodeMcpRequest`] - supplying the Group of Tools the Route should be responsible for. Because we're using the standard [`Add-PodeRoute`] you can configure any path you require, as well a authentication, middleware, etc.
+This can be done via the usual [`Add-PodeRoute`](../../../Functions/Routes/Add-PodeRoute), and then within its ScriptBlock you call [`Resolve-PodeMcpRequest`](../../../Functions/MCP/Resolve-PodeMcpRequest) - supplying the Group of Tools the Route should be responsible for. Because we're using the standard [`Add-PodeRoute`](../../../Functions/Routes/Add-PodeRoute) you can configure any path you require, as well a authentication, middleware, etc.
 
-The [`Resolve-PodeMcpRequest`] call deals with parsing the MCP server request, and the handling of `initialize`, `tools/list`, and `tools/call` requests:
+The [`Resolve-PodeMcpRequest`](../../../Functions/MCP/Resolve-PodeMcpRequest) call deals with parsing the MCP server request, and the handling of `initialize`, `tools/list`, and `tools/call` requests:
 
 ```powershell
 Add-PodeRoute -Method Post -Path '/mcp' -ScriptBlock {

--- a/docs/Tutorials/Misc/MCP.md
+++ b/docs/Tutorials/Misc/MCP.md
@@ -1,0 +1,210 @@
+# MCP
+
+!!! note
+    This is an initial implementation of MCP support, while initial testing has worked please expect aspects of the implementation to possibly change.
+
+You can create MCP tools in PowerShell and host them via Pode over HTTP(S), for use by MCP servers such as GitHub Copilot.
+
+There is support for the tools to have, or not have, parameters; you can also describe the tool/parameters for the MCP server using [JSON Schema](../JsonSchema).
+
+## Groups
+
+Tools are bundled into Groups, which lets you create a Tool and add it into one or more Groups - for example, you could have a `Default` Group where all Tools are added, or you could have a `ReadOnly` and `Admin` Groups to separate Tools.
+
+To create a Group use [`Add-PodeMcpGroup`] with a Name and optional Description:
+
+```powershell
+Add-PodeMcpGroup -Name 'Default'
+Add-PodeMcpGroup -Name 'ReadOnly'
+Add-PodeMcpGroup -Name 'Admin' -Description 'Admin only Tools for management of services'
+```
+
+## Tools
+
+An MCP Tool is simply just a ScriptBlock, with a Name and Description, and then added to the server using [`Add-PodeMcpTool`] - you also need to supply one or more Groups to assign the Tool into.
+
+If the supplied ScriptBlock has no parameters, there's nothing more for you to do. However, if your ScriptBlock does have parameters then you'll need to define and describe them - you can use `-AutoSchema` for simple parameter, or the [JSON Schema](../JsonSchema) functions for advanced definitions.
+
+### No Parameters
+
+The following creates a new MCP Tool for returning all Windows Service names, regardless of state. This Tool has no parameters which need to be supplied, so a ScriptBlock, Name, Description, and Group is all that's required:
+
+```powershell
+Add-PodeMcpTool -Name 'GetWindowsServices' -Description 'Returns all Windows service names' -Group 'Default' -ScriptBlock {
+        $services = Get-Service -ErrorAction Ignore | Select-Object Name
+        return New-PodeMcpTextContent -Value $services
+    }
+```
+
+Once added to your MCP server, you can ask `What services are on this machine?` and it will invoke the above Tool.
+
+### AutoSchema
+
+When creating a Tool which accepts parameters there is the option to have Pode automatically generate the JSON Schema, to do this you should supply `-AutoSchema` to [`Add-PodeMcpTool`].
+
+!!! important
+    Only simple types are supported: string, int, long, double, float, and bool (including arrays of these types).
+
+To aid the generation, the following parameter Attributes are respected:
+
+* `Parameter`
+  * `Mandatory` for knowing if the parameter is required
+  * `HelpMessage` is used as the parameter description
+  * `DontShow` is used to not generate schema for the parameter
+* `ValidateRange` is used the the min/max on integer/number types
+* `ValidateSet` is used as the enum value for types
+* `ValidateLength` is used for the min/max length on string types
+* `ValidateCount` is used for min/max items on array types
+
+Furthermore, the following PowerShell parameter types map the the following JSON Schema types:
+
+| PowerShell | JSON      |
+| ---------- | --------- |
+| `[string]` | `string`  |
+| `[int]`    | `integer` |
+| `[long]`   | `integer` |
+| `[double]` | `number`  |
+| `[float]`  | `number`  |
+| `[bool]`   | `boolean` |
+
+For example, the following Tool will return the Windows Services on the current machine which are in a specified State:
+
+```powershell
+Add-PodeMcpTool -Name 'GetWindowsServicesByState' -Description 'Returns Windows service names for a given state' -Group 'Default' -AutoSchema -ScriptBlock {
+    param(
+        [Parameter(Mandatory = $true, HelpMessage = 'The state of the services to retrieve')]
+        [ValidateSet('Running', 'Stopped', 'Paused')]
+        [string]
+        $State
+    )
+
+    $services = Get-Service -ErrorAction Ignore | Where-Object { $_.Status -ieq $State } | Select-Object Name
+    if (($null -eq $services) -or (Test-PodeIsEmpty $services)) {
+        $services = "No services found in the '$State' state."
+    }
+
+    return New-PodeMcpTextContent -Value $services
+}
+```
+
+Once added to your MCP server, you can ask `What services are running on this machine?` or `What services are stopped on this machine?` and it will invoke the above Tool.
+
+### Custom Schema
+
+Unlike the above automatically generated schema, there is also the option to manually define the schema yourself using [JSON Schema](../JsonSchema).
+
+To do this you'll need to supply `-PassThru` to [`Add-PodeMcpTool`], and pipe the result into [`Add-PodeMcpToolProperty`] and describe the parameters - chaining the [`Add-PodeMcpToolProperty`] calls for each ScriptBlock parameter you need to define.
+
+For example, building slightly on the above AutoSchema example, the following Tool will test if a specific Windows Service is present and in the specified State - but the schema is built manually. It is highly recommended to supply `-Description` to the JSON Schema functions, to help the MCP server further understand the parameters:
+
+```powershell
+Add-PodeMcpTool -Name 'TestWindowsServiceState' -Description 'Tests if a specified service is in a specified state' -Group 'Default' -ScriptBlock {
+    param(
+        [string]
+        $Name,
+
+        [ValidateSet('Running', 'Stopped', 'Paused')]
+        [string]
+        $State
+    )
+
+    $service = Get-Service -Name $Name -ErrorAction Ignore
+    if ($null -eq $service) {
+        return New-PodeMcpTextContent -Value "Service '$Name' not found."
+    }
+
+    if ($service.Status -ieq $State) {
+        return New-PodeMcpTextContent -Value "Service '$Name' is in the '$State' state."
+    }
+
+    return New-PodeMcpTextContent -Value "Service '$Name' is not in the '$State' state. Current state: $($service.Status)"
+} -PassThru |
+    Add-PodeMcpToolProperty -Name 'Name' -Required -Definition (
+        New-PodeJsonSchemaString -Description 'The name of the service to check'
+    ) -PassThru |
+    Add-PodeMcpToolProperty -Name 'State' -Required -Definition (
+        New-PodeJsonSchemaString -Description 'The state to check for the service' -Enum 'Running', 'Stopped', 'Paused'
+    )
+```
+
+Once added to your MCP server, you can ask `Is the WinRM service running on this machine?` and it will invoke the above Tool.
+
+## Response Types
+
+In the above Tool examples you'll have likely spotted the Tools return [`New-PodeMcpTextContent`]. This is because MCP tools should respond with one or more of the following types: text, image, and audio - each of which are represented by:
+
+* [`New-PodeMcpTextContent`]
+* [`New-PodeMcpImageContent`]
+* [`New-PodeMcpAudioContent`]
+
+These functions are mandatory to return from Tool ScriptBlocks, so Pode can appropriately format the responses.
+
+## Routing
+
+To actually host the created Tools, and let an MCP server list/invoke them, you need to configure Routing within Pode.
+
+This can be done via the usual [`Add-PodeRoute`], and then within its ScriptBlock you call [`Resolve-PodeMcpRequest`] - supplying the Group of Tools the Route should be responsible for. Because we're using the standard [`Add-PodeRoute`] you can configure any path you require, as well a authentication, middleware, etc.
+
+The [`Resolve-PodeMcpRequest`] call deals with parsing the MCP server request, and the handling of `initialize`, `tools/list`, and `tools/call` requests:
+
+```powershell
+Add-PodeRoute -Method Post -Path '/mcp' -ScriptBlock {
+    Resolve-PodeMcpRequest -Group 'Default'
+}
+```
+
+## MCP Server
+
+To connect your MCP server of choice, you will need to configure it to look at the HTTP endpoint and Route path you've configured - if a "type" is needed it should be `http`.
+
+### GitHub Copilot
+
+For example, to configure GitHub Copilot in Visual Studio Code you would create a `.vscode/mcp.json` file with the following content (replace `url` with your configure endpoint/path):
+
+```json
+{
+    "servers": {
+        "services": {
+            "type": "http",
+            "url": "http://localhost:8080/mcp"
+        }
+    }
+}
+```
+
+Once saved, you can open Copilot Chat and ask it questions to call your defined Tools.
+
+## Full Example
+
+The following is a simple but full example of a Pode server, which configures a simple MCP Tool which can be consumed by an MCP server. Once running, you'll need to configure your MCP server to look for tools at `http://localhost:8080/mcp`. Once connected, you'll be able to ask `What services are running on this machine?`.
+
+```powershell
+Start-PodeServer -Threads 2 {
+    Add-PodeEndpoint -Address localhost -Port 8080 -Protocol Http
+
+    # Create a simple default group for MCP tools
+    Add-PodeMcpGroup -Name 'Default' -Description 'Default group for MCP tools'
+
+    # Add a simple MCP tool for returning windows services names for a given state
+    Add-PodeMcpTool -Name 'GetWindowsServicesByState' -Description 'Returns Windows service names for a given state' -Group 'Default' -AutoSchema -ScriptBlock {
+        param(
+            [Parameter(Mandatory = $true, HelpMessage = 'The state of the services to retrieve')]
+            [ValidateSet('Running', 'Stopped', 'Paused')]
+            [string]
+            $State
+        )
+
+        $services = Get-Service -ErrorAction Ignore | Where-Object { $_.Status -ieq $State } | Select-Object Name
+        if (($null -eq $services) -or (Test-PodeIsEmpty $services)) {
+            $services = "No services found in the '$State' state."
+        }
+
+        return New-PodeMcpTextContent -Value $services
+    }
+
+    # Add the MCP route
+    Add-PodeRoute -Method Post -Path '/mcp' -ScriptBlock {
+        Resolve-PodeMcpRequest -Group 'Default'
+    }
+}
+```

--- a/docs/Tutorials/Misc/MCP.md
+++ b/docs/Tutorials/Misc/MCP.md
@@ -3,7 +3,7 @@
 !!! note
     This is an initial implementation of MCP support, while initial testing has worked please expect aspects of the implementation to possibly change.
 
-You can create MCP tools in PowerShell and host them via Pode over HTTP(S), for use by MCP servers such as GitHub Copilot.
+You can create MCP tools in PowerShell and host them via Pode over HTTP(S), for use by MCP servers such as GitHub Copilot. Information on MCP Tools can be [found here](https://modelcontextprotocol.info/docs/concepts/tools/).
 
 There is support for the tools to have, or not have, parameters; you can also describe the tool/parameters for the MCP server using [JSON Schema](../JsonSchema).
 

--- a/examples/Web-Mcp.ps1
+++ b/examples/Web-Mcp.ps1
@@ -1,0 +1,88 @@
+<#
+.SYNOPSIS
+    A PowerShell script to set up a Pode server with simple MCP tools for MCP clients.
+
+.DESCRIPTION
+    This script sets up a Pode server that listens on a specified port, and provides a simple set of tools for MCP clients to interact with.
+
+.EXAMPLE
+    To run the sample: ./Web-Mcp.ps1
+.LINK
+    https://github.com/Badgerati/Pode/blob/develop/examples/Web-Mcp.ps1
+
+.NOTES
+    Author: Pode Team
+    License: MIT License
+#>
+try {
+    # Determine the script path and Pode module path
+    $ScriptPath = (Split-Path -Parent -Path $MyInvocation.MyCommand.Path)
+    $podePath = Split-Path -Parent -Path $ScriptPath
+
+    # Import the Pode module from the source path if it exists, otherwise from installed modules
+    if (Test-Path -Path "$($podePath)/src/Pode.psm1" -PathType Leaf) {
+        Import-Module "$($podePath)/src/Pode.psm1" -Force -ErrorAction Stop
+    }
+    else {
+        Import-Module -Name 'Pode' -MaximumVersion 2.99 -ErrorAction Stop
+    }
+}
+catch { throw }
+
+# or just:
+# Import-Module Pode
+
+# create a server, and start listening on port 8081
+Start-PodeServer -Threads 2 {
+
+    # listen on localhost:8081
+    Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http
+
+    # request logging
+    New-PodeLoggingMethod -Terminal -Batch 10 -BatchTimeout 10 | Enable-PodeRequestLogging
+    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+
+    # Create a simple default group for MCP tools
+    Add-PodeMcpGroup -Name 'Default' -Description 'Default group for MCP tools'
+
+    # Add a simple MCP tool for returning a random greeting
+    Add-PodeMcpTool -Name 'Greet' -Description 'Returns a random greeting' -Group 'Default' -ScriptBlock {
+        $greetings = @('Hello', 'Hi', 'Hey', 'Greetings', 'Salutations')
+        $greeting = Get-Random -InputObject $greetings
+        return New-PodeMcpTextContent -Value "$($greeting) from the Pode MCP tool!"
+    }
+
+    # Add a simple MCP tool for returning a random greeting to a person
+    Add-PodeMcpTool -Name 'GreetPerson' -Description 'Returns a random greeting to a person' -Group 'Default' -AutoSchema -ScriptBlock {
+        param(
+            [Parameter(Mandatory = $true, HelpMessage = 'The name of the person to greet')]
+            [string]$Name
+        )
+        $greetings = @('Hello', 'Hi', 'Hey', 'Greetings', 'Salutations')
+        $greeting = Get-Random -InputObject $greetings
+        return New-PodeMcpTextContent -Value "$($greeting), $($Name)! from the Pode MCP tool!"
+    }
+
+    # Add a simple MCP tool for returning a random greeting to a person in a location
+    Add-PodeMcpTool -Name 'GreetPersonInLocation' -Description 'Returns a random greeting to a person in a location' -Group 'Default' -ScriptBlock {
+        param(
+            [string]$Name,
+            [string]$Location
+        )
+        $greetings = @('Hello', 'Hi', 'Hey', 'Greetings', 'Salutations')
+        $greeting = Get-Random -InputObject $greetings
+        return New-PodeMcpTextContent -Value "$($greeting), $($Name) from $($Location)! via the Pode MCP tool!"
+    } -PassThru |
+        Add-PodeMcpToolProperty -Name 'Name' -Required -Definition (
+            New-PodeJsonSchemaString -Description 'The name of the person to greet'
+        ) -PassThru |
+        Add-PodeMcpToolProperty -Name 'Location' -Required -Definition (
+            New-PodeJsonSchemaString -Description 'The location of the person to greet'
+        )
+
+    # Add the MCP route
+    Add-PodeRoute -Method Post -Path '/mcp-tests' -ScriptBlock {
+        # $WebEvent.Data | ConvertTo-Json | Out-Default
+        Resolve-PodeMcpRequest -Group 'Default'
+    }
+}

--- a/examples/Web-McpServices.ps1
+++ b/examples/Web-McpServices.ps1
@@ -1,0 +1,105 @@
+<#
+.SYNOPSIS
+    A PowerShell script to set up a Pode server with simple MCP tools for MCP clients.
+
+.DESCRIPTION
+    This script sets up a Pode server that listens on a specified port, and provides a simple set of tools for MCP clients to interact with.
+
+.EXAMPLE
+    To run the sample: ./Web-Mcp.ps1
+.LINK
+    https://github.com/Badgerati/Pode/blob/develop/examples/Web-Mcp.ps1
+
+.NOTES
+    Author: Pode Team
+    License: MIT License
+#>
+try {
+    # Determine the script path and Pode module path
+    $ScriptPath = (Split-Path -Parent -Path $MyInvocation.MyCommand.Path)
+    $podePath = Split-Path -Parent -Path $ScriptPath
+
+    # Import the Pode module from the source path if it exists, otherwise from installed modules
+    if (Test-Path -Path "$($podePath)/src/Pode.psm1" -PathType Leaf) {
+        Import-Module "$($podePath)/src/Pode.psm1" -Force -ErrorAction Stop
+    }
+    else {
+        Import-Module -Name 'Pode' -MaximumVersion 2.99 -ErrorAction Stop
+    }
+}
+catch { throw }
+
+# or just:
+# Import-Module Pode
+
+# create a server, and start listening on port 8081
+Start-PodeServer -Threads 2 {
+
+    # listen on localhost:8081
+    Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http
+
+    # request logging
+    New-PodeLoggingMethod -Terminal -Batch 10 -BatchTimeout 10 | Enable-PodeRequestLogging
+    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+
+    # Create a simple default group for MCP tools
+    Add-PodeMcpGroup -Name 'Default' -Description 'Default group for MCP tools'
+
+    # Add a simple MCP tool for returning all windows service names
+    Add-PodeMcpTool -Name 'GetWindowsServices' -Description 'Returns all Windows service names' -Group 'Default' -ScriptBlock {
+        $services = Get-Service -ErrorAction Ignore | Select-Object Name
+        return New-PodeMcpTextContent -Value $services
+    }
+
+    # Add a simple MCP tool for returning windows services names for a given state
+    Add-PodeMcpTool -Name 'GetWindowsServicesByState' -Description 'Returns Windows service names for a given state' -Group 'Default' -AutoSchema -ScriptBlock {
+        param(
+            [Parameter(Mandatory = $true, HelpMessage = 'The state of the services to retrieve')]
+            [ValidateSet('Running', 'Stopped', 'Paused')]
+            [string]
+            $State
+        )
+
+        $services = Get-Service -ErrorAction Ignore | Where-Object { $_.Status -ieq $State } | Select-Object Name
+        if (($null -eq $services) -or (Test-PodeIsEmpty $services)) {
+            $services = "No services found in the '$State' state."
+        }
+
+        return New-PodeMcpTextContent -Value $services
+    }
+
+    # Add a simple MCP tool for testing if a specified service is in a specified state
+    Add-PodeMcpTool -Name 'TestWindowsServiceState' -Description 'Tests if a specified service is in a specified state' -Group 'Default' -ScriptBlock {
+        param(
+            [string]
+            $Name,
+
+            [ValidateSet('Running', 'Stopped', 'Paused')]
+            [string]
+            $State
+        )
+
+        $service = Get-Service -Name $Name -ErrorAction Ignore
+        if ($null -eq $service) {
+            return New-PodeMcpTextContent -Value "Service '$Name' not found."
+        }
+
+        if ($service.Status -ieq $State) {
+            return New-PodeMcpTextContent -Value "Service '$Name' is in the '$State' state."
+        }
+
+        return New-PodeMcpTextContent -Value "Service '$Name' is not in the '$State' state. Current state: $($service.Status)"
+    } -PassThru |
+        Add-PodeMcpToolProperty -Name 'Name' -Required -Definition (
+            New-PodeJsonSchemaString -Description 'The name of the service to check'
+        ) -PassThru |
+        Add-PodeMcpToolProperty -Name 'State' -Required -Definition (
+            New-PodeJsonSchemaString -Description 'The state to check for the service' -Enum 'Running', 'Stopped', 'Paused'
+        )
+
+    # Add the MCP route
+    Add-PodeRoute -Method Post -Path '/mcp-services' -ScriptBlock {
+        $WebEvent.Data | ConvertTo-Json | Out-Default
+        Resolve-PodeMcpRequest -Group 'Default'
+    }
+}

--- a/pode.build.ps1
+++ b/pode.build.ps1
@@ -1380,7 +1380,10 @@ Add-BuildTask Test Build, TestNoBuild
 #>
 
 # Synopsis: Run the documentation locally
-Add-BuildTask Docs DocsDeps, DocsHelpBuild, {
+Add-BuildTask Docs DocsDeps, DocsHelpBuild, DocsNoBuild
+
+# Synopsis: Run the documentation locally without building
+Add-BuildTask DocsNoBuild DocsDeps, {
     mkdocs serve --open
 }
 

--- a/src/Locales/ar/Pode.psd1
+++ b/src/Locales/ar/Pode.psd1
@@ -336,4 +336,14 @@
     signalEventNotRegisteredExceptionMessage                          = '{0} حدث غير مسجل لاتصال Signal {1}: {2}'
     sseEventAlreadyRegisteredExceptionMessage                         = '{0} حدث مسجل بالفعل لاتصال SSE {1}: {2}'
     sseEventNotRegisteredExceptionMessage                             = '{0} حدث غير مسجل لاتصال SSE {1}: {2}'
+    jsonSchemaObjectPropertyMissingNameExceptionMessage               = "يجب أن يتضمن كل تعريف خاصية كائن مخطط JSON مفتاح 'الاسم'."
+    jsonSchemaObjectMaxPropsLessThanMinPropsExceptionMessage          = 'لا يمكن أن تكون MaxProperties أقل من MinProperties لخاصية مخطط JSON للكائن.'
+    jsonSchemaArrayMaxItemsLessThanMinItemsExceptionMessage           = 'لا يمكن أن تكون MaxItems أقل من MinItems لخاصية مخطط JSON الخاص بالمصفوفة (array JSON Schema).'
+    jsonSchemaStringMaxLengthLessThanMinLengthExceptionMessage        = 'لا يمكن أن يكون MaxLength أقل من MinLength لخاصية مخطط JSON للسلاسل النصية.'
+    jsonSchemaNumberMaximumLessThanMinimumExceptionMessage            = 'لا يمكن أن يكون الحد الأقصى أقل من الحد الأدنى لخاصية JSON Schema {0}.'
+    mcpToolAutoSchemaUnsupportedParameterTypeExceptionMessage         = "نوع المعامل غير المدعوم '{0}' للمعامل '{1}' في أداة '{2}'. توليد المخطط التلقائي يدعم فقط أنواع السلاسل والمعلومات الذاتية والطويلة والمزدوجة والطفوية والبول."
+    mcpToolGroupDoesNotExistExceptionMessage                          = "مجموعة أدوات MCP '{0}' غير موجودة."
+    mcpToolDoesNotExistExceptionMessage                               = "أداة MCP '{0}' غير موجودة."
+    mcpToolAlreadyExistsExceptionMessage                              = "أداة MCP '{0}' موجودة بالفعل."
+    mcpToolGroupAlreadyExistsExceptionMessage                         = "مجموعة أدوات MCP '{0}' موجودة بالفعل."
 }

--- a/src/Locales/de/Pode.psd1
+++ b/src/Locales/de/Pode.psd1
@@ -336,4 +336,14 @@
     signalEventNotRegisteredExceptionMessage                          = 'Das Ereignis {0} ist nicht für die Signalverbindung {1} registriert.'
     sseEventAlreadyRegisteredExceptionMessage                         = 'Das Ereignis {0} ist bereits für die SSE-Verbindung {1} registriert.'
     sseEventNotRegisteredExceptionMessage                             = 'Das Ereignis {0} ist nicht für die SSE-Verbindung {1} registriert.'
+    jsonSchemaObjectPropertyMissingNameExceptionMessage               = "Jede Eigenschaftsdefinition eines JSON-Schema-Objekts muss einen 'Name'-Schlüssel enthalten."
+    jsonSchemaObjectMaxPropsLessThanMinPropsExceptionMessage          = 'MaxProperties darf nicht kleiner als MinProperties für eine JSON-Schema-Objekteigenschaft sein.'
+    jsonSchemaArrayMaxItemsLessThanMinItemsExceptionMessage           = 'MaxItems darf nicht kleiner als MinItems für eine JSON-Schema-Arrayeigenschaft sein.'
+    jsonSchemaStringMaxLengthLessThanMinLengthExceptionMessage        = 'MaxLength darf nicht kleiner als MinLength für eine JSON-Schema-Stringeigenschaft sein.'
+    jsonSchemaNumberMaximumLessThanMinimumExceptionMessage            = 'Maximum darf nicht kleiner als Minimum für eine JSON-Schema-Zahleneigenschaft sein.'
+    mcpToolAutoSchemaUnsupportedParameterTypeExceptionMessage         = "Nicht unterstützter Parametertyp '{0}' für den Parameter '{1}' im Werkzeug '{2}'. Auto-Schema-Generierung unterstützt nur String-, Int-, Long-, Double-, Float- und Bool-Typen."
+    mcpToolGroupDoesNotExistExceptionMessage                          = "Die MCP-Toolgruppe '{0}' existiert nicht."
+    mcpToolDoesNotExistExceptionMessage                               = "Das MCP-Tool '{0}' existiert nicht."
+    mcpToolAlreadyExistsExceptionMessage                              = "Das MCP-Tool '{0}' existiert bereits."
+    mcpToolGroupAlreadyExistsExceptionMessage                         = "Die MCP-Toolgruppe '{0}' existiert bereits."
 }

--- a/src/Locales/en-us/Pode.psd1
+++ b/src/Locales/en-us/Pode.psd1
@@ -336,4 +336,14 @@
     signalEventNotRegisteredExceptionMessage                          = '{0} event not registered for Signal connection {1}: {2}'
     sseEventAlreadyRegisteredExceptionMessage                         = '{0} event already registered for SSE connection {1}: {2}'
     sseEventNotRegisteredExceptionMessage                             = '{0} event not registered for SSE connection {1}: {2}'
+    jsonSchemaObjectPropertyMissingNameExceptionMessage               = "Each JSON Schema Object property definition must include a 'Name' key."
+    jsonSchemaObjectMaxPropsLessThanMinPropsExceptionMessage          = 'MaxProperties cannot be less than MinProperties for object JSON Schema property.'
+    jsonSchemaArrayMaxItemsLessThanMinItemsExceptionMessage           = 'MaxItems cannot be less than MinItems for array JSON Schema property.'
+    jsonSchemaStringMaxLengthLessThanMinLengthExceptionMessage        = 'MaxLength cannot be less than MinLength for string JSON Schema property.'
+    jsonSchemaNumberMaximumLessThanMinimumExceptionMessage            = 'Maximum cannot be less than Minimum for {0} JSON Schema property.'
+    mcpToolAutoSchemaUnsupportedParameterTypeExceptionMessage         = "Unsupported parameter type '{0}' for parameter '{1}' in tool '{2}'. Auto schema generation only supports string, int, long, double, float, and bool types."
+    mcpToolGroupDoesNotExistExceptionMessage                          = "The MCP tool group '{0}' does not exist."
+    mcpToolDoesNotExistExceptionMessage                               = "The MCP tool '{0}' does not exist."
+    mcpToolAlreadyExistsExceptionMessage                              = "The MCP tool '{0}' already exists."
+    mcpToolGroupAlreadyExistsExceptionMessage                         = "The MCP tool group '{0}' already exists."
 }

--- a/src/Locales/en/Pode.psd1
+++ b/src/Locales/en/Pode.psd1
@@ -336,4 +336,14 @@
     signalEventNotRegisteredExceptionMessage                          = '{0} event not registered for Signal connection {1}: {2}'
     sseEventAlreadyRegisteredExceptionMessage                         = '{0} event already registered for SSE connection {1}: {2}'
     sseEventNotRegisteredExceptionMessage                             = '{0} event not registered for SSE connection {1}: {2}'
+    jsonSchemaObjectPropertyMissingNameExceptionMessage               = "Each JSON Schema Object property definition must include a 'Name' key."
+    jsonSchemaObjectMaxPropsLessThanMinPropsExceptionMessage          = 'MaxProperties cannot be less than MinProperties for object JSON Schema property.'
+    jsonSchemaArrayMaxItemsLessThanMinItemsExceptionMessage           = 'MaxItems cannot be less than MinItems for array JSON Schema property.'
+    jsonSchemaStringMaxLengthLessThanMinLengthExceptionMessage        = 'MaxLength cannot be less than MinLength for string JSON Schema property.'
+    jsonSchemaNumberMaximumLessThanMinimumExceptionMessage            = 'Maximum cannot be less than Minimum for {0} JSON Schema property.'
+    mcpToolAutoSchemaUnsupportedParameterTypeExceptionMessage         = "Unsupported parameter type '{0}' for parameter '{1}' in tool '{2}'. Auto schema generation only supports string, int, long, double, float, and bool types."
+    mcpToolGroupDoesNotExistExceptionMessage                          = "The MCP tool group '{0}' does not exist."
+    mcpToolDoesNotExistExceptionMessage                               = "The MCP tool '{0}' does not exist."
+    mcpToolAlreadyExistsExceptionMessage                              = "The MCP tool '{0}' already exists."
+    mcpToolGroupAlreadyExistsExceptionMessage                         = "The MCP tool group '{0}' already exists."
 }

--- a/src/Locales/es/Pode.psd1
+++ b/src/Locales/es/Pode.psd1
@@ -336,4 +336,14 @@
     signalEventNotRegisteredExceptionMessage                          = 'El evento {0} no está registrado para la conexión Signal {1}.'
     sseEventAlreadyRegisteredExceptionMessage                         = 'El evento {0} ya está registrado para la conexión SSE {1}.'
     sseEventNotRegisteredExceptionMessage                             = 'El evento {0} no está registrado para la conexión SSE {1}.'
+    jsonSchemaObjectPropertyMissingNameExceptionMessage               = "Cada definición de propiedad de objeto JSON Schema debe incluir una clave 'Name'."
+    jsonSchemaObjectMaxPropsLessThanMinPropsExceptionMessage          = 'MaxProperties no puede ser menor que MinProperties para la propiedad JSON Schema de tipo objeto.'
+    jsonSchemaArrayMaxItemsLessThanMinItemsExceptionMessage           = 'MaxItems no puede ser menor que MinItems para la propiedad JSON Schema de tipo array.'
+    jsonSchemaStringMaxLengthLessThanMinLengthExceptionMessage        = 'MaxLength no puede ser menor que MinLength para la propiedad JSON Schema de tipo string.'
+    jsonSchemaNumberMaximumLessThanMinimumExceptionMessage            = 'Maximum no puede ser menor que Minimum para la propiedad JSON Schema de tipo number.'
+    mcpToolAutoSchemaUnsupportedParameterTypeExceptionMessage         = "Tipo de parámetro no soportado '{0}' para el parámetro '{1}' en la herramienta '{2}'. La generación automática de esquemas solo soporta tipos de cadena, int, largo, doble, flotante y bool."
+    mcpToolGroupDoesNotExistExceptionMessage                          = "El grupo de herramientas MCP '{0}' no existe."
+    mcpToolDoesNotExistExceptionMessage                               = "La herramienta MCP '{0}' no existe."
+    mcpToolAlreadyExistsExceptionMessage                              = "La herramienta MCP '{0}' ya existe."
+    mcpToolGroupAlreadyExistsExceptionMessage                         = "El grupo de herramientas MCP '{0}' ya existe."
 }

--- a/src/Locales/fr/Pode.psd1
+++ b/src/Locales/fr/Pode.psd1
@@ -336,4 +336,14 @@
     signalEventNotRegisteredExceptionMessage                          = "L'événement '{0}' n'est pas enregistré pour la connexion Signal '{1}'."
     sseEventAlreadyRegisteredExceptionMessage                         = "L'événement '{0}' est déjà enregistré pour la connexion SSE '{1}'."
     sseEventNotRegisteredExceptionMessage                             = "L'événement '{0}' n'est pas enregistré pour la connexion SSE '{1}'."
+    jsonSchemaObjectPropertyMissingNameExceptionMessage               = "Une propriété d'objet dans le schéma JSON est manquante d'un nom."
+    jsonSchemaObjectMaxPropsLessThanMinPropsExceptionMessage          = 'MaxProperties ne peut pas être inférieur à MinProperties pour la propriété JSON Schema de type objet.'
+    jsonSchemaArrayMaxItemsLessThanMinItemsExceptionMessage           = 'MaxItems ne peut pas être inférieur à MinItems pour la propriété JSON Schema de type tableau.'
+    jsonSchemaStringMaxLengthLessThanMinLengthExceptionMessage        = 'MaxLength ne peut pas être inférieur à MinLength pour la propriété JSON Schema de type chaîne.'
+    jsonSchemaNumberMaximumLessThanMinimumExceptionMessage            = 'Maximum ne peut pas être inférieur à Minimum pour la propriété JSON Schema de type nombre.'
+    mcpToolAutoSchemaUnsupportedParameterTypeExceptionMessage         = "Type de paramètre non pris en charge '{0}' pour le paramètre '{1}' dans l'outil '{2}'. La génération automatique de schéma ne prend en charge que les types string, int, long, double, float et bool."
+    mcpToolGroupDoesNotExistExceptionMessage                          = "Le groupe d'outils MCP '{0}' n'existe pas."
+    mcpToolDoesNotExistExceptionMessage                               = "L'outil MCP '{0}' n'existe pas."
+    mcpToolAlreadyExistsExceptionMessage                              = "L'outil MCP '{0}' existe déjà."
+    mcpToolGroupAlreadyExistsExceptionMessage                         = "Le groupe d'outils MCP '{0}' existe déjà."
 }

--- a/src/Locales/it/Pode.psd1
+++ b/src/Locales/it/Pode.psd1
@@ -336,4 +336,14 @@
     signalEventNotRegisteredExceptionMessage                          = "L'événement '{0}' n'est pas enregistré pour la connexion Signal '{1}'."
     sseEventAlreadyRegisteredExceptionMessage                         = "L'événement '{0}' est déjà enregistré pour la connexion SSE '{1}'."
     sseEventNotRegisteredExceptionMessage                             = "L'événement '{0}' n'est pas enregistré pour la connexion SSE '{1}'."
+    jsonSchemaObjectPropertyMissingNameExceptionMessage               = "La proprietà di uno schema di oggetto JSON non ha un nome. Assegna un nome a questa proprietà usando il parametro 'Name'."
+    jsonSchemaObjectMaxPropsLessThanMinPropsExceptionMessage          = 'MaxProperties non può essere inferiore a MinProperties per la proprietà dello schema JSON di tipo oggetto.'
+    jsonSchemaArrayMaxItemsLessThanMinItemsExceptionMessage           = 'MaxItems non può essere inferiore a MinItems per la proprietà dello schema JSON di tipo array.'
+    jsonSchemaStringMaxLengthLessThanMinLengthExceptionMessage        = 'MaxLength non può essere inferiore a MinLength per la proprietà dello schema JSON di tipo stringa.'
+    jsonSchemaNumberMaximumLessThanMinimumExceptionMessage            = 'Maximum non può essere inferiore a Minimum per la proprietà dello schema JSON di tipo numero.'
+    mcpToolAutoSchemaUnsupportedParameterTypeExceptionMessage         = "Parametro non supportato tipo '{0}' per il parametro '{1}' nello strumento '{2}'. La generazione automatica di schema supporta solo i tipi stringa, int, long, double, float e bool."
+    mcpToolGroupDoesNotExistExceptionMessage                          = "Il gruppo di strumenti MCP '{0}' non esiste."
+    mcpToolDoesNotExistExceptionMessage                               = "Lo strumento MCP '{0}' non esiste."
+    mcpToolAlreadyExistsExceptionMessage                              = "Lo strumento MCP '{0}' esiste già."
+    mcpToolGroupAlreadyExistsExceptionMessage                         = "Il gruppo di strumenti MCP '{0}' esiste già."
 }

--- a/src/Locales/ja/Pode.psd1
+++ b/src/Locales/ja/Pode.psd1
@@ -336,4 +336,14 @@
     signalEventNotRegisteredExceptionMessage                          = "名前が '{0}' のSignalイベントは登録されていません。"
     sseEventAlreadyRegisteredExceptionMessage                         = "名前が '{0}' のSSEイベントは既に登録されています。"
     sseEventNotRegisteredExceptionMessage                             = "名前が '{0}' のSSEイベントは登録されていません。"
+    jsonSchemaObjectPropertyMissingNameExceptionMessage               = 'JSONスキーマのオブジェクトプロパティに名前がありません。'
+    jsonSchemaObjectMaxPropsLessThanMinPropsExceptionMessage          = 'JSONスキーマのオブジェクトプロパティの最大数が最小数より少ないです。'
+    jsonSchemaArrayMaxItemsLessThanMinItemsExceptionMessage           = 'JSONスキーマの配列の最大アイテム数が最小アイテム数より少ないです。'
+    jsonSchemaStringMaxLengthLessThanMinLengthExceptionMessage        = 'JSONスキーマの文字列の最大長が最小長より短いです。'
+    jsonSchemaNumberMaximumLessThanMinimumExceptionMessage            = 'JSONスキーマプロパティの最大値は最小{0}小さくなってはなりません。'
+    mcpToolAutoSchemaUnsupportedParameterTypeExceptionMessage         = 'ツール「{2}」のパラメータ「{1}」に対してサポートされていないパラメータ型「{0}」。オートスキーマ生成は文字列、int、long、double、float、bool型のみをサポートします。'
+    mcpToolGroupDoesNotExistExceptionMessage                          = 'MCPツールグループ「{0}」は存在しません。'
+    mcpToolDoesNotExistExceptionMessage                               = 'MCPツール「{0}」は存在しません。'
+    mcpToolAlreadyExistsExceptionMessage                              = 'MCPツール「{0}」は既に存在します。'
+    mcpToolGroupAlreadyExistsExceptionMessage                         = 'MCPツールグループ「{0}」は既に存在します。'
 }

--- a/src/Locales/ko/Pode.psd1
+++ b/src/Locales/ko/Pode.psd1
@@ -336,5 +336,14 @@
     signalEventNotRegisteredExceptionMessage                          = "이름이 '{0}'인 Signal 이벤트는 등록되어 있지 않습니다."
     sseEventAlreadyRegisteredExceptionMessage                         = "이름이 '{0}'인 SSE 이벤트는 이미 등록되어 있습니다."
     sseEventNotRegisteredExceptionMessage                             = "이름이 '{0}'인 SSE 이벤트는 등록되어 있지 않습니다."
-
+    jsonSchemaObjectPropertyMissingNameExceptionMessage               = 'JSON 스키마 객체 속성에 이름이 없습니다.'
+    jsonSchemaObjectMaxPropsLessThanMinPropsExceptionMessage          = 'JSON 스키마 객체 속성의 최대 속성 수가 최소 속성 수보다 적습니다.'
+    jsonSchemaArrayMaxItemsLessThanMinItemsExceptionMessage           = 'JSON 스키마 배열의 최대 항목 수가 최소 항목 수보다 적습니다.'
+    jsonSchemaStringMaxLengthLessThanMinLengthExceptionMessage        = 'JSON 스키마 문자열의 최대 길이가 최소 길이보다 짧습니다.'
+    jsonSchemaNumberMaximumLessThanMinimumExceptionMessage            = 'JSON 스키마 속성의 최대는 최소{0} 작아서는 안 됩니다.'
+    mcpToolAutoSchemaUnsupportedParameterTypeExceptionMessage         = "도구 '{2}'에서 매개변수 '{1}'에 해당하는 지원되지 않는 매개변수 유형 '{0}'. 자동 스키마 생성은 문자열, 정수, 롱, 더블, 플로트, 불리언 타입만 지원합니다."
+    mcpToolGroupDoesNotExistExceptionMessage                          = "MCP 툴 그룹 '{0}'은 존재하지 않습니다."
+    mcpToolDoesNotExistExceptionMessage                               = "MCP 도구 '{0}'은 존재하지 않습니다."
+    mcpToolAlreadyExistsExceptionMessage                              = "MCP 도구 '{0}'은 이미 존재합니다."
+    mcpToolGroupAlreadyExistsExceptionMessage                         = "MCP 도구 그룹 '{0}'은 이미 존재합니다."
 }

--- a/src/Locales/nl/Pode.psd1
+++ b/src/Locales/nl/Pode.psd1
@@ -336,4 +336,14 @@
     signalEventNotRegisteredExceptionMessage                          = "Signal-evenement met de naam '{0}' is niet geregistreerd."
     sseEventAlreadyRegisteredExceptionMessage                         = "SSE-evenement met de naam '{0}' is al geregistreerd."
     sseEventNotRegisteredExceptionMessage                             = "SSE-evenement met de naam '{0}' is niet geregistreerd."
+    jsonSchemaObjectPropertyMissingNameExceptionMessage               = "Elke definitie van de eigenschap van JSON Schema Object moet een 'Name'-sleutel bevatten."
+    jsonSchemaObjectMaxPropsLessThanMinPropsExceptionMessage          = 'Het maximum aantal eigenschappen van het JSON-schema-object is kleiner dan het minimum aantal eigenschappen.'
+    jsonSchemaArrayMaxItemsLessThanMinItemsExceptionMessage           = 'Het maximum aantal items van het JSON-schema-array is kleiner dan het minimum aantal items.'
+    jsonSchemaStringMaxLengthLessThanMinLengthExceptionMessage        = 'De maximale lengte van de JSON-schema-string is kleiner dan de minimale lengte.'
+    jsonSchemaNumberMaximumLessThanMinimumExceptionMessage            = 'Maximum mag niet kleiner zijn dan Minimum voor {0} JSON Schema-eigenschap.'
+    mcpToolAutoSchemaUnsupportedParameterTypeExceptionMessage         = "Niet-ondersteund parametertype '{0}' voor parameter '{1}' in tool '{2}'. Auto-schema generatie ondersteunt alleen string-, int-, long-, double-, float- en bool-typen."
+    mcpToolGroupDoesNotExistExceptionMessage                          = "De MCP-toolgroep '{0}' bestaat niet."
+    mcpToolDoesNotExistExceptionMessage                               = "De MCP-tool '{0}' bestaat niet."
+    mcpToolAlreadyExistsExceptionMessage                              = "De MCP-tool '{0}' bestaat al."
+    mcpToolGroupAlreadyExistsExceptionMessage                         = "De MCP-toolgroep '{0}' bestaat al."
 }

--- a/src/Locales/pl/Pode.psd1
+++ b/src/Locales/pl/Pode.psd1
@@ -336,4 +336,14 @@
     signalEventNotRegisteredExceptionMessage                          = "Zdarzenie Signal o nazwie '{0}' nie jest zarejestrowane."
     sseEventAlreadyRegisteredExceptionMessage                         = "Zdarzenie SSE o nazwie '{0}' jest już zarejestrowane."
     sseEventNotRegisteredExceptionMessage                             = "Zdarzenie SSE o nazwie '{0}' nie jest zarejestrowane."
+    jsonSchemaObjectPropertyMissingNameExceptionMessage               = "Każda definicja właściwości obiektu schematu JSON musi zawierać klucz 'Nazwa'."
+    jsonSchemaObjectMaxPropsLessThanMinPropsExceptionMessage          = 'MaxProperties, nie może być mniejsze niż MinProperties dla obiektu właściwości JSON Schema.'
+    jsonSchemaArrayMaxItemsLessThanMinItemsExceptionMessage           = 'MaxItems nie może być mniejszy niż MinItems dla właściwości array JSON Schema.'
+    jsonSchemaStringMaxLengthLessThanMinLengthExceptionMessage        = 'MaxLength nie może być mniejsza niż MinLength dla właściwości schematu JSON w ciągu ciągów.'
+    jsonSchemaNumberMaximumLessThanMinimumExceptionMessage            = 'Maksimum nie może być mniejsze niż Minimum dla {0} właściwości schematu JSON.'
+    mcpToolAutoSchemaUnsupportedParameterTypeExceptionMessage         = "Nieobsługiwany typ parametru '{0}' dla parametru '{1}' w narzędziu '{2}'. Automatyczne generowanie schematu obsługuje tylko typy stringów, int, long, double, float i bool."
+    mcpToolGroupDoesNotExistExceptionMessage                          = "Grupa narzędzi MCP '{0}' nie istnieje."
+    mcpToolDoesNotExistExceptionMessage                               = "Narzędzie MCP '{0}' nie istnieje."
+    mcpToolAlreadyExistsExceptionMessage                              = "Narzędzie MCP '{0}' już istnieje."
+    mcpToolGroupAlreadyExistsExceptionMessage                         = "Grupa narzędzi MCP '{0}' już istnieje."
 }

--- a/src/Locales/pt/Pode.psd1
+++ b/src/Locales/pt/Pode.psd1
@@ -336,4 +336,14 @@
     signalEventNotRegisteredExceptionMessage                          = "Evento Signal com o nome '{0}' não está registrado."
     sseEventAlreadyRegisteredExceptionMessage                         = "Evento SSE com o nome '{0}' já está registrado."
     sseEventNotRegisteredExceptionMessage                             = "Evento SSE com o nome '{0}' não está registrado."
+    jsonSchemaObjectPropertyMissingNameExceptionMessage               = "Cada definição de propriedade do Objeto de Esquema JSON deve incluir uma chave 'Nome'."
+    jsonSchemaObjectMaxPropsLessThanMinPropsExceptionMessage          = 'As propriedades MaxProperties não podem ser menores que MinProperties para a propriedade do esquema JSON do objeto.'
+    jsonSchemaArrayMaxItemsLessThanMinItemsExceptionMessage           = 'MaxItems não pode ser menor que MinItems para a propriedade do esquema JSON do array.'
+    jsonSchemaStringMaxLengthLessThanMinLengthExceptionMessage        = 'MaxLength não pode ser menor que MinLength para a propriedade do esquema JSON da string.'
+    jsonSchemaNumberMaximumLessThanMinimumExceptionMessage            = 'O máximo não pode ser menor que o mínimo para {0} propriedade de esquema JSON.'
+    mcpToolAutoSchemaUnsupportedParameterTypeExceptionMessage         = "Parâmetro não suportado tipo '{0}' para o parâmetro '{1}' na ferramenta '{2}'. A geração automática de esquemas só suporta tipos string, int, long, double, float e bool."
+    mcpToolGroupDoesNotExistExceptionMessage                          = "O grupo de ferramentas MCP '{0}' não existe."
+    mcpToolDoesNotExistExceptionMessage                               = "A ferramenta MCP '{0}' não existe."
+    mcpToolAlreadyExistsExceptionMessage                              = "A ferramenta MCP '{0}' já existe."
+    mcpToolGroupAlreadyExistsExceptionMessage                         = "O grupo de ferramentas MCP '{0}' já existe."
 }

--- a/src/Locales/zh/Pode.psd1
+++ b/src/Locales/zh/Pode.psd1
@@ -336,4 +336,14 @@
     signalEventNotRegisteredExceptionMessage                          = "事件 Signal 名称为 '{0}' 未注册。"
     sseEventAlreadyRegisteredExceptionMessage                         = "事件 SSE 名称为 '{0}' 已注册。"
     sseEventNotRegisteredExceptionMessage                             = "事件 SSE 名称为 '{0}' 未注册。"
+    jsonSchemaObjectPropertyMissingNameExceptionMessage               = "每个 JSON 模式对象属性定义必须包含一个'Name'键。"
+    jsonSchemaObjectMaxPropsLessThanMinPropsExceptionMessage          = '对于对象 JSON Schema 属性，MaxProperties 不能小于 MinProperties。'
+    jsonSchemaArrayMaxItemsLessThanMinItemsExceptionMessage           = 'MaxItems 不能小于 MinItems 以应数组 JSON Schema 属性。'
+    jsonSchemaStringMaxLengthLessThanMinLengthExceptionMessage        = '对于字符串 JSON Schema 属性，MaxLength 不能小于 MinLength。'
+    jsonSchemaNumberMaximumLessThanMinimumExceptionMessage            = '对于{0} JSON模式属性，最大值不能小于最小值。'
+    mcpToolAutoSchemaUnsupportedParameterTypeExceptionMessage         = "工具'{2}'中参数'{1}'的不支持参数类型为'{0}'。自动模式生成只支持字符串、整数、长、双重、浮点和布尔类型。"
+    mcpToolGroupDoesNotExistExceptionMessage                          = 'MCP工具组"{0}"不存在。'
+    mcpToolDoesNotExistExceptionMessage                               = "MCP工具'{0}'不存在。"
+    mcpToolAlreadyExistsExceptionMessage                              = "MCP工具'{0}'已经存在。"
+    mcpToolGroupAlreadyExistsExceptionMessage                         = "MCP工具组'{0}'已经存在。"
 }

--- a/src/Pode.psd1
+++ b/src/Pode.psd1
@@ -570,7 +570,37 @@
         'New-PodeLimitRouteComponent',
         'New-PodeLimitEndpointComponent',
         'New-PodeLimitMethodComponent',
-        'New-PodeLimitHeaderComponent'
+        'New-PodeLimitHeaderComponent',
+
+        # mcp
+        'Resolve-PodeMcpRequest',
+        'New-PodeMcpTextContent',
+        'New-PodeMcpImageContent',
+        'New-PodeMcpAudioContent',
+        'Add-PodeMcpTool',
+        'Add-PodeMcpToolProperty',
+        'Get-PodeMcpTool',
+        'Test-PodeMcpTool',
+        'Remove-PodeMcpTool',
+        'Update-PodeMcpTool',
+        'Add-PodeMcpGroup',
+        'Remove-PodeMcpGroup',
+        'Get-PodeMcpGroup',
+        'Test-PodeMcpGroup',
+        'Clear-PodeMcpGroup',
+        'Register-PodeMcpToolToGroup',
+        'Unregister-PodeMcpToolFromGroup',
+
+        # json schema
+        'New-PodeJsonSchemaNull',
+        'New-PodeJsonSchemaBoolean',
+        'New-PodeJsonSchemaInteger',
+        'New-PodeJsonSchemaNumber',
+        'New-PodeJsonSchemaString',
+        'New-PodeJsonSchemaArray',
+        'New-PodeJsonSchemaObject',
+        'Merge-PodeJsonSchema',
+        'New-PodeJsonSchemaProperty'
     )
 
     # Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.

--- a/src/Private/Console.ps1
+++ b/src/Private/Console.ps1
@@ -1234,7 +1234,7 @@ function Write-PodeConsoleHeader {
     }
 
     # Write the header with timestamp, Pode version, and status.
-    Write-PodeHost "`r$timestamp Pode $(Get-PodeVersion) (PID: $($PID)) [" -ForegroundColor $headerColor -Force:$Force -NoNewLine
+    Write-PodeHost "`r$timestamp Pode $($PodeContext.Server.Version) (PID: $($PID)) [" -ForegroundColor $headerColor -Force:$Force -NoNewLine
     Write-PodeHost "$Status" -ForegroundColor $StatusColor -Force:$Force -NoNewLine
 
     if ($DisableHttp) {

--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -100,6 +100,7 @@ function New-PodeContext {
     $ctx.Server.PodeModule = (Get-PodeModuleInfo)
     $ctx.Server.Console = $Console
     $ctx.Server.ComputerName = [System.Net.DNS]::GetHostName()
+    $ctx.Server.Version = Get-PodeVersion
 
     # list of created listeners/consumers
     $ctx.Listeners = @()
@@ -302,7 +303,7 @@ function New-PodeContext {
     if ((Test-PodeHasConsole) -and ! $Daemon) {
         try {
             if (! (Test-PodeIsISEHost)) {
-                # If the session is not configured for quiet mode, modify console behavior
+                # If the session is not configured for quiet mode, modify console behaviour
                 if (!$ctx.Server.Console.Quiet) {
                     # Hide the cursor to improve the console appearance
                     [System.Console]::CursorVisible = $false
@@ -319,7 +320,7 @@ function New-PodeContext {
             }
         }
         catch {
-            # Console support is partial , configure the context for non-console behavior
+            # Console support is partial , configure the context for non-console behaviour
             $ctx.Server.Console.DisableTermination = $true  # Prevent termination
             $ctx.Server.Console.DisableConsoleInput = $true # Disable console input
             $ctx.Server.Console.Quiet = $true               # Silence the console
@@ -327,7 +328,7 @@ function New-PodeContext {
         }
     }
     else {
-        # If not running in a console-like environment, configure the context for non-console behavior
+        # If not running in a console-like environment, configure the context for non-console behaviour
         $ctx.Server.Console.DisableTermination = $true  # Prevent termination
         $ctx.Server.Console.DisableConsoleInput = $true # Disable console input
         $ctx.Server.Console.Quiet = $true               # Silence the console
@@ -415,6 +416,12 @@ function New-PodeContext {
     $ctx.Server.Handlers = @{
         smtp    = @{}
         service = @{}
+    }
+
+    # tools and groups for MCP
+    $ctx.Server.Mcp = @{
+        Tools  = @{}
+        Groups = @{}
     }
 
     # setup basic access placeholders

--- a/src/Private/MCP.ps1
+++ b/src/Private/MCP.ps1
@@ -1,0 +1,341 @@
+function Test-PodeMcpRequest {
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Group
+    )
+
+    # check if the group exists, if not return an error
+    if (!(Test-PodeMcpGroup -Name $Group)) {
+        Write-PodeMcpErrorResponse -Message "Group '$($Group)' not found" -Type InternalError
+        return
+    }
+
+    # ensure request has valid jsonrpc version
+    if ($WebEvent.Data['jsonrpc'] -ne '2.0') {
+        Write-PodeMcpErrorResponse -Message 'Invalid JSON-RPC version' -Type InvalidRequest
+        return $false
+    }
+
+    # do we have a MCP method, error if not
+    $method = $WebEvent.Data['method']
+    if ([string]::IsNullOrEmpty($method)) {
+        Write-PodeMcpErrorResponse -Message 'Missing method' -Type InvalidRequest
+        return $false
+    }
+
+    # for non-notification methods, ensure we have an ID
+    if ([string]::IsNullOrEmpty($WebEvent.Data['id']) -and ($method -inotlike 'notifications/*')) {
+        Write-PodeMcpErrorResponse -Message 'Missing ID for non-notification method' -Type InvalidRequest
+        return $false
+    }
+
+    return $true
+}
+
+# https://www.jsonrpc.org/specification
+function Write-PodeMcpErrorResponse {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Message,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('ParseError', 'InvalidRequest', 'MethodNotFound', 'InvalidParams', 'InternalError')]
+        [string]
+        $Type,
+
+        [Parameter()]
+        [int]
+        $StatusCode = 400
+    )
+
+    # determine the error code
+    $errCode = switch ($Type.ToLowerInvariant()) {
+        'parseerror' { -32700 }
+        'invalidrequest' { -32600 }
+        'methodnotfound' { -32601 }
+        'invalidparams' { -32602 }
+        'internalerror' { -32603 }
+    }
+
+    # write the response
+    $response = @{
+        jsonrpc = '2.0'
+        id      = $WebEvent.Data['id']
+        error   = @{
+            code    = $errCode
+            message = $Message
+        }
+    }
+
+    Write-PodeJsonResponse -Value $response -StatusCode $StatusCode
+}
+
+# https://www.jsonrpc.org/specification
+function Write-PodeMcpSuccessResponse {
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [hashtable]
+        $Result = $null
+    )
+
+    # if the result is null, return a 202 Accepted with no content
+    if ($null -eq $Result) {
+        Set-PodeResponseStatus -Code 202
+        return
+    }
+
+    # otherwise, return a 200 OK with the result
+    $response = @{
+        jsonrpc = '2.0'
+        id      = $WebEvent.Data['id']
+        result  = $Result
+    }
+
+    Write-PodeJsonResponse -Value $response
+}
+
+function Invoke-PodeMcpInitialize {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]
+        $ServerName,
+
+        [Parameter()]
+        [string]
+        $ServerVersion
+    )
+
+    if ([string]::IsNullOrEmpty($ServerVersion)) {
+        $ServerVersion = $PodeContext.Server.Version
+    }
+
+    return @{
+        protocolVersion = '2025-11-25'
+        capabilities    = @{
+            tools = @{
+                listChanged = $false
+            }
+        }
+        serverInfo      = @{
+            name    = $ServerName
+            version = $ServerVersion
+        }
+    }
+}
+
+function Invoke-PodeMcpToolList {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Group
+    )
+
+    # build the tools content
+    $content = @{
+        tools = @()
+    }
+
+    # loop through the tools in the group and add them to the content
+    foreach ($toolName in $PodeContext.Server.Mcp.Groups[$Group].Tools) {
+        $tool = $PodeContext.Server.Mcp.Tools[$toolName]
+
+        $content.tools += @{
+            name        = $tool.Name
+            description = $tool.Description
+            inputSchema = New-PodeJsonSchemaObject -Property $tool.Properties
+        }
+    }
+
+    return $content
+}
+
+function Invoke-PodeMcpToolCall {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Group
+    )
+
+    # get tool name and arguments
+    $toolName = $WebEvent.Data['params']['name']
+    $toolArgs = $WebEvent.Data['params']['arguments']
+
+    # check if the tool exists, if not return an error
+    if (!(Test-PodeMcpTool -Group $Group -Name $toolName)) {
+        Write-PodeMcpErrorResponse -Message "Tool '$($toolName)' not found in group '$($Group)'" -Type InvalidParams
+        return $null
+    }
+
+    $tool = $PodeContext.Server.Mcp.Tools[$toolName]
+
+    # attempt to invoke the scriptblock, passing in the arguments
+    try {
+        [hashtable[]]$result = Invoke-PodeScriptBlock -ScriptBlock $tool.ScriptBlock -Arguments $toolArgs -Scoped -Splat -Return
+    }
+    catch {
+        Write-PodeMcpErrorResponse -Message "Error invoking tool '$($toolName)' in group '$($Group)': $($_.Exception.Message)" -Type InternalError -StatusCode 500
+        $_ | Write-PodeErrorLog
+        return $null
+    }
+
+    return @{
+        content = $result
+        isError = $false
+    }
+}
+
+function Add-PodeMcpToolAutoSchema {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [hashtable]
+        $Tool,
+
+        [Parameter(Mandatory = $true)]
+        [scriptblock]
+        $ScriptBlock
+    )
+
+    # do nothing if we don't have any parameters
+    if (($null -eq $ScriptBlock.Ast.ParamBlock) -or ($ScriptBlock.Ast.ParamBlock.Parameters.Count -eq 0)) {
+        return
+    }
+
+    foreach ($param in $ScriptBlock.Ast.ParamBlock.Parameters) {
+        # get values from param attributes, such as Mandatory, HelpMessage, and also any Validate attributes
+        $isMandatory = $false
+        $helpMessage = $null
+        $dontShow = $false
+        $validRangeMin = $null
+        $validRangeMax = $null
+        $validSet = $null
+        $validLengthMin = $null
+        $validLengthMax = $null
+        $validCountMin = $null
+        $validCountMax = $null
+
+        foreach ($attr in $param.Attributes) {
+            switch ($attr.TypeName.FullName.ToLowerInvariant()) {
+                'parameter' {
+                    foreach ($arg in $attr.NamedArguments) {
+                        switch ($arg.ArgumentName.ToLowerInvariant()) {
+                            'mandatory' {
+                                $isMandatory = $arg.Argument.Extent.Text -eq '$true'
+                            }
+                            'helpmessage' {
+                                $helpMessage = $arg.Argument.Value.ToString()
+                            }
+                            'dontshow' {
+                                $dontShow = $arg.Argument.Extent.Text -eq '$true'
+                            }
+                        }
+                    }
+                }
+
+                'validaterange' {
+                    $validRangeMin = $attr.PositionalArguments[0].Value
+                    $validRangeMax = $attr.PositionalArguments[1].Value
+                }
+
+                'validateset' {
+                    $validSet = $attr.PositionalArguments.Value
+                }
+
+                'validatelength' {
+                    $validLengthMin = $attr.PositionalArguments[0].Value
+                    $validLengthMax = $attr.PositionalArguments[1].Value
+                }
+
+                'validatecount' {
+                    $validCountMin = $attr.PositionalArguments[0].Value
+                    $validCountMax = $attr.PositionalArguments[1].Value
+                }
+            }
+        }
+
+        # if don't show is set, skip this parameter
+        if ($dontShow) {
+            continue
+        }
+
+        # build the property definition for parameter, based on the parameter type
+        $paramName = $param.Name.Extent.Text.TrimStart('$')
+        $definition = $null
+
+        # build params for base types
+        $_params = @{}
+        if (($null -ne $validRangeMin) -or ($null -ne $validRangeMax)) {
+            $_params.Minimum = $validRangeMin
+            $_params.Maximum = $validRangeMax
+        }
+        if (($null -ne $validLengthMin) -or ($null -ne $validLengthMax)) {
+            $_params.MinLength = $validLengthMin
+            $_params.MaxLength = $validLengthMax
+        }
+        if ($null -ne $validSet) {
+            $_params.Enum = $validSet
+        }
+
+        # what is the base type
+        $type = $param.StaticType
+        if ($param.StaticType.IsArray) {
+            $type = $param.StaticType.GetElementType()
+        }
+        else {
+            $_params.Description = $helpMessage
+        }
+
+        switch ($type) {
+            'string' {
+                $definition = New-PodeJsonSchemaString @_params
+            }
+
+            { $_ -iin 'int', 'long' } {
+                $definition = New-PodeJsonSchemaInteger @_params
+            }
+
+            { $_ -iin 'double', 'float' } {
+                $definition = New-PodeJsonSchemaNumber @_params
+            }
+
+            'bool' {
+                $definition = New-PodeJsonSchemaBoolean @_params
+            }
+
+            default {
+                # Unsupported parameter type '$($type)' for parameter '$($paramName)' in tool '$($Tool.Name)'. Auto schema generation only supports string, int, long, double, float, and bool types.
+                throw ($PodeLocale.mcpToolAutoSchemaUnsupportedParameterTypeExceptionMessage -f $type, $paramName, $Tool.Name)
+            }
+        }
+
+        # if it's an array, we need to wrap the definition in an array definition
+        if ($param.StaticType.IsArray) {
+            $_params = @{
+                Item        = $definition
+                Description = $helpMessage
+            }
+
+            if (($null -ne $validCountMin) -or ($null -ne $validCountMax)) {
+                $_params.MinItems = $validCountMin
+                $_params.MaxItems = $validCountMax
+            }
+
+            $definition = New-PodeJsonSchemaArray @_params
+        }
+
+        # add the property to the tool's properties
+        Add-PodeMcpToolProperty -Tool $Tool -Name $paramName -Required:$isMandatory -Definition $definition
+    }
+}

--- a/src/Private/MCP.ps1
+++ b/src/Private/MCP.ps1
@@ -10,7 +10,7 @@ function Test-PodeMcpRequest {
     # check if the group exists, if not return an error
     if (!(Test-PodeMcpGroup -Name $Group)) {
         Write-PodeMcpErrorResponse -Message "Group '$($Group)' not found" -Type InternalError
-        return
+        return $false
     }
 
     # ensure request has valid jsonrpc version

--- a/src/Private/Server.ps1
+++ b/src/Private/Server.ps1
@@ -274,6 +274,10 @@ function Restart-PodeInternalServer {
         # clear file watchers
         $PodeContext.Fim.Items.Clear()
 
+        # clear MCP tools
+        $PodeContext.Server.Mcp.Tools.Clear()
+        $PodeContext.Server.Mcp.Groups.Clear()
+
         # auto-importers
         Reset-PodeAutoImportConfiguration
 

--- a/src/Public/JsonSchema.ps1
+++ b/src/Public/JsonSchema.ps1
@@ -1,0 +1,785 @@
+<#
+.SYNOPSIS
+Creates a Null JSON Schema type definition.
+
+.DESCRIPTION
+This function creates a JSON Schema type definition for a Null type.
+
+.PARAMETER Description
+An optional Description.
+
+.EXAMPLE
+New-PodeJsonSchemaNull
+
+.EXAMPLE
+New-PodeJsonSchemaNull -Description 'This is a null type'
+#>
+function New-PodeJsonSchemaNull {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter()]
+        [string]
+        $Description
+    )
+
+    # build the property definition
+    $def = @{
+        type = 'null'
+    }
+
+    if ($PSBoundParameters.ContainsKey('Description') -and ![string]::IsNullOrEmpty($Description)) {
+        $def.description = $Description
+    }
+
+    return $def
+}
+
+<#
+.SYNOPSIS
+Creates a Boolean JSON Schema type definition.
+
+.DESCRIPTION
+This function creates a JSON Schema type definition for a Boolean type.
+
+.PARAMETER Constant
+An optional Constant value.
+
+.PARAMETER Description
+An optional Description.
+
+.EXAMPLE
+New-PodeJsonSchemaBoolean
+
+.EXAMPLE
+New-PodeJsonSchemaBoolean -Constant $true -Description 'Some property that must be true'
+#>
+function New-PodeJsonSchemaBoolean {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter()]
+        [bool]
+        $Constant,
+
+        [Parameter()]
+        [string]
+        $Description
+    )
+
+    # build the property definition
+    $def = @{
+        type = 'boolean'
+    }
+
+    if ($PSBoundParameters.ContainsKey('Constant')) {
+        $def.const = $Constant
+    }
+
+    if ($PSBoundParameters.ContainsKey('Description') -and ![string]::IsNullOrEmpty($Description)) {
+        $def.description = $Description
+    }
+
+    return $def
+}
+
+<#
+.SYNOPSIS
+Creates an Integer JSON Schema type definition.
+
+.DESCRIPTION
+This function creates a JSON Schema type definition for an Integer type.
+
+.PARAMETER MultipleOf
+An optional value that the integer must be a multiple of.
+
+.PARAMETER Minimum
+An optional minimum value for the integer.
+
+.PARAMETER Maximum
+An optional maximum value for the integer.
+
+.PARAMETER Constant
+An optional Constant value.
+
+.PARAMETER Enum
+An optional array of values that the integer can be.
+
+.PARAMETER ExclusiveMinimum
+An optional switch to indicate if the minimum value is exclusive.
+
+.PARAMETER ExclusiveMaximum
+An optional switch to indicate if the maximum value is exclusive.
+
+.PARAMETER Description
+An optional Description.
+
+.EXAMPLE
+New-PodeJsonSchemaInteger
+
+.EXAMPLE
+New-PodeJsonSchemaInteger -Minimum 0 -Maximum 100 -Description 'A percentage of some value'
+
+.EXAMPLE
+New-PodeJsonSchemaInteger -Enum 1, 2, 4, 8 -Description 'Number of CPU cores to use'
+
+.EXAMPLE
+New-PodeJsonSchemaInteger -MultipleOf 5 -Description 'A value that must be a multiple of 5'
+
+.EXAMPLE
+New-PodeJsonSchemaInteger -Minimum 0 -ExclusiveMinimum -Description 'A value that must be greater than 0'
+
+.EXAMPLE
+New-PodeJsonSchemaInteger -Maximum 100 -ExclusiveMaximum -Description 'A value that must be less than 100'
+#>
+function New-PodeJsonSchemaInteger {
+    [CmdletBinding(DefaultParameterSetName = 'Dynamic')]
+    [OutputType([hashtable])]
+    param(
+        [Parameter(ParameterSetName = 'Dynamic')]
+        [ValidateRange(0, [int]::MaxValue)]
+        [int]
+        $MultipleOf,
+
+        [Parameter(ParameterSetName = 'Dynamic')]
+        [int]
+        $Minimum,
+
+        [Parameter(ParameterSetName = 'Dynamic')]
+        [int]
+        $Maximum,
+
+        [Parameter(ParameterSetName = 'Constant')]
+        [string]
+        $Constant,
+
+        [Parameter(ParameterSetName = 'Enum')]
+        [int[]]
+        $Enum,
+
+        [Parameter(ParameterSetName = 'Dynamic')]
+        [switch]
+        $ExclusiveMinimum,
+
+        [Parameter(ParameterSetName = 'Dynamic')]
+        [switch]
+        $ExclusiveMaximum,
+
+        [Parameter()]
+        [string]
+        $Description
+    )
+
+    # build the property definition
+    $def = @{
+        type = 'integer'
+    }
+
+    if ($PSBoundParameters.ContainsKey('Constant')) {
+        $def.const = $Constant
+    }
+
+    if ($PSBoundParameters.ContainsKey('Enum')) {
+        $def.enum = @($Enum)
+    }
+
+    if ($PSBoundParameters.ContainsKey('MultipleOf')) {
+        $def.multipleOf = $MultipleOf
+    }
+
+    if ($PSBoundParameters.ContainsKey('Minimum')) {
+        $def.minimum = $Minimum
+    }
+    if ($PSBoundParameters.ContainsKey('Maximum')) {
+        $def.maximum = $Maximum
+    }
+    if ($def.ContainsKey('minimum') -and $def.ContainsKey('maximum') -and ($def.maximum -lt $def.minimum)) {
+        # Maximum cannot be less than Minimum for integer JSON Schema property'
+        throw ($PodeLocale.jsonSchemaNumberMaximumLessThanMinimumExceptionMessage -f 'integer')
+    }
+
+    if ($PSBoundParameters.ContainsKey('ExclusiveMinimum')) {
+        $def.exclusiveMinimum = $true
+    }
+    if ($PSBoundParameters.ContainsKey('ExclusiveMaximum')) {
+        $def.exclusiveMaximum = $true
+    }
+
+    if ($PSBoundParameters.ContainsKey('Description') -and ![string]::IsNullOrEmpty($Description)) {
+        $def.description = $Description
+    }
+
+    return $def
+}
+
+<#
+.SYNOPSIS
+Creates a Number JSON Schema type definition.
+
+.DESCRIPTION
+This function creates a JSON Schema type definition for a Number type.
+
+.PARAMETER MultipleOf
+An optional value that the number must be a multiple of.
+
+.PARAMETER Minimum
+An optional minimum value for the number.
+
+.PARAMETER Maximum
+An optional maximum value for the number.
+
+.PARAMETER Constant
+An optional Constant value.
+
+.PARAMETER Enum
+An optional array of values that the number can be.
+
+.PARAMETER ExclusiveMinimum
+An optional switch to indicate if the minimum value is exclusive.
+
+.PARAMETER ExclusiveMaximum
+An optional switch to indicate if the maximum value is exclusive.
+
+.PARAMETER Description
+An optional Description.
+
+.EXAMPLE
+New-PodeJsonSchemaNumber
+
+.EXAMPLE
+New-PodeJsonSchemaNumber -Minimum 0.0 -Maximum 1.0 -Description 'A ratio between 0 and 1'
+
+.EXAMPLE
+New-PodeJsonSchemaNumber -Enum 3.14, 2.718, 1.618 -Description 'Some famous mathematical constants'
+
+.EXAMPLE
+New-PodeJsonSchemaNumber -MultipleOf 0.01 -Description 'A value that must be a multiple of 0.01'
+
+.EXAMPLE
+New-PodeJsonSchemaNumber -Minimum 0.0 -ExclusiveMinimum -Description 'A value that must be greater than 0.0'
+
+.EXAMPLE
+New-PodeJsonSchemaNumber -Maximum 100.0 -ExclusiveMaximum -Description 'A value that must be less than 100.0'
+#>
+function New-PodeJsonSchemaNumber {
+    [CmdletBinding(DefaultParameterSetName = 'Dynamic')]
+    [OutputType([hashtable])]
+    param(
+        [Parameter(ParameterSetName = 'Dynamic')]
+        [ValidateRange(0, [int]::MaxValue)]
+        [double]
+        $MultipleOf,
+
+        [Parameter(ParameterSetName = 'Dynamic')]
+        [double]
+        $Minimum,
+
+        [Parameter(ParameterSetName = 'Dynamic')]
+        [double]
+        $Maximum,
+
+        [Parameter(ParameterSetName = 'Constant')]
+        [string]
+        $Constant,
+
+        [Parameter(ParameterSetName = 'Enum')]
+        [double[]]
+        $Enum,
+
+        [Parameter(ParameterSetName = 'Dynamic')]
+        [switch]
+        $ExclusiveMinimum,
+
+        [Parameter(ParameterSetName = 'Dynamic')]
+        [switch]
+        $ExclusiveMaximum,
+
+        [Parameter()]
+        [string]
+        $Description
+    )
+
+    # build the property definition
+    $def = @{
+        type = 'number'
+    }
+
+    if ($PSBoundParameters.ContainsKey('Constant')) {
+        $def.const = $Constant
+    }
+
+    if ($PSBoundParameters.ContainsKey('Enum')) {
+        $def.enum = @($Enum)
+    }
+
+    if ($PSBoundParameters.ContainsKey('MultipleOf')) {
+        $def.multipleOf = $MultipleOf
+    }
+
+    if ($PSBoundParameters.ContainsKey('Minimum')) {
+        $def.minimum = $Minimum
+    }
+    if ($PSBoundParameters.ContainsKey('Maximum')) {
+        $def.maximum = $Maximum
+    }
+    if ($def.ContainsKey('minimum') -and $def.ContainsKey('maximum') -and ($def.maximum -lt $def.minimum)) {
+        # Maximum cannot be less than Minimum for number JSON Schema property
+        throw ($PodeLocale.jsonSchemaNumberMaximumLessThanMinimumExceptionMessage -f 'number')
+    }
+
+    if ($PSBoundParameters.ContainsKey('ExclusiveMinimum')) {
+        $def.exclusiveMinimum = $true
+    }
+    if ($PSBoundParameters.ContainsKey('ExclusiveMaximum')) {
+        $def.exclusiveMaximum = $true
+    }
+
+    if ($PSBoundParameters.ContainsKey('Description') -and ![string]::IsNullOrEmpty($Description)) {
+        $def.description = $Description
+    }
+
+    return $def
+}
+
+<#
+.SYNOPSIS
+Creates a String JSON Schema type definition.
+
+.DESCRIPTION
+This function creates a JSON Schema type definition for a String type.
+
+.PARAMETER Pattern
+An optional regular expression pattern that the string must match.
+
+.PARAMETER MinLength
+An optional minimum length for the string.
+
+.PARAMETER MaxLength
+An optional maximum length for the string.
+
+.PARAMETER Constant
+An optional Constant value.
+
+.PARAMETER Enum
+An optional array of values that the string can be.
+
+.PARAMETER Description
+An optional Description.
+
+.EXAMPLE
+New-PodeJsonSchemaString
+
+.EXAMPLE
+New-PodeJsonSchemaString -Pattern '^[a-zA-Z0-9]+$' -Description 'A string that must be alphanumeric'
+
+.EXAMPLE
+New-PodeJsonSchemaString -MinLength 5 -MaxLength 10 -Description 'A string that must be between 5 and 10 characters long'
+
+.EXAMPLE
+New-PodeJsonSchemaString -Enum 'red', 'green', 'blue' -Description 'A string that must be one of the specified colours'
+
+.EXAMPLE
+New-PodeJsonSchemaString -Constant 'fixed value' -Description 'A string that must be exactly "fixed value"'
+#>
+function New-PodeJsonSchemaString {
+    [CmdletBinding(DefaultParameterSetName = 'Dynamic')]
+    [OutputType([hashtable])]
+    param(
+        [Parameter(ParameterSetName = 'Dynamic')]
+        [string]
+        $Pattern,
+
+        [Parameter(ParameterSetName = 'Dynamic')]
+        [ValidateRange(0, [int]::MaxValue)]
+        [int]
+        $MinLength,
+
+        [Parameter(ParameterSetName = 'Dynamic')]
+        [ValidateRange(0, [int]::MaxValue)]
+        [int]
+        $MaxLength,
+
+        [Parameter(ParameterSetName = 'Constant')]
+        [string]
+        $Constant,
+
+        [Parameter(ParameterSetName = 'Enum')]
+        [string[]]
+        $Enum,
+
+        [Parameter()]
+        [string]
+        $Description
+    )
+
+    # build the property definition
+    $def = @{
+        type = 'string'
+    }
+
+    if ($PSBoundParameters.ContainsKey('Constant')) {
+        $def.const = $Constant
+    }
+
+    if ($PSBoundParameters.ContainsKey('Enum')) {
+        $def.enum = @($Enum)
+    }
+
+    if ($PSBoundParameters.ContainsKey('Pattern')) {
+        $def.pattern = $Pattern
+    }
+
+    if ($PSBoundParameters.ContainsKey('MinLength')) {
+        $def.minLength = $MinLength
+    }
+    if ($PSBoundParameters.ContainsKey('MaxLength')) {
+        $def.maxLength = $MaxLength
+    }
+    if ($def.ContainsKey('minLength') -and $def.ContainsKey('maxLength') -and ($def.maxLength -lt $def.minLength)) {
+        # MaxLength cannot be less than MinLength for string JSON Schema property
+        throw $PodeLocale.jsonSchemaStringMaxLengthLessThanMinLengthExceptionMessage
+    }
+
+    if ($PSBoundParameters.ContainsKey('Description') -and ![string]::IsNullOrEmpty($Description)) {
+        $def.description = $Description
+    }
+
+    return $def
+}
+
+<#
+.SYNOPSIS
+Creates an Array JSON Schema type definition.
+
+.DESCRIPTION
+This function creates a JSON Schema type definition for an Array type.
+
+.PARAMETER Item
+A hashtable representing the JSON Schema type definition for the items in the array.
+
+.PARAMETER MinItems
+An optional minimum number of items in the array.
+
+.PARAMETER MaxItems
+An optional maximum number of items in the array.
+
+.PARAMETER Description
+An optional Description.
+
+.PARAMETER Unique
+An optional switch to indicate if the items in the array must be unique.
+
+.EXAMPLE
+# create a JSON Schema definition for an array of strings
+New-PodeJsonSchemaArray -Item (New-PodeJsonSchemaString)
+
+.EXAMPLE
+# create a JSON Schema definition for an array of integers with at least 1 item and at most 5 items
+New-PodeJsonSchemaArray -Item (New-PodeJsonSchemaInteger) -MinItems 1 -MaxItems 5
+
+.EXAMPLE
+# create a JSON Schema definition for an array of unique strings with a description
+New-PodeJsonSchemaArray -Item (New-PodeJsonSchemaString) -Unique
+#>
+function New-PodeJsonSchemaArray {
+    [CmdletBinding(DefaultParameterSetName = 'Items')]
+    [OutputType([hashtable])]
+    param(
+        [Parameter(Mandatory = $true, ParameterSetName = 'Items')]
+        [hashtable]
+        $Item,
+
+        [Parameter(ParameterSetName = 'Items')]
+        [ValidateRange(0, [int]::MaxValue)]
+        [int]
+        $MinItems,
+
+        [Parameter(ParameterSetName = 'Items')]
+        [ValidateRange(0, [int]::MaxValue)]
+        [int]
+        $MaxItems,
+
+        [Parameter()]
+        [string]
+        $Description,
+
+        [switch]
+        $Unique
+    )
+
+    # build the property definition
+    $def = @{
+        type  = 'array'
+        items = $Item
+    }
+
+    if ($PSBoundParameters.ContainsKey('MinItems')) {
+        $def.minItems = $MinItems
+    }
+    if ($PSBoundParameters.ContainsKey('MaxItems')) {
+        $def.maxItems = $MaxItems
+    }
+    if ($def.ContainsKey('minItems') -and $def.ContainsKey('maxItems') -and ($def.maxItems -lt $def.minItems)) {
+        # MaxItems cannot be less than MinItems for array JSON Schema property
+        throw $PodeLocale.jsonSchemaArrayMaxItemsLessThanMinItemsExceptionMessage
+    }
+
+    if ($PSBoundParameters.ContainsKey('Unique')) {
+        $def.uniqueItems = $Unique.IsPresent
+    }
+
+    if ($PSBoundParameters.ContainsKey('Description') -and ![string]::IsNullOrEmpty($Description)) {
+        $def.description = $Description
+    }
+
+    return $def
+}
+
+<#
+.SYNOPSIS
+Creates an Object JSON Schema type definition.
+
+.DESCRIPTION
+This function creates a JSON Schema type definition for an Object type.
+
+.PARAMETER Property
+A hashtable representing the JSON Schema property definition for a property of the object.
+This parameter can be specified multiple times to define multiple properties.
+Property definitions should be created using the New-PodeJsonSchemaProperty function.
+
+.PARAMETER MinProperties
+An optional minimum number of properties in the object.
+
+.PARAMETER MaxProperties
+An optional maximum number of properties in the object.
+
+.PARAMETER Description
+An optional description.
+
+.EXAMPLE
+# create a JSON Schema definition for an object with a required string property "name" and an optional integer property "age"
+New-PodeJsonSchemaObject -Property @(
+    (New-PodeJsonSchemaProperty -Name 'name' -Definition (New-PodeJsonSchemaString) -Required),
+    (New-PodeJsonSchemaProperty -Name 'age' -Definition (New-PodeJsonSchemaInteger))
+) -Description 'A person object with a required name and an optional age'
+
+.EXAMPLE
+# create a JSON Schema definition for an object with no properties, but a description - can accept any number of properties
+New-PodeJsonSchemaObject -Description 'An empty object with a description'
+
+.EXAMPLE
+# create a JSON Schema definition for an object with a minimum of 1 property and a maximum of 5 properties
+New-PodeJsonSchemaObject -MinProperties 1 -MaxProperties 5
+#>
+function New-PodeJsonSchemaObject {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter()]
+        [hashtable[]]
+        $Property,
+
+        [Parameter()]
+        [ValidateRange(0, [int]::MaxValue)]
+        [int]
+        $MinProperties,
+
+        [Parameter()]
+        [ValidateRange(0, [int]::MaxValue)]
+        [int]
+        $MaxProperties,
+
+        [Parameter()]
+        [string]
+        $Description
+    )
+
+    # build the property definition
+    $def = @{
+        type = 'object'
+    }
+
+    if ($PSBoundParameters.ContainsKey('Description') -and ![string]::IsNullOrEmpty($Description)) {
+        $def.description = $Description
+    }
+
+    if ($PSBoundParameters.ContainsKey('MinProperties')) {
+        $def.minProperties = $MinProperties
+    }
+    if ($PSBoundParameters.ContainsKey('MaxProperties')) {
+        $def.maxProperties = $MaxProperties
+    }
+    if ($def.ContainsKey('minProperties') -and $def.ContainsKey('maxProperties') -and ($def.maxProperties -lt $def.minProperties)) {
+        # MaxProperties cannot be less than MinProperties for object JSON Schema property
+        throw $PodeLocale.jsonSchemaObjectMaxPropsLessThanMinPropsExceptionMessage
+    }
+
+    # if no properties, just return the definition
+    if (($null -eq $Property) -or ($Property.Count -eq 0)) {
+        return $def
+    }
+
+    # otherwise, add the properties to the definition
+    $def.properties = @{}
+    $requiredProps = @()
+
+    foreach ($prop in $Property) {
+        if (!$prop.ContainsKey('Name')) {
+            # Each JSON Schema Object property definition must include a "Name" key
+            throw $PodeLocale.jsonSchemaObjectPropertyMissingNameExceptionMessage
+        }
+
+        $name = $prop.Name
+        $def.properties[$name] = $prop.Definition
+
+        if ($prop.Required) {
+            $requiredProps += $name
+        }
+    }
+
+    if ($requiredProps.Length -gt 0) {
+        $def.required = $requiredProps
+    }
+
+    return $def
+}
+
+<#
+.SYNOPSIS
+Creates a merged JSON Schema type definition using a specified merge type.
+
+.DESCRIPTION
+This function creates a merged JSON Schema type definition using a specified merge type (AllOf, AnyOf, OneOf, Not)
+and an array of JSON Schema definitions to merge.
+
+.PARAMETER Type
+The type of merge to perform. Must be one of 'AllOf', 'AnyOf', 'OneOf', or 'Not'.
+
+.PARAMETER Definition
+An array of JSON Schema type definitions to merge.
+
+.EXAMPLE
+# create a JSON Schema definition that requires a value to match all of the specified schemas
+Merge-PodeJsonSchema -Type 'AllOf' -Definition @(
+    (New-PodeJsonSchemaString -Pattern '^[a-zA-Z]+$' -Description 'Must be a string of letters only'),
+    (New-PodeJsonSchemaString -MinLength 5 -MaxLength 10 -Description 'Must be between 5 and 10 characters long')
+)
+
+.EXAMPLE
+# create a JSON Schema definition that requires a value to match at least one of the specified schemas
+Merge-PodeJsonSchema -Type 'AnyOf' -Definition @(
+    (New-PodeJsonSchemaInteger -Minimum 0 -Maximum 100 -Description 'A percentage of some value'),
+    (New-PodeJsonSchemaString -Enum 'red', 'green', 'blue' -Description 'A string that must be one of the specified colours')
+)
+
+.EXAMPLE
+# create a JSON Schema definition that requires a value to match exactly one of the specified schemas
+Merge-PodeJsonSchema -Type 'OneOf' -Definition @(
+    (New-PodeJsonSchemaInteger -Minimum 0 -Maximum 100 -Description 'A percentage of some value'),
+    (New-PodeJsonSchemaString -Enum 'red', 'green', 'blue' -Description 'A string that must be one of the specified colours')
+)
+
+.EXAMPLE
+# create a JSON Schema definition that requires a value to NOT match any of the specified schemas
+Merge-PodeJsonSchema -Type 'Not' -Definition @(
+    (New-PodeJsonSchemaInteger -Minimum 0 -Maximum 100 -Description 'A percentage of some value'),
+    (New-PodeJsonSchemaString -Enum 'red', 'green', 'blue' -Description 'A string that must be one of the specified colours')
+)
+#>
+function Merge-PodeJsonSchema {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('AllOf', 'AnyOf', 'OneOf', 'Not')]
+        [string]
+        $Type,
+
+        [Parameter(Mandatory = $true)]
+        [hashtable[]]
+        $Definition
+    )
+
+    $typeName = [string]::Empty
+    switch ($Type.ToLowerInvariant()) {
+        'allof' { $typeName = 'allOf' }
+        'anyof' { $typeName = 'anyOf' }
+        'oneof' { $typeName = 'oneOf' }
+        'not' { $typeName = 'not' }
+    }
+
+    $def = @{
+        $typeName = @($Definition)
+    }
+
+    return $def
+}
+
+<#
+.SYNOPSIS
+Creates a JSON Schema property definition for use in an object schema.
+
+.DESCRIPTION
+This function creates a JSON Schema property definition for use in an object schema.
+
+.PARAMETER Name
+The name of the property.
+
+.PARAMETER Definition
+A hashtable representing the JSON Schema type definition for the property.
+This should be created using one of the other New-PodeJsonSchema* functions.
+
+.PARAMETER Required
+Indicates whether the property is required.
+
+.LINK
+https://json-schema.org/understanding-json-schema/reference/type
+
+.EXAMPLE
+# create a JSON Schema property definition for a required string property "name" with a description
+New-PodeJsonSchemaProperty -Name 'name' -Definition (
+    New-PodeJsonSchemaString -Description 'The name of the person'
+) -Required
+
+.EXAMPLE
+# create a JSON Schema property definition for an optional integer property "age" with a description
+New-PodeJsonSchemaProperty -Name 'age' -Definition (
+    New-PodeJsonSchemaInteger -Description 'The age of the person'
+)
+
+.EXAMPLE
+# create a JSON Schema property definition for a required array property "tags" with a description, where the items in the array must be unique strings
+New-PodeJsonSchemaProperty -Name 'tags' -Definition (
+    New-PodeJsonSchemaArray -Unique -Item (
+        New-PodeJsonSchemaString
+    ) -Description 'An array of unique tags for the person'
+) -Required
+
+.EXAMPLE
+# create a JSON Schema property definition for an optional property "metadata" with a description, where the value can be any object with a minimum of 1 property
+New-PodeJsonSchemaProperty -Name 'metadata' -Definition (
+    New-PodeJsonSchemaObject -MinProperties 1 -Description 'Additional metadata about the person'
+)
+#>
+function New-PodeJsonSchemaProperty {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Name,
+
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [hashtable]
+        $Definition,
+
+        [switch]
+        $Required
+    )
+
+    return @{
+        Name       = $Name
+        Definition = $Definition
+        Required   = $Required.IsPresent
+    }
+}

--- a/src/Public/MCP.ps1
+++ b/src/Public/MCP.ps1
@@ -1,0 +1,1036 @@
+<#
+.SYNOPSIS
+Resolves an MCP request from a client, invoking the appropriate logic based on the method and returning a response.
+
+.DESCRIPTION
+This function is responsible for handling incoming MCP requests, validating them, and invoking the appropriate logic
+based on the requested method. It supports methods for initializing the MCP connection, listing available tools, calling
+specific tools, and handling notifications.
+
+Responses are returned in JSON-RPC 2.0 format.
+
+.PARAMETER Group
+The group to which the MCP tools belong. This allows for organizing tools into different groups.
+
+.PARAMETER ServerName
+The name of the MCP server. (Default: 'Pode MCP Server').
+
+.PARAMETER ServerVersion
+The version of the MCP server. (Default: Current Pode version).
+
+.EXAMPLE
+# resolve requests for MCP tools in a default group, using Pode server name and version
+Add-PodeMcpGroup -Name 'default'
+Resolve-PodeMcpRequest -Group 'default'
+
+.EXAMPLE
+# resolve requests for MCP tools in a custom group, with custom server name and version
+Add-PodeMcpGroup -Name 'custom'
+Resolve-PodeMcpRequest -Group 'custom' -ServerName 'Custom MCP Server' -ServerVersion '1.0.0'
+#>
+function Resolve-PodeMcpRequest {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $Group,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $ServerName = 'Pode MCP Server',
+
+        [Parameter()]
+        [string]
+        $ServerVersion
+    )
+
+    # validate the request
+    if (!(Test-PodeMcpRequest -Group $Group)) {
+        return
+    }
+
+    # invoke the appropriate logic per the MCP method
+    $content = @{}
+
+    switch ($WebEvent.Data['method'].ToLowerInvariant()) {
+        'initialize' {
+            # logic to initialize the MCP connection
+            $content = Invoke-PodeMcpInitialize -ServerName $ServerName -ServerVersion $ServerVersion
+            Write-PodeMcpSuccessResponse -Result $content
+        }
+
+        'tools/list' {
+            # logic to list available tools
+            $content = Invoke-PodeMcpToolList -Group $Group
+            Write-PodeMcpSuccessResponse -Result $content
+        }
+
+        'tools/call' {
+            # logic to call a specific tool
+            $content = Invoke-PodeMcpToolCall -Group $Group
+            if ($null -ne $content) {
+                Write-PodeMcpSuccessResponse -Result $content
+            }
+        }
+
+        { $_ -ilike 'notifications/*' } {
+            # handle something here eventually, for now set send an HTTP 202
+            Write-PodeMcpSuccessResponse
+        }
+
+        default {
+            Write-PodeMcpErrorResponse -Message "Method '$($_)' not found" -Type MethodNotFound
+        }
+    }
+}
+
+<#
+.SYNOPSIS
+Builds a Textual response object for an MCP tool, which can be returned to the client.
+
+.DESCRIPTION
+This function creates a hashtable representing a textual response for an MCP tool. The hashtable includes a
+'type' key with the value 'text', and a 'text' key containing the provided value. If the provided value is not a string,
+it will be converted to a string using Out-String.
+
+.PARAMETER Value
+The value to be included in the textual response. This can be any object, which will be converted to a string if necessary.
+
+.EXAMPLE
+# create a simple text response for an MCP tool
+New-PodeMcpTextContent -Value 'Hello, world!'
+
+.EXAMPLE
+# create a text response for an MCP tool from a non-string object
+$data = @{ Name = 'Alice'; Age = 30 }
+New-PodeMcpTextContent -Value $data
+#>
+function New-PodeMcpTextContent {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter()]
+        [object]
+        $Value
+    )
+
+    if ($null -eq $Value) {
+        $Value = [string]::Empty
+    }
+    elseif ($Value -isnot [string]) {
+        $Value = $Value | Out-String
+    }
+
+    return @{
+        type = 'text'
+        text = $Value
+    }
+}
+
+<#
+.SYNOPSIS
+Builds an Image response object for an MCP tool, which can be returned to the client.
+
+.DESCRIPTION
+This function creates a hashtable representing an image response for an MCP tool. The hashtable includes a
+'type' key with the value 'image', a 'data' key containing the base64-encoded image data, and a 'mimeType' key
+specifying the MIME type of the image.
+
+.PARAMETER Bytes
+The byte array representing the image data.
+
+.PARAMETER MimeType
+The MIME type of the image.
+
+.EXAMPLE
+# create an image response for an MCP tool
+$imageBytes = [System.IO.File]::ReadAllBytes('path\to\image.png')
+New-PodeMcpImageContent -Bytes $imageBytes -MimeType 'image/png'
+#>
+function New-PodeMcpImageContent {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter()]
+        [byte[]]
+        $Bytes,
+
+        [Parameter(Mandatory = $true)]
+        [string]
+        $MimeType
+    )
+
+    if ($null -eq $Bytes) {
+        $Bytes = @()
+    }
+
+    return @{
+        type     = 'image'
+        data     = [Convert]::ToBase64String($Bytes)
+        mimeType = $MimeType
+    }
+}
+
+<#
+.SYNOPSIS
+Builds an Audio response object for an MCP tool, which can be returned to the client.
+
+.DESCRIPTION
+This function creates a hashtable representing an audio response for an MCP tool. The hashtable includes a
+'type' key with the value 'audio', a 'data' key containing the base64-encoded audio data, and a 'mimeType' key
+specifying the MIME type of the audio.
+
+.PARAMETER Bytes
+The byte array representing the audio data.
+
+.PARAMETER MimeType
+The MIME type of the audio.
+
+.EXAMPLE
+# create an audio response for an MCP tool
+$audioBytes = [System.IO.File]::ReadAllBytes('path\to\audio.mp3')
+New-PodeMcpAudioContent -Bytes $audioBytes -MimeType 'audio/mpeg'
+#>
+function New-PodeMcpAudioContent {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter()]
+        [byte[]]
+        $Bytes,
+
+        [Parameter(Mandatory = $true)]
+        [string]
+        $MimeType
+    )
+
+    if ($null -eq $Bytes) {
+        $Bytes = @()
+    }
+
+    return @{
+        type     = 'audio'
+        data     = [Convert]::ToBase64String($Bytes)
+        mimeType = $MimeType
+    }
+}
+
+<#
+.SYNOPSIS
+Adds a new MCP tool to the server.
+
+.DESCRIPTION
+Adds a new MCP tool to the server, optionally inside a custom Group.
+
+.PARAMETER Name
+The name of the MCP tool.
+
+.PARAMETER Description
+A brief description of the MCP tool, this is required to help MCP clients understand what the tool does.
+
+.PARAMETER ScriptBlock
+The ScriptBlock that defines the MCP tool's functionality.
+
+.PARAMETER Group
+The Group(s) to which the MCP tool belongs.
+
+.PARAMETER AutoSchema
+If set, the input schema for the tool will attempt to be automatically generated based on the parameters of the provided
+ScriptBlock - using parameter attributes for additional context.
+
+This only supports basic parameter types: string, int, long, double, float, and bool (including arrays of these types).
+
+If supplied you don't need to manually define properties via Add-PodeMcpToolProperty, but you can still do so if you want
+to and override the auto-generated schema for specific properties.
+
+.PARAMETER PassThru
+If set, the function will return the tool after it has been added to enable pipeline chaining.
+
+.EXAMPLE
+# add a simple MCP tool to a default group
+Add-PodeMcpGroup -Name 'default'
+Add-PodeMcpTool -Name 'Greet' -Description 'Returns a random greeting' -Group 'default' -ScriptBlock {
+    $greetings = @('Hello', 'Hi', 'Hey', 'Greetings', 'Salutations')
+    $greeting = Get-Random -InputObject $greetings
+    return New-PodeMcpTextContent -Value "$($greeting) from the Pode MCP tool!"
+}
+
+.EXAMPLE
+# add a simple MCP tool to a custom group with auto-generated schema
+Add-PodeMcpGroup -Name 'custom'
+Add-PodeMcpTool -Name 'GreetPerson' -Description 'Returns a random greeting to a person' -Group 'custom' -AutoSchema -ScriptBlock {
+    param(
+        [Parameter(Mandatory = $true, HelpMessage = 'The name of the person to greet')]
+        [string]$Name
+    )
+    $greetings = @('Hello', 'Hi', 'Hey', 'Greetings', 'Salutations')
+    $greeting = Get-Random -InputObject $greetings
+    return New-PodeMcpTextContent -Value "$($greeting), $($Name)! from the Pode MCP tool!"
+}
+
+.EXAMPLE
+# add a simple MCP tool to a custom group, and return the tool for chaining
+Add-PodeMcpGroup -Name 'custom'
+Add-PodeMcpTool -Name 'GreetPersonInLocation' -Description 'Returns a random greeting to a person' -Group 'custom' -ScriptBlock {
+    param(
+        [string]$Name
+    )
+    $greetings = @('Hello', 'Hi', 'Hey', 'Greetings', 'Salutations')
+    $greeting = Get-Random -InputObject $greetings
+    return New-PodeMcpTextContent -Value "$($greeting), $($Name)! via the Pode MCP tool!"
+} -PassThru |
+    Add-PodeMcpToolProperty -Name 'Name' -Required -Definition (
+        New-PodeJsonSchemaString -Description 'The name of the person to greet'
+    )
+#>
+function Add-PodeMcpTool {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Name,
+
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Description,
+
+        [Parameter(Mandatory = $true)]
+        [scriptblock]
+        $ScriptBlock,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]
+        $Group,
+
+        [switch]
+        $AutoSchema,
+
+        [switch]
+        $PassThru
+    )
+
+    # make sure groups are unique
+    $Group = $Group | Sort-Object -Unique
+
+    # ensure the tool doesn't already exist, if so throw an error
+    if (Test-PodeMcpTool -Name $Name) {
+        throw ($PodeLocale.mcpToolAlreadyExistsExceptionMessage -f $Name)
+    }
+
+    # ensure the group(s) exist, if not throw an error
+    foreach ($g in $Group) {
+        if (Test-PodeMcpGroup -Name $g) {
+            continue
+        }
+
+        throw ($PodeLocale.mcpToolGroupDoesNotExistExceptionMessage -f $g)
+    }
+
+    # initialize the tool info
+    $toolInfo = @{
+        Name        = $Name
+        Description = $Description
+        ScriptBlock = $ScriptBlock
+        Groups      = @($Group)
+        Properties  = @()
+    }
+
+    # if auto-schema allowed, attempt to generate basic input schema from the scriptblock parameters
+    if ($AutoSchema) {
+        Add-PodeMcpToolAutoSchema -Tool $toolInfo -ScriptBlock $ScriptBlock
+    }
+
+    # add the tool
+    $PodeContext.Server.Mcp.Tools[$Name] = $toolInfo
+
+    # add the tool to the specified group(s)
+    foreach ($g in $Group) {
+        $PodeContext.Server.Mcp.Groups[$g].Tools += $Name
+    }
+
+    # if required, return the tool info for chaining
+    if ($PassThru) {
+        return $toolInfo
+    }
+}
+
+<#
+.SYNOPSIS
+Adds a property to an existing MCP tool, which will be included in the tool's input schema.
+
+.DESCRIPTION
+Adds a property to an existing MCP tool, which will be included in the tool's input schema. This allows you to define
+the expected input for the tool, which can be used by MCP clients to understand how to call the tool and provide
+better user experiences.
+
+.PARAMETER Tool
+The Tool to which the property should be added; this will be the output of Add-PodeMcpTool if -PassThru is used.
+
+.PARAMETER Name
+The Name of the property.
+
+.PARAMETER Definition
+The Definition of the property, which will be a JSON Schema built using the New-PodeJsonSchema* cmdlets.
+
+.PARAMETER Required
+Indicates whether the property is required.
+
+.PARAMETER PassThru
+If set, the function will return the tool after the property has been added to enable pipeline chaining.
+
+.LINK
+https://modelcontextprotocol.info/docs/concepts/tools/
+
+.EXAMPLE
+# add a property to an MCP tool using the output from Add-PodeMcpTool
+Add-PodeMcpTool -Name 'GreetPersonInLocation' -Description 'Returns a random greeting to a person in a location' -ScriptBlock {
+    param(
+        [string]$Name,
+        [string]$Location
+    )
+    $greetings = @('Hello', 'Hi', 'Hey', 'Greetings', 'Salutations')
+    $greeting = Get-Random -InputObject $greetings
+    return New-PodeMcpTextContent -Value "$($greeting), $($Name) from $($Location)! via the Pode MCP tool!"
+} -PassThru |
+    Add-PodeMcpToolProperty -Name 'Name' -Required -Definition (
+        New-PodeJsonSchemaString -Description 'The name of the person to greet'
+    ) |
+    Add-PodeMcpToolProperty -Name 'Location' -Required -Definition (
+        New-PodeJsonSchemaString -Description 'The location of the person to greet'
+    )
+#>
+function Add-PodeMcpToolProperty {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true, Position = 0)]
+        [ValidateNotNullOrEmpty()]
+        [hashtable]
+        $Tool,
+
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Name,
+
+        [Parameter(Mandatory = $true)]
+        [hashtable]
+        $Definition,
+
+        [switch]
+        $Required,
+
+        [switch]
+        $PassThru
+    )
+
+    # build the property definition
+    $def = $Definition | New-PodeJsonSchemaProperty -Name $Name -Required:$Required
+
+    # add the property to the tool's properties
+    $Tool.Properties += $def
+
+    # return tool if requested
+    if ($PassThru) {
+        return $Tool
+    }
+}
+
+<#
+.SYNOPSIS
+Retrieves an MCP tool(s).
+
+.DESCRIPTION
+Retrieves an MCP tool or tools from the server based on the provided name and group.
+
+.PARAMETER Name
+The Name of the MCP tool to retrieve. If not specified, all tools in the specified group will be returned.
+
+.PARAMETER Group
+The Group(s) from which to retrieve the MCP tool(s).
+
+.EXAMPLE
+# retrieve a specific MCP tool by name from a default group
+Get-PodeMcpTool -Name 'GreetPerson' -Group 'default'
+
+.EXAMPLE
+# retrieve all MCP tools from a specific group
+Get-PodeMcpTool -Group 'custom'
+
+.EXAMPLE
+# attempt to retrieve a non-existent tool, which will return null
+Get-PodeMcpTool -Name 'NonExistentTool'
+
+.EXAMPLE
+# attempt to retrieve tools from a non-existent group, which will return null
+Get-PodeMcpTool -Group 'NonExistentGroup'
+#>
+function Get-PodeMcpTool {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    [OutputType([hashtable[]])]
+    param(
+        [Parameter()]
+        [string[]]
+        $Name,
+
+        [Parameter()]
+        [string[]]
+        $Group
+    )
+
+    $hasNames = ![string]::IsNullOrEmpty($Name)
+    $hasGroups = ![string]::IsNullOrEmpty($Group)
+
+    # if no group(s) or tool name(s) provided, return all tools
+    if (!$hasGroups -and !$hasNames) {
+        return $PodeContext.Server.Mcp.Tools.Values
+    }
+
+    # if group(s) provided, get tools in group(s)
+    $groupTools = @()
+    if ($hasGroups) {
+        $groupTools = $Group | Foreach-Object {
+            if ($PodeContext.Server.Mcp.Groups.ContainsKey($_)) {
+                $PodeContext.Server.Mcp.Groups[$_].Tools
+            }
+        } | Sort-Object -Unique
+    }
+
+    # if no tool name(s) provided, use group tools - if group(s) provided we need to filter
+    if (!$hasNames) {
+        $Name = $groupTools
+    }
+    elseif ($hasGroups) {
+        $Name = $Name | Where-Object { $groupTools -icontains $_ }
+    }
+
+    # now return tools if they exist
+    return $Name | ForEach-Object {
+        if ($PodeContext.Server.Mcp.Tools.ContainsKey($_)) {
+            $PodeContext.Server.Mcp.Tools[$_]
+        }
+    }
+}
+
+<#
+.SYNOPSIS
+Tests the existence of an MCP tool.
+
+.DESCRIPTION
+Tests whether an MCP tool exists, or if it exists in the specified group.
+
+.PARAMETER Name
+The Name of the MCP tool, if not specified the function will check if any tools exist in the specified group.
+
+.PARAMETER Group
+The Group in which to check for the MCP tool(s).
+
+.EXAMPLE
+# test for the existence of a specific MCP tool by name from a default group
+Test-PodeMcpTool -Name 'GreetPerson' -Group 'default'
+
+.EXAMPLE
+# test for the existence of any MCP tools in a specific group
+Test-PodeMcpTool -Group 'custom'
+
+.EXAMPLE
+# test for the existence of a non-existent tool, which will return false
+Test-PodeMcpTool -Name 'NonExistentTool'
+#>
+function Test-PodeMcpTool {
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter()]
+        [string]
+        $Name,
+
+        [Parameter()]
+        [string]
+        $Group
+    )
+
+    $hasName = ![string]::IsNullOrEmpty($Name)
+    $hasGroup = ![string]::IsNullOrEmpty($Group)
+
+    # if no name or group, return true if any tools exist
+    if (!$hasName -and !$hasGroup) {
+        return $PodeContext.Server.Mcp.Tools.Count -gt 0
+    }
+
+    # if no group provided, return true if tool exists
+    if (!$hasGroup) {
+        return $PodeContext.Server.Mcp.Tools.ContainsKey($Name)
+    }
+
+    # if no name provided, return true if any tools in group
+    if (!$hasName) {
+        return $PodeContext.Server.Mcp.Groups.ContainsKey($Group) -and
+        ($PodeContext.Server.Mcp.Groups[$Group].Tools.Count -gt 0)
+    }
+
+    # otherwise both provided, return true if tool exists in group
+    return $PodeContext.Server.Mcp.Groups.ContainsKey($Group) -and
+    ($PodeContext.Server.Mcp.Groups[$Group].Tools -icontains $Name) -and
+    $PodeContext.Server.Mcp.Tools.ContainsKey($Name)
+}
+
+<#
+.SYNOPSIS
+Removes an MCP tool.
+
+.DESCRIPTION
+Removes an MCP tool in general, or from the specified group.
+
+.PARAMETER Name
+The Name of the MCP tool to remove.
+
+.PARAMETER Group
+The Group from which to remove the MCP tool.
+
+.EXAMPLE
+# remove a specific MCP tool from all groups, and the tool itself
+Remove-PodeMcpTool -Name 'GreetPerson'
+
+.EXAMPLE
+# remove a specific MCP tool from a specific group only - but keep the tool itself in case it's in other groups
+Remove-PodeMcpTool -Name 'GreetPerson' -Group 'custom'
+
+.EXAMPLE
+# attempt to remove a non-existent tool, which will do nothing
+Remove-PodeMcpTool -Name 'NonExistentTool'
+#>
+function Remove-PodeMcpTool {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Name,
+
+        [Parameter()]
+        [string[]]
+        $Group
+    )
+
+    # if the tool doesn't exist, do nothing
+    if (!$PodeContext.Server.Mcp.Tools.ContainsKey($Name)) {
+        return
+    }
+
+    # if no groups specified, get the groups the tool is in
+    $hasGroups = ![string]::IsNullOrEmpty($Group)
+    if (!$hasGroups) {
+        $Group = $PodeContext.Server.Mcp.Tools[$Name].Groups
+    }
+
+    # remove the tool from each group
+    foreach ($g in $Group) {
+        if ($PodeContext.Server.Mcp.Groups.ContainsKey($g)) {
+            $null = $PodeContext.Server.Mcp.Groups[$g].Tools.Remove($Name)
+        }
+    }
+
+    # if no groups were specified then remove the tool entirely
+    if (!$hasGroups) {
+        $null = $PodeContext.Server.Mcp.Tools.Remove($Name)
+    }
+
+    # otherwise, keep the tool but remove the group(s) from its info
+    else {
+        $tool = $PodeContext.Server.Mcp.Tools[$Name]
+        $tool.Groups = $tool.Groups | Where-Object { $_ -inotin $Group }
+    }
+}
+
+<#
+.SYNOPSIS
+Updates an existing MCP tool.
+
+.DESCRIPTION
+Updates the properties of an existing MCP tool, including its description, scriptblock, and/or resetting the properties.
+
+.PARAMETER Name
+The Name of the MCP tool to update.
+
+.PARAMETER Description
+An optional new Description for the MCP tool.
+
+.PARAMETER ScriptBlock
+An optional new ScriptBlock for the MCP tool.
+
+.PARAMETER ResetProperties
+A switch to reset the Properties of the MCP tool, if a new ScriptBlock has changed the parameters which need to be supplied.
+
+.PARAMETER PassThru
+A switch parameter to return the updated MCP tool.
+
+.EXAMPLE
+# update the description of an existing MCP tool
+Update-PodeMcpTool -Name 'GreetPerson' -Description 'Returns a random greeting to a person, updated description'
+
+.EXAMPLE
+# update the scriptblock of an existing MCP tool, and reset its properties
+Update-PodeMcpTool -Name 'GreetPerson' -ScriptBlock {
+    param(
+        [string]$Name,
+        [string]$Location
+    )
+    $greetings = @('Hello', 'Hi', 'Hey', 'Greetings', 'Salutations')
+    $greeting = Get-Random -InputObject $greetings
+    return New-PodeMcpTextContent -Value "$($greeting), $($Name) from $($Location)! via the updated Pode MCP tool!"
+} -ResetProperties
+#>
+function Update-PodeMcpTool {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Name,
+
+        [Parameter()]
+        [string]
+        $Description,
+
+        [Parameter()]
+        [scriptblock]
+        $ScriptBlock,
+
+        [switch]
+        $ResetProperties,
+
+        [switch]
+        $PassThru
+    )
+
+    # error if the tool doesn't exist
+    if (!$PodeContext.Server.Mcp.Tools.ContainsKey($Name)) {
+        # The MCP tool '$($Name)' does not exist
+        throw ($PodeLocale.mcpToolDoesNotExistExceptionMessage -f $Name)
+    }
+
+    $tool = $PodeContext.Server.Mcp.Tools[$Name]
+
+    # update tool description
+    if ($PSBoundParameters.ContainsKey('Description')) {
+        $tool.Description = $Description
+    }
+
+    # update tool scriptblock
+    if ($PSBoundParameters.ContainsKey('ScriptBlock')) {
+        $tool.ScriptBlock = $ScriptBlock
+    }
+
+    # reset tool properties if requested
+    if ($ResetProperties) {
+        $tool.Properties = @()
+    }
+
+    # return tool if requested
+    if ($PassThru) {
+        return $tool
+    }
+}
+
+<#
+.SYNOPSIS
+Adds a new MCP tool group to the server.
+
+.DESCRIPTION
+Adds a new MCP tool group to the server, which can be used to organize tools into different categories.
+
+.PARAMETER Name
+The Name of the MCP tool group.
+
+.PARAMETER Description
+An optional brief Description for the MCP tool group.
+
+.EXAMPLE
+# add a new MCP tool group
+Add-PodeMcpGroup -Name 'default' -Description 'The default group for MCP tools'
+#>
+function Add-PodeMcpGroup {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $Name,
+
+        [Parameter()]
+        [string]
+        $Description
+    )
+
+    if ($PodeContext.Server.Mcp.Groups.ContainsKey($Name)) {
+        # The MCP tool group '$($Name)' already exists
+        throw ($PodeLocale.mcpToolGroupAlreadyExistsExceptionMessage -f $Name)
+    }
+
+    $PodeContext.Server.Mcp.Groups[$Name] = @{
+        Name        = $Name
+        Description = $Description
+        Tools       = @()
+    }
+}
+
+<#
+.SYNOPSIS
+Removes an MCP tool group from the server.
+
+.DESCRIPTION
+Removes an MCP tool group from the server.
+
+.PARAMETER Name
+The Name of the MCP tool group to remove.
+
+.EXAMPLE
+# remove an MCP tool group
+Remove-PodeMcpGroup -Name 'default'
+#>
+function Remove-PodeMcpGroup {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Name
+    )
+
+    # skip if group doesn't exist
+    if (!$PodeContext.Server.Mcp.Groups.ContainsKey($Name)) {
+        return
+    }
+
+    # remove the group from any tools that were in it
+    foreach ($toolName in $PodeContext.Server.Mcp.Groups[$Name].Tools) {
+        if ($PodeContext.Server.Mcp.Tools.ContainsKey($toolName)) {
+            $tool = $PodeContext.Server.Mcp.Tools[$toolName]
+            $tool.Groups = $tool.Groups | Where-Object { $_ -ne $Name }
+        }
+    }
+
+    # remove the group
+    $null = $PodeContext.Server.Mcp.Groups.Remove($Name)
+}
+
+<#
+.SYNOPSIS
+Retrieves an MCP tool group or groups.
+
+.DESCRIPTION
+Retrieves an MCP tool group or groups from the server.
+
+.PARAMETER Name
+The Name of the MCP tool group to retrieve. If not specified, all groups will be returned.
+
+.EXAMPLE
+# retrieve a specific MCP tool group by name
+Get-PodeMcpGroup -Name 'default'
+#>
+function Get-PodeMcpGroup {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    [OutputType([hashtable[]])]
+    param(
+        [Parameter()]
+        [string[]]
+        $Name
+    )
+
+    # if no name, return all groups
+    if ([string]::IsNullOrEmpty($Name)) {
+        return $PodeContext.Server.Mcp.Groups.Values
+    }
+
+    # otherwise, return specified group(s) if it exists
+    $groups = @()
+    foreach ($n in $Name) {
+        if ($PodeContext.Server.Mcp.Groups.ContainsKey($n)) {
+            $groups += $PodeContext.Server.Mcp.Groups[$n]
+        }
+    }
+
+    return $groups
+}
+
+<#
+.SYNOPSIS
+Tests the existence of an MCP tool group.
+
+.DESCRIPTION
+Tests the existence of an MCP tool group.
+
+.PARAMETER Name
+The Name of the MCP tool group to test. If not specified, the function will return true if any groups exist.
+
+.EXAMPLE
+# test if a specific MCP tool group exists
+Test-PodeMcpGroup -Name 'default'
+
+.EXAMPLE
+# test if any MCP tool groups exist
+Test-PodeMcpGroup
+#>
+function Test-PodeMcpGroup {
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter()]
+        [string]
+        $Name
+    )
+
+    # if no name, return true if any groups exist
+    if ([string]::IsNullOrEmpty($Name)) {
+        return $PodeContext.Server.Mcp.Groups.Count -gt 0
+    }
+
+    # otherwise, return true if specified group exists
+    return $PodeContext.Server.Mcp.Groups.ContainsKey($Name)
+}
+
+<#
+.SYNOPSIS
+Clears all tools from an MCP tool group.
+
+.DESCRIPTION
+Clears all tools from an MCP tool group.
+
+.PARAMETER Name
+The Name of the MCP tool group to clear.
+
+.EXAMPLE
+# clear all tools from a specific MCP tool group
+Clear-PodeMcpGroup -Name 'default'
+#>
+function Clear-PodeMcpGroup {
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [string]
+        $Name
+    )
+
+    # if group exists, clear its tools
+    if (!$PodeContext.Server.Mcp.Groups.ContainsKey($Name)) {
+        return
+    }
+
+    # remove the group from any tools that were in it
+    foreach ($toolName in $PodeContext.Server.Mcp.Groups[$Name].Tools) {
+        if ($PodeContext.Server.Mcp.Tools.ContainsKey($toolName)) {
+            $tool = $PodeContext.Server.Mcp.Tools[$toolName]
+            $tool.Groups = $tool.Groups | Where-Object { $_ -ne $Name }
+        }
+    }
+
+    # clear the tools from the group
+    $PodeContext.Server.Mcp.Groups[$Name].Tools.Clear()
+}
+
+<#
+.SYNOPSIS
+Registers an MCP tool to a group.
+
+.DESCRIPTION
+Registers an MCP tool to a specified MCP tool group.
+
+.PARAMETER Name
+The Name of the MCP tool to register.
+
+.PARAMETER Group
+The Name of the MCP tool group to register the tool to.
+
+.EXAMPLE
+# register a specific MCP tool to a specific MCP tool group
+Register-PodeMcpToolToGroup -Name 'tool1' -Group 'default'
+#>
+function Register-PodeMcpToolToGroup {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Name,
+
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Group
+    )
+
+    # error if group or tool doesn't exist
+    if (!$PodeContext.Server.Mcp.Tools.ContainsKey($Name)) {
+        # The MCP tool '$($Name)' does not exist
+        throw ($PodeLocale.mcpToolDoesNotExistExceptionMessage -f $Name)
+    }
+
+    if (!$PodeContext.Server.Mcp.Groups.ContainsKey($Group)) {
+        # The MCP tool group '$($Group)' does not exist
+        throw ($PodeLocale.mcpToolGroupDoesNotExistExceptionMessage -f $Group)
+    }
+
+    # add the tool to the group if it's not already in it
+    if ($PodeContext.Server.Mcp.Groups[$Group].Tools -inotcontains $Name) {
+        $PodeContext.Server.Mcp.Groups[$Group].Tools += $Name
+    }
+
+    # add the group to the tool's info if it's not already in it
+    $tool = $PodeContext.Server.Mcp.Tools[$Name]
+    if ($tool.Groups -inotcontains $Group) {
+        $tool.Groups += $Group
+    }
+}
+
+<#
+.SYNOPSIS
+Unregisters an MCP tool from a group.
+
+.DESCRIPTION
+Unregisters an MCP tool from a specified MCP tool group.
+
+.PARAMETER Name
+The Name of the MCP tool to unregister.
+
+.PARAMETER Group
+The Name of the MCP tool group to unregister the tool from.
+
+.EXAMPLE
+# unregister a specific MCP tool from a specific MCP tool group
+Unregister-PodeMcpToolFromGroup -Name 'tool1' -Group 'default'
+#>
+function Unregister-PodeMcpToolFromGroup {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Name,
+
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Group
+    )
+
+    # error if group or tool doesn't exist
+    if (!$PodeContext.Server.Mcp.Tools.ContainsKey($Name)) {
+        # The MCP tool '$($Name)' does not exist
+        throw ($PodeLocale.mcpToolDoesNotExistExceptionMessage -f $Name)
+    }
+
+    if (!$PodeContext.Server.Mcp.Groups.ContainsKey($Group)) {
+        # The MCP tool group '$($Group)' does not exist
+        throw ($PodeLocale.mcpToolGroupDoesNotExistExceptionMessage -f $Group)
+    }
+
+    # remove the tool from the group if it's in it
+    if ($PodeContext.Server.Mcp.Groups[$Group].Tools -icontains $Name) {
+        $null = $PodeContext.Server.Mcp.Groups[$Group].Tools.Remove($Name)
+    }
+
+    # remove the group from the tool's info if it's in it
+    $tool = $PodeContext.Server.Mcp.Tools[$Name]
+    if ($tool.Groups -icontains $Group) {
+        $null = $tool.Groups.Remove($Group)
+    }
+}

--- a/tests/unit/JsonSchema.Tests.ps1
+++ b/tests/unit/JsonSchema.Tests.ps1
@@ -1,0 +1,481 @@
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
+param()
+
+InModuleScope -ModuleName 'Pode' {
+    Describe 'New-PodeJsonSchemaNull' {
+        It 'Basic' {
+            $def = New-PodeJsonSchemaNull
+            $def | Should -BeOfType [hashtable]
+
+            $def.type | Should -Be 'null'
+            $def.Keys.Count | Should -Be 1
+        }
+
+        It 'Full' {
+            $def = New-PodeJsonSchemaNull -Description 'A null value'
+            $def | Should -BeOfType [hashtable]
+
+            $def.type | Should -Be 'null'
+            $def.description | Should -Be 'A null value'
+        }
+    }
+
+    Describe 'New-PodeJsonSchemaBoolean' {
+        It 'Basic' {
+            $def = New-PodeJsonSchemaBoolean
+            $def | Should -BeOfType [hashtable]
+
+            $def.type | Should -Be 'boolean'
+            $def.Keys.Count | Should -Be 1
+        }
+
+        It 'Description' {
+            $def = New-PodeJsonSchemaBoolean -Description 'A boolean value'
+            $def | Should -BeOfType [hashtable]
+
+            $def.type | Should -Be 'boolean'
+            $def.description | Should -Be 'A boolean value'
+            $def.Keys.Count | Should -Be 2
+        }
+
+        It 'Constant' {
+            $def = New-PodeJsonSchemaBoolean -Constant $true
+            $def | Should -BeOfType [hashtable]
+
+            $def.type | Should -Be 'boolean'
+            $def.const | Should -Be $true
+            $def.Keys.Count | Should -Be 2
+        }
+
+        It 'Full' {
+            $def = New-PodeJsonSchemaBoolean -Description 'A boolean value that must be true' -Constant $true
+            $def | Should -BeOfType [hashtable]
+
+            $def.type | Should -Be 'boolean'
+            $def.description | Should -Be 'A boolean value that must be true'
+            $def.const | Should -Be $true
+            $def.Keys.Count | Should -Be 3
+        }
+    }
+
+    Describe 'New-PodeJsonSchemaInteger' {
+        It 'Basic' {
+            $def = New-PodeJsonSchemaInteger
+            $def | Should -BeOfType [hashtable]
+
+            $def.type | Should -Be 'integer'
+            $def.Keys.Count | Should -Be 1
+        }
+
+        It 'Description' {
+            $def = New-PodeJsonSchemaInteger -Description 'An integer value'
+            $def | Should -BeOfType [hashtable]
+
+            $def.type | Should -Be 'integer'
+            $def.description | Should -Be 'An integer value'
+            $def.Keys.Count | Should -Be 2
+        }
+
+        It 'Constant' {
+            $def = New-PodeJsonSchemaInteger -Constant 42
+            $def | Should -BeOfType [hashtable]
+
+            $def.type | Should -Be 'integer'
+            $def.const | Should -Be 42
+            $def.Keys.Count | Should -Be 2
+        }
+
+        It 'Minimum and Maximum' {
+            $def = New-PodeJsonSchemaInteger -Minimum 0 -Maximum 100
+            $def | Should -BeOfType [hashtable]
+
+            $def.type | Should -Be 'integer'
+            $def.minimum | Should -Be 0
+            $def.maximum | Should -Be 100
+            $def.Keys.Count | Should -Be 3
+        }
+
+        It 'Maximum less than Minimum' {
+            { New-PodeJsonSchemaInteger -Minimum 100 -Maximum 0 } | Should -Throw
+        }
+
+        It 'MultipleOf' {
+            $def = New-PodeJsonSchemaInteger -MultipleOf 5
+            $def | Should -BeOfType [hashtable]
+
+            $def.type | Should -Be 'integer'
+            $def.multipleOf | Should -Be 5
+            $def.Keys.Count | Should -Be 2
+        }
+
+        It 'Enum' {
+            $def = New-PodeJsonSchemaInteger -Enum 1, 2, 3
+            $def | Should -BeOfType [hashtable]
+
+            $def.type | Should -Be 'integer'
+            $def.enum | Should -Be @(1, 2, 3)
+            $def.Keys.Count | Should -Be 2
+        }
+
+        It 'Exclusive Minimum and Maximum' {
+            $def = New-PodeJsonSchemaInteger -Minimum 0 -Maximum 100 -ExclusiveMinimum -ExclusiveMaximum
+            $def | Should -BeOfType [hashtable]
+
+            $def.type | Should -Be 'integer'
+            $def.minimum | Should -Be 0
+            $def.maximum | Should -Be 100
+            $def.exclusiveMinimum | Should -Be $true
+            $def.exclusiveMaximum | Should -Be $true
+            $def.Keys.Count | Should -Be 5
+        }
+    }
+
+    Describe 'New-PodeJsonSchemaNumber' {
+        It 'Basic' {
+            $def = New-PodeJsonSchemaNumber
+            $def | Should -BeOfType [hashtable]
+
+            $def.type | Should -Be 'number'
+            $def.Keys.Count | Should -Be 1
+        }
+
+        It 'Description' {
+            $def = New-PodeJsonSchemaNumber -Description 'A number value'
+            $def | Should -BeOfType [hashtable]
+
+            $def.type | Should -Be 'number'
+            $def.description | Should -Be 'A number value'
+            $def.Keys.Count | Should -Be 2
+        }
+
+        It 'Constant' {
+            $def = New-PodeJsonSchemaNumber -Constant 3.14
+            $def | Should -BeOfType [hashtable]
+
+            $def.type | Should -Be 'number'
+            $def.const | Should -Be 3.14
+            $def.Keys.Count | Should -Be 2
+        }
+
+        It 'Minimum and Maximum' {
+            $def = New-PodeJsonSchemaNumber -Minimum 0 -Maximum 100
+            $def | Should -BeOfType [hashtable]
+
+            $def.type | Should -Be 'number'
+            $def.minimum | Should -Be 0
+            $def.maximum | Should -Be 100
+            $def.Keys.Count | Should -Be 3
+        }
+
+        It 'Maximum less than Minimum' {
+            { New-PodeJsonSchemaNumber -Minimum 100 -Maximum 0 } | Should -Throw
+        }
+
+        It 'MultipleOf' {
+            $def = New-PodeJsonSchemaNumber -MultipleOf 5
+            $def | Should -BeOfType [hashtable]
+
+            $def.type | Should -Be 'number'
+            $def.multipleOf | Should -Be 5
+            $def.Keys.Count | Should -Be 2
+        }
+
+        It 'Enum' {
+            $def = New-PodeJsonSchemaNumber -Enum 1, 2, 3
+            $def | Should -BeOfType [hashtable]
+
+            $def.type | Should -Be 'number'
+            $def.enum | Should -Be @(1, 2, 3)
+            $def.Keys.Count | Should -Be 2
+        }
+
+        It 'Exclusive Minimum and Maximum' {
+            $def = New-PodeJsonSchemaNumber -Minimum 0 -Maximum 100 -ExclusiveMinimum -ExclusiveMaximum
+            $def | Should -BeOfType [hashtable]
+
+            $def.type | Should -Be 'number'
+            $def.minimum | Should -Be 0
+            $def.maximum | Should -Be 100
+            $def.exclusiveMinimum | Should -Be $true
+            $def.exclusiveMaximum | Should -Be $true
+            $def.Keys.Count | Should -Be 5
+        }
+    }
+
+    Describe 'New-PodeJsonSchemaString' {
+        It 'Basic' {
+            $def = New-PodeJsonSchemaString
+            $def | Should -BeOfType [hashtable]
+
+            $def.type | Should -Be 'string'
+            $def.Keys.Count | Should -Be 1
+        }
+
+        It 'Description' {
+            $def = New-PodeJsonSchemaString -Description 'A string value'
+            $def | Should -BeOfType [hashtable]
+
+            $def.type | Should -Be 'string'
+            $def.description | Should -Be 'A string value'
+            $def.Keys.Count | Should -Be 2
+        }
+
+        It 'Constant' {
+            $def = New-PodeJsonSchemaString -Constant 'Hello'
+            $def | Should -BeOfType [hashtable]
+
+            $def.type | Should -Be 'string'
+            $def.const | Should -Be 'Hello'
+            $def.Keys.Count | Should -Be 2
+        }
+
+        It 'MinLength and MaxLength' {
+            $def = New-PodeJsonSchemaString -MinLength 5 -MaxLength 10
+            $def | Should -BeOfType [hashtable]
+
+            $def.type | Should -Be 'string'
+            $def.minLength | Should -Be 5
+            $def.maxLength | Should -Be 10
+            $def.Keys.Count | Should -Be 3
+        }
+
+        It 'MaxLength less than MinLength' {
+            { New-PodeJsonSchemaString -MinLength 10 -MaxLength 5 } | Should -Throw
+        }
+
+        It 'Pattern' {
+            $def = New-PodeJsonSchemaString -Pattern '^[a-zA-Z]+$'
+            $def | Should -BeOfType [hashtable]
+
+            $def.type | Should -Be 'string'
+            $def.pattern | Should -Be '^[a-zA-Z]+$'
+            $def.Keys.Count | Should -Be 2
+        }
+
+        It 'Enum' {
+            $def = New-PodeJsonSchemaString -Enum 'red', 'green', 'blue'
+            $def | Should -BeOfType [hashtable]
+
+            $def.type | Should -Be 'string'
+            $def.enum | Should -Be @('red', 'green', 'blue')
+            $def.Keys.Count | Should -Be 2
+        }
+    }
+
+    Describe 'New-PodeJsonSchemaArray' {
+        It 'Basic' {
+            $def = New-PodeJsonSchemaArray -Item (New-PodeJsonSchemaString)
+            $def | Should -BeOfType [hashtable]
+
+            $def.type | Should -Be 'array'
+            $def.items | Should -BeOfType [hashtable]
+            $def.Keys.Count | Should -Be 2
+
+            $def.items.type | Should -Be 'string'
+            $def.items.Keys.Count | Should -Be 1
+        }
+
+        It 'Description' {
+            $def = New-PodeJsonSchemaArray -Description 'An array value' -Item (New-PodeJsonSchemaString)
+            $def | Should -BeOfType [hashtable]
+
+            $def.type | Should -Be 'array'
+            $def.description | Should -Be 'An array value'
+            $def.items | Should -BeOfType [hashtable]
+            $def.Keys.Count | Should -Be 3
+
+            $def.items.type | Should -Be 'string'
+            $def.items.Keys.Count | Should -Be 1
+        }
+
+        It 'MinItems and MaxItems' {
+            $def = New-PodeJsonSchemaArray -Item (New-PodeJsonSchemaString) -MinItems 1 -MaxItems 5
+            $def | Should -BeOfType [hashtable]
+
+            $def.type | Should -Be 'array'
+            $def.items | Should -BeOfType [hashtable]
+            $def.minItems | Should -Be 1
+            $def.maxItems | Should -Be 5
+            $def.Keys.Count | Should -Be 4
+
+            $def.items.type | Should -Be 'string'
+            $def.items.Keys.Count | Should -Be 1
+        }
+
+        It 'MaxItems less than MinItems' {
+            { New-PodeJsonSchemaArray -Item (New-PodeJsonSchemaString) -MinItems 5 -MaxItems 1 } | Should -Throw
+        }
+
+        It 'Unique' {
+            $def = New-PodeJsonSchemaArray -Item (New-PodeJsonSchemaString) -Unique
+            $def | Should -BeOfType [hashtable]
+
+            $def.type | Should -Be 'array'
+            $def.items | Should -BeOfType [hashtable]
+            $def.uniqueItems | Should -Be $true
+            $def.Keys.Count | Should -Be 3
+
+            $def.items.type | Should -Be 'string'
+            $def.items.Keys.Count | Should -Be 1
+        }
+    }
+
+    Describe 'New-PodeJsonSchemaObject' {
+        It 'Basic' {
+            $def = New-PodeJsonSchemaObject
+            $def | Should -BeOfType [hashtable]
+
+            $def.type | Should -Be 'object'
+            $def.Keys.Count | Should -Be 1
+        }
+
+        It 'Description' {
+            $def = New-PodeJsonSchemaObject -Description 'An object value'
+            $def | Should -BeOfType [hashtable]
+
+            $def.type | Should -Be 'object'
+            $def.description | Should -Be 'An object value'
+            $def.Keys.Count | Should -Be 2
+        }
+
+        It 'MinProperties and MaxProperties' {
+            $def = New-PodeJsonSchemaObject -MinProperties 1 -MaxProperties 5
+            $def | Should -BeOfType [hashtable]
+
+            $def.type | Should -Be 'object'
+            $def.minProperties | Should -Be 1
+            $def.maxProperties | Should -Be 5
+            $def.Keys.Count | Should -Be 3
+        }
+
+        It 'MaxProperties less than MinProperties' {
+            { New-PodeJsonSchemaObject -MinProperties 5 -MaxProperties 1 } | Should -Throw
+        }
+
+        It 'Properties' {
+            $def = New-PodeJsonSchemaObject -Property @(
+                New-PodeJsonSchemaProperty -Name 'name' -Definition (New-PodeJsonSchemaString)
+                New-PodeJsonSchemaProperty -Name 'age' -Definition (New-PodeJsonSchemaInteger)
+            )
+            $def | Should -BeOfType [hashtable]
+
+            $def.type | Should -Be 'object'
+            $def.properties | Should -BeOfType [hashtable]
+            $def.Keys.Count | Should -Be 2
+
+            $def.properties.name.type | Should -Be 'string'
+            $def.properties.name.Keys.Count | Should -Be 1
+
+            $def.properties.age.type | Should -Be 'integer'
+            $def.properties.age.Keys.Count | Should -Be 1
+        }
+
+        It 'Required Properties' {
+            $def = New-PodeJsonSchemaObject -Property @(
+                New-PodeJsonSchemaProperty -Name 'name' -Definition (New-PodeJsonSchemaString) -Required
+                New-PodeJsonSchemaProperty -Name 'age' -Definition (New-PodeJsonSchemaInteger)
+            )
+            $def | Should -BeOfType [hashtable]
+
+            $def.type | Should -Be 'object'
+            $def.properties | Should -BeOfType [hashtable]
+            $def.required | Should -Be @('name')
+            $def.Keys.Count | Should -Be 3
+
+            $def.properties.name.type | Should -Be 'string'
+            $def.properties.name.Keys.Count | Should -Be 1
+
+            $def.properties.age.type | Should -Be 'integer'
+            $def.properties.age.Keys.Count | Should -Be 1
+        }
+    }
+
+    Describe 'Merge-PodeJsonSchema' {
+        It 'AllOf' {
+            $def = Merge-PodeJsonSchema -Type AllOf -Definition @(
+                New-PodeJsonSchemaString -MinLength 5
+                New-PodeJsonSchemaString -MaxLength 100
+            )
+            $def | Should -BeOfType [hashtable]
+            $def.Keys.Count | Should -Be 1
+
+            Should -ActualValue $def.allOf -BeOfType [array]
+            $def.allOf.Length | Should -Be 2
+
+            $def.allOf[0].type | Should -Be 'string'
+            $def.allOf[0].minLength | Should -Be 5
+
+            $def.allOf[1].type | Should -Be 'string'
+            $def.allOf[1].maxLength | Should -Be 100
+        }
+
+        It 'AnyOf' {
+            $def = Merge-PodeJsonSchema -Type AnyOf -Definition @(
+                New-PodeJsonSchemaString
+                New-PodeJsonSchemaNull
+            )
+            $def | Should -BeOfType [hashtable]
+            $def.Keys.Count | Should -Be 1
+
+            Should -ActualValue $def.anyOf -BeOfType [array]
+            $def.anyOf.Length | Should -Be 2
+
+            $def.anyOf[0].type | Should -Be 'string'
+            $def.anyOf[1].type | Should -Be 'null'
+        }
+
+        It 'OneOf' {
+            $def = Merge-PodeJsonSchema -Type OneOf -Definition @(
+                New-PodeJsonSchemaString
+                New-PodeJsonSchemaNull
+            )
+            $def | Should -BeOfType [hashtable]
+            $def.Keys.Count | Should -Be 1
+
+            Should -ActualValue $def.oneOf -BeOfType [array]
+            $def.oneOf.Length | Should -Be 2
+
+            $def.oneOf[0].type | Should -Be 'string'
+            $def.oneOf[1].type | Should -Be 'null'
+        }
+
+        It 'Not' {
+            $def = Merge-PodeJsonSchema -Type Not -Definition (New-PodeJsonSchemaString)
+            $def | Should -BeOfType [hashtable]
+            $def.Keys.Count | Should -Be 1
+
+            Should -ActualValue $def.not -BeOfType [array]
+            $def.not.Length | Should -Be 1
+
+            $def.not[0].type | Should -Be 'string'
+        }
+    }
+
+    Describe 'New-PodeJsonSchemaProperty' {
+        It 'Basic' {
+            $def = New-PodeJsonSchemaProperty -Name 'name' -Definition (New-PodeJsonSchemaString)
+            $def | Should -BeOfType [hashtable]
+
+            $def.Name | Should -Be 'name'
+            $def.Required | Should -Be $false
+            $def.Keys.Count | Should -Be 3
+
+            $def.Definition | Should -BeOfType [hashtable]
+            $def.Definition.type | Should -Be 'string'
+            $def.Definition.Keys.Count | Should -Be 1
+        }
+
+        It 'Required' {
+            $def = New-PodeJsonSchemaProperty -Name 'name' -Definition (New-PodeJsonSchemaString) -Required
+            $def | Should -BeOfType [hashtable]
+
+            $def.Name | Should -Be 'name'
+            $def.Required | Should -Be $true
+            $def.Keys.Count | Should -Be 3
+
+            $def.Definition | Should -BeOfType [hashtable]
+            $def.Definition.type | Should -Be 'string'
+            $def.Definition.Keys.Count | Should -Be 1
+        }
+    }
+}

--- a/tests/unit/Server.Tests.ps1
+++ b/tests/unit/Server.Tests.ps1
@@ -128,6 +128,10 @@ InModuleScope -ModuleName 'Pode' {
                     Logging         = @{
                         Types = @{ 'key' = 'value' }
                     }
+                    Mcp             = @{
+                        Tools  = @{}
+                        Groups = @{}
+                    }
                     Middleware      = @{ 'key' = 'value' }
                     Endpoints       = @{ 'key' = 'value' }
                     EndpointsMap    = @{ 'key' = 'value' }


### PR DESCRIPTION
### Description of the Change
This adds initial support for creating and host MCP Tools in Pode, as well as utility functions for creating JSON Schema definitions - similar to the existing OpenAPI support.

The MCP Tool support is in the early stages, so could change overtime as further MCP Servers are tested.

Current support for MCP:
* Hosting a Route to parse requests from MCP Servers - initialize, tools/list, and tools/call
* Creating MCP Tools via ScriptBlocks - both parameterless and with parameters
* Assigning Tools into Groups, allowing different Routes to manage different Tools
* Ability to add parameter definitions via JSON Schema - both manually and automatically
* JSON RPC error code support for servers

Current JSON Schema support:
* Types supported: null, string, integer, number, boolean, array, object
* Property support for objects - to define a name/required for a schema
* Support for merging schemas into allOf, anyOf, oneOf, and not.
* (re-usable references currently not implemented)

### Examples
Creates and hosts an MCP Tool at `http://localhost:8080/mcp`, which allows you to ask a connected MCP server `Get me all services running on this machine`

```powershell
Start-PodeServer -Threads 2 {
    Add-PodeEndpoint -Address localhost -Port 8080 -Protocol Http

    # Create a simple default group for MCP tools
    Add-PodeMcpGroup -Name 'Default' -Description 'Default group for MCP tools'

    # Add a simple MCP tool for returning windows services names for a given state
    Add-PodeMcpTool -Name 'GetWindowsServicesByState' -Description 'Returns Windows service names for a given state' -Group 'Default' -ScriptBlock {
        param(
            [ValidateSet('Running', 'Stopped', 'Paused')]
            [string]
            $State
        )

        $services = Get-Service -ErrorAction Ignore | Where-Object { $_.Status -ieq $State } | Select-Object Name
        if (($null -eq $services) -or (Test-PodeIsEmpty $services)) {
            $services = "No services found in the '$State' state."
        }

        return New-PodeMcpTextContent -Value $services
    } -PassThru |
        Add-PodeMcpToolProperty -Name 'State' -Required -Definition (
            New-PodeJsonSchemaString -Description 'The state of services to check' -Enum 'Running', 'Stopped', 'Paused'
        )

    # Add the MCP route
    Add-PodeRoute -Method Post -Path '/mcp' -ScriptBlock {
        Resolve-PodeMcpRequest -Group 'Default'
    }
}
```
