### PR TITLE
Ensure connections are closed appropriately on IO and Socket Exceptions

### DIFF
--- a/examples/IIS-Example.ps1
+++ b/examples/IIS-Example.ps1
@@ -10,7 +10,6 @@
 .EXAMPLE
     To run the sample: ./IIS-Example.ps1
 
-
     Invoke-RestMethod -Uri http://localhost:8081 -Method Get
 
     Invoke-RestMethod -Uri http://localhost:8081/run-task -Method Get
@@ -43,11 +42,13 @@ catch { throw }
 
 # create a server, and start listening on port 8081
 Start-PodeServer {
-
-    # listen on localhost:8081
+    # listen on localhost:8081 or HTTP_PLATFORM_PORT for httpPlatformHandler
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http
-    New-PodeLoggingMethod -Terminal | Enable-PodeRequestLogging
-    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+    # Add-PodeEndpoint -Address localhost -Port $env:HTTP_PLATFORM_PORT -Protocol Http
+
+    # enable logging to file
+    New-PodeLoggingMethod -File -Name 'requests' | Enable-PodeRequestLogging
+    New-PodeLoggingMethod -File -Name 'errors' | Enable-PodeErrorLogging
 
     # Add-PodeLimitAccessRule -Name 'DenyLocal' -Action Deny -Component @(
     #     New-PodeLimitIPComponent -IP localhost -Location XForwardedFor

--- a/examples/web.config
+++ b/examples/web.config
@@ -1,8 +1,11 @@
-<configuration>
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ASP.NET CORE CONFIG -->
+<!-- <configuration>
   <location path="." inheritInChildApplications="false">
     <system.webServer>
       <handlers>
         <remove name="WebDAV" />
+        <remove name="httpPlatformHandler" />
         <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModuleV2" resourceType="Unspecified" />
         <remove name="ExtensionlessUrlHandler-Integrated-4.0" />
         <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" />
@@ -14,7 +17,12 @@
         <remove name="WebDAVModule" />
       </modules>
 
-      <aspNetCore processPath="pwsh.exe" arguments=".\IIS-Example.ps1" stdoutLogEnabled="true" stdoutLogFile=".\logs\stdout" hostingModel="OutOfProcess"/>
+      <aspNetCore
+        processPath="C:\tools\pwsh\pwsh.exe"
+        arguments=".\IIS-Example.ps1"
+        stdoutLogEnabled="true"
+        stdoutLogFile=".\logs\stdout"
+        hostingModel="OutOfProcess" />
 
       <security>
         <authorization>
@@ -24,4 +32,31 @@
       </security>
     </system.webServer>
   </location>
+</configuration> -->
+
+<!-- HTTP_PLATFORM_HANDLER CONFIG -->
+<configuration>
+  <system.webServer>
+    <handlers>
+      <remove name="WebDAV" />
+      <remove name="aspNetCore" />
+      <add name="httpPlatformHandler" path="*" verb="*" modules="httpPlatformHandler" resourceType="Unspecified" />
+    </handlers>
+
+    <httpPlatform
+      processPath="C:\tools\pwsh\pwsh.exe"
+      arguments="-NoProfile -ExecutionPolicy Bypass -File &quot;.\IIS-Example.ps1&quot;"
+      forwardWindowsAuthToken="false"
+      stdoutLogEnabled="true"
+      stdoutLogFile=".\logs\stdout"
+      startupTimeLimit="60" >
+
+      <environmentVariables>
+        <environmentVariable name="PODE_HOST" value="IIS" />
+      </environmentVariables>
+
+    </httpPlatform>
+
+    <httpErrors existingResponse="PassThrough" />
+  </system.webServer>
 </configuration>

--- a/src/Listener/Protocols/Common/Requests/PodeRequestHandler.cs
+++ b/src/Listener/Protocols/Common/Requests/PodeRequestHandler.cs
@@ -298,13 +298,6 @@ namespace Pode.Protocols.Common.Requests
             {
                 PodeHelpers.WriteException(ex, Context.Listener, PodeLoggingLevel.Verbose);
             }
-            catch (IOException ex)
-            {
-                if (Context.Listener.IsConnected)
-                {
-                    PodeHelpers.WriteException(ex, Context.Listener, PodeLoggingLevel.Debug);
-                }
-            }
             catch (ObjectDisposedException ex)
             {
                 if (Context.Listener.IsConnected)
@@ -316,26 +309,32 @@ namespace Pode.Protocols.Common.Requests
             {
                 if (Context.Listener.IsConnected)
                 {
-                    PodeHelpers.WriteException(ex, Context.Listener, PodeLoggingLevel.Error);
                     Error = Strategy.CreateException(ex, PodeRequestStatusType.ServerError);
                 }
             }
             catch (PodeRequestException ex)
             {
-                PodeHelpers.WriteException(ex, Context.Listener, PodeLoggingLevel.Error);
                 Error = ex;
+            }
+            catch (Exception ex) when (ex is IOException || ex is ObjectDisposedException)
+            {
+                // let the calling method handle these exceptions
+                throw;
             }
             catch (Exception ex)
             {
-                PodeHelpers.WriteException(ex, Context.Listener, PodeLoggingLevel.Error);
-                Error = Strategy.CreateException(ex, PodeRequestStatusType.ServerError);
+                // unexpected exception, log and return a generic error response
+                if (Context.Listener.IsConnected)
+                {
+                    Error = Strategy.CreateException(ex, PodeRequestStatusType.ServerError);
+                }
             }
             finally
             {
                 PartialDispose();
             }
 
-            return false;
+            return true;
         }
 
         /// <summary>


### PR DESCRIPTION
### Description of the Change
When IO or Socket Exceptions are thrown, the underlying connection wasn't being appropriately closed; this led to the request replaying endlessly.

### Related Issue
Resolves #1717 