### PR TITLE
Fixes error when User object isn't a Hashtable when checking Auth events

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) [2017-2025] [Matthew Kelly (Badgerati)]
+Copyright (c) [2017-2026] [Matthew Kelly (Badgerati)]
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Private/Authentication.ps1
+++ b/src/Private/Authentication.ps1
@@ -2402,7 +2402,7 @@ function Invoke-PodeAuthEvent {
         $Type,
 
         [Parameter(Mandatory = $true)]
-        [hashtable]
+        [object]
         $User,
 
         [Parameter()]


### PR DESCRIPTION
### Description of the Change
Fixes error when User object isn't a Hashtable when checking Auth events. I've set the type to be `[object]` as internally the User will either be a Hashtable or PSCustomObject, but custom Auth handlers could have other unknown/custom types for the User object.

### Related Issue
Resolves #1688 