### PR TITLE
Fixes an Empty Parameter issue for Merged Authentication

### DIFF
--- a/docs/Tutorials/Authentication/Overview.md
+++ b/docs/Tutorials/Authentication/Overview.md
@@ -430,9 +430,9 @@ Various metadata which triggered the Authentication event is supplied to your sc
 !!! info
     When registering an event against a standard `Add-PodeAuth` method, the `Name` property in `$TriggeredEvent` will always be the name of that Authentication Method.
 
-    However, in the case of `Merge-PodeAuth` methods, the event will be triggered for the child Authentication Method which caused the event to be successful; it will then also be called for each "merge" parent of that child Authentication method.
+    However, in the case of `Merge-PodeAuth` methods, the event will be triggered for the child Authentication Method which caused the event to be successful in the ase of `Valid=OR`, or it will be triggered for just the merged Authentication in the case of `Valid=AND`; it will then also be called for each "merge" parent of that child Authentication method.
 
-    For example, if you have two Authentication methods: "Basic" and "API", and then you merge this into one "OR" Authentication method "MergedAuth", then if "API" caused the Login event to be successful the event will be triggered for "API" but then also for "MergedAuth" (assuming any event registrations exist).
+    For example, in the case of `Valid=OR`: if you have two Authentication methods "Basic" and "API", and then you merge this into one "OR" Authentication method "MergedAuth", then if "API" caused the Login event to be successful the event will be triggered for "API" but then also for "MergedAuth" (assuming any event registrations exist).
 
 ### Unregister
 

--- a/docs/Tutorials/Authentication/Overview.md
+++ b/docs/Tutorials/Authentication/Overview.md
@@ -430,9 +430,9 @@ Various metadata which triggered the Authentication event is supplied to your sc
 !!! info
     When registering an event against a standard `Add-PodeAuth` method, the `Name` property in `$TriggeredEvent` will always be the name of that Authentication Method.
 
-    However, in the case of `Merge-PodeAuth` methods, the event will be triggered for the child Authentication Method which caused the event to be successful in the ase of `Valid=OR`, or it will be triggered for just the merged Authentication in the case of `Valid=AND`; it will then also be called for each "merge" parent of that child Authentication method.
+    However, in the case of `Merge-PodeAuth` methods, the event will be triggered for the child Authentication Method which caused the event to be successful in the ase of `Valid=One`, or it will be triggered for just the merged Authentication in the case of `Valid=All`. It will then also be called for each "merge" parent of that Authentication method.
 
-    For example, in the case of `Valid=OR`: if you have two Authentication methods "Basic" and "API", and then you merge this into one "OR" Authentication method "MergedAuth", then if "API" caused the Login event to be successful the event will be triggered for "API" but then also for "MergedAuth" (assuming any event registrations exist).
+    For example, in the case of `Valid=One`: if you have two Authentication methods "Basic" and "API", and then you merge this into one "OR" Authentication method "MergedAuth", then if "API" caused the Login event to be successful the event will be triggered for "API" but then also for "MergedAuth" (assuming any event registrations exist).
 
 ### Unregister
 

--- a/examples/Web-AuthMerged.ps1
+++ b/examples/Web-AuthMerged.ps1
@@ -14,11 +14,11 @@
         Invoke-RestMethod -Method Get -Uri 'http://localhost:8081/users' -Headers @{ 'X-API-KEY' = 'test-api-key'; Authorization = 'Basic bW9ydHk6cGlja2xl' }
 
     Failure:
-        Invoke-RestMethod -Method Get -Uri 'http://localhost:8081/users' -Headers @{ 'X-API-KEY' = 'test-api-key'; Authorization = 'Basic bW9ydHk6cmljaw=='
+        Invoke-RestMethod -Method Get -Uri 'http://localhost:8081/users' -Headers @{ 'X-API-KEY' = 'test-api-key'; Authorization = 'Basic bW9ydHk6cmljaw==' }
 
 .LINK
     https://github.com/Badgerati/Pode/blob/develop/examples/Web-AuthMerged.ps1
-    
+
 .NOTES
     Author: Pode Team
     License: MIT License

--- a/src/Private/Authentication.ps1
+++ b/src/Private/Authentication.ps1
@@ -1504,6 +1504,7 @@ function Test-PodeAuthInternal {
     }
 
     # trigger successful auth event
+    $WebEvent.Auth | Out-Default
     Invoke-PodeAuthEvent -Name $WebEvent.Auth.Name -Type Login -User $WebEvent.Auth.User
 
     # set the status to success
@@ -2396,7 +2397,7 @@ function Invoke-PodeAuthEvent {
     param(
         [Parameter(Mandatory = $true)]
         [string]
-        $Name, # Name of the Auth method connection
+        $Name,
 
         [Parameter(Mandatory = $true)]
         [ValidateSet('Login', 'Logout')]
@@ -2420,7 +2421,7 @@ function Invoke-PodeAuthEvent {
     $auth = $PodeContext.Server.Authentications.Methods[$Name]
 
     # if this is a merged auth, then we need to also attempt to invoke events for the parent auths
-    if ($auth.Merged) {
+    if ($auth.Merged -and ![string]::IsNullOrEmpty($auth.Parent)) {
         Invoke-PodeAuthEvent -Name $auth.Parent -Type $Type -User $User -ArgumentList $ArgumentList
     }
 

--- a/src/Private/Authentication.ps1
+++ b/src/Private/Authentication.ps1
@@ -1504,7 +1504,6 @@ function Test-PodeAuthInternal {
     }
 
     # trigger successful auth event
-    $WebEvent.Auth | Out-Default
     Invoke-PodeAuthEvent -Name $WebEvent.Auth.Name -Type Login -User $WebEvent.Auth.User
 
     # set the status to success


### PR DESCRIPTION
### Description of the Change
When you have a Merged Authentication, using `Valid=And`, the following error would be thrown:

```
Cannot bind argument to parameter 'Name' because it is an empty string
```

This is caused by an erroneous check on a Merged Auths "parent", and not checking it exists first.