### PR TITLE
Fixes request body parsing failing when BOM is present

### DIFF
--- a/src/Listener/Utilities/PodeHelpers.cs
+++ b/src/Listener/Utilities/PodeHelpers.cs
@@ -30,6 +30,7 @@ namespace Pode.Utilities
         public const byte DASH_BYTE = 45;
         public const byte PERIOD_BYTE = 46;
         public const int MAX_BUFFER_SIZE = 16384;
+        public const char BOM = (char)0xFEFF;
 
         private static string _dotnet_version = string.Empty;
         private static bool _is_net_framework = false;

--- a/src/Listener/Utilities/PodeHelpers.cs
+++ b/src/Listener/Utilities/PodeHelpers.cs
@@ -30,7 +30,6 @@ namespace Pode.Utilities
         public const byte DASH_BYTE = 45;
         public const byte PERIOD_BYTE = 46;
         public const int MAX_BUFFER_SIZE = 16384;
-        public const char BOM = (char)0xFEFF;
 
         private static string _dotnet_version = string.Empty;
         private static bool _is_net_framework = false;
@@ -339,6 +338,30 @@ namespace Pode.Utilities
             }
 
             return fileInfo;
+        }
+
+        public static string RemoveBOM(string value)
+        {
+            // return if no value
+            if (string.IsNullOrEmpty(value))
+            {
+                return value;
+            }
+
+            // check for utf-16 BOM and remove if found
+            if (value[0] == (char)0xFEFF)
+            {
+                return value.Substring(1);
+            }
+
+            // check for utf-8 BOM and remove if found
+            if (value.Length > 2 && value[0] == (char)0xEF && value[1] == (char)0xBB && value[2] == (char)0xBF)
+            {
+                return value.Substring(3);
+            }
+
+            // no BOM found, return original value
+            return value;
         }
     }
 }

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -1561,6 +1561,11 @@ function ConvertFrom-PodeRequestContent {
             }
         }
 
+        # remove any BOM if there is one
+        if (($null -ne $Content) -and $Content.StartsWith([PodeHelpers]::BOM)) {
+            $Content = $Content.Substring(1)
+        }
+
         # if there is no content then do nothing
         if ([string]::IsNullOrWhiteSpace($Content)) {
             return $Result
@@ -1569,7 +1574,7 @@ function ConvertFrom-PodeRequestContent {
         # check if there is a defined custom body parser
         if ($PodeContext.Server.BodyParsers.ContainsKey($ContentType)) {
             $parser = $PodeContext.Server.BodyParsers[$ContentType]
-            $Result.Data = (Invoke-PodeScriptBlock -ScriptBlock $parser.ScriptBlock -Arguments $Content -UsingVariables $parser.UsingVariables -Return)
+            $Result.Data = Invoke-PodeScriptBlock -ScriptBlock $parser.ScriptBlock -Arguments $Content -UsingVariables $parser.UsingVariables -Return
             $Content = $null
             return $Result
         }

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -1562,9 +1562,7 @@ function ConvertFrom-PodeRequestContent {
         }
 
         # remove any BOM if there is one
-        if (($null -ne $Content) -and $Content.StartsWith([PodeHelpers]::BOM)) {
-            $Content = $Content.Substring(1)
-        }
+        $Content = [PodeHelpers]::RemoveBOM($Content)
 
         # if there is no content then do nothing
         if ([string]::IsNullOrWhiteSpace($Content)) {

--- a/tests/unit/Helpers.Tests.ps1
+++ b/tests/unit/Helpers.Tests.ps1
@@ -559,9 +559,63 @@ InModuleScope -ModuleName 'Pode' {
                 $result.Data.root.value | Should -Be 'test'
             }
 
+            It 'Returns xml data with utf-16 BOM' {
+                $PodeContext = @{ 'Server' = @{ 'Type' = 'http'; 'BodyParsers' = @{} } }
+                $value = [char]0xFEFF + '<root><value>test</value></root>'
+
+                $result = ConvertFrom-PodeRequestContent -Request @{
+                    Body            = $value
+                    ContentEncoding = [System.Text.Encoding]::UTF8
+                } -ContentType 'text/xml'
+
+                $result.Data | Should -Not -Be $null
+                $result.Data.root | Should -Not -Be $null
+                $result.Data.root.value | Should -Be 'test'
+            }
+
+            It 'Returns xml data with utf-8 BOM' {
+                $PodeContext = @{ 'Server' = @{ 'Type' = 'http'; 'BodyParsers' = @{} } }
+                $value = [char]0xEF + [char]0xBB + [char]0xBF + '<root><value>test</value></root>'
+
+                $result = ConvertFrom-PodeRequestContent -Request @{
+                    Body            = $value
+                    ContentEncoding = [System.Text.Encoding]::UTF8
+                } -ContentType 'text/xml'
+
+                $result.Data | Should -Not -Be $null
+                $result.Data.root | Should -Not -Be $null
+                $result.Data.root.value | Should -Be 'test'
+            }
+
             It 'Returns json data' {
                 $PodeContext = @{ 'Server' = @{ 'Type' = 'http'; 'BodyParsers' = @{} } }
                 $value = '{ "value": "test" }'
+
+                $result = ConvertFrom-PodeRequestContent -Request @{
+                    Body            = $value
+                    ContentEncoding = [System.Text.Encoding]::UTF8
+                } -ContentType 'application/json'
+
+                $result.Data | Should -Not -Be $null
+                $result.Data.value | Should -Be 'test'
+            }
+
+            It 'Returns json data with utf-16 BOM' {
+                $PodeContext = @{ 'Server' = @{ 'Type' = 'http'; 'BodyParsers' = @{} } }
+                $value = [char]0xFEFF + '{ "value": "test" }'
+
+                $result = ConvertFrom-PodeRequestContent -Request @{
+                    Body            = $value
+                    ContentEncoding = [System.Text.Encoding]::UTF8
+                } -ContentType 'application/json'
+
+                $result.Data | Should -Not -Be $null
+                $result.Data.value | Should -Be 'test'
+            }
+
+            It 'Returns json data with utf-8 BOM' {
+                $PodeContext = @{ 'Server' = @{ 'Type' = 'http'; 'BodyParsers' = @{} } }
+                $value = [char]0xEF + [char]0xBB + [char]0xBF + '{ "value": "test" }'
 
                 $result = ConvertFrom-PodeRequestContent -Request @{
                     Body            = $value


### PR DESCRIPTION
### Description of the Change
Before parsing the supplied request body, Pode will remove the BOM character if present - as this breaks JSON, XML, CSV, etc. parsing.

### Related Issue
Resolves #1604 