### PR TITLE
Give all CI workflows a minimum of a Windows matrix

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -28,10 +28,12 @@ env:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: false
+      matrix:
+        os: [windows-latest]
 
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/ci-no-build-needed.yml
+++ b/.github/workflows/ci-no-build-needed.yml
@@ -45,10 +45,12 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: false
+      matrix:
+        os: [windows-latest]
 
     steps:
     - name: Install Invoke-Build

--- a/.github/workflows/ci-powershell.yml
+++ b/.github/workflows/ci-powershell.yml
@@ -24,10 +24,12 @@ env:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: false
+      matrix:
+        os: [windows-latest]
 
     steps:
     - uses: actions/checkout@v6


### PR DESCRIPTION
For branch protection to work better, give all CI workflows a minimum of a Windows OS matrix.
