### PR TITLE
Adds -NoEnumerate switch for Get-PodeCache to avoid IEnumerable unwrapping behaviour

### DIFF
--- a/docs/Tutorials/Caching.md
+++ b/docs/Tutorials/Caching.md
@@ -44,6 +44,11 @@ Add-PodeRoute -Method Get -Path '/' -ScriptBlock {
 }
 ```
 
+!!! tip
+    If you cache an IEnumerable object, such as: Array, ArrayList, Queue, Stack, etc. PowerShell's default behaviour is to unwrap these, and if they are empty then `$null` will be returned.
+
+    To avoid this, and have Pode instead return the raw object, supply `-NoEnumerate` to `Get-PodeCache`. This doesn't work on `$cache:`, this will always unwrap, so you will need to use `Get-PodeCache` instead.
+
 You can test if an item exists in the cache, and isn't expired, using [`Test-PodeCache`](../../Functions/Caching/Test-PodeCache) - this is useful to call if the cached value for a key happens to genuinely be `$null`, so you can see if the key does exist.
 
 If you need to invalidate a cached value you can use [`Remove-PodeCache`](../../Functions/Caching/Remove-PodeCache), or if you need to invalidate the whole cache you can use [`Clear-PodeCache`](../../Functions/Caching/Clear-PodeCache).

--- a/src/Private/Caching.ps1
+++ b/src/Private/Caching.ps1
@@ -25,7 +25,7 @@ function Get-PodeCacheInternal {
     }
 
     # return just the value as default
-    return $meta.Value
+    return , $meta.Value
 }
 
 function Set-PodeCacheInternal {

--- a/src/Public/Caching.ps1
+++ b/src/Public/Caching.ps1
@@ -14,8 +14,8 @@ An optional cache Storage name. (Default: in-memory)
 .PARAMETER Metadata
 If supplied, and if supported by the cache storage, an metadata such as expiry times will also be returned.
 
-.PARAMETER Enumerate
-If supplied, and if the value returned from the cache is an IEnumerable, it will be unwrapped per normal PowerShell behaviour.
+.PARAMETER NoEnumerate
+If supplied, and if the value returned from the cache is an IEnumerable, it will not be unwrapped per normal PowerShell behaviour.
 
 .EXAMPLE
 $value = Get-PodeCache -Key 'ExampleKey'
@@ -25,6 +25,9 @@ $value = Get-PodeCache -Key 'ExampleKey' -Storage 'ExampleStorage'
 
 .EXAMPLE
 $value = Get-PodeCache -Key 'ExampleKey' -Metadata
+
+.EXAMPLE
+$value = Get-PodeCache -Key 'ExampleKey' -NoEnumerate
 
 .EXAMPLE
 $value = $cache:ExampleKey
@@ -45,7 +48,7 @@ function Get-PodeCache {
         $Metadata,
 
         [switch]
-        $Enumerate
+        $NoEnumerate
     )
 
     # inmem or custom storage?
@@ -57,22 +60,22 @@ function Get-PodeCache {
     if ([string]::IsNullOrEmpty($Storage)) {
         $item = Get-PodeCacheInternal -Key $Key -Metadata:$Metadata
 
-        if ($Enumerate) {
-            return $item
+        if ($NoEnumerate) {
+            return , $item
         }
 
-        return , $item
+        return $item
     }
 
     # used custom storage
     if (Test-PodeCacheStorage -Name $Storage) {
         $item = Invoke-PodeScriptBlock -ScriptBlock $PodeContext.Server.Cache.Storage[$Storage].Get -Arguments @($Key, $Metadata.IsPresent) -Splat -Return
 
-        if ($Enumerate) {
-            return $item
+        if ($NoEnumerate) {
+            return , $item
         }
 
-        return , $item
+        return $item
     }
 
     # storage not found!

--- a/src/Public/Caching.ps1
+++ b/src/Public/Caching.ps1
@@ -14,6 +14,9 @@ An optional cache Storage name. (Default: in-memory)
 .PARAMETER Metadata
 If supplied, and if supported by the cache storage, an metadata such as expiry times will also be returned.
 
+.PARAMETER Enumerate
+If supplied, and if the value returned from the cache is an IEnumerable, it will be unwrapped per normal PowerShell behaviour.
+
 .EXAMPLE
 $value = Get-PodeCache -Key 'ExampleKey'
 
@@ -28,6 +31,7 @@ $value = $cache:ExampleKey
 #>
 function Get-PodeCache {
     [CmdletBinding()]
+    [OutputType([object[]])]
     param(
         [Parameter(Mandatory = $true)]
         [string]
@@ -38,7 +42,10 @@ function Get-PodeCache {
         $Storage = $null,
 
         [switch]
-        $Metadata
+        $Metadata,
+
+        [switch]
+        $Enumerate
     )
 
     # inmem or custom storage?
@@ -48,12 +55,24 @@ function Get-PodeCache {
 
     # use inmem cache
     if ([string]::IsNullOrEmpty($Storage)) {
-        return (Get-PodeCacheInternal -Key $Key -Metadata:$Metadata)
+        $item = Get-PodeCacheInternal -Key $Key -Metadata:$Metadata
+
+        if ($Enumerate) {
+            return $item
+        }
+
+        return , $item
     }
 
     # used custom storage
     if (Test-PodeCacheStorage -Name $Storage) {
-        return (Invoke-PodeScriptBlock -ScriptBlock $PodeContext.Server.Cache.Storage[$Storage].Get -Arguments @($Key, $Metadata.IsPresent) -Splat -Return)
+        $item = Invoke-PodeScriptBlock -ScriptBlock $PodeContext.Server.Cache.Storage[$Storage].Get -Arguments @($Key, $Metadata.IsPresent) -Splat -Return
+
+        if ($Enumerate) {
+            return $item
+        }
+
+        return , $item
     }
 
     # storage not found!
@@ -75,7 +94,7 @@ The Key to be set.
 The value of the key to be set, can be any object type.
 
 .PARAMETER Ttl
-An optional TTL value, in seconds. The default is whatever "Get-PodeCacheDefaultTtl" retuns, which will be 3600 seconds when not set.
+An optional TTL value, in seconds. The default is whatever "Get-PodeCacheDefaultTtl" returns, which will be 3600 seconds when not set.
 
 .PARAMETER Storage
 An optional cache Storage name. (Default: in-memory)


### PR DESCRIPTION
### Description of the Change
There is a new `-NoEnumerate` switch on `Get-PodeCache`, which will return IEnumerable items as-is and not have PowerShell attempt to unwrap them - such as Array, ArrayList, Queue, etc.

### Related Issue
Resolves #1707

### Examples
```powershell
# create a queue object and cache it
$queue = [System.Collections.Queue]::new(10)
Set-PodeCache -Key 'Example' -InputObject $queue

# retrieve the raw queue object
$queue = Get-PodeCache -Key 'Example' -NoEnumerate
```
