### PR TITLE
Move Docker images to .NET SDK images, on .NET10 and PowerShell 7.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM mcr.microsoft.com/powershell:7.5-ubuntu-24.04
+FROM mcr.microsoft.com/dotnet/sdk:10.0-resolute
 LABEL maintainer="Matthew Kelly (Badgerati)"
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
 RUN mkdir -p /usr/local/share/powershell/Modules/Pode
 COPY ./pkg/ /usr/local/share/powershell/Modules/Pode

--- a/arm32.dockerfile
+++ b/arm32.dockerfile
@@ -1,4 +1,5 @@
-FROM mcr.microsoft.com/powershell:7.5-ubuntu-22.04-arm32
+FROM mcr.microsoft.com/dotnet/sdk:10.0-resolute-arm32v7
 LABEL maintainer="Matthew Kelly (Badgerati)"
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
 RUN mkdir -p /usr/local/share/powershell/Modules/Pode
 COPY ./pkg/ /usr/local/share/powershell/Modules/Pode

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,5 +1,5 @@
-FROM mcr.microsoft.com/dotnet/sdk:10.0-alpine3.23
+FROM mcr.microsoft.com/dotnet/sdk:10.0-resolute
 LABEL maintainer="Matthew Kelly (Badgerati)"
 ENV POWERSHELL_TELEMETRY_OPTOUT=1
 RUN mkdir -p /usr/local/share/powershell/Modules/Pode
-COPY ./pkg/ /usr/local/share/powershell/Modules/Pode
+COPY ./src/ /usr/local/share/powershell/Modules/Pode

--- a/docs/Getting-Started/Installation.md
+++ b/docs/Getting-Started/Installation.md
@@ -41,7 +41,7 @@ Install-Module -Name Pode
 [![Docker](https://img.shields.io/docker/stars/badgerati/pode.svg?label=Stars)](https://hub.docker.com/r/badgerati/pode/)
 [![Docker](https://img.shields.io/docker/pulls/badgerati/pode.svg?label=Pulls)](https://hub.docker.com/r/badgerati/pode/)
 
-Pode can run on *nix environments, therefore it only makes sense for there to be Docker images for you to use! The images use the latest version of PowerShell v7.5 on either an Ubuntu Noble image (default), an Alpine image, or an ARM32 image (for Raspberry Pis).
+Pode can run on *nix environments, therefore it only makes sense for there to be Docker images for you to use! The images use the latest version of PowerShell v7.6 on either an Ubuntu Resolute image (default), an Alpine 3.23 image, or an ARM32 image (for Raspberry Pis).
 
 * To pull down the latest Pode image you can do:
 
@@ -50,7 +50,7 @@ Pode can run on *nix environments, therefore it only makes sense for there to be
 docker pull badgerati/pode:latest
 
 # or the following for a specific version:
-docker pull badgerati/pode:2.2.2
+docker pull badgerati/pode:2.13.2
 ```
 
 * To pull down the Alpine Pode image you can do:
@@ -60,7 +60,7 @@ docker pull badgerati/pode:2.2.2
 docker pull badgerati/pode:latest-alpine
 
 # or the following for a specific version:
-docker pull badgerati/pode:2.2.2-alpine
+docker pull badgerati/pode:2.13.2-alpine
 ```
 
 * To pull down the ARM32 Pode image you can do:
@@ -70,7 +70,7 @@ docker pull badgerati/pode:2.2.2-alpine
 docker pull badgerati/pode:latest-arm32
 
 # or the following for a specific version:
-docker pull badgerati/pode:2.2.2-arm32
+docker pull badgerati/pode:2.13.2-arm32
 ```
 
 Once pulled, you can [view here](../../Hosting/Docker) on how to use the image.
@@ -86,7 +86,7 @@ You can also get the Pode docker image from the GitHub Package Registry! The ima
 docker pull docker.pkg.github.com/badgerati/pode/pode:latest
 
 # or the following for a specific version:
-docker pull docker.pkg.github.com/badgerati/pode/pode:2.2.2
+docker pull docker.pkg.github.com/badgerati/pode/pode:2.13.2
 ```
 
 * To pull down the Alpine Pode image you can do:
@@ -96,7 +96,7 @@ docker pull docker.pkg.github.com/badgerati/pode/pode:2.2.2
 docker pull docker.pkg.github.com/badgerati/pode/pode:latest-alpine
 
 # or the following for a specific version:
-docker pull docker.pkg.github.com/badgerati/pode/pode:2.2.2-alpine
+docker pull docker.pkg.github.com/badgerati/pode/pode:2.13.2-alpine
 ```
 
 * To pull down the ARM32 Pode image you can do:
@@ -106,7 +106,7 @@ docker pull docker.pkg.github.com/badgerati/pode/pode:2.2.2-alpine
 docker pull docker.pkg.github.com/badgerati/pode/pode:latest-arm32
 
 # or the following for a specific version:
-docker pull docker.pkg.github.com/badgerati/pode/pode:2.2.2-arm32
+docker pull docker.pkg.github.com/badgerati/pode/pode:2.13.2-arm32
 ```
 
 Once pulled, you can [view here](../../Hosting/Docker) on how to use the image.

--- a/docs/Hosting/Docker.md
+++ b/docs/Hosting/Docker.md
@@ -2,7 +2,7 @@
 
 Pode has a Docker image that you can use to host your server, for instructions on pulling these images you can [look here](../../Installation).
 
-The images use PowerShell v7.5 on either an Ubuntu Noble (default), Alpine, or ARM32 image.
+The images use .NET SDK 10.0 with PowerShell v7.6 bundled, on either an Ubuntu Resolute (default), Alpine 3.23, or ARM32 image.
 
 ## Images
 
@@ -11,7 +11,7 @@ The images use PowerShell v7.5 on either an Ubuntu Noble (default), Alpine, or A
 
 ### Default
 
-The default Pode image is an Ubuntu Noble image with PowerShell v7.5 and Pode installed. An example of using this image in your Dockerfile could be as follows:
+The default Pode image is an Ubuntu Resolute image, and Pode installed. An example of using this image in your Dockerfile could be as follows:
 
 ```dockerfile
 # pull down the pode image
@@ -32,7 +32,7 @@ CMD [ "pwsh", "-c", "cd /usr/src/app; ./web-pages-docker.ps1" ]
 
 ### Alpine
 
-Pode also has an image for Alpine, an example of using this image in your Dockerfile could be as follows:
+Pode also has an image for Alpine 3.23, an example of using this image in your Dockerfile could be as follows:
 
 ```dockerfile
 # pull down the pode image

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -22,7 +22,7 @@ Sometimes there could be more, if patch releases are needed. But sometimes there
 
 ### Features
 
-- [ ] NTLM and/or Kerberos authentication - likely it's own module [#402](https://github.com/Badgerati/Pode/issues/402)
+- [x] NTLM and/or Kerberos authentication - [#402](https://github.com/Badgerati/Pode/issues/402)
 - [ ] More logging provider support - such as Azure, AWS, and Splunk. These could be baked into Pode or be standalone modules
 - [ ] Better support for a more "serverless" Pode feel via Docker, such as auto-loading routes from a folder
 - [ ] Starting Pode as a background job from CLI, instead of blocking [#553](https://github.com/Badgerati/Pode/issues/553)


### PR DESCRIPTION
### Description of the Change
Migrates the Docker images from `mcr.microsoft.com/powershell` to `mcr.microsoft.com/dotnet/sdk`.

PowerShell is now bundled with the .NET SDK images. The .NET10 SDK will come bundled with PowerShell 7.6