### PR TITLE
Fixes a race condition during idle connections timing out; Fixes older requests not being reset

### DIFF
--- a/src/Listener/Protocols/Common/Contexts/IPodeContext.cs
+++ b/src/Listener/Protocols/Common/Contexts/IPodeContext.cs
@@ -72,6 +72,11 @@ namespace Pode.Protocols.Common.Contexts
         Task Initialise();
 
         /// <summary>
+        /// Resets the request timeout by restarting the timeout timer.
+        /// </summary>
+        void ResetTimeout();
+
+        /// <summary>
         /// Cancels the request timeout by disposing of the timeout timer.
         /// </summary>
         void CancelTimeout();

--- a/src/Listener/Protocols/Common/Contexts/PodeContext.cs
+++ b/src/Listener/Protocols/Common/Contexts/PodeContext.cs
@@ -428,7 +428,7 @@ namespace Pode.Protocols.Common.Contexts
                     }
 
                     // Attempt to reset the request.
-                    Request.Reset(!_awaitingContent);
+                    Request.Reset(IsErrored || IsTimeout);
 
                     // Dispose of request and response if not keep-alive or forced.
                     if (!_awaitingContent && (!IsKeepAlive || force))

--- a/src/Listener/Protocols/Common/Contexts/PodeContext.cs
+++ b/src/Listener/Protocols/Common/Contexts/PodeContext.cs
@@ -70,6 +70,7 @@ namespace Pode.Protocols.Common.Contexts
         // Determines if the context should be closed immediately.
         public bool CloseImmediately => State == PodeContextState.Error
                 || State == PodeContextState.Closing
+                || State == PodeContextState.Closed
                 || State == PodeContextState.Timeout
                 || (Request?.CloseImmediately ?? true);
 
@@ -140,8 +141,8 @@ namespace Pode.Protocols.Common.Contexts
                 PodeHelpers.WriteErrorMessage("TimeoutCallback triggered", Listener, PodeLoggingLevel.Debug, this);
                 PodeHelpers.WriteErrorMessage($"Request timeout reached: {Listener.RequestTimeout} seconds", Listener, PodeLoggingLevel.Warning, this);
 
-                ContextTimeoutToken.Cancel();
                 State = PodeContextState.Timeout;
+                ContextTimeoutToken.Cancel();
 
                 Request.Timeout();
                 Response.StatusCode = Request.Error.StatusCode;
@@ -158,6 +159,28 @@ namespace Pode.Protocols.Common.Contexts
         protected virtual void NewTimeoutTimer()
         {
             TimeoutTimer = new Timer(TimeoutCallback, null, Listener.RequestTimeout * 1000, Timeout.Infinite);
+        }
+
+        /// <summary>
+        /// Resets the request timeout by restarting the timeout timer.
+        /// </summary>
+        public void ResetTimeout()
+        {
+            if (TimeoutTimer == default || IsTimeout)
+            {
+                return;
+            }
+
+            TimeoutTimer.Change(Listener.RequestTimeout * 1000, Timeout.Infinite);
+        }
+
+        /// <summary>
+        /// Cancels the request timeout by disposing of the timeout timer.
+        /// </summary>
+        public void CancelTimeout()
+        {
+            TimeoutTimer?.Dispose();
+            TimeoutTimer = null;
         }
 
         /// <summary>
@@ -183,15 +206,6 @@ namespace Pode.Protocols.Common.Contexts
             State = Request.State == PodeStreamState.Open
                 ? PodeContextState.Open
                 : PodeContextState.Error;
-        }
-
-        /// <summary>
-        /// Cancels the request timeout by disposing of the timeout timer.
-        /// </summary>
-        public void CancelTimeout()
-        {
-            TimeoutTimer?.Dispose();
-            TimeoutTimer = null;
         }
 
         /// <summary>
@@ -245,7 +259,11 @@ namespace Pode.Protocols.Common.Contexts
         /// <returns>A Task representing the async operation.</returns>
         protected virtual async Task EndReceive(bool close)
         {
-            State = close ? PodeContextState.Closing : PodeContextState.Received;
+            if (State == PodeContextState.Receiving)
+            {
+                State = close ? PodeContextState.Closing : PodeContextState.Received;
+            }
+
             await Handle().ConfigureAwait(false);
         }
 
@@ -409,11 +427,8 @@ namespace Pode.Protocols.Common.Contexts
                         }
                     }
 
-                    // Reset request if it's allowed, and was processable.
-                    if (Request.IsResettable && Request.IsProcessable)
-                    {
-                        Request.Reset();
-                    }
+                    // Attempt to reset the request.
+                    Request.Reset(!_awaitingContent);
 
                     // Dispose of request and response if not keep-alive or forced.
                     if (!_awaitingContent && (!IsKeepAlive || force))

--- a/src/Listener/Protocols/Common/Requests/IPodeRequestStrategy.cs
+++ b/src/Listener/Protocols/Common/Requests/IPodeRequestStrategy.cs
@@ -34,7 +34,7 @@ namespace Pode.Protocols.Common.Requests
         // Methods for parsing, validating, and resetting the request
         Task<bool> Parse(byte[] bytes, CancellationToken cancellationToken);
         bool Validate(byte[] bytes);
-        void Reset();
+        void Reset(bool force = false);
 
         // Utility methods
         T GetContext<T>() where T : IPodeContext;

--- a/src/Listener/Protocols/Common/Requests/PodeRequestHandler.cs
+++ b/src/Listener/Protocols/Common/Requests/PodeRequestHandler.cs
@@ -265,6 +265,9 @@ namespace Pode.Protocols.Common.Requests
                             break;
                         }
 
+                        // Reset the timeout timer on received data, to prevent timeouts during long uploads or slow connections
+                        Context.ResetTimeout();
+
                         // Write the data to the buffer stream
 #if NETCOREAPP2_1_OR_GREATER
                         await BufferStream.WriteAsync(localBuffer.AsMemory(0, read), cancellationToken).ConfigureAwait(false);
@@ -434,14 +437,14 @@ namespace Pode.Protocols.Common.Requests
             return true;
         }
 
-        public void Reset()
+        public void Reset(bool force = false)
         {
             if (!IsResettable)
             {
                 return;
             }
 
-            Strategy?.Reset();
+            Strategy?.Reset(force);
         }
 
         public async Task Flush()

--- a/src/Listener/Protocols/Common/Requests/PodeRequestStrategy.cs
+++ b/src/Listener/Protocols/Common/Requests/PodeRequestStrategy.cs
@@ -69,7 +69,8 @@ namespace Pode.Protocols.Common.Requests
         /// <summary>
         /// Resets the request state. Can be overridden by derived classes.
         /// </summary>
-        public abstract void Reset();
+        /// <param name="force">Indicates whether to force the reset, even if the request is not marked as resettable or processable.</param>
+        public abstract void Reset(bool force = false);
 
         /// <summary>
         /// Gets the context associated with the request handler.

--- a/src/Listener/Protocols/Http/Client/Signals/PodeSignalOpCode.cs
+++ b/src/Listener/Protocols/Http/Client/Signals/PodeSignalOpCode.cs
@@ -2,6 +2,7 @@ namespace Pode.Protocols.Http.Client.Signals
 {
     public enum PodeSignalOpCode
     {
+        None = -1,
         Continuation = 0,
         Text = 1,
         Binary = 2,

--- a/src/Listener/Protocols/Http/PodeHttpRequestStrategy.cs
+++ b/src/Listener/Protocols/Http/PodeHttpRequestStrategy.cs
@@ -114,7 +114,33 @@ namespace Pode.Protocols.Http
             Type = PodeProtocolType.Http;
         }
 
-        public override void Reset() { }
+        public override void Reset(bool force = false)
+        {
+            if (!force && !AwaitingContent)
+            {
+                return;
+            }
+
+            PodeHelpers.WriteErrorMessage($"Request reset", Handler.Context.Listener, PodeLoggingLevel.Verbose, Handler.Context);
+
+            HttpMethod = string.Empty;
+            QueryString = default;
+            Protocol = "HTTP/1.1";
+            ProtocolVersion = "1.1";
+            ContentType = string.Empty;
+            ContentLength = 0;
+            ContentEncoding = System.Text.Encoding.UTF8;
+            TransferEncoding = string.Empty;
+            UserAgent = string.Empty;
+            UrlReferrer = string.Empty;
+            Url = default;
+            Headers = default;
+            RawBody = default;
+            Host = string.Empty;
+            Form?.Dispose();
+            Form = default;
+            _body = string.Empty;
+        }
 
         public override bool Validate(byte[] bytes)
         {

--- a/src/Listener/Protocols/Http/PodeHttpRequestStrategy.cs
+++ b/src/Listener/Protocols/Http/PodeHttpRequestStrategy.cs
@@ -116,7 +116,7 @@ namespace Pode.Protocols.Http
 
         public override void Reset(bool force = false)
         {
-            if (!force && !AwaitingContent)
+            if (!force && AwaitingContent)
             {
                 return;
             }

--- a/src/Listener/Protocols/Http/PodeSignalRequestStrategy.cs
+++ b/src/Listener/Protocols/Http/PodeSignalRequestStrategy.cs
@@ -17,7 +17,7 @@ namespace Pode.Protocols.Http
     public class PodeSignalRequestStrategy : PodeRequestStrategy
     {
         // The WebSocket operation code extracted from the incoming frame.
-        public PodeSignalOpCode OpCode { get; private set; }
+        public PodeSignalOpCode OpCode { get; private set; } = PodeSignalOpCode.None;
 
         // The decoded message body as a string.
         public string Body { get; private set; }
@@ -54,7 +54,11 @@ namespace Pode.Protocols.Http
         // It excludes control frames (Ping/Pong) and ensures that a non-empty body exists.
         public override bool IsProcessable
         {
-            get => base.IsProcessable && OpCode != PodeSignalOpCode.Pong && OpCode != PodeSignalOpCode.Ping && !string.IsNullOrEmpty(Body);
+            get => base.IsProcessable
+                && OpCode != PodeSignalOpCode.Pong
+                && OpCode != PodeSignalOpCode.Ping
+                && OpCode != PodeSignalOpCode.None
+                && !string.IsNullOrEmpty(Body);
         }
 
         // The current frame being processed.
@@ -235,7 +239,14 @@ namespace Pode.Protocols.Http
             return true;
         }
 
-        public override void Reset() { }
+        public override void Reset(bool force = false)
+        {
+            OpCode = PodeSignalOpCode.None;
+            Body = string.Empty;
+            ContentLength = 0;
+            RawBody = default;
+        }
+
         public override void PartialDispose() { }
 
         /// <summary>
@@ -255,6 +266,15 @@ namespace Pode.Protocols.Http
                 // Log a message indicating the WebSocket is being closed.
                 PodeHelpers.WriteErrorMessage($"Closing Websocket", Handler.Context.Listener, PodeLoggingLevel.Verbose, Handler.Context);
                 Signal.Close().Wait();
+
+                Body = string.Empty;
+                RawBody = default;
+
+                if (BodyStream != default)
+                {
+                    BodyStream.Dispose();
+                    BodyStream = default;
+                }
             }
 
             // Call the base class Dispose to clean up other resources.

--- a/src/Listener/Protocols/Smtp/PodeSmtpRequestStrategy.cs
+++ b/src/Listener/Protocols/Smtp/PodeSmtpRequestStrategy.cs
@@ -160,7 +160,7 @@ namespace Pode.Protocols.Smtp
                     return true;
                 }
 
-                Reset();
+                Reset(true);
                 Command = PodeSmtpCommand.StartTls;
                 await SendStatus(220, "Ready to start TLS", isSub: false);
                 await Handler.UpgradeToSSL(cancellationToken).ConfigureAwait(false);
@@ -170,7 +170,7 @@ namespace Pode.Protocols.Smtp
             // reset
             if (IsCommand(content, "RSET"))
             {
-                Reset();
+                Reset(true);
                 Command = PodeSmtpCommand.Reset;
                 SetStatus(250, "OK");
                 return true;
@@ -259,8 +259,13 @@ namespace Pode.Protocols.Smtp
             return true;
         }
 
-        public override void Reset()
+        public override void Reset(bool force = false)
         {
+            if (!force && !IsProcessable)
+            {
+                return;
+            }
+
             PodeHelpers.WriteErrorMessage($"Request reset", Handler.Context.Listener, PodeLoggingLevel.Verbose, Handler.Context);
 
             _canProcess = false;

--- a/src/Listener/Protocols/Tcp/PodeTcpRequestStrategy.cs
+++ b/src/Listener/Protocols/Tcp/PodeTcpRequestStrategy.cs
@@ -67,8 +67,13 @@ namespace Pode.Protocols.Tcp
             return Task.FromResult(true);
         }
 
-        public override void Reset()
+        public override void Reset(bool force = false)
         {
+            if (!force && !IsProcessable)
+            {
+                return;
+            }
+
             PodeHelpers.WriteErrorMessage($"Request reset", Handler.Context.Listener, PodeLoggingLevel.Verbose, Handler.Context);
             _body = string.Empty;
             RawBody = default;

--- a/src/Private/PodeServer.ps1
+++ b/src/Private/PodeServer.ps1
@@ -297,7 +297,6 @@ function Start-PodeWebServer {
 
                 # end do-while
             } while (Test-PodeSuspensionToken) # Check for suspension token and wait for the debugger to reset if active
-
         }
 
         # start the runspace for listening on x-number of threads

--- a/src/Public/Responses.ps1
+++ b/src/Public/Responses.ps1
@@ -1344,7 +1344,7 @@ function Set-PodeResponseStatus {
     )
 
     # already sent? skip
-    if ($WebEvent.Response.Sent) {
+    if (($null -eq $WebEvent) -or $WebEvent.Response.Sent) {
         return
     }
 


### PR DESCRIPTION
### Description of the Change
In the timeout callback handler, the CancellationToken and State were being set in the wrong order, meaning the token was cancelled and then the state set to "Timeout". This meant the request receiver could "finish processing" and attempt to pass empty requests through to Pode.

The lines have now been flipped, so State is observed appropriately. Additional old requests will now be reset, to clear out older data.

### Related Issue
* Resolves #1693 
* Resolves #1697 
