### PR TITLE
Fix to prevent path traversal in Static Routes when rooted paths are used

### DIFF
--- a/src/Locales/ar/Pode.psd1
+++ b/src/Locales/ar/Pode.psd1
@@ -346,4 +346,5 @@
     mcpToolDoesNotExistExceptionMessage                               = "أداة MCP '{0}' غير موجودة."
     mcpToolAlreadyExistsExceptionMessage                              = "أداة MCP '{0}' موجودة بالفعل."
     mcpToolGroupAlreadyExistsExceptionMessage                         = "مجموعة أدوات MCP '{0}' موجودة بالفعل."
+    staticRouteDefaultCannotBeRootedExceptionMessage                  = "لا يمكن أن تكون القيم الافتراضية للمسار الثابت مسارات جذرية. القيمة الافتراضية غير صالحة: '{0}'"
 }

--- a/src/Locales/de/Pode.psd1
+++ b/src/Locales/de/Pode.psd1
@@ -346,4 +346,5 @@
     mcpToolDoesNotExistExceptionMessage                               = "Das MCP-Tool '{0}' existiert nicht."
     mcpToolAlreadyExistsExceptionMessage                              = "Das MCP-Tool '{0}' existiert bereits."
     mcpToolGroupAlreadyExistsExceptionMessage                         = "Die MCP-Toolgruppe '{0}' existiert bereits."
+    staticRouteDefaultCannotBeRootedExceptionMessage                  = "Die Standardwerte für statische Routen können keine gerooteten Pfade sein. Ungültiger Standardwert: '{0}'"
 }

--- a/src/Locales/en-us/Pode.psd1
+++ b/src/Locales/en-us/Pode.psd1
@@ -346,4 +346,5 @@
     mcpToolDoesNotExistExceptionMessage                               = "The MCP tool '{0}' does not exist."
     mcpToolAlreadyExistsExceptionMessage                              = "The MCP tool '{0}' already exists."
     mcpToolGroupAlreadyExistsExceptionMessage                         = "The MCP tool group '{0}' already exists."
+    staticRouteDefaultCannotBeRootedExceptionMessage                  = "Static route defaults cannot be rooted paths. Invalid default: '{0}'"
 }

--- a/src/Locales/en/Pode.psd1
+++ b/src/Locales/en/Pode.psd1
@@ -346,4 +346,5 @@
     mcpToolDoesNotExistExceptionMessage                               = "The MCP tool '{0}' does not exist."
     mcpToolAlreadyExistsExceptionMessage                              = "The MCP tool '{0}' already exists."
     mcpToolGroupAlreadyExistsExceptionMessage                         = "The MCP tool group '{0}' already exists."
+    staticRouteDefaultCannotBeRootedExceptionMessage                  = "Static route defaults cannot be rooted paths. Invalid default: '{0}'"
 }

--- a/src/Locales/es/Pode.psd1
+++ b/src/Locales/es/Pode.psd1
@@ -346,4 +346,5 @@
     mcpToolDoesNotExistExceptionMessage                               = "La herramienta MCP '{0}' no existe."
     mcpToolAlreadyExistsExceptionMessage                              = "La herramienta MCP '{0}' ya existe."
     mcpToolGroupAlreadyExistsExceptionMessage                         = "El grupo de herramientas MCP '{0}' ya existe."
+    staticRouteDefaultCannotBeRootedExceptionMessage                  = "Los valores predeterminados de las rutas estáticas no pueden ser rutas absolutas. Valor predeterminado no válido: '{0}'"
 }

--- a/src/Locales/fr/Pode.psd1
+++ b/src/Locales/fr/Pode.psd1
@@ -346,4 +346,5 @@
     mcpToolDoesNotExistExceptionMessage                               = "L'outil MCP '{0}' n'existe pas."
     mcpToolAlreadyExistsExceptionMessage                              = "L'outil MCP '{0}' existe déjà."
     mcpToolGroupAlreadyExistsExceptionMessage                         = "Le groupe d'outils MCP '{0}' existe déjà."
+    staticRouteDefaultCannotBeRootedExceptionMessage                  = "Les valeurs par défaut des routes statiques ne peuvent pas être des chemins absolus. Valeur par défaut non valide : '{0}'"
 }

--- a/src/Locales/it/Pode.psd1
+++ b/src/Locales/it/Pode.psd1
@@ -346,4 +346,5 @@
     mcpToolDoesNotExistExceptionMessage                               = "Lo strumento MCP '{0}' non esiste."
     mcpToolAlreadyExistsExceptionMessage                              = "Lo strumento MCP '{0}' esiste già."
     mcpToolGroupAlreadyExistsExceptionMessage                         = "Il gruppo di strumenti MCP '{0}' esiste già."
+    staticRouteDefaultCannotBeRootedExceptionMessage                  = "I valori predefiniti delle route statiche non possono essere percorsi assoluti. Valore predefinito non valido: '{0}'"
 }

--- a/src/Locales/ja/Pode.psd1
+++ b/src/Locales/ja/Pode.psd1
@@ -346,4 +346,5 @@
     mcpToolDoesNotExistExceptionMessage                               = 'MCPツール「{0}」は存在しません。'
     mcpToolAlreadyExistsExceptionMessage                              = 'MCPツール「{0}」は既に存在します。'
     mcpToolGroupAlreadyExistsExceptionMessage                         = 'MCPツールグループ「{0}」は既に存在します。'
+    staticRouteDefaultCannotBeRootedExceptionMessage                  = "静的ルートのデフォルトはルートパスにできません。無効なデフォルト: '{0}'"
 }

--- a/src/Locales/ko/Pode.psd1
+++ b/src/Locales/ko/Pode.psd1
@@ -346,4 +346,5 @@
     mcpToolDoesNotExistExceptionMessage                               = "MCP 도구 '{0}'은 존재하지 않습니다."
     mcpToolAlreadyExistsExceptionMessage                              = "MCP 도구 '{0}'은 이미 존재합니다."
     mcpToolGroupAlreadyExistsExceptionMessage                         = "MCP 도구 그룹 '{0}'은 이미 존재합니다."
+    staticRouteDefaultCannotBeRootedExceptionMessage                  = "정적 경로의 기본값은 루트 경로일 수 없습니다. 잘못된 기본값: '{0}'"
 }

--- a/src/Locales/nl/Pode.psd1
+++ b/src/Locales/nl/Pode.psd1
@@ -346,4 +346,5 @@
     mcpToolDoesNotExistExceptionMessage                               = "De MCP-tool '{0}' bestaat niet."
     mcpToolAlreadyExistsExceptionMessage                              = "De MCP-tool '{0}' bestaat al."
     mcpToolGroupAlreadyExistsExceptionMessage                         = "De MCP-toolgroep '{0}' bestaat al."
+    staticRouteDefaultCannotBeRootedExceptionMessage                  = "Statische route-standaarden kunnen geen geroot pad zijn. Ongeldige standaard: '{0}'"
 }

--- a/src/Locales/pl/Pode.psd1
+++ b/src/Locales/pl/Pode.psd1
@@ -346,4 +346,5 @@
     mcpToolDoesNotExistExceptionMessage                               = "Narzędzie MCP '{0}' nie istnieje."
     mcpToolAlreadyExistsExceptionMessage                              = "Narzędzie MCP '{0}' już istnieje."
     mcpToolGroupAlreadyExistsExceptionMessage                         = "Grupa narzędzi MCP '{0}' już istnieje."
+    staticRouteDefaultCannotBeRootedExceptionMessage                  = "Domyślne wartości statycznej trasy nie mogą być ścieżkami zrootowanymi. Nieprawidłowa wartość domyślna: '{0}'"
 }

--- a/src/Locales/pt/Pode.psd1
+++ b/src/Locales/pt/Pode.psd1
@@ -346,4 +346,5 @@
     mcpToolDoesNotExistExceptionMessage                               = "A ferramenta MCP '{0}' não existe."
     mcpToolAlreadyExistsExceptionMessage                              = "A ferramenta MCP '{0}' já existe."
     mcpToolGroupAlreadyExistsExceptionMessage                         = "O grupo de ferramentas MCP '{0}' já existe."
+    staticRouteDefaultCannotBeRootedExceptionMessage                  = "Os valores padrão da rota estática não podem ser caminhos raiz. Valor padrão inválido: '{0}'"
 }

--- a/src/Locales/zh/Pode.psd1
+++ b/src/Locales/zh/Pode.psd1
@@ -346,4 +346,5 @@
     mcpToolDoesNotExistExceptionMessage                               = "MCP工具'{0}'不存在。"
     mcpToolAlreadyExistsExceptionMessage                              = "MCP工具'{0}'已经存在。"
     mcpToolGroupAlreadyExistsExceptionMessage                         = "MCP工具组'{0}'已经存在。"
+    staticRouteDefaultCannotBeRootedExceptionMessage                  = "静态路由的默认值不能是根路径。无效的默认值: '{0}'"
 }

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -688,7 +688,8 @@ function New-PodePSDrive {
 
     # if the path supplied doesn't exist, error
     if (!(Test-Path $Path)) {
-        throw ($PodeLocale.pathNotExistExceptionMessage -f $Path)#"Path does not exist: $($Path)"
+        # Path does not exist: $($Path)
+        throw ($PodeLocale.pathNotExistExceptionMessage -f $Path)
     }
 
     # resolve the path

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -1882,7 +1882,7 @@ function Test-PodePathIsFile {
         return $false
     }
 
-    return (![string]::IsNullOrEmpty([System.IO.Path]::GetExtension($Path)))
+    return ![string]::IsNullOrEmpty([System.IO.Path]::GetExtension($Path))
 }
 
 function Test-PodePathIsWildcard {

--- a/src/Private/Routes.ps1
+++ b/src/Private/Routes.ps1
@@ -125,7 +125,7 @@ function Find-PodePublicRoute {
     }
 
     # check if file exists in the public drive
-    $source = [System.IO.Path]::Combine($publicPath, $Path.TrimStart('/', '\'))
+    $source = [System.IO.Path]::Combine($publicPath, $Path)
     $fileInfo = Test-PodePath -Path $source -NoStatus -Force -ReturnItem
     if ($null -eq $fileInfo) {
         return $null

--- a/src/Private/Routes.ps1
+++ b/src/Private/Routes.ps1
@@ -113,15 +113,24 @@ function Find-PodePublicRoute {
     # escape characters in the path
     $Path = Protect-PodePath -Path $Path -NoEscape:$NoEscape
 
-    # use the public static directory - but only if path is a file
+    # ignore if path is not a file
     if (!(Test-PodePathIsFile -Path $Path)) {
         return $null
     }
 
+    # if path is rooted, ignore
+    if ([System.IO.Path]::IsPathRooted($Path)) {
+        return $null
+    }
+
+    # check if file exists in the public drive
     $source = [System.IO.Path]::Combine($publicPath, $Path.TrimStart('/', '\'))
     $fileInfo = Test-PodePath -Path $source -NoStatus -Force -ReturnItem
-
     if ($null -eq $fileInfo) {
+        return $null
+    }
+
+    if (!$source.StartsWith($publicPath.TrimEnd('\', '/'), [StringComparison]::OrdinalIgnoreCase)) {
         return $null
     }
 
@@ -197,7 +206,7 @@ function Find-PodeStaticRoute {
 
     # if we have a defined static route, use that
     if ($null -ne $found) {
-        # see if we have a file
+        # see if we have a valid, non-rooted, file
         $file = [string]::Empty
         $matchingPath = "$($found.Path.Replace('*', '.+?'))$"
 
@@ -205,8 +214,13 @@ function Find-PodeStaticRoute {
             $file = Protect-PodeValue -Value $Matches['file'] -Default ([string]::Empty)
         }
 
+        if ([System.IO.Path]::IsPathRooted($file)) {
+            return $null
+        }
+
         # if $file doesn't exist return $null
-        $fileInfo = Get-Item -Path ([System.IO.Path]::Combine($found.Source, $file)) -Force -ErrorAction Ignore
+        $filePath = [System.IO.Path]::Combine($found.Source, $file)
+        $fileInfo = Get-Item -Path $filePath -Force -ErrorAction Ignore
         if ($null -eq $fileInfo) {
             return $null
         }
@@ -214,21 +228,30 @@ function Find-PodeStaticRoute {
         # if this is a folder, we need to check defaults
         if (!$found.Download -and $fileInfo.PSIsContainer -and (($null -ne $found.Defaults) -and ($found.Defaults.Count -gt 0))) {
             foreach ($def in $found.Defaults) {
-                if ([string]::IsNullOrEmpty($def)) {
+                if ([string]::IsNullOrEmpty($def) -or [System.IO.Path]::IsPathRooted($def)) {
                     continue
                 }
 
-                $defFileInfo = Get-Item -Path ([System.IO.Path]::Combine($fileInfo.FullName, $def)) -Force -ErrorAction Ignore
-                if ($null -ne $defFileInfo) {
-                    $file = [System.IO.Path]::Combine($file, $def)
-                    $fileInfo = $defFileInfo
-                    $isDefault = $true
-                    break
+                $defFilePath = [System.IO.Path]::Combine($filePath, $def)
+                $defFileInfo = Get-Item -Path $defFilePath -Force -ErrorAction Ignore
+                if ($null -eq $defFileInfo) {
+                    continue
                 }
+
+                $source = [System.IO.Path]::Combine($found.Source, $file, $def)
+                $fileInfo = $defFileInfo
+                $isDefault = $true
+                break
             }
         }
+        else {
+            $source = $filePath
+        }
 
-        $source = [System.IO.Path]::Combine($found.Source, $file)
+        # ensure the source is within the route source
+        if (![string]::IsNullOrEmpty($source) -and !$source.StartsWith($found.Source.TrimEnd('\', '/'), [StringComparison]::OrdinalIgnoreCase)) {
+            return $null
+        }
     }
 
     # check public, if flagged

--- a/src/Private/Routes.ps1
+++ b/src/Private/Routes.ps1
@@ -112,6 +112,7 @@ function Find-PodePublicRoute {
 
     # escape characters in the path
     $Path = Protect-PodePath -Path $Path -NoEscape:$NoEscape
+    $Path = $Path.TrimStart('/', '\')
 
     # ignore if path is not a file
     if (!(Test-PodePathIsFile -Path $Path)) {
@@ -258,6 +259,10 @@ function Find-PodeStaticRoute {
     if ($CheckPublic -and [string]::IsNullOrEmpty($source)) {
         # check if we have a public route
         $pubRoute = Find-PodePublicRoute -Path $Path
+        if ($null -eq $pubRoute) {
+            return $null
+        }
+
         $source = $pubRoute.Source
         $fileInfo = $pubRoute.FileInfo
 

--- a/src/Public/Routes.ps1
+++ b/src/Public/Routes.ps1
@@ -795,6 +795,12 @@ function Add-PodeStaticRoute {
         $Defaults = Get-PodeStaticRouteDefault
     }
 
+    foreach ($def in $Defaults) {
+        if ([System.IO.Path]::IsPathRooted($def)) {
+            throw ($PodeLocale.staticRouteDefaultCannotBeRootedExceptionMessage -f $def)
+        }
+    }
+
     if (!$RedirectToDefault) {
         $RedirectToDefault = $PodeContext.Server.Web.Static.RedirectToDefault
     }


### PR DESCRIPTION
### Description of the Change
Ensures that rooted paths cannot be provided when requesting static content from the server, and therefore preventing path traversal.

Achieved in two ways:
* Use `Path.IsPathRooted` on child paths before using `Path.Combine`
* Ensure the result path has the expected Pode drive source after combining

### Related Issue
Resolves #1667 