### PR TITLE
Read file size from FileStream, not FileInfo, for correct symlinked file sizes

### DIFF
--- a/src/Listener/Protocols/Http/PodeHttpResponse.cs
+++ b/src/Listener/Protocols/Http/PodeHttpResponse.cs
@@ -149,10 +149,10 @@ namespace Pode.Protocols.Http
             }
 
             var fileInfo = PodeHelpers.FileExists(file);
-            ContentLength64 = fileInfo.Length;
 
             using (var fileStream = fileInfo.OpenRead())
             {
+                ContentLength64 = fileStream.Length;
                 await PodeHelpers.CopyFileTo(fileStream, OutputStream, Context.Listener.CancellationToken).ConfigureAwait(false);
             }
         }


### PR DESCRIPTION
### Description of the Change
The `FileInfo.Length` was only reporting the symlink file size when attaching files, using `FileStream.Length` reports the correct size.

### Related Issue
Resolves #1597 