### PR TITLE
Fixes an error being thrown when a Logout Route is called for non-authenticated sessions

### DIFF
--- a/src/Private/Authentication.ps1
+++ b/src/Private/Authentication.ps1
@@ -1400,7 +1400,9 @@ function Test-PodeAuthInternal {
     # check for logout command
     if ($Logout) {
         # trigger logout event
-        Invoke-PodeAuthEvent -Name $WebEvent.Session.Data.Auth.Name -Type Logout -User $WebEvent.Session.Data.Auth.User
+        if ($null -ne $WebEvent.Session.Data.Auth) {
+            Invoke-PodeAuthEvent -Name $WebEvent.Session.Data.Auth.Name -Type Logout -User $WebEvent.Session.Data.Auth.User
+        }
 
         # remove the auth session
         Remove-PodeAuthSession


### PR DESCRIPTION
### Description of the Change
If a `-Logout` Route was ever called by a non-authenticated session, then no Authentication Name or User object was available - leading to "Parameter not supplied" errors.

This now checks that a Session Auth object is available during logout, before calling the Events logic.

### Related Issue
Resolves #1694 