### PR TITLE
Add support for running CI when just JavaScript package versions are bumped

### DIFF
--- a/.github/workflows/ci-no-build-needed.yml
+++ b/.github/workflows/ci-no-build-needed.yml
@@ -21,6 +21,7 @@ on:
     - 'Dockerfile'
     - '*.dockerfile'
     - 'PSScriptAnalyzerSettings.psd1'
+    - 'package.json'
   pull_request:
     branches:
     - '*'
@@ -40,6 +41,7 @@ on:
     - 'Dockerfile'
     - '*.dockerfile'
     - 'PSScriptAnalyzerSettings.psd1'
+    - 'package.json'
 
 jobs:
   build:

--- a/.github/workflows/ci-pwsh_lts.yml
+++ b/.github/workflows/ci-pwsh_lts.yml
@@ -12,6 +12,7 @@ on:
     - '.github/workflows/ci-pwsh_lts.yml'
     - 'Dockerfile'
     - '*.dockerfile'
+    - 'package.json'
   pull_request:
     branches:
     - '*'
@@ -22,6 +23,7 @@ on:
     - '.github/workflows/ci-pwsh_lts.yml'
     - 'Dockerfile'
     - '*.dockerfile'
+    - 'package.json'
 
 env:
   INVOKE_BUILD_VERSION: '5.14.22'


### PR DESCRIPTION
### Description of the Change
When only `package.json` is updated, no CI is run. This changes enables CI to run when only JS package versions are bumped.

Only enabling on PWSH LTS CI as we only need a valid build/move/pack on the latest PowerShell.