### PR TITLE
Fixes a bug causing the server config to not be reloaded after the first server restart

### DIFF
--- a/src/Pode.psd1
+++ b/src/Pode.psd1
@@ -146,6 +146,8 @@
         'Use-PodeStream',
         'Use-PodeScript',
         'Get-PodeConfig',
+        'Test-PodeConfigEnabled',
+        'Get-PodeConfigPath',
         'Add-PodeEndware',
         'Use-PodeEndware',
         'Import-PodeModule',

--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -912,10 +912,14 @@ function Open-PodeConfiguration {
         return $config
     }
 
-    # where are we loading the config file from, server root or custom path?
+    # where are we loading the config file from, server root, custom path, or current directory?
     $configPath = $ServerRoot
     if (![string]::IsNullOrEmpty($ConfigFile)) {
         $configPath = Join-PodeServerRoot -Folder $ConfigFile -Root $ServerRoot
+    }
+
+    if ([string]::IsNullOrEmpty($configPath)) {
+        $configPath = $PWD.Path
     }
 
     # if path isn't a file, then we need to find the default config file in the folder

--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -217,20 +217,8 @@ function New-PodeContext {
         }
     }
 
-    # Load the server configuration based on the provided parameters.
-    # If $IgnoreServerConfig is set, an empty configuration (@{}) is assigned; otherwise, the configuration is loaded using Open-PodeConfiguration.
-    $ctx.Server.Configuration = if ($IgnoreServerConfig) { @{} }
-    else {
-        Open-PodeConfiguration -ServerRoot $ServerRoot -Context $ctx -ConfigFile $ConfigFile
-    }
-
-    # Set the 'Enabled' property of the server configuration.
-    # This is based on whether $IgnoreServerConfig is explicitly present (false if present, true otherwise).
-    $ctx.Server.Configuration.Enabled = ! $IgnoreServerConfig.IsPresent
-
-    # Assign the specified configuration file path (if any) to the 'ConfigFile' property of the server configuration.
-    # This allows tracking which configuration file was used, even if overridden.
-    $ctx.Server.Configuration.ConfigFile = $ConfigFile
+    # Load the server configuration based on the provided parameters
+    $ctx.Server.Configuration = Open-PodeConfiguration -ServerRoot $ServerRoot -Context $ctx -ConfigFile $ConfigFile -Ignore:$IgnoreServerConfig
 
     # over status page exceptions
     if (!(Test-PodeIsEmpty $StatusPageExceptions)) {
@@ -243,8 +231,8 @@ function New-PodeContext {
 
     # configure the server's root path
     $ctx.Server.Root = $ServerRoot
-    if (!(Test-PodeIsEmpty $ctx.Server.Configuration.Server.Root)) {
-        $ctx.Server.Root = Get-PodeRelativePath -Path $ctx.Server.Configuration.Server.Root -RootPath $ctx.Server.Root -JoinRoot -Resolve -TestPath
+    if (!(Test-PodeIsEmpty $ctx.Server.Configuration.Data.Server.Root)) {
+        $ctx.Server.Root = Get-PodeRelativePath -Path $ctx.Server.Configuration.Data.Server.Root -RootPath $ctx.Server.Root -JoinRoot -Resolve -TestPath
     }
 
     if (Test-PodeIsEmpty $ctx.Server.Root) {
@@ -875,28 +863,23 @@ function New-PodeStateContext {
         Server        = $Context.Server
     }
 }
+
 <#
 .SYNOPSIS
-    Opens and processes the Pode server configuration.
+Opens and processes the Pode server configuration.
 
 .DESCRIPTION
-    This function handles loading the Pode server configuration file. It supports custom configurations specified by environment variables,
-    a provided file path, or falls back to the default `server.psd1` file. The function sets the configuration for both the server and web contexts.
+This function handles loading the Pode server configuration file. It supports custom configurations specified by environment variables,
+a provided file path, or falls back to the default `server.psd1` file. The function sets the configuration for both the server and web contexts.
 
 .PARAMETER ServerRoot
-    Specifies the root directory of the server. Defaults to `$null` if not provided.
+Specifies the root directory of the server. Defaults to `$null` if not provided.
 
 .PARAMETER Context
-    Specifies the context to set configurations for Pode server and web.
+Specifies the context to set configurations for Pode server and web.
 
 .PARAMETER ConfigFile
-    Allows specifying a custom configuration file path. If provided, it overrides any other configuration file.
-
-.OUTPUTS
-    Hashtable representing the loaded configuration.
-
-.NOTES
-    This is an internal function and may change in future releases of Pode.
+Allows specifying a custom configuration file path. If provided, it overrides any other configuration file.
 #>
 function Open-PodeConfiguration {
     [CmdletBinding()]
@@ -911,38 +894,59 @@ function Open-PodeConfiguration {
 
         [Parameter()]
         [string]
-        $ConfigFile
+        $ConfigFile,
+
+        [switch]
+        $Ignore
     )
 
     # Initialize an empty configuration hashtable
-    $config = @{}
+    $config = @{
+        Enabled = !$Ignore.IsPresent
+        Path    = $null
+        Data    = @{}
+    }
 
-    # Set the path to the default root configuration file
-    $configPath = (Join-PodeServerRoot -Folder '.' -FilePath 'server.psd1' -Root $ServerRoot)
+    # return empty config if we're ignoring loading the config file
+    if ($Ignore) {
+        return $config
+    }
 
-    # Check for an environment-specific configuration file if the environment variable is set
-    if (!(Test-PodeIsEmpty $env:PODE_ENVIRONMENT)) {
-        $_path = (Join-PodeServerRoot -Folder '.' -FilePath "server.$($env:PODE_ENVIRONMENT).psd1" -Root $ServerRoot)
-        if (Test-PodePath -Path $_path -NoStatus) {
-            $configPath = $_path
+    # where are we loading the config file from, server root or custom path?
+    $configPath = $ServerRoot
+    if (![string]::IsNullOrEmpty($ConfigFile)) {
+        $configPath = Join-PodeServerRoot -Folder $ConfigFile -Root $ServerRoot
+    }
+
+    # if path isn't a file, then we need to find the default config file in the folder
+    if (!(Test-Path -Path $configPath -PathType Leaf)) {
+        $tmpPath = [System.IO.Path]::Combine($configPath, 'server.psd1')
+
+        if (![string]::IsNullOrEmpty($env:PODE_ENVIRONMENT)) {
+            $tmpEnvPath = [System.IO.Path]::Combine($configPath, "server.$($env:PODE_ENVIRONMENT).psd1")
+            if (Test-Path -Path $tmpEnvPath) {
+                $tmpPath = $tmpEnvPath
+            }
         }
+
+        $configPath = $tmpPath
     }
 
-    # Override the configuration path if a valid ConfigFile parameter is provided
-    if (!([string]::IsNullOrEmpty($ConfigFile))) {
-        #-and (Test-Path -Path $ConfigFile -PathType Leaf)) {
-        $configPath = Get-PodeRelativePath -Path $ConfigFile -JoinRoot -Resolve -RootPath $ServerRoot -TestPath
+    # ensure the path exists, if not disabled config and return
+    if (!(Test-Path -Path $configPath)) {
+        $config.Enabled = $false
+        return $config
     }
 
-    # check the path exists, and load the config
-    if (Test-PodePath -Path $configPath -NoStatus) {
-        # Import the configuration from the file
-        $config = Import-PowerShellDataFile -Path $configPath -ErrorAction Stop
+    # set the config path
+    $config.Path = $configPath
 
-        # Set the server and web configurations in the provided context
-        Set-PodeServerConfiguration -Configuration $config.Server -Context $Context
-        Set-PodeWebConfiguration -Configuration $config.Web -Context $Context
-    }
+    # Import the configuration from the file
+    $config.Data = Import-PowerShellDataFile -Path $configPath -ErrorAction Stop
+
+    # Set the server and web configurations in the provided context
+    Set-PodeServerConfiguration -Configuration $config.Data.Server -Context $Context
+    Set-PodeWebConfiguration -Configuration $config.Data.Web -Context $Context
 
     # Return the loaded configuration
     return $config
@@ -1079,8 +1083,6 @@ function Set-PodeServerConfiguration {
             Metrics   = Protect-PodeValue -Value $Configuration.Console.KeyBindings.Metrics -Default $Context.Server.Console.KeyBindings.Metrics -EnumType ([type][System.ConsoleKey])
         }
     }
-
-
 }
 
 function Set-PodeWebConfiguration {

--- a/src/Private/Events.ps1
+++ b/src/Private/Events.ps1
@@ -14,7 +14,8 @@ function Invoke-PodeEvent {
     $strType = $Type.ToString()
 
     # do nothing if no events
-    if ((Test-PodeIsEmpty $PodeContext.Server.Events) -or
+    if (($null -eq $PodeContext.Server.Events) -or
+        ($PodeContext.Server.Events.Count -eq 0) -or
         !$PodeContext.Server.Events.ContainsKey($strType) -or
         $PodeContext.Server.Events[$strType].Count -eq 0) {
         return

--- a/src/Private/Events.ps1
+++ b/src/Private/Events.ps1
@@ -14,7 +14,8 @@ function Invoke-PodeEvent {
     $strType = $Type.ToString()
 
     # do nothing if no events
-    if (!$PodeContext.Server.Events.ContainsKey($strType) -or
+    if ((Test-PodeIsEmpty $PodeContext.Server.Events) -or
+        !$PodeContext.Server.Events.ContainsKey($strType) -or
         $PodeContext.Server.Events[$strType].Count -eq 0) {
         return
     }

--- a/src/Private/Secrets.ps1
+++ b/src/Private/Secrets.ps1
@@ -220,7 +220,7 @@ function Unlock-PodeSecretCustomVault {
         # unlock the vault, and get back an expiry
         $expiry = Invoke-PodeScriptBlock -ScriptBlock $VaultConfig.Custom.Unlock -Splat -Return -Arguments @(
             $VaultConfig.Parameters,
-        (ConvertFrom-SecureString -SecureString $VaultConfig.Unlock.Secret -AsPlainText)
+            (ConvertFrom-SecureString -SecureString $VaultConfig.Unlock.Secret -AsPlainText)
         )
 
         # return expiry if given, otherwise check interval
@@ -510,7 +510,7 @@ function Unregister-PodeSecretVaultsInternal {
         return
     }
 
-    # Iterate through each vault and attempt unregistration
+    # Iterate through each vault and attempt to unregister it
     foreach ($vault in $PodeContext.Server.Secrets.Vaults.Values.Name) {
         if ([string]::IsNullOrEmpty($vault)) {
             continue
@@ -550,12 +550,12 @@ function Protect-PodeSecretValueType {
     }
 
     if (!(
-         ($Value -is [string]) -or
-         ($Value -is [securestring]) -or
-         ($Value -is [hashtable]) -or
-         ($Value -is [byte[]]) -or
-         ($Value -is [pscredential]) -or
-         ($Value -is [System.Management.Automation.OrderedHashtable])
+            ($Value -is [string]) -or
+            ($Value -is [securestring]) -or
+            ($Value -is [hashtable]) -or
+            ($Value -is [byte[]]) -or
+            ($Value -is [pscredential]) -or
+            ($Value -is [System.Management.Automation.OrderedHashtable])
         )) {
         throw ($PodeLocale.invalidSecretValueTypeExceptionMessage -f $Value.GetType().Name) #"Value to set secret to is of an invalid type. Expected either String, SecureString, HashTable, Byte[], or PSCredential. But got: $($Value.GetType().Name)"
     }

--- a/src/Private/Server.ps1
+++ b/src/Private/Server.ps1
@@ -297,7 +297,7 @@ function Restart-PodeInternalServer {
         $PodeContext.Server.EndpointsMap.Clear()
 
         # clear openapi
-        $PodeContext.Server.OpenAPI = Initialize-PodeOpenApiTable -DefaultDefinitionTag $PodeContext.Server.Configuration.Web.OpenApi.DefaultDefinitionTag
+        $PodeContext.Server.OpenAPI = Initialize-PodeOpenApiTable -DefaultDefinitionTag $PodeContext.Server.Configuration.Data.Web.OpenApi.DefaultDefinitionTag
 
         # clear the sockets
         $PodeContext.Server.Http.Listener = $null
@@ -356,10 +356,9 @@ function Restart-PodeInternalServer {
         # recreate the session tokens
         Reset-PodeCancellationToken -Type Cancellation, Restart, Suspend, Resume, Terminate, Disable
 
-        # if the configuration is enable reload it
+        # if the configuration is enabled reload it
         if ($PodeContext.Server.Configuration.Enabled) {
-            # reload the configuration
-            $PodeContext.Server.Configuration = Open-PodeConfiguration -Context $PodeContext -ConfigFile $PodeContext.Server.Configuration.ConfigFile
+            $PodeContext.Server.Configuration = Open-PodeConfiguration -Context $PodeContext -ConfigFile $PodeContext.Server.Configuration.Path
         }
 
         # restart the server

--- a/src/Public/Core.ps1
+++ b/src/Public/Core.ps1
@@ -217,8 +217,11 @@ function Start-PodeServer {
     end {
         if ($pipelineItemCount -gt 1) {
             throw ($PodeLocale.fnDoesNotAcceptArrayAsPipelineInputExceptionMessage -f $($MyInvocation.MyCommand.Name))
-        }    # Store the name of the current runspace
+        }
+
+        # Store the name of the current runspace
         $previousRunspaceName = Get-PodeCurrentRunspaceName
+
         # Sets the name of the current runspace
         Set-PodeCurrentRunspaceName -Name 'PodeServer'
 

--- a/src/Public/Utilities.ps1
+++ b/src/Public/Utilities.ps1
@@ -233,7 +233,43 @@ function Get-PodeConfig {
     [OutputType([hashtable])]
     param()
 
-    return $PodeContext.Server.Configuration
+    return $PodeContext.Server.Configuration.Data
+}
+
+<#
+.SYNOPSIS
+Returns whether the loading of a server configuration file is enabled or not.
+
+.DESCRIPTION
+Returns whether the loading of a server configuration file is enabled or not.
+
+.EXAMPLE
+if (Test-PodeConfigEnabled) { /* logic */ }
+#>
+function Test-PodeConfigEnabled {
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param()
+
+    return [bool]$PodeContext.Server.Configuration.Enabled
+}
+
+<#
+.SYNOPSIS
+Returns the path of the loaded server configuration file.
+
+.DESCRIPTION
+Returns the path of the loaded server configuration file.
+
+.EXAMPLE
+$configPath = Get-PodeConfigPath
+#>
+function Get-PodeConfigPath {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param()
+
+    return $PodeContext.Server.Configuration.Path
 }
 
 <#

--- a/tests/unit/Context.Tests.ps1
+++ b/tests/unit/Context.Tests.ps1
@@ -9,7 +9,12 @@ InModuleScope -ModuleName 'Pode' {
     Describe 'Get-PodeConfig' {
         It 'Returns JSON config' {
             $json = '{ "settings": { "port": 90 } }'
-            $PodeContext.Server = @{ 'Configuration' = ($json | ConvertFrom-Json) }
+            $PodeContext.Server = @{
+                Configuration = @{
+                    Data = ($json | ConvertFrom-Json)
+                }
+            }
+
             $config = Get-PodeConfig
             $config | Should -Not -Be $null
             $config.settings.port | Should -Be 90

--- a/tests/unit/Server.Tests.ps1
+++ b/tests/unit/Server.Tests.ps1
@@ -154,7 +154,13 @@ InModuleScope -ModuleName 'Pode' {
                     Output          = @{
                         Variables = @{ 'key' = 'value' }
                     }
-                    Configuration   = @{ Enabled = $false; Server = @{'key' = 'value' } }
+                    Configuration   = @{
+                        Enabled = $false
+                        Path    = 'server.psd1'
+                        Data    = @{
+                            Server = @{'key' = 'value' }
+                        }
+                    }
                     Sockets         = @{
                         Listeners = @()
                         Queues    = @{
@@ -283,9 +289,10 @@ InModuleScope -ModuleName 'Pode' {
             $PodeContext.Server.Sessions.Count | Should -Be 0
             $PodeContext.Server.Authentications.Methods.Count | Should -Be 0
             $PodeContext.Server.State.Count | Should -Be 0
-            $PodeContext.Server.Configuration.Count | Should -Be 2
+            $PodeContext.Server.Configuration.Count | Should -Be 3
+            $PodeContext.Server.Configuration.Data.Count | Should -Be 1
             $PodeContext.Server.Configuration.Enabled | Should -BeFalse
-            $PodeContext.Server.Configuration.Server.Key | Should -Be 'value'
+            $PodeContext.Server.Configuration.Data.Server.Key | Should -Be 'value'
 
             $PodeContext.Timers.Items.Count | Should -Be 0
             $PodeContext.Schedules.Items.Count | Should -Be 0


### PR DESCRIPTION
### Description of the Change
Cleans up the server configuration loading logic in `Open-PodeConfiguration`, and fixes a bug in `Restart-PodeInternalServer` where the config wouldn't be reloaded after the first server restart.

Also adds two new helper functions:
* `Get-PodeConfigPath`
* `Test-PodeConfigEnabled`

### Related Issue
Resolves #1578