### PR TITLE
Log Methods are now their own functions; Log Methods now run in their own Runspaces; Log Events are now thread-safe; Log Types now support multiple Log Methods; Custom Log Types now support -Raw item pass-thru; Backend .NET logs now utilise Pode's logging functionality

### DIFF
--- a/docs/Tutorials/Logging/Methods/Custom.md
+++ b/docs/Tutorials/Logging/Methods/Custom.md
@@ -31,5 +31,5 @@ $s3_logging = New-PodeLogCustomType -ArgumentList $s3_options -ScriptBlock {
         -SecretKey $s3_opts.SecretKey
 }
 
-$s3_logging | Enable-PodeRequestLogging
+$s3_logging | Enable-PodeRequestLogType
 ```

--- a/docs/Tutorials/Logging/Methods/Custom.md
+++ b/docs/Tutorials/Logging/Methods/Custom.md
@@ -1,19 +1,19 @@
 # Custom
 
-Sometimes you don't want to log to a file, or the terminal; instead you want to log to something better, like LogStash, Splunk, Athena, or any other central logging platform. Although Pode doesn't have these inbuilt (yet!) it is possible to create a custom logging method, where you define a ScriptBlock with logic to send logs to these platforms.
+Sometimes you don't want to log to a file, or the terminal; instead you want to log to different provider, like LogStash, Splunk, Athena, or any other central logging platform. Although Pode doesn't have these inbuilt (yet!) it is possible to create a custom logging Method, where you define a ScriptBlock with logic to send logs to these platforms. To do this you can use [`New-PodeLogCustomMethod`](../../../../Functions/Logging/New-PodeLogCustomMethod).
 
-These custom method can be used for any log type - Requests, Error, or Custom.
+These custom Methods can be used for any log Type - Requests, Error, or Custom Types.
 
 The ScriptBlock you create will be supplied two arguments:
 
-1. The item to be logged. This could be a string (from Requests/Errors), or any custom type.
-2. The options you supplied on [`New-PodeLoggingMethod`](../../../../Functions/Logging/New-PodeLoggingMethod).
+1. The transformed log item to be logged. This could be a string (from Requests/Errors), or any custom type.
+2. The options you supplied on [`New-PodeLogCustomMethod`](../../../../Functions/Logging/New-PodeLogCustomMethod).
 
 ## Examples
 
 ### Send to S3 Bucket
 
-This example will take whatever item is supplied to it, convert it to a string, and then send it off to some S3 bucket in AWS. In this case, it will be logging Requests:
+This example will take whatever transformed log item is supplied to it, convert it to a string, and then send it off to some S3 bucket in AWS. In this case, it will be logging Requests:
 
 ```powershell
 $s3_options = @{
@@ -21,7 +21,7 @@ $s3_options = @{
     SecretKey = $SecretKey
 }
 
-$s3_logging = New-PodeLoggingType -Custom -ArgumentList $s3_options -ScriptBlock {
+$s3_logging = New-PodeLogCustomType -ArgumentList $s3_options -ScriptBlock {
     param($item, $s3_opts)
 
     Write-S3Object `

--- a/docs/Tutorials/Logging/Methods/Custom.md
+++ b/docs/Tutorials/Logging/Methods/Custom.md
@@ -2,6 +2,9 @@
 
 Sometimes you don't want to log to a file, or the terminal; instead you want to log to different provider, like LogStash, Splunk, Athena, or any other central logging platform. Although Pode doesn't have these inbuilt (yet!) it is possible to create a custom logging Method, where you define a ScriptBlock with logic to send logs to these platforms. To do this you can use [`New-PodeLogCustomMethod`](../../../../Functions/Logging/New-PodeLogCustomMethod).
 
+!!! important
+    The `New-PodeLoggingMethod` function is now deprecated, please use [`New-PodeLogCustomMethod`](../../../../Functions/Logging/New-PodeLogCustomMethod) instead.
+
 These custom Methods can be used for any log Type - Requests, Error, or Custom Types.
 
 The ScriptBlock you create will be supplied two arguments:

--- a/docs/Tutorials/Logging/Methods/EventViewer.md
+++ b/docs/Tutorials/Logging/Methods/EventViewer.md
@@ -1,6 +1,6 @@
 # Event Viewer
 
-You can log items to the Windows Event Viewer, using Pode's unbuilt Event Viewer logging Method, via [`New-PodeLogEventViewerMethod`](../../../../Functions/Logging/New-PodeLogEventViewerMethod). You can log anything, but it's best to use this in conjunction with [`Enable-PodeErrorLogging`](../../../../Functions/Logging/Enable-PodeErrorLogging) and [`Write-PodeErrorLog`](../../../../Functions/Logging/Write-PodeErrorLog).
+You can log items to the Windows Event Viewer, using Pode's unbuilt Event Viewer logging Method, via [`New-PodeLogEventViewerMethod`](../../../../Functions/Logging/New-PodeLogEventViewerMethod). You can log anything, but it's best to use this in conjunction with [`Enable-PodeErrorLogType`](../../../../Functions/Logging/Enable-PodeErrorLogType) and [`Write-PodeErrorLog`](../../../../Functions/Logging/Write-PodeErrorLog).
 
 !!! note
     Errors will be logged using an appropriate error level, but other log items will be logged as Informational.
@@ -23,7 +23,7 @@ Once the source is created, Pode can log to the Event Viewer without being an ad
 To enable and log errors to the Event Viewer, the following will work:
 
 ```powershell
-New-PodeLogEventViewerMethod | Enable-PodeErrorLogging
+New-PodeLogEventViewerMethod | Enable-PodeErrorLogType
 ```
 
 This will log to the `Application` log using `Pode` as the source.
@@ -33,7 +33,7 @@ This will log to the `Application` log using `Pode` as the source.
 To log to a different event log, other than Application, you can specify the log via `-EventLogName`:
 
 ```powershell
-New-PodeLogEventViewerMethod -EventLogName SomeLogName | Enable-PodeErrorLogging
+New-PodeLogEventViewerMethod -EventLogName SomeLogName | Enable-PodeErrorLogType
 ```
 
 ## Event Source
@@ -41,5 +41,5 @@ New-PodeLogEventViewerMethod -EventLogName SomeLogName | Enable-PodeErrorLogging
 To log using a different source, other than Pode, you can specify the source via `-Source`:
 
 ```powershell
-New-PodeLogEventViewerMethod -Source WebsiteName | Enable-PodeErrorLogging
+New-PodeLogEventViewerMethod -Source WebsiteName | Enable-PodeErrorLogType
 ```

--- a/docs/Tutorials/Logging/Methods/EventViewer.md
+++ b/docs/Tutorials/Logging/Methods/EventViewer.md
@@ -1,10 +1,12 @@
 # Event Viewer
 
-You can log items to the Windows Event Viewer, using Pode's unbuilt Event Viewer logging logic. You can log anything, but it's best to use this in conjunction with [`Enable-PodeErrorLogging`](../../../../Functions/Logging/Enable-PodeErrorLogging) and [`Write-PodeErrorLog`](../../../../Functions/Logging/Write-PodeErrorLog).
+You can log items to the Windows Event Viewer, using Pode's unbuilt Event Viewer logging Method, via [`New-PodeLogEventViewerMethod`](../../../../Functions/Logging/New-PodeLogEventViewerMethod). You can log anything, but it's best to use this in conjunction with [`Enable-PodeErrorLogging`](../../../../Functions/Logging/Enable-PodeErrorLogging) and [`Write-PodeErrorLog`](../../../../Functions/Logging/Write-PodeErrorLog).
 
-Errors will be logged using an appropriate error level, but other log items will be logged as Informational by default.
+!!! note
+    Errors will be logged using an appropriate error level, but other log items will be logged as Informational.
 
-By default, Pode will log to the Application log with a source of Pode, and an Event ID of 0.
+!!! important
+    By default, Pode will log to the Application log with a source of Pode, and an Event ID of 0.
 
 ## Usage
 
@@ -21,7 +23,7 @@ Once the source is created, Pode can log to the Event Viewer without being an ad
 To enable and log errors to the Event Viewer, the following will work:
 
 ```powershell
-New-PodeLoggingMethod -EventViewer | Enable-PodeErrorLogging
+New-PodeLogEventViewerMethod | Enable-PodeErrorLogging
 ```
 
 This will log to the `Application` log using `Pode` as the source.
@@ -31,7 +33,7 @@ This will log to the `Application` log using `Pode` as the source.
 To log to a different event log, other than Application, you can specify the log via `-EventLogName`:
 
 ```powershell
-New-PodeLoggingMethod -EventViewer -EventLogName SomeLogName | Enable-PodeErrorLogging
+New-PodeLogEventViewerMethod -EventLogName SomeLogName | Enable-PodeErrorLogging
 ```
 
 ## Event Source
@@ -39,5 +41,5 @@ New-PodeLoggingMethod -EventViewer -EventLogName SomeLogName | Enable-PodeErrorL
 To log using a different source, other than Pode, you can specify the source via `-Source`:
 
 ```powershell
-New-PodeLoggingMethod -EventViewer -Source WebsiteName | Enable-PodeErrorLogging
+New-PodeLogEventViewerMethod -Source WebsiteName | Enable-PodeErrorLogging
 ```

--- a/docs/Tutorials/Logging/Methods/EventViewer.md
+++ b/docs/Tutorials/Logging/Methods/EventViewer.md
@@ -8,6 +8,9 @@ You can log items to the Windows Event Viewer, using Pode's unbuilt Event Viewer
 !!! important
     By default, Pode will log to the Application log with a source of Pode, and an Event ID of 0.
 
+!!! important
+    The `New-PodeLoggingMethod` function is now deprecated, please use [`New-PodeLogEventViewerMethod`](../../../../Functions/Logging/New-PodeLogEventViewerMethod) instead.
+
 ## Usage
 
 When using this log method, Pode will first check if the source exists, and will then attempt to create it. To do this, you will need to be running Pode as an administrator.

--- a/docs/Tutorials/Logging/Methods/File.md
+++ b/docs/Tutorials/Logging/Methods/File.md
@@ -14,7 +14,7 @@ By default, Pode will store all log files in a `./logs` directory at the root of
 The following example will setup the file logging Method for logging Requests:
 
 ```powershell
-New-PodeLogFileMethod -Name 'requests' | Enable-PodeRequestLogging
+New-PodeLogFileMethod -Name 'requests' | Enable-PodeRequestLogType
 ```
 
 ### Maximum Days
@@ -22,7 +22,7 @@ New-PodeLogFileMethod -Name 'requests' | Enable-PodeRequestLogging
 The following example will configure file logging to only keep a maximum number of days of logs. Ie, if you set `-MaxDays` to 4, then Pode will only store the last 4 days worth of logs.
 
 ```powershell
-New-PodeLogFileMethod -Name 'requests' -MaxDays 4 | Enable-PodeRequestLogging
+New-PodeLogFileMethod -Name 'requests' -MaxDays 4 | Enable-PodeRequestLogType
 ```
 
 ### Maximum Size
@@ -32,7 +32,7 @@ The following example will configure file logging to keep logging to a file unti
 In this example, the maximum size it limited to 10MB:
 
 ```powershell
-New-PodeLogFileMethod -Name 'requests' -MaxSize 10MB | Enable-PodeRequestLogging
+New-PodeLogFileMethod -Name 'requests' -MaxSize 10MB | Enable-PodeRequestLogType
 ```
 
 ### Custom Path
@@ -40,5 +40,5 @@ New-PodeLogFileMethod -Name 'requests' -MaxSize 10MB | Enable-PodeRequestLogging
 By default Pode puts all logs in the `./logs` directory. You can use a custom path by using `-Path`:
 
 ```powershell
-New-PodeLogFileMethod -Name 'requests' -Path 'E:/logs' | Enable-PodeRequestLogging
+New-PodeLogFileMethod -Name 'requests' -Path 'E:/logs' | Enable-PodeRequestLogType
 ```

--- a/docs/Tutorials/Logging/Methods/File.md
+++ b/docs/Tutorials/Logging/Methods/File.md
@@ -1,17 +1,20 @@
 # File
 
-You can log items to a file using Pode's inbuilt file logging logic. The inbuilt logic allows you to define a maximum number of days to keep files, as well as a maximum file size. The logic will convert any item to a string, and then write it to file.
+You can log items to a file using Pode's inbuilt file logging Method, via [`New-PodeLogFileMethod`](../../../../Functions/Logging/New-PodeLogFileMethod). This allows you to define a maximum number of days to keep files, as well as a maximum file size.
 
-By default, Pode will create all log files in a `./logs` directory at the root of your server. Each log file will be stored by day, eg: `<name>_2019-08-02_001.log`. The last `001` number specifies the log number for that day - if files are be limited by size.
+!!! note
+    This will convert the supplied transformed log items into a string, if it isn't one already.
+
+By default, Pode will store all log files in a `./logs` directory at the root of your server. Each log file will be stored by day, eg: `<name>_2019-08-02_001.log`. The last `001` number specifies the log number for that day - if files are be limited by size.
 
 ## Examples
 
 ### Basic
 
-The following example will setup the file logging method for logging Requests:
+The following example will setup the file logging Method for logging Requests:
 
 ```powershell
-New-PodeLoggingMethod -File -Name 'requests' | Enable-PodeRequestLogging
+New-PodeLogFileMethod -Name 'requests' | Enable-PodeRequestLogging
 ```
 
 ### Maximum Days
@@ -19,7 +22,7 @@ New-PodeLoggingMethod -File -Name 'requests' | Enable-PodeRequestLogging
 The following example will configure file logging to only keep a maximum number of days of logs. Ie, if you set `-MaxDays` to 4, then Pode will only store the last 4 days worth of logs.
 
 ```powershell
-New-PodeLoggingMethod -File -Name 'requests' -MaxDays 4 | Enable-PodeRequestLogging
+New-PodeLogFileMethod -Name 'requests' -MaxDays 4 | Enable-PodeRequestLogging
 ```
 
 ### Maximum Size
@@ -29,7 +32,7 @@ The following example will configure file logging to keep logging to a file unti
 In this example, the maximum size it limited to 10MB:
 
 ```powershell
-New-PodeLoggingMethod -File -Name 'requests' -MaxSize 10MB | Enable-PodeRequestLogging
+New-PodeLogFileMethod -Name 'requests' -MaxSize 10MB | Enable-PodeRequestLogging
 ```
 
 ### Custom Path
@@ -37,5 +40,5 @@ New-PodeLoggingMethod -File -Name 'requests' -MaxSize 10MB | Enable-PodeRequestL
 By default Pode puts all logs in the `./logs` directory. You can use a custom path by using `-Path`:
 
 ```powershell
-New-PodeLoggingMethod -File -Name 'requests' -Path 'E:/logs' | Enable-PodeRequestLogging
+New-PodeLogFileMethod -Name 'requests' -Path 'E:/logs' | Enable-PodeRequestLogging
 ```

--- a/docs/Tutorials/Logging/Methods/File.md
+++ b/docs/Tutorials/Logging/Methods/File.md
@@ -5,6 +5,9 @@ You can log items to a file using Pode's inbuilt file logging Method, via [`New-
 !!! note
     This will convert the supplied transformed log items into a string, if it isn't one already.
 
+!!! important
+    The `New-PodeLoggingMethod` function is now deprecated, please use [`New-PodeLogFileMethod`](../../../../Functions/Logging/New-PodeLogFileMethod) instead.
+
 By default, Pode will store all log files in a `./logs` directory at the root of your server. Each log file will be stored by day, eg: `<name>_2019-08-02_001.log`. The last `001` number specifies the log number for that day - if files are be limited by size.
 
 ## Examples

--- a/docs/Tutorials/Logging/Methods/Terminal.md
+++ b/docs/Tutorials/Logging/Methods/Terminal.md
@@ -12,5 +12,5 @@ You can log items to the terminal using Pode's inbuilt terminal Method, via [`Ne
 The following example will setup the terminal logging Method for logging Requests:
 
 ```powershell
-New-PodeLogTerminalMethod | Enable-PodeRequestLogging
+New-PodeLogTerminalMethod | Enable-PodeRequestLogType
 ```

--- a/docs/Tutorials/Logging/Methods/Terminal.md
+++ b/docs/Tutorials/Logging/Methods/Terminal.md
@@ -1,13 +1,16 @@
 # Terminal
 
-You can log items to the terminal using Pode's inbuilt terminal logic. The inbuilt logic will convert any item to a string, and output it to the terminal.
+You can log items to the terminal using Pode's inbuilt terminal Method, via [`New-PodeLogTerminalMethod`](../../../../Functions/Logging/New-PodeLogTerminalMethod).
+
+!!! note
+    This will convert the supplied transformed log items into a string, if it isn't one already.
 
 ## Examples
 
 ### Basic
 
-The following example will setup the terminal logging method for logging Requests:
+The following example will setup the terminal logging Method for logging Requests:
 
 ```powershell
-New-PodeLoggingMethod -Terminal | Enable-PodeRequestLogging
+New-PodeLogTerminalMethod | Enable-PodeRequestLogging
 ```

--- a/docs/Tutorials/Logging/Methods/Terminal.md
+++ b/docs/Tutorials/Logging/Methods/Terminal.md
@@ -5,6 +5,9 @@ You can log items to the terminal using Pode's inbuilt terminal Method, via [`Ne
 !!! note
     This will convert the supplied transformed log items into a string, if it isn't one already.
 
+!!! important
+    The `New-PodeLoggingMethod` function is now deprecated, please use [`New-PodeLogTerminalMethod`](../../../../Functions/Logging/New-PodeLogTerminalMethod) instead.
+
 ## Examples
 
 ### Basic

--- a/docs/Tutorials/Logging/Overview.md
+++ b/docs/Tutorials/Logging/Overview.md
@@ -130,7 +130,7 @@ To help speed this up you can create a batching info object using [`New-PodeLogB
 
 ```powershell
 $batchInfo = New-PodeLogBatchInfo -Size 10
-New-PodeLogTerminalMethod -BatchInfo $batchInfo | Enable-PodeRequestLogging
+New-PodeLogTerminalMethod -BatchInfo $batchInfo | Enable-PodeRequestLogType
 ```
 
 Instead of writing logs one-by-one, the above will cache transformed log items. Once the appropriate number of cached log items is met (in this case 10), all of the log items will be sent to the log Method at once. This means that the log Method's scriptblock will receive an array of items, rather than a single item.

--- a/docs/Tutorials/Logging/Overview.md
+++ b/docs/Tutorials/Logging/Overview.md
@@ -1,21 +1,49 @@
 # Overview
 
-There are two aspects to logging in Pode: Methods and Types.
+There are two aspects to logging in Pode: Types and Methods.
 
-* Methods define how log items should be recorded, such as to a file, terminal, or event viewer.
-* Types define how items to log are transformed, and what should be supplied to the Method.
+* **Types** define how log items are transformed, and what should be supplied to the Method, such as Error or Request.
+* **Methods** define how the transformed log items should be recorded, such as to a file, terminal, or event viewer.
 
-For example when you supply an Exception to [`Write-PodeErrorLog`](../../../Functions/Logging/Write-PodeErrorLog), this Exception is first supplied to Pode's inbuilt Error logging type. This type transforms any Exception (or Error Record) into a string which can then be supplied to the File logging method.
+Think of it like an ETL data pipeline:
 
-In Pode you can use File, Terminal, Event Viewer, or a Custom method. As well as Request, Error, or a Custom type.
+```mermaid
+graph LR
+    Extract("`**Log Item**
+    (Extract)`")
 
-This means you could write a logging method to output to an S3 bucket, Splunk, or any other logging platform.
+    Transform("`**Type**
+    (Transform)`")
+
+    Load("`**Method**
+    (Load)`")
+
+    Extract --> Transform
+    Transform --> Load
+```
+
+While we're technically not "extracting" data, the log item is the initial entity/data in the pipeline. After which it is transformed by the Log Type (Error, Request, etc.), and then loaded - or "outputted" - to an appropriate log source like file/etc.
+
+For example when you supply an Exception to [`Write-PodeErrorLog`](../../../Functions/Logging/Write-PodeErrorLog), the Exception passed to Pode's inbuilt Error logging Type which transforms it into a string; which is then passed to a logging Method - like a File or Terminal - to be outputted/recorded.
+
+Pode has several inbuilt logging Methods for you to use:
+
+* [Terminal](../Methods/Terminal)
+* [File](../Methods/File)
+* [Event Viewer](../Methods/EventViewer)
+* [Custom](../Methods/Custom)
+
+As well as some inbuilt logging Types:
+
+* [Error](../Types/Errors)
+* [Requests](../Types/Requests)
+* [Custom](../Types/Custom)
 
 ## Masking Values
 
-When logging items Pode has support to mask sensitive information. This is supported in File and Terminal methods by default, but can also be supported in Custom methods via the [`Protect-PodeLogItem`](../../../Functions/Logging/Protect-PodeLogItem) function.
+When logging items you have the ability to mask sensitive information. This is supported in all inbuilt log Methods by default (except Custom) - it can be supported in Custom methods via [`Protect-PodeLogItem`](../../../Functions/Logging/Protect-PodeLogItem).
 
-Information to mask is determined using RegEx defined within the `server.psd1` configuration file. You can supply multiple patterns, and even define what the mask is - the default being `********`.
+Information to mask is determined using regex defined within the `server.psd1` configuration file. You can supply multiple patterns, and even define what the mask is - the default being `********`.
 
 !!! note
     Patterns are case-insensitive.
@@ -37,7 +65,7 @@ For example, to mask all password fields that could be logged you could use the 
 This would turn:
 
 ```plain
-Username, Password=Hunter, Email
+Username, Password=Hunter2, Email
 ```
 
 into
@@ -46,7 +74,7 @@ into
 Username, ********, Email
 ```
 
-Instead of masking the whole value that matches, there is support for two RegEx groups:
+Instead of masking the whole value that matches, there is support for two regex groups:
 
 * `keep_before`
 * `keep_after`
@@ -70,7 +98,7 @@ For example, expanding on the above, to keep the `Password=` text you could use 
 This would turn:
 
 ```plain
-Username, Password=Hunter, Email
+Username, Password=Hunter2, Email
 ```
 
 into
@@ -98,14 +126,13 @@ To specify a custom mask, you can do this in the configuration file:
 
 By default all log items are recorded one-by-one, but this can obviously become very slow if a lot of log items are being processed.
 
-To help speed this up, you can specify a batch size on your logging method:
+To help speed this up you can create a batching info object using [`New-PodeLogBatchInfo`](../../../Functions/Logging/New-PodeLogBatchInfo), and supply it to your logging Method:
 
 ```powershell
-New-PodeLoggingMethod -Terminal -Batch 10 | Enable-PodeRequestLogging
+$batchInfo = New-PodeLogBatchInfo -Size 10
+New-PodeLogTerminalMethod -BatchInfo $batchInfo | Enable-PodeRequestLogging
 ```
 
-Instead of writing logs one-by-one, the above will keep transformed log items in an array. Once the array matches the batch size of 10, all items will be sent to the method at once.
+Instead of writing logs one-by-one, the above will cache transformed log items. Once the appropriate number of cached log items is met (in this case 10), all of the log items will be sent to the log Method at once. This means that the log Method's scriptblock will receive an array of items, rather than a single item.
 
-This means that the method's scriptblock will receive an array of items, rather than a single item.
-
-You can also sent a `-BatchTimeout` value, in seconds, so that if your batch size it 10 but only 5 log items are added, then after the timeout value the logs items will be sent to your method.
+You can also specify a `-Timeout` value, in seconds, so that if your batch size is 10 but only 5 log items are added, then after the timeout value the log items will be sent to your method regardless the current number of cached log items.

--- a/docs/Tutorials/Logging/Overview.md
+++ b/docs/Tutorials/Logging/Overview.md
@@ -26,14 +26,14 @@ While we're technically not "extracting" data, the log item is the initial entit
 
 For example when you supply an Exception to [`Write-PodeErrorLog`](../../../Functions/Logging/Write-PodeErrorLog), the Exception passed to Pode's inbuilt Error logging Type which transforms it into a string; which is then passed to a logging Method - like a File or Terminal - to be outputted/recorded.
 
-Pode has several inbuilt logging Methods for you to use:
+Pode has several built-in logging Methods for you to use:
 
 * [Terminal](../Methods/Terminal)
 * [File](../Methods/File)
 * [Event Viewer](../Methods/EventViewer)
 * [Custom](../Methods/Custom)
 
-As well as some inbuilt logging Types:
+As well as some built-in logging Types:
 
 * [Error](../Types/Errors)
 * [Requests](../Types/Requests)

--- a/docs/Tutorials/Logging/Types/Custom.md
+++ b/docs/Tutorials/Logging/Types/Custom.md
@@ -1,22 +1,22 @@
 # Custom
 
-You can define Custom logging types in Pode by using the [`Add-PodeLogger`](../../../../Functions/Logging/Add-PodeLogger) function. Much like Requests and Errors, this function too accepts any logging method from [`New-PodeLoggingMethod`](../../../../Functions/Logging/New-PodeLoggingMethod).
+You can define a Custom logging Type in Pode by using [`Add-PodeLogType`](../../../../Functions/Logging/Add-PodeLogType). Much like Requests and Errors, this function too accepts any logging Method - such as the [Terminal](../../Methods/Terminal) Method.
 
-When adding a Custom logger, you supply a `-ScriptBlock` plus an array of optional arguments in `-ArgumentList`. The function also requires a unique `-Name`, so that it can be referenced from the [`Write-PodeLog`](../../../../Functions/Logging/Write-PodeLog) function.
+When adding a Custom logging Type, you supply a `-ScriptBlock` plus an array of optional arguments in `-ArgumentList`. The function also requires a unique `-Name`, so that it can be referenced from [`Write-PodeLog`](../../../../Functions/Logging/Write-PodeLog).
 
 The ScriptBlock will be supplied with the following arguments:
 
-1. The item to log that was supplied via [`Write-PodeLog`](../../../../Functions/Logging/Write-PodeLog).
-2. The arguments that were supplied from [`Add-PodeLogger`](../../../../Functions/Logging/Add-PodeLogger)'s `-ArgumentList` parameter.
+1. A transformed, or raw, log item to log that was supplied via [`Write-PodeLog`](../../../../Functions/Logging/Write-PodeLog).
+2. The arguments that were supplied from [`Add-PodeLogType`](../../../../Functions/Logging/Add-PodeLogType)'s `-ArgumentList` parameter.
 
 ## Examples
 
 ### Write to File
 
-This example will create a Custom logging method that will take some custom hashtable, transform it into a string, and then return the string. That string will then be passed to the inbuilt File logging method:
+This example will create a Custom logging Type that will take some custom hashtable, transform it into a string, and then pass that to the inbuilt File logging Method:
 
 ```powershell
-New-PodeLoggingMethod -File -Name 'Custom' | Add-PodeLogger -Name 'Main' -ScriptBlock {
+New-PodeLogFileMethod -Name 'Custom' | Add-PodeLogType -Name 'Main' -ScriptBlock {
     param($item, $arg1, $arg2)
     return "$($item.Key1), $($item.Key2), $($item.Key3)"
 } -ArgumentList $arg1, $arg2

--- a/docs/Tutorials/Logging/Types/Custom.md
+++ b/docs/Tutorials/Logging/Types/Custom.md
@@ -1,6 +1,6 @@
 # Custom
 
-You can define a Custom logging Type in Pode by using [`Add-PodeLogType`](../../../../Functions/Logging/Add-PodeLogType). Much like Requests and Errors, this function too accepts any logging Method - such as the [Terminal](../../Methods/Terminal) Method.
+You can define a Custom logging Type in Pode by using [`Add-PodeLogType`](../../../../Functions/Logging/Add-PodeLogType). Much like Requests and Errors, this function too accepts one or more logging Methods - such as the [Terminal](../../Methods/Terminal) Method.
 
 When adding a Custom logging Type, you supply a `-ScriptBlock` plus an array of optional arguments in `-ArgumentList`. The function also requires a unique `-Name`, so that it can be referenced from [`Write-PodeLog`](../../../../Functions/Logging/Write-PodeLog).
 

--- a/docs/Tutorials/Logging/Types/Custom.md
+++ b/docs/Tutorials/Logging/Types/Custom.md
@@ -2,6 +2,9 @@
 
 You can define a Custom logging Type in Pode by using [`Add-PodeLogType`](../../../../Functions/Logging/Add-PodeLogType). Much like Requests and Errors, this function too accepts one or more logging Methods - such as the [Terminal](../../Methods/Terminal) Method.
 
+!!! important
+    The `Add-PodeLogger` function is now deprecated, please use [`Add-PodeLogType`](../../../../Functions/Logging/Add-PodeLogType) instead.
+
 When adding a Custom logging Type, you supply a `-ScriptBlock` plus an array of optional arguments in `-ArgumentList`. The function also requires a unique `-Name`, so that it can be referenced from [`Write-PodeLog`](../../../../Functions/Logging/Write-PodeLog).
 
 The ScriptBlock will be supplied with the following arguments:
@@ -44,3 +47,16 @@ Write-PodeLog -Name 'Main' -InputObject @{
     Key3 = 'Value3'
 }
 ```
+
+### Using Raw Item
+
+The following example uses the Terminal logging Method, and sets a Custom logging Type to return and supply the raw log item to the Terminal Method's scriptblock. The Terminal Method simply outputs the raw item to the CLI.
+
+```powershell
+New-PodeLogTerminalMethod | Add-PodeLogType -Name 'Example' -Raw
+
+# then log to it via:
+Write-PodeLog -Name 'Example' -InputObject 'This message will simply be outputted to CLI'
+```
+
+This is useful when all you're supplying to your Custom log Type is strings or other primitive value types.

--- a/docs/Tutorials/Logging/Types/Custom.md
+++ b/docs/Tutorials/Logging/Types/Custom.md
@@ -9,6 +9,23 @@ The ScriptBlock will be supplied with the following arguments:
 1. A transformed, or raw, log item to log that was supplied via [`Write-PodeLog`](../../../../Functions/Logging/Write-PodeLog).
 2. The arguments that were supplied from [`Add-PodeLogType`](../../../../Functions/Logging/Add-PodeLogType)'s `-ArgumentList` parameter.
 
+## Log Levels
+
+The Custom logging Type uses the following log levels (Informational is the default):
+
+* `Error`
+* `Warning`
+* `Informational`
+* `Verbose`
+* `Debug`
+
+You can alter the log level by supplying `-Levels` to [`Add-PodeLogType`](../../../../Functions/Logging/Add-PodeLogType) - you can supply one or more.
+
+!!! tip
+    To enable all log levels more easily, simply supply `-Levels '*'`
+
+You can control the log level of custom log items being written, by supplying `-Level` to [`Write-PodeLog`](../../../../Functions/Logging/Write-PodeLog) - Informational being the default.
+
 ## Examples
 
 ### Write to File

--- a/docs/Tutorials/Logging/Types/Custom.md
+++ b/docs/Tutorials/Logging/Types/Custom.md
@@ -31,12 +31,34 @@ You can control the log level of custom log items being written, by supplying `-
 
 ## Examples
 
-### Write to File
+### Log to File
 
 This example will create a Custom logging Type that will take some custom hashtable, transform it into a string, and then pass that to the inbuilt File logging Method:
 
 ```powershell
 New-PodeLogFileMethod -Name 'Custom' | Add-PodeLogType -Name 'Main' -ScriptBlock {
+    param($item, $arg1, $arg2)
+    return "$($item.Key1), $($item.Key2), $($item.Key3)"
+} -ArgumentList $arg1, $arg2
+
+Write-PodeLog -Name 'Main' -InputObject @{
+    Key1 = 'Value1'
+    Key2 = 'Value2'
+    Key3 = 'Value3'
+}
+```
+
+### Log to Multiple
+
+The following example will also enable a Custom logging Type, but will output all items to the Terminal and to a File:
+
+```powershell
+$methods = @(
+    New-PodeLogTerminalMethod
+    New-PodeLogFileMethod -Name 'Custom'
+)
+
+$methods | Add-PodeLogType -Name 'Main' -ScriptBlock {
     param($item, $arg1, $arg2)
     return "$($item.Key1), $($item.Key2), $($item.Key3)"
 } -ArgumentList $arg1, $arg2

--- a/docs/Tutorials/Logging/Types/Errors.md
+++ b/docs/Tutorials/Logging/Types/Errors.md
@@ -1,25 +1,27 @@
 # Errors
 
-Pode has inbuilt Error logging logic, that parses Exceptions and ErrorRecords, and will return a valid log item for whatever method of logging you supply.
+Pode has an inbuilt Error logging Type, that parses and transforms Exceptions/ErrorRecords, and will return a valid log item for whatever logging Method you supply.
 
 It also has support for error levels (such as Error, Warning, Verbose), with support for only allowing certain levels to be logged. By default, Error is always logged if no levels are supplied.
 
 ## Enabling
 
-To enable and use Error logging you use [`Enable-PodeErrorLogging`](../../../../Functions/Logging/Enable-PodeErrorLogging), supplying a logging method from [`New-PodeLoggingMethod`](../../../../Functions/Logging/New-PodeLoggingMethod). You can supply your own errors to be logged by using [`New-PodeLoggingMethod`](../../../../Functions/Logging/New-PodeLoggingMethod).
+To enable and use the Error logging Type you use [`Enable-PodeErrorLogging`](../../../../Functions/Logging/Enable-PodeErrorLogging), supplying a logging Method - such as the [Terminal](../../Methods/Terminal) Method.
 
 When Pode logs an error, the information being logged is as follows:
 
-* `Date` - The date/time the error occurred.
-* `Level` - The level of the error, such as Error or verbose.
-* `Server` - The name of the machine from where the error occurred.
-* `Category` - The category/type of error that was thrown.
-* `Message` - The error message.
-* `StackTrace` - The error StackTrace.
+| Property     | Description                                           |
+| ------------ | ----------------------------------------------------- |
+| `Date`       | The date/time the error occurred                      |
+| `Level`      | The level of the error, such as Error or verbose      |
+| `Server`     | The name of the machine from where the error occurred |
+| `Category`   | The category/type of error that was thrown            |
+| `Message`    | The error message                                     |
+| `StackTrace` | The error StackTrace                                  |
 
 ## Error Levels
 
-The Error logging logic uses the following Error levels:
+The Error logging logic uses the following Error levels (Error is the default):
 
 * `Error`
 * `Warning`
@@ -46,7 +48,7 @@ To log an error at a different level, you can also supply a `-Level`.
 
 ## Internal Logging
 
-When error logging is enabled, you'll start to also see inbuilt logging from Pode. Pode at present has internal Error logging, as well as Debug and Verbose logging from its Listener.
+When error logging is enabled, you'll start to also see internal logging from Pode. Pode at present has internal Error logging, as well as Debug and Verbose logging from its various Adapters.
 
 The internal error logging will show you unhandled exceptions from routes, middleware, etc.
 
@@ -57,7 +59,7 @@ The internal error logging will show you unhandled exceptions from routes, middl
 The following example simply enables Error logging, and will output all items to the terminal - by default, only Error level items are logged:
 
 ```powershell
-New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+New-PodeLogTerminalMethod | Enable-PodeErrorLogging
 ```
 
 ### Log Verbose
@@ -65,15 +67,15 @@ New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
 The following example will enable Error logging, and it will log all errors levels except Debug:
 
 ```powershell
-New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging -Levels Error, Warning, Informational, Verbose
+New-PodeLogTerminalMethod | Enable-PodeErrorLogging -Levels Error, Warning, Informational, Verbose
 ```
 
 ### Using Raw Item
 
-The following example uses a Custom logging method, and sets Error logging to return and supply the raw hashtable to the Custom method's scriptblock. The Custom method simply logs the Server and Message to the terminal (but could be to something like an S3 bucket):
+The following example uses a Custom logging Method, and sets Error logging to return and supply the raw log item to the Custom Method's scriptblock. The Custom Method simply logs the Server and Message to the terminal (but could be to something like an S3 bucket):
 
 ```powershell
-$method = New-PodeLoggingMethod -Custom -ScriptBlock {
+$method = New-PodeLogCustomMethod -ScriptBlock {
     param($item)
     "$($item.Server) - $($item.Message)" | Out-Default
 }
@@ -83,7 +85,7 @@ $method | Enable-PodeErrorLogging -Raw
 
 ## Raw Error
 
-The raw Error hashtable that will be supplied to any Custom logging methods will look as follows:
+The raw log item that the Error log Type will supply to any Custom logging Methods will look as follows:
 
 ```powershell
 @{

--- a/docs/Tutorials/Logging/Types/Errors.md
+++ b/docs/Tutorials/Logging/Types/Errors.md
@@ -6,7 +6,7 @@ It also has support for error levels (such as Error, Warning, Verbose), with sup
 
 ## Enabling
 
-To enable and use the Error logging Type you use [`Enable-PodeErrorLogging`](../../../../Functions/Logging/Enable-PodeErrorLogging), supplying a logging Method - such as the [Terminal](../../Methods/Terminal) Method.
+To enable and use the Error logging Type you use [`Enable-PodeErrorLogType`](../../../../Functions/Logging/Enable-PodeErrorLogType), supplying a logging Method - such as the [Terminal](../../Methods/Terminal) Method.
 
 When Pode logs an error, the information being logged is as follows:
 
@@ -59,7 +59,7 @@ The internal error logging will show you unhandled exceptions from routes, middl
 The following example simply enables Error logging, and will output all items to the terminal - by default, only Error level items are logged:
 
 ```powershell
-New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+New-PodeLogTerminalMethod | Enable-PodeErrorLogType
 ```
 
 ### Log Verbose
@@ -67,7 +67,7 @@ New-PodeLogTerminalMethod | Enable-PodeErrorLogging
 The following example will enable Error logging, and it will log all errors levels except Debug:
 
 ```powershell
-New-PodeLogTerminalMethod | Enable-PodeErrorLogging -Levels Error, Warning, Informational, Verbose
+New-PodeLogTerminalMethod | Enable-PodeErrorLogType -Levels Error, Warning, Informational, Verbose
 ```
 
 ### Using Raw Item
@@ -80,7 +80,7 @@ $method = New-PodeLogCustomMethod -ScriptBlock {
     "$($item.Server) - $($item.Message)" | Out-Default
 }
 
-$method | Enable-PodeErrorLogging -Raw
+$method | Enable-PodeErrorLogType -Raw
 ```
 
 ## Raw Error

--- a/docs/Tutorials/Logging/Types/Errors.md
+++ b/docs/Tutorials/Logging/Types/Errors.md
@@ -6,7 +6,7 @@ It also has support for error levels (such as Error, Warning, Verbose), with sup
 
 ## Enabling
 
-To enable and use the Error logging Type you use [`Enable-PodeErrorLogType`](../../../../Functions/Logging/Enable-PodeErrorLogType), supplying a logging Method - such as the [Terminal](../../Methods/Terminal) Method.
+To enable and use the Error logging Type you use [`Enable-PodeErrorLogType`](../../../../Functions/Logging/Enable-PodeErrorLogType), supplying one or more logging Methods - such as the [Terminal](../../Methods/Terminal) Method.
 
 When Pode logs an error, the information being logged is as follows:
 

--- a/docs/Tutorials/Logging/Types/Errors.md
+++ b/docs/Tutorials/Logging/Types/Errors.md
@@ -19,15 +19,20 @@ When Pode logs an error, the information being logged is as follows:
 | `Message`    | The error message                                     |
 | `StackTrace` | The error StackTrace                                  |
 
-## Error Levels
+## Log Levels
 
-The Error logging logic uses the following Error levels (Error is the default):
+The Error logging Type uses the following log levels (Error is the default):
 
 * `Error`
 * `Warning`
 * `Informational`
 * `Verbose`
 * `Debug`
+
+You can alter the log level by supplying `-Levels` to [`Enable-PodeErrorLogType`](../../../../Functions/Logging/Enable-PodeErrorLogType) - you can supply one or more.
+
+!!! tip
+    To enable all log levels more easily, simply supply `-Levels '*'`
 
 ## Writing Errors
 
@@ -43,8 +48,6 @@ catch {
     $_ | Write-PodeErrorLog
 }
 ```
-
-To log an error at a different level, you can also supply a `-Level`.
 
 ## Internal Logging
 
@@ -89,11 +92,11 @@ The raw log item that the Error log Type will supply to any Custom logging Metho
 
 ```powershell
 @{
-    Date = [datetime]::Now
-    Level = 'Error'
-    Server = 'ComputerName'
-    Category = 'InvalidOperation: (:) [], RuntimeException'
-    Message = 'You cannot call a method on a null-valued expression.'
+    Date       = [datetime]::Now
+    Level      = 'Error'
+    Server     = 'ComputerName'
+    Category   = 'InvalidOperation: (:) [], RuntimeException'
+    Message    = 'You cannot call a method on a null-valued expression.'
     StackTrace = 'at <ScriptBlock>, <No file>: line 45'
 }
 ```

--- a/docs/Tutorials/Logging/Types/Errors.md
+++ b/docs/Tutorials/Logging/Types/Errors.md
@@ -8,6 +8,9 @@ It also has support for error levels (such as Error, Warning, Verbose), with sup
 
 To enable and use the Error logging Type you use [`Enable-PodeErrorLogType`](../../../../Functions/Logging/Enable-PodeErrorLogType), supplying one or more logging Methods - such as the [Terminal](../../Methods/Terminal) Method.
 
+!!! important
+    The `Enable-PodeErrorLogging` function is now deprecated, please use [`Enable-PodeErrorLogType`](../../../../Functions/Logging/Enable-PodeErrorLogType) instead.
+
 When Pode logs an error, the information being logged is as follows:
 
 | Property     | Description                                           |
@@ -95,6 +98,7 @@ The raw log item that the Error log Type will supply to any Custom logging Metho
     Date       = [datetime]::Now
     Level      = 'Error'
     Server     = 'ComputerName'
+    ContextId  = '6087a032-8e02-43ed-bbd8-e783b9839f3a'
     Category   = 'InvalidOperation: (:) [], RuntimeException'
     Message    = 'You cannot call a method on a null-valued expression.'
     StackTrace = 'at <ScriptBlock>, <No file>: line 45'

--- a/docs/Tutorials/Logging/Types/Errors.md
+++ b/docs/Tutorials/Logging/Types/Errors.md
@@ -39,7 +39,7 @@ You can alter the log level by supplying `-Levels` to [`Enable-PodeErrorLogType`
 
 ## Writing Errors
 
-You can log additional errors by using [`Write-PodeErrorLog`](../../../../Functions/Logging/Write-PodeErrorLog), which takes an Exception or an ErrorRecord (both of which can be piped). If you log an Exception you can optionally pass `-CheckInnerException`, which will also log the inner exception.
+You can log additional errors by using [`Write-PodeErrorLog`](../../../../Functions/Logging/Write-PodeErrorLog), which takes an Exception, ErrorRecord, or Message. If you log an Exception you can optionally pass `-CheckInnerException`, which will also log the inner exception.
 
 For example, to log an error:
 
@@ -50,6 +50,12 @@ try {
 catch {
     $_ | Write-PodeErrorLog
 }
+```
+
+Or, a raw string message:
+
+```powershell
+'Some error message' | Write-PodeErrorLog -Level Warning
 ```
 
 ## Internal Logging

--- a/docs/Tutorials/Logging/Types/Errors.md
+++ b/docs/Tutorials/Logging/Types/Errors.md
@@ -68,6 +68,19 @@ The following example simply enables Error logging, and will output all items to
 New-PodeLogTerminalMethod | Enable-PodeErrorLogType
 ```
 
+### Log to Multiple
+
+The following example will also enable Error logging, but will output all items to the Terminal and to a File:
+
+```powershell
+$methods = @(
+    New-PodeLogTerminalMethod
+    New-PodeLogFileMethod -Name 'errors'
+)
+
+$methods | Enable-PodeErrorLogType
+```
+
 ### Log Verbose
 
 The following example will enable Error logging, and it will log all errors levels except Debug:

--- a/docs/Tutorials/Logging/Types/Requests.md
+++ b/docs/Tutorials/Logging/Types/Requests.md
@@ -1,12 +1,12 @@
 # Requests
 
-Pode has inbuilt Request logging logic, that will parse and return a valid log item for whatever method of logging you supply.
+Pode has an inbuilt Request logging Type, which will parse and transform a valid log item for use with any supplied logging Method.
 
 ## Enabling
 
-To enable and use the Request logging you use the [`Enable-PodeRequestLogging`](../../../../Functions/Logging/Enable-PodeRequestLogging) function, supplying a logging method from [`New-PodeLoggingMethod`](../../../../Functions/Logging/New-PodeLoggingMethod).
+To enable and use the Request logging Type you use [`Enable-PodeRequestLogging`](../../../../Functions/Logging/Enable-PodeRequestLogging), supplying a logging Method - such as the [Terminal](../../Methods/Terminal) Method.
 
-The Request type logic will format a string using [Combined Log Format](https://httpd.apache.org/docs/1.3/logs.html#combined). This string is then supplied to the logging method's scriptblock. If you're using a Custom logging method and want the raw hashtable instead, you can supply `-Raw` to [`Enable-PodeRequestLogging`](../../../../Functions/Logging/Enable-PodeRequestLogging).
+The Request logging Type will transform a supplied raw log item into a [Combined Log Format](https://httpd.apache.org/docs/1.3/logs.html#combined) string. This string is then supplied to the logging Method's scriptblock. If you're using a Custom logging method and want the raw log item instead, you can supply `-Raw` to [`Enable-PodeRequestLogging`](../../../../Functions/Logging/Enable-PodeRequestLogging).
 
 ## Examples
 
@@ -15,15 +15,15 @@ The Request type logic will format a string using [Combined Log Format](https://
 The following example simply enables Request logging, and will output all items to the terminal:
 
 ```powershell
-New-PodeLoggingMethod -Terminal | Enable-PodeRequestLogging
+New-PodeLogTerminalMethod | Enable-PodeRequestLogging
 ```
 
 ### Using Raw Item
 
-The following example uses a Custom logging method, and sets Request logging to return and supply the raw hashtable to the Custom method's scriptblock. The Custom method simply logs the Host an StatusCode to the terminal (but could be to something like an S3 bucket):
+The following example uses a Custom logging Method, and sets Request logging Type to return and supply the raw log item to the Custom method's scriptblock instead of a transformed one. The Custom Method simply logs the Host and StatusCode to the terminal (but could be to something like an S3 bucket):
 
 ```powershell
-$method = New-PodeLoggingMethod -Custom -ScriptBlock {
+$method = New-PodeLogCustomMethod -ScriptBlock {
     param($item)
     "$($item.Host) - $($item.Response.StatusCode)" | Out-Default
 }
@@ -49,7 +49,7 @@ Enable-PodeRequestLogging -UsernameProperty 'Meta.Username'
 
 ## Raw Request
 
-The raw Request hashtable that will be supplied to any Custom logging methods will look as follows:
+The raw log item that the Request log Type will supply to any Custom logging Methods will look as follows:
 
 ```powershell
 @{

--- a/docs/Tutorials/Logging/Types/Requests.md
+++ b/docs/Tutorials/Logging/Types/Requests.md
@@ -4,9 +4,9 @@ Pode has an inbuilt Request logging Type, which will parse and transform a valid
 
 ## Enabling
 
-To enable and use the Request logging Type you use [`Enable-PodeRequestLogging`](../../../../Functions/Logging/Enable-PodeRequestLogging), supplying a logging Method - such as the [Terminal](../../Methods/Terminal) Method.
+To enable and use the Request logging Type you use [`Enable-PodeRequestLogType`](../../../../Functions/Logging/Enable-PodeRequestLogType), supplying a logging Method - such as the [Terminal](../../Methods/Terminal) Method.
 
-The Request logging Type will transform a supplied raw log item into a [Combined Log Format](https://httpd.apache.org/docs/1.3/logs.html#combined) string. This string is then supplied to the logging Method's scriptblock. If you're using a Custom logging method and want the raw log item instead, you can supply `-Raw` to [`Enable-PodeRequestLogging`](../../../../Functions/Logging/Enable-PodeRequestLogging).
+The Request logging Type will transform a supplied raw log item into a [Combined Log Format](https://httpd.apache.org/docs/1.3/logs.html#combined) string. This string is then supplied to the logging Method's scriptblock. If you're using a Custom logging method and want the raw log item instead, you can supply `-Raw` to [`Enable-PodeRequestLogType`](../../../../Functions/Logging/Enable-PodeRequestLogType).
 
 ## Examples
 
@@ -15,7 +15,7 @@ The Request logging Type will transform a supplied raw log item into a [Combined
 The following example simply enables Request logging, and will output all items to the terminal:
 
 ```powershell
-New-PodeLogTerminalMethod | Enable-PodeRequestLogging
+New-PodeLogTerminalMethod | Enable-PodeRequestLogType
 ```
 
 ### Using Raw Item
@@ -28,7 +28,7 @@ $method = New-PodeLogCustomMethod -ScriptBlock {
     "$($item.Host) - $($item.Response.StatusCode)" | Out-Default
 }
 
-$method | Enable-PodeRequestLogging -Raw
+$method | Enable-PodeRequestLogType -Raw
 ```
 
 ### Username
@@ -38,13 +38,13 @@ If you're not using any Authentication then the "user" field in the log will alw
 For example, if the username was actually user "ID":
 
 ```powershell
-Enable-PodeRequestLogging -UsernameProperty 'ID'
+Enable-PodeRequestLogType -UsernameProperty 'ID'
 ```
 
 Or if the username was inside another "Meta" property, and then within a "Username" property inside the Meta object:
 
 ```powershell
-Enable-PodeRequestLogging -UsernameProperty 'Meta.Username'
+Enable-PodeRequestLogType -UsernameProperty 'Meta.Username'
 ```
 
 ## Raw Request

--- a/docs/Tutorials/Logging/Types/Requests.md
+++ b/docs/Tutorials/Logging/Types/Requests.md
@@ -53,21 +53,21 @@ The raw log item that the Request log Type will supply to any Custom logging Met
 
 ```powershell
 @{
-    Host = '10.10.0.3'
+    Host            = '10.10.0.3'
     RfcUserIdentity = '-'
-    User = '-'
-    Date = '14/Jun/2018:20:23:52 +01:00'
+    User            = '-'
+    Date            = '14/Jun/2018:20:23:52 +01:00'
     Request = @{
-        Method = 'GET'
+        Method   = 'GET'
         Resource = '/api/users'
         Protocol = "HTTP/1.1"
         Referrer = '-'
-        Agent = '<user-agent>'
+        Agent    = '<user-agent>'
     }
     Response = @{
-        StatusCode = '200'
+        StatusCode        = '200'
         StatusDescription = 'OK'
-        Size = '9001'
+        Size              = '9001'
     }
 }
 ```

--- a/docs/Tutorials/Logging/Types/Requests.md
+++ b/docs/Tutorials/Logging/Types/Requests.md
@@ -4,7 +4,7 @@ Pode has an inbuilt Request logging Type, which will parse and transform a valid
 
 ## Enabling
 
-To enable and use the Request logging Type you use [`Enable-PodeRequestLogType`](../../../../Functions/Logging/Enable-PodeRequestLogType), supplying a logging Method - such as the [Terminal](../../Methods/Terminal) Method.
+To enable and use the Request logging Type you use [`Enable-PodeRequestLogType`](../../../../Functions/Logging/Enable-PodeRequestLogType), supplying one or more logging Methods - such as the [Terminal](../../Methods/Terminal) Method.
 
 The Request logging Type will transform a supplied raw log item into a [Combined Log Format](https://httpd.apache.org/docs/1.3/logs.html#combined) string. This string is then supplied to the logging Method's scriptblock. If you're using a Custom logging method and want the raw log item instead, you can supply `-Raw` to [`Enable-PodeRequestLogType`](../../../../Functions/Logging/Enable-PodeRequestLogType).
 

--- a/docs/Tutorials/Logging/Types/Requests.md
+++ b/docs/Tutorials/Logging/Types/Requests.md
@@ -6,6 +6,9 @@ Pode has an inbuilt Request logging Type, which will parse and transform a valid
 
 To enable and use the Request logging Type you use [`Enable-PodeRequestLogType`](../../../../Functions/Logging/Enable-PodeRequestLogType), supplying one or more logging Methods - such as the [Terminal](../../Methods/Terminal) Method.
 
+!!! important
+    The `Enable-PodeRequestLogging` function is now deprecated, please use [`Enable-PodeRequestLogType`](../../../../Functions/Logging/Enable-PodeRequestLogType) instead.
+
 The Request logging Type will transform a supplied raw log item into a [Combined Log Format](https://httpd.apache.org/docs/1.3/logs.html#combined) string. This string is then supplied to the logging Method's scriptblock. If you're using a Custom logging method and want the raw log item instead, you can supply `-Raw` to [`Enable-PodeRequestLogType`](../../../../Functions/Logging/Enable-PodeRequestLogType).
 
 ## Examples
@@ -57,9 +60,13 @@ The raw log item that the Request log Type will supply to any Custom logging Met
     RfcUserIdentity = '-'
     User            = '-'
     Date            = '14/Jun/2018:20:23:52 +01:00'
+    UtcDate         = [datetime]
     Request = @{
         Method   = 'GET'
+        Hostname = '127.0.0.1:8090'
+        Scheme   = 'http'
         Resource = '/api/users'
+        Query    = 'limit=100'
         Protocol = "HTTP/1.1"
         Referrer = '-'
         Agent    = '<user-agent>'

--- a/docs/Tutorials/Logging/Types/Requests.md
+++ b/docs/Tutorials/Logging/Types/Requests.md
@@ -15,10 +15,23 @@ The Request logging Type will transform a supplied raw log item into a [Combined
 
 ### Log to Terminal
 
-The following example simply enables Request logging, and will output all items to the terminal:
+The following example simply enables Request logging, and will output all items to the Terminal:
 
 ```powershell
 New-PodeLogTerminalMethod | Enable-PodeRequestLogType
+```
+
+### Log to Multiple
+
+The following example will also enable Request logging, but will output all items to the Terminal and to a File:
+
+```powershell
+$methods = @(
+    New-PodeLogTerminalMethod
+    New-PodeLogFileMethod -Name 'requests'
+)
+
+$methods | Enable-PodeRequestLogType
 ```
 
 ### Using Raw Item

--- a/examples/Caching.ps1
+++ b/examples/Caching.ps1
@@ -48,7 +48,7 @@ Start-PodeServer -Threads 3 {
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http
 
     # log errors
-    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogType
 
     Set-PodeCacheDefaultTtl -Value 60
 

--- a/examples/Caching.ps1
+++ b/examples/Caching.ps1
@@ -48,7 +48,7 @@ Start-PodeServer -Threads 3 {
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http
 
     # log errors
-    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
 
     Set-PodeCacheDefaultTtl -Value 60
 

--- a/examples/Create-Routes.ps1
+++ b/examples/Create-Routes.ps1
@@ -35,7 +35,7 @@ catch { throw }
 
 Start-PodeServer -Threads 1 -ScriptBlock {
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http
-    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogType
 
     Add-PodeRoute -PassThru -Method Get -Path '/routeCreateScriptBlock/:id' -ScriptBlock ([ScriptBlock]::Create( (Get-Content -Path "$ScriptPath\scripts\routeScript.ps1" -Raw))) |
         Set-PodeOARouteInfo -Summary 'Test' -OperationId 'routeCreateScriptBlock' -PassThru |

--- a/examples/Create-Routes.ps1
+++ b/examples/Create-Routes.ps1
@@ -35,7 +35,7 @@ catch { throw }
 
 Start-PodeServer -Threads 1 -ScriptBlock {
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http
-    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
 
     Add-PodeRoute -PassThru -Method Get -Path '/routeCreateScriptBlock/:id' -ScriptBlock ([ScriptBlock]::Create( (Get-Content -Path "$ScriptPath\scripts\routeScript.ps1" -Raw))) |
         Set-PodeOARouteInfo -Summary 'Test' -OperationId 'routeCreateScriptBlock' -PassThru |

--- a/examples/Dot-SourceScript.ps1
+++ b/examples/Dot-SourceScript.ps1
@@ -39,7 +39,7 @@ catch { throw }
 # runs the logic once, then exits
 Start-PodeServer {
 
-    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
     Use-PodeScript -Path './modules/Script1.ps1'
 
 }

--- a/examples/Dot-SourceScript.ps1
+++ b/examples/Dot-SourceScript.ps1
@@ -39,7 +39,7 @@ catch { throw }
 # runs the logic once, then exits
 Start-PodeServer {
 
-    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogType
     Use-PodeScript -Path './modules/Script1.ps1'
 
 }

--- a/examples/File-Watchers.ps1
+++ b/examples/File-Watchers.ps1
@@ -39,7 +39,7 @@ catch { throw }
 Start-PodeServer -Verbose {
 
     # enable logging
-    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
 
     Add-PodeFileWatcher -Path $ScriptPath -Include '*.ps1' -ScriptBlock {
         "[$($FileEvent.Type)][$($FileEvent.Parameters['project'])]: $($FileEvent.FullPath)" | Out-Default

--- a/examples/File-Watchers.ps1
+++ b/examples/File-Watchers.ps1
@@ -39,7 +39,7 @@ catch { throw }
 Start-PodeServer -Verbose {
 
     # enable logging
-    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogType
 
     Add-PodeFileWatcher -Path $ScriptPath -Include '*.ps1' -ScriptBlock {
         "[$($FileEvent.Type)][$($FileEvent.Parameters['project'])]: $($FileEvent.FullPath)" | Out-Default

--- a/examples/FileBrowser/FileBrowser.ps1
+++ b/examples/FileBrowser/FileBrowser.ps1
@@ -45,8 +45,8 @@ Start-PodeServer -ConfigFile '..\Server.psd1' -ScriptBlock {
 
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http -Default
 
-    New-PodeLoggingMethod -Terminal | Enable-PodeRequestLogging
-    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeRequestLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
 
     # setup basic auth (base64> username:password in header)
     New-PodeAuthScheme -Basic -Realm 'Pode Static Page' | Add-PodeAuth -Name 'Validate' -Sessionless -ScriptBlock {

--- a/examples/FileBrowser/FileBrowser.ps1
+++ b/examples/FileBrowser/FileBrowser.ps1
@@ -45,8 +45,8 @@ Start-PodeServer -ConfigFile '..\Server.psd1' -ScriptBlock {
 
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http -Default
 
-    New-PodeLogTerminalMethod | Enable-PodeRequestLogging
-    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeRequestLogType
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogType
 
     # setup basic auth (base64> username:password in header)
     New-PodeAuthScheme -Basic -Realm 'Pode Static Page' | Add-PodeAuth -Name 'Validate' -Sessionless -ScriptBlock {

--- a/examples/IIS-Example.ps1
+++ b/examples/IIS-Example.ps1
@@ -46,8 +46,8 @@ Start-PodeServer {
 
     # listen on localhost:8081
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http
-    New-PodeLogTerminalMethod | Enable-PodeRequestLogging
-    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeRequestLogType
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogType
 
     # Add-PodeLimitAccessRule -Name 'DenyLocal' -Action Deny -Component @(
     #     New-PodeLimitIPComponent -IP localhost -Location XForwardedFor

--- a/examples/IIS-Example.ps1
+++ b/examples/IIS-Example.ps1
@@ -46,8 +46,8 @@ Start-PodeServer {
 
     # listen on localhost:8081
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http
-    New-PodeLoggingMethod -Terminal | Enable-PodeRequestLogging
-    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeRequestLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
 
     # Add-PodeLimitAccessRule -Name 'DenyLocal' -Action Deny -Component @(
     #     New-PodeLimitIPComponent -IP localhost -Location XForwardedFor

--- a/examples/Logging.ps1
+++ b/examples/Logging.ps1
@@ -50,15 +50,15 @@ Start-PodeServer {
 
     switch ($LOGGING_TYPE.ToLowerInvariant()) {
         'terminal' {
-            New-PodeLoggingMethod -Terminal | Enable-PodeRequestLogging
+            New-PodeLogTerminalMethod | Enable-PodeRequestLogging
         }
 
         'file' {
-            New-PodeLoggingMethod -File -Name 'requests' -MaxDays 4 | Enable-PodeRequestLogging
+            New-PodeLogFileMethod -Name 'requests' -MaxDays 4 | Enable-PodeRequestLogging
         }
 
         'custom' {
-            $type = New-PodeLoggingMethod -Custom -ScriptBlock {
+            $type = New-PodeLogCustomMethod -ScriptBlock {
                 param($item)
                 # send request row to S3
             }

--- a/examples/Logging.ps1
+++ b/examples/Logging.ps1
@@ -50,11 +50,11 @@ Start-PodeServer {
 
     switch ($LOGGING_TYPE.ToLowerInvariant()) {
         'terminal' {
-            New-PodeLogTerminalMethod | Enable-PodeRequestLogging
+            New-PodeLogTerminalMethod | Enable-PodeRequestLogType
         }
 
         'file' {
-            New-PodeLogFileMethod -Name 'requests' -MaxDays 4 | Enable-PodeRequestLogging
+            New-PodeLogFileMethod -Name 'requests' -MaxDays 4 | Enable-PodeRequestLogType
         }
 
         'custom' {
@@ -63,7 +63,7 @@ Start-PodeServer {
                 # send request row to S3
             }
 
-            $type | Enable-PodeRequestLogging
+            $type | Enable-PodeRequestLogType
         }
     }
 

--- a/examples/Mail-Server.ps1
+++ b/examples/Mail-Server.ps1
@@ -51,7 +51,7 @@ Start-PodeServer -Threads 2 {
     Add-PodeEndpoint -Address localhost -Protocol Smtps -SelfSigned -TlsMode Implicit
 
     # enable logging
-    New-PodeLogTerminalMethod | Enable-PodeErrorLogging -Levels Error, Debug
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogType -Levels Error, Debug
 
     # allow the local ip
     #Add-PodeAccessRule -Access Allow -Type IP -Values 127.0.0.1

--- a/examples/Mail-Server.ps1
+++ b/examples/Mail-Server.ps1
@@ -51,7 +51,7 @@ Start-PodeServer -Threads 2 {
     Add-PodeEndpoint -Address localhost -Protocol Smtps -SelfSigned -TlsMode Implicit
 
     # enable logging
-    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging -Levels Error, Debug
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogging -Levels Error, Debug
 
     # allow the local ip
     #Add-PodeAccessRule -Access Allow -Type IP -Values 127.0.0.1

--- a/examples/OneOff-Script.ps1
+++ b/examples/OneOff-Script.ps1
@@ -38,7 +38,7 @@ catch { throw }
 # runs the logic once, then exits
 Start-PodeServer {
 
-    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
     Write-PodeHost 'hello, world!'
 
 }

--- a/examples/OneOff-Script.ps1
+++ b/examples/OneOff-Script.ps1
@@ -38,7 +38,7 @@ catch { throw }
 # runs the logic once, then exits
 Start-PodeServer {
 
-    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogType
     Write-PodeHost 'hello, world!'
 
 }

--- a/examples/OpenApi-SimplePotato.ps1
+++ b/examples/OpenApi-SimplePotato.ps1
@@ -43,8 +43,8 @@ catch {
 Start-PodeServer {
 
 	# Enable terminal logging for requests and errors
-	New-PodeLogTerminalMethod | Enable-PodeRequestLogging
-	New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+	New-PodeLogTerminalMethod | Enable-PodeRequestLogType
+	New-PodeLogTerminalMethod | Enable-PodeErrorLogType
 
 	# Define the endpoint for the server
 	Add-PodeEndpoint -Address 127.0.0.1 -Port 8080 -Protocol Http

--- a/examples/OpenApi-SimplePotato.ps1
+++ b/examples/OpenApi-SimplePotato.ps1
@@ -43,8 +43,8 @@ catch {
 Start-PodeServer {
 
 	# Enable terminal logging for requests and errors
-	New-PodeLoggingMethod -Terminal | Enable-PodeRequestLogging
-	New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+	New-PodeLogTerminalMethod | Enable-PodeRequestLogging
+	New-PodeLogTerminalMethod | Enable-PodeErrorLogging
 
 	# Define the endpoint for the server
 	Add-PodeEndpoint -Address 127.0.0.1 -Port 8080 -Protocol Http

--- a/examples/OpenApi-TuttiFrutti.ps1
+++ b/examples/OpenApi-TuttiFrutti.ps1
@@ -70,7 +70,7 @@ catch { throw }
 Start-PodeServer  -Threads 1 -Daemon:$Daemon  -IgnoreServerConfig:$IgnoreServerConfig -ScriptBlock {
     Add-PodeEndpoint -Address localhost -Port $PortV3 -Protocol Http -Default -Name 'endpoint_v3'
     Add-PodeEndpoint -Address localhost -Port $PortV3_1 -Protocol Http -Name 'endpoint_v3.1'
-    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
     $InfoDescription = @'
 This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about Swagger at [http://swagger.io](http://swagger.io).
 In the third iteration of the pet store, we've switched to the design first approach!

--- a/examples/OpenApi-TuttiFrutti.ps1
+++ b/examples/OpenApi-TuttiFrutti.ps1
@@ -70,7 +70,7 @@ catch { throw }
 Start-PodeServer  -Threads 1 -Daemon:$Daemon  -IgnoreServerConfig:$IgnoreServerConfig -ScriptBlock {
     Add-PodeEndpoint -Address localhost -Port $PortV3 -Protocol Http -Default -Name 'endpoint_v3'
     Add-PodeEndpoint -Address localhost -Port $PortV3_1 -Protocol Http -Name 'endpoint_v3.1'
-    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogType
     $InfoDescription = @'
 This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about Swagger at [http://swagger.io](http://swagger.io).
 In the third iteration of the pet store, we've switched to the design first approach!

--- a/examples/PetStore/Petstore-OpenApi.ps1
+++ b/examples/PetStore/Petstore-OpenApi.ps1
@@ -115,7 +115,7 @@ Start-PodeServer -Threads 1 -ScriptBlock {
     Add-PodeFavicon -Default
 
     # Enable error logging
-    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogType
 
     # Configure CORS
     Set-PodeSecurityAccessControl -Origin '*' -Duration 7200 -WithOptions -AuthorizationHeader -autoMethods -AutoHeader -Credentials -CrossDomainXhrRequests

--- a/examples/PetStore/Petstore-OpenApi.ps1
+++ b/examples/PetStore/Petstore-OpenApi.ps1
@@ -115,7 +115,7 @@ Start-PodeServer -Threads 1 -ScriptBlock {
     Add-PodeFavicon -Default
 
     # Enable error logging
-    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
 
     # Configure CORS
     Set-PodeSecurityAccessControl -Origin '*' -Duration 7200 -WithOptions -AuthorizationHeader -autoMethods -AutoHeader -Credentials -CrossDomainXhrRequests

--- a/examples/PetStore/Petstore-OpenApiMultiTag.ps1
+++ b/examples/PetStore/Petstore-OpenApiMultiTag.ps1
@@ -103,7 +103,7 @@ Start-PodeServer -Threads 1 -ScriptBlock {
         Add-PodeEndpoint -Address (Get-PodeConfig).Address -Port (Get-PodeConfig).RestFulPort -Protocol Http -Default -Name 'endpoint_v3'
         Add-PodeEndpoint -Address (Get-PodeConfig).Address -Port ((Get-PodeConfig).RestFulPort + 1) -Protocol Http -Name 'endpoint_v3.1'
     }
-    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogType
 
     #Configure CORS
     Set-PodeSecurityAccessControl -Origin '*'  -Duration 7200   -WithOptions   -AuthorizationHeader -autoMethods -AutoHeader -Credentials -CrossDomainXhrRequests  #-Header 'content-type' # -Header   'Accept','Content-Type' ,'Connection' #-Headers '*' 'x-requested-with' ,'crossdomain'#

--- a/examples/PetStore/Petstore-OpenApiMultiTag.ps1
+++ b/examples/PetStore/Petstore-OpenApiMultiTag.ps1
@@ -103,7 +103,7 @@ Start-PodeServer -Threads 1 -ScriptBlock {
         Add-PodeEndpoint -Address (Get-PodeConfig).Address -Port (Get-PodeConfig).RestFulPort -Protocol Http -Default -Name 'endpoint_v3'
         Add-PodeEndpoint -Address (Get-PodeConfig).Address -Port ((Get-PodeConfig).RestFulPort + 1) -Protocol Http -Name 'endpoint_v3.1'
     }
-    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
 
     #Configure CORS
     Set-PodeSecurityAccessControl -Origin '*'  -Duration 7200   -WithOptions   -AuthorizationHeader -autoMethods -AutoHeader -Credentials -CrossDomainXhrRequests  #-Header 'content-type' # -Header   'Accept','Content-Type' ,'Connection' #-Headers '*' 'x-requested-with' ,'crossdomain'#
@@ -507,8 +507,8 @@ Some useful links:
             } | Set-PodeOARouteInfo -Summary 'Updates pet with ID' -Description 'Updates a pet in the store with form data' -Tags 'pet' -OperationId 'updatePetWithForm' -PassThru |
                 Set-PodeOARequest -PassThru -Parameters  ( New-PodeOAIntProperty -Name 'petId' -Description 'ID of pet that needs to be updated'  -Format Int64 |
                         ConvertTo-PodeOAParameter -In Path -Required ),
-                                    (  New-PodeOAStringProperty -Name 'name' -Description 'Name of pet that needs to be updated' | ConvertTo-PodeOAParameter -In Query ) ,
-                                    (  New-PodeOAStringProperty -Name 'status' -Description 'Status of pet that needs to be updated' | ConvertTo-PodeOAParameter -In Query ) |
+                    (  New-PodeOAStringProperty -Name 'name' -Description 'Name of pet that needs to be updated' | ConvertTo-PodeOAParameter -In Query ) ,
+                    (  New-PodeOAStringProperty -Name 'status' -Description 'Status of pet that needs to be updated' | ConvertTo-PodeOAParameter -In Query ) |
                     Add-PodeOAResponse -StatusCode 405 -Description 'Invalid Input'
 
             <#
@@ -552,8 +552,8 @@ Some useful links:
                 }
             } | Set-PodeOARouteInfo -Summary 'Uploads an image' -Tags 'pet' -OperationId 'uploadFile' -PassThru |
                 Set-PodeOARequest -Parameters @(
-                                            (  New-PodeOAIntProperty -Name 'petId' -Format Int64 -Description 'ID of pet to update' -Required | ConvertTo-PodeOAParameter -In Path ),
-                                            (  New-PodeOAStringProperty -Name 'additionalMetadata' -Description 'Additional Metadata' | ConvertTo-PodeOAParameter -In Query )
+                    (  New-PodeOAIntProperty -Name 'petId' -Format Int64 -Description 'ID of pet to update' -Required | ConvertTo-PodeOAParameter -In Path ),
+                    (  New-PodeOAStringProperty -Name 'additionalMetadata' -Description 'Additional Metadata' | ConvertTo-PodeOAParameter -In Query )
                 ) -RequestBody (
                     New-PodeOARequestBody  -Content  ( New-PodeOAContentMediaType -ContentType 'application/octet-stream' -Upload )
                 ) -PassThru |
@@ -631,7 +631,7 @@ Some useful links:
                 }
             } | Set-PodeOARouteInfo -Summary 'Find purchase order by ID' -Description 'For valid response try integer IDs with value <= 5 or > 10. Other values will generate exceptions.' -Tags 'store' -OperationId 'getOrderById' -PassThru |
                 Set-PodeOARequest -PassThru -Parameters @(
-                                (  New-PodeOAIntProperty -Name 'orderId' -Format Int64 -Description 'ID of order that needs to be fetched' -Required | ConvertTo-PodeOAParameter -In Path )
+                    (  New-PodeOAIntProperty -Name 'orderId' -Format Int64 -Description 'ID of order that needs to be fetched' -Required | ConvertTo-PodeOAParameter -In Path )
                 ) |
                 Add-PodeOAResponse -StatusCode 200 -Description 'Successful operation' -Content  (New-PodeOAContentMediaType -ContentType 'application/json', 'application/xml'  -Content 'Order'  ) -PassThru |
                 Add-PodeOAResponse -StatusCode 400 -Description 'Invalid ID supplied' -PassThru |
@@ -656,7 +656,7 @@ Some useful links:
                 }
             } | Set-PodeOARouteInfo -Summary 'Delete purchase order by ID' -Description 'For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors.' -Tags 'store' -OperationId 'deleteOrder' -PassThru |
                 Set-PodeOARequest -PassThru -Parameters @(
-                                    (  New-PodeOAIntProperty -Name 'orderId' -Format Int64 -Description ' ID of the order that needs to be deleted' -Required | ConvertTo-PodeOAParameter -In Path )
+                    (  New-PodeOAIntProperty -Name 'orderId' -Format Int64 -Description ' ID of the order that needs to be deleted' -Required | ConvertTo-PodeOAParameter -In Path )
                 ) |
                 Add-PodeOAResponse -StatusCode 400 -Description 'Invalid ID supplied' -PassThru |
                 Add-PodeOAResponse -StatusCode 404 -Description 'Order not found'
@@ -780,7 +780,7 @@ Some useful links:
                 }
             } | Set-PodeOARouteInfo -Summary 'Logs user into the system.'  -Tags 'user' -OperationId 'loginUser' -PassThru |
                 Set-PodeOARequest  -Parameters  (  New-PodeOAStringProperty -Name 'username' -Description 'The user name for login' | ConvertTo-PodeOAParameter -In Query ),
-                                (  New-PodeOAStringProperty -Name 'password' -Description 'The password for login in clear text' -Format Password | ConvertTo-PodeOAParameter -In Query ) -PassThru |
+                (  New-PodeOAStringProperty -Name 'password' -Description 'The password for login in clear text' -Format Password | ConvertTo-PodeOAParameter -In Query ) -PassThru |
                 Add-PodeOAResponse -StatusCode 200 -Description 'Successful operation' -Content (New-PodeOAContentMediaType -ContentType 'application/json', 'application/xml' -Content 'string' ) `
                     -Headers (New-PodeOAIntProperty  -Name 'X-Rate-Limit' -Description 'calls per hour allowed by the user' -Format Int32),
                 (New-PodeOAStringProperty -Name 'X-Expires-After' -Description 'date in UTC when token expires' -Format Date-Time) -PassThru |

--- a/examples/Shared-State.ps1
+++ b/examples/Shared-State.ps1
@@ -42,8 +42,8 @@ catch { throw }
 Start-PodeServer {
 
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http
-    New-PodeLogTerminalMethod | Enable-PodeRequestLogging
-    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeRequestLogType
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogType
 
     # re-initialise the state
     Restore-PodeState -Path './state.json'

--- a/examples/Shared-State.ps1
+++ b/examples/Shared-State.ps1
@@ -42,8 +42,8 @@ catch { throw }
 Start-PodeServer {
 
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http
-    New-PodeLoggingMethod -Terminal | Enable-PodeRequestLogging
-    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeRequestLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
 
     # re-initialise the state
     Restore-PodeState -Path './state.json'

--- a/examples/Suspend-Resume.ps1
+++ b/examples/Suspend-Resume.ps1
@@ -72,7 +72,7 @@ Start-PodeServer -Threads 4 -EnablePool Tasks -IgnoreServerConfig -ScriptBlock {
     Set-PodeViewEngine -Type Html
 
     # Enable error logging
-    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
 
 
     # Enable OpenAPI documentation

--- a/examples/Suspend-Resume.ps1
+++ b/examples/Suspend-Resume.ps1
@@ -72,7 +72,7 @@ Start-PodeServer -Threads 4 -EnablePool Tasks -IgnoreServerConfig -ScriptBlock {
     Set-PodeViewEngine -Type Html
 
     # Enable error logging
-    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogType
 
 
     # Enable OpenAPI documentation

--- a/examples/SwaggerEditor/Swagger-Editor.ps1
+++ b/examples/SwaggerEditor/Swagger-Editor.ps1
@@ -46,8 +46,8 @@ Start-PodeServer -ConfigFile '..\Server.psd1' -Threads 2 {
 
     # listen on localhost:8081
     Add-PodeEndpoint -Address localhost -Port $port -Protocol Http
-    New-PodeLogTerminalMethod | Enable-PodeRequestLogging
-    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeRequestLogType
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogType
 
     # set view engine to pode renderer
     Set-PodeViewEngine -Type HTML

--- a/examples/SwaggerEditor/Swagger-Editor.ps1
+++ b/examples/SwaggerEditor/Swagger-Editor.ps1
@@ -46,8 +46,8 @@ Start-PodeServer -ConfigFile '..\Server.psd1' -Threads 2 {
 
     # listen on localhost:8081
     Add-PodeEndpoint -Address localhost -Port $port -Protocol Http
-    New-PodeLoggingMethod -Terminal | Enable-PodeRequestLogging
-    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeRequestLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
 
     # set view engine to pode renderer
     Set-PodeViewEngine -Type HTML

--- a/examples/Tasks.ps1
+++ b/examples/Tasks.ps1
@@ -42,7 +42,7 @@ catch { throw }
 Start-PodeServer {
 
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http
-    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogType
 
     Add-PodeTask -Name 'Test1' -ScriptBlock {
         'a string'

--- a/examples/Tasks.ps1
+++ b/examples/Tasks.ps1
@@ -42,7 +42,7 @@ catch { throw }
 Start-PodeServer {
 
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http
-    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
 
     Add-PodeTask -Name 'Test1' -ScriptBlock {
         'a string'

--- a/examples/Tcp-Server.ps1
+++ b/examples/Tcp-Server.ps1
@@ -42,7 +42,7 @@ Start-PodeServer -Threads 2 {
     # Add-PodeEndpoint -Address localhost -Port 9000 -Protocol Tcps -SelfSigned -CRLFMessageEnd -TlsMode Implicit -Acknowledge 'Welcome!'
 
     # enable logging
-    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogType
 
     Add-PodeVerb -Verb 'HELLO' -ScriptBlock {
         Write-PodeTcpClient -Message 'HI'

--- a/examples/Tcp-Server.ps1
+++ b/examples/Tcp-Server.ps1
@@ -42,7 +42,7 @@ Start-PodeServer -Threads 2 {
     # Add-PodeEndpoint -Address localhost -Port 9000 -Protocol Tcps -SelfSigned -CRLFMessageEnd -TlsMode Implicit -Acknowledge 'Welcome!'
 
     # enable logging
-    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
 
     Add-PodeVerb -Verb 'HELLO' -ScriptBlock {
         Write-PodeTcpClient -Message 'HI'

--- a/examples/Tcp-ServerAuth.ps1
+++ b/examples/Tcp-ServerAuth.ps1
@@ -40,7 +40,7 @@ Start-PodeServer -Threads 2 {
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Tcp -CRLFMessageEnd
 
     # enable logging
-    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogType
 
     # create a role access method get retrieves roles from a database
     New-PodeAccessScheme -Type Role | Add-PodeAccess -Name 'RoleExample' -ScriptBlock {

--- a/examples/Tcp-ServerAuth.ps1
+++ b/examples/Tcp-ServerAuth.ps1
@@ -40,7 +40,7 @@ Start-PodeServer -Threads 2 {
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Tcp -CRLFMessageEnd
 
     # enable logging
-    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
 
     # create a role access method get retrieves roles from a database
     New-PodeAccessScheme -Type Role | Add-PodeAccess -Name 'RoleExample' -ScriptBlock {

--- a/examples/Tcp-ServerHttp.ps1
+++ b/examples/Tcp-ServerHttp.ps1
@@ -40,7 +40,7 @@ Start-PodeServer -Threads 2 {
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Tcp
 
     # enable logging
-    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogType
 
     # example limits
     # Add-PodeLimitAccessRule -Name 'Main' -Action Deny -Component @(

--- a/examples/Tcp-ServerHttp.ps1
+++ b/examples/Tcp-ServerHttp.ps1
@@ -40,7 +40,7 @@ Start-PodeServer -Threads 2 {
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Tcp
 
     # enable logging
-    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
 
     # example limits
     # Add-PodeLimitAccessRule -Name 'Main' -Action Deny -Component @(

--- a/examples/Tcp-ServerMultiEndpoint.ps1
+++ b/examples/Tcp-ServerMultiEndpoint.ps1
@@ -41,7 +41,7 @@ Start-PodeServer -Threads 2 {
     Add-PodeEndpoint -Address localhost -Hostname 'foo.pode.com' -Port 9000 -Protocol Tcp -Name 'EP2' -Acknowledge 'Hello there!' -CRLFMessageEnd
 
     # enable logging
-    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
 
     # hello verb for endpoint1
     Add-PodeVerb -Verb 'HELLO :forename :surname' -EndpointName EP1 -ScriptBlock {

--- a/examples/Tcp-ServerMultiEndpoint.ps1
+++ b/examples/Tcp-ServerMultiEndpoint.ps1
@@ -41,7 +41,7 @@ Start-PodeServer -Threads 2 {
     Add-PodeEndpoint -Address localhost -Hostname 'foo.pode.com' -Port 9000 -Protocol Tcp -Name 'EP2' -Acknowledge 'Hello there!' -CRLFMessageEnd
 
     # enable logging
-    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogType
 
     # hello verb for endpoint1
     Add-PodeVerb -Verb 'HELLO :forename :surname' -EndpointName EP1 -ScriptBlock {

--- a/examples/Threading.ps1
+++ b/examples/Threading.ps1
@@ -67,7 +67,7 @@ catch { throw }
 Start-PodeServer -Threads 2 {
 
     Add-PodeEndpoint -Address localhost -Port $Port -Protocol Http
-    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
 
     # custom locks
     New-PodeLockable -Name 'TestLock'

--- a/examples/Threading.ps1
+++ b/examples/Threading.ps1
@@ -67,7 +67,7 @@ catch { throw }
 Start-PodeServer -Threads 2 {
 
     Add-PodeEndpoint -Address localhost -Port $Port -Protocol Http
-    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogType
 
     # custom locks
     New-PodeLockable -Name 'TestLock'

--- a/examples/Web-AuthApiKey.ps1
+++ b/examples/Web-AuthApiKey.ps1
@@ -56,8 +56,8 @@ Start-PodeServer -Threads 2 {
     # listen on localhost:8081
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http
 
-    New-PodeLoggingMethod -File -Name 'requests' | Enable-PodeRequestLogging
-    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+    New-PodeLogFileMethod -Name 'requests' | Enable-PodeRequestLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
 
     # setup bearer auth
     New-PodeAuthScheme -ApiKey -Location $Location | Add-PodeAuth -Name 'Validate' -Sessionless -ScriptBlock {

--- a/examples/Web-AuthApiKey.ps1
+++ b/examples/Web-AuthApiKey.ps1
@@ -56,8 +56,8 @@ Start-PodeServer -Threads 2 {
     # listen on localhost:8081
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http
 
-    New-PodeLogFileMethod -Name 'requests' | Enable-PodeRequestLogging
-    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+    New-PodeLogFileMethod -Name 'requests' | Enable-PodeRequestLogType
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogType
 
     # setup bearer auth
     New-PodeAuthScheme -ApiKey -Location $Location | Add-PodeAuth -Name 'Validate' -Sessionless -ScriptBlock {

--- a/examples/Web-AuthBasic.ps1
+++ b/examples/Web-AuthBasic.ps1
@@ -55,7 +55,7 @@ Start-PodeServer -Threads 2 {
 
     # request logging
     $batchInfo = New-PodeLogBatchInfo -Size 10 -Timeout 10
-    New-PodeLogTerminalMethod -Batch $batchInfo | Enable-PodeRequestLogging
+    New-PodeLogTerminalMethod -Batch $batchInfo | Enable-PodeRequestLogType
 
     # setup basic auth (base64> username:password in header)
     New-PodeAuthScheme -Basic -Realm 'Pode Example Page' | Add-PodeAuth -Name 'Validate' -Sessionless -ScriptBlock {

--- a/examples/Web-AuthBasic.ps1
+++ b/examples/Web-AuthBasic.ps1
@@ -54,7 +54,8 @@ Start-PodeServer -Threads 2 {
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http
 
     # request logging
-    New-PodeLoggingMethod -Terminal -Batch 10 -BatchTimeout 10 | Enable-PodeRequestLogging
+    $batchInfo = New-PodeLogBatchInfo -Size 10 -Timeout 10
+    New-PodeLogTerminalMethod -Batch $batchInfo | Enable-PodeRequestLogging
 
     # setup basic auth (base64> username:password in header)
     New-PodeAuthScheme -Basic -Realm 'Pode Example Page' | Add-PodeAuth -Name 'Validate' -Sessionless -ScriptBlock {
@@ -75,7 +76,7 @@ Start-PodeServer -Threads 2 {
         return @{ Message = 'Invalid details supplied' }
     }
 
-    
+
     # POST request to get current user (since there's no session, authentication will always happen)
     Add-PodeRoute -Method Post -Path '/users' -Authentication 'Validate' -ScriptBlock {
         Write-PodeJsonResponse -Value @{

--- a/examples/Web-AuthBasicBearer.ps1
+++ b/examples/Web-AuthBasicBearer.ps1
@@ -42,7 +42,7 @@ Start-PodeServer -Threads 2 {
     # listen on localhost:8081
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http
 
-    New-PodeLoggingMethod -File -Name 'requests' | Enable-PodeRequestLogging
+    New-PodeLogFileMethod -Name 'requests' | Enable-PodeRequestLogging
 
     # setup bearer auth
     New-PodeAuthScheme -Bearer -Scope write | Add-PodeAuth -Name 'Validate' -Sessionless -ScriptBlock {
@@ -51,8 +51,8 @@ Start-PodeServer -Threads 2 {
         # here you'd check a real user storage, this is just for example
         if ($token -ieq 'test-token') {
             return @{
-                User = @{
-                    ID ='M0R7Y302'
+                User  = @{
+                    ID   = 'M0R7Y302'
                     Name = 'Morty'
                     Type = 'Human'
                 }
@@ -69,11 +69,11 @@ Start-PodeServer -Threads 2 {
             Users = @(
                 @{
                     Name = 'Deep Thought'
-                    Age = 42
+                    Age  = 42
                 },
                 @{
                     Name = 'Leeroy Jenkins'
-                    Age = 1337
+                    Age  = 1337
                 }
             )
         }

--- a/examples/Web-AuthBasicBearer.ps1
+++ b/examples/Web-AuthBasicBearer.ps1
@@ -42,7 +42,7 @@ Start-PodeServer -Threads 2 {
     # listen on localhost:8081
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http
 
-    New-PodeLogFileMethod -Name 'requests' | Enable-PodeRequestLogging
+    New-PodeLogFileMethod -Name 'requests' | Enable-PodeRequestLogType
 
     # setup bearer auth
     New-PodeAuthScheme -Bearer -Scope write | Add-PodeAuth -Name 'Validate' -Sessionless -ScriptBlock {

--- a/examples/Web-AuthBasicHeader.ps1
+++ b/examples/Web-AuthBasicHeader.ps1
@@ -57,7 +57,7 @@ Start-PodeServer -Threads 2 {
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http
 
     # enable error logging
-    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogType
 
     # setup session details
     Enable-PodeSessionMiddleware -Duration 120 -Extend -UseHeaders -Strict

--- a/examples/Web-AuthBasicHeader.ps1
+++ b/examples/Web-AuthBasicHeader.ps1
@@ -57,7 +57,7 @@ Start-PodeServer -Threads 2 {
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http
 
     # enable error logging
-    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
 
     # setup session details
     Enable-PodeSessionMiddleware -Duration 120 -Extend -UseHeaders -Strict

--- a/examples/Web-AuthForm.ps1
+++ b/examples/Web-AuthForm.ps1
@@ -57,7 +57,7 @@ Start-PodeServer -Threads 2 {
     Set-PodeViewEngine -Type Pode
 
     # enable error logging
-    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
 
     # setup session details
     Enable-PodeSessionMiddleware -Duration 120 -Extend

--- a/examples/Web-AuthForm.ps1
+++ b/examples/Web-AuthForm.ps1
@@ -57,7 +57,7 @@ Start-PodeServer -Threads 2 {
     Set-PodeViewEngine -Type Pode
 
     # enable error logging
-    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogType
 
     # setup session details
     Enable-PodeSessionMiddleware -Duration 120 -Extend

--- a/examples/Web-AuthFormAccess.ps1
+++ b/examples/Web-AuthFormAccess.ps1
@@ -54,7 +54,7 @@ Start-PodeServer -Threads 2 {
     Set-PodeViewEngine -Type Pode
 
     # enable error logging
-    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
 
     # setup session details
     Enable-PodeSessionMiddleware -Duration 120 -Extend

--- a/examples/Web-AuthFormAccess.ps1
+++ b/examples/Web-AuthFormAccess.ps1
@@ -54,7 +54,7 @@ Start-PodeServer -Threads 2 {
     Set-PodeViewEngine -Type Pode
 
     # enable error logging
-    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogType
 
     # setup session details
     Enable-PodeSessionMiddleware -Duration 120 -Extend

--- a/examples/Web-AuthFormAd.ps1
+++ b/examples/Web-AuthFormAd.ps1
@@ -48,7 +48,7 @@ Start-PodeServer -Threads 2 {
 
     # listen on localhost:8081
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http
-    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogType
 
     # set the view engine
     Set-PodeViewEngine -Type Pode

--- a/examples/Web-AuthFormAd.ps1
+++ b/examples/Web-AuthFormAd.ps1
@@ -48,7 +48,7 @@ Start-PodeServer -Threads 2 {
 
     # listen on localhost:8081
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http
-    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
 
     # set the view engine
     Set-PodeViewEngine -Type Pode

--- a/examples/Web-AuthFormAnon.ps1
+++ b/examples/Web-AuthFormAnon.ps1
@@ -58,7 +58,7 @@ Start-PodeServer -Threads 2 {
     Set-PodeViewEngine -Type Pode
 
     # enable error logging
-    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogType
 
     # setup session details
     Enable-PodeSessionMiddleware -Duration 120 -Extend

--- a/examples/Web-AuthFormAnon.ps1
+++ b/examples/Web-AuthFormAnon.ps1
@@ -58,7 +58,7 @@ Start-PodeServer -Threads 2 {
     Set-PodeViewEngine -Type Pode
 
     # enable error logging
-    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
 
     # setup session details
     Enable-PodeSessionMiddleware -Duration 120 -Extend

--- a/examples/Web-AuthFormCreds.ps1
+++ b/examples/Web-AuthFormCreds.ps1
@@ -58,7 +58,7 @@ Start-PodeServer -Threads 2 {
     Set-PodeViewEngine -Type Pode
 
     # enable error logging
-    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogType
 
     # setup session details
     Enable-PodeSessionMiddleware -Duration 120 -Extend

--- a/examples/Web-AuthFormCreds.ps1
+++ b/examples/Web-AuthFormCreds.ps1
@@ -58,7 +58,7 @@ Start-PodeServer -Threads 2 {
     Set-PodeViewEngine -Type Pode
 
     # enable error logging
-    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
 
     # setup session details
     Enable-PodeSessionMiddleware -Duration 120 -Extend

--- a/examples/Web-AuthFormFile.ps1
+++ b/examples/Web-AuthFormFile.ps1
@@ -51,7 +51,7 @@ Start-PodeServer -Threads 2 {
 
     # listen on localhost:8081
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http
-    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
 
     # set the view engine
     Set-PodeViewEngine -Type Pode

--- a/examples/Web-AuthFormFile.ps1
+++ b/examples/Web-AuthFormFile.ps1
@@ -51,7 +51,7 @@ Start-PodeServer -Threads 2 {
 
     # listen on localhost:8081
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http
-    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogType
 
     # set the view engine
     Set-PodeViewEngine -Type Pode

--- a/examples/Web-AuthFormLocal.ps1
+++ b/examples/Web-AuthFormLocal.ps1
@@ -46,7 +46,7 @@ Start-PodeServer -Threads 2 {
 
     # listen on localhost:8081
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http
-    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
 
     # set the view engine
     Set-PodeViewEngine -Type Pode

--- a/examples/Web-AuthFormLocal.ps1
+++ b/examples/Web-AuthFormLocal.ps1
@@ -46,7 +46,7 @@ Start-PodeServer -Threads 2 {
 
     # listen on localhost:8081
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http
-    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogType
 
     # set the view engine
     Set-PodeViewEngine -Type Pode

--- a/examples/Web-AuthFormMerged.ps1
+++ b/examples/Web-AuthFormMerged.ps1
@@ -52,7 +52,7 @@ Start-PodeServer -Threads 2 {
     Set-PodeViewEngine -Type Pode
 
     # enable error logging
-    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogType
 
     # setup session details
     Enable-PodeSessionMiddleware -Duration 120 -Extend

--- a/examples/Web-AuthFormMerged.ps1
+++ b/examples/Web-AuthFormMerged.ps1
@@ -52,7 +52,7 @@ Start-PodeServer -Threads 2 {
     Set-PodeViewEngine -Type Pode
 
     # enable error logging
-    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
 
     # setup session details
     Enable-PodeSessionMiddleware -Duration 120 -Extend

--- a/examples/Web-AuthFormSessionAuth.ps1
+++ b/examples/Web-AuthFormSessionAuth.ps1
@@ -54,7 +54,7 @@ Start-PodeServer -Threads 2 {
     Set-PodeViewEngine -Type Pode
 
     # enable error logging
-    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
 
     # setup session details
     Enable-PodeSessionMiddleware -Duration 120 -Extend

--- a/examples/Web-AuthFormSessionAuth.ps1
+++ b/examples/Web-AuthFormSessionAuth.ps1
@@ -54,7 +54,7 @@ Start-PodeServer -Threads 2 {
     Set-PodeViewEngine -Type Pode
 
     # enable error logging
-    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogType
 
     # setup session details
     Enable-PodeSessionMiddleware -Duration 120 -Extend

--- a/examples/Web-AuthMerged.ps1
+++ b/examples/Web-AuthMerged.ps1
@@ -46,11 +46,11 @@ Start-PodeServer -Threads 2 {
 
     # listen on localhost:8081
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http
-    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogType
 
     # request logging
     $batchInfo = New-PodeLogBatchInfo -Size 10 -Timeout 10
-    New-PodeLogTerminalMethod -Batch $batchInfo | Enable-PodeRequestLogging
+    New-PodeLogTerminalMethod -Batch $batchInfo | Enable-PodeRequestLogType
 
     # setup access
     New-PodeAccessScheme -Type Role | Add-PodeAccess -Name 'Rbac'

--- a/examples/Web-AuthMerged.ps1
+++ b/examples/Web-AuthMerged.ps1
@@ -18,7 +18,7 @@
 
 .LINK
     https://github.com/Badgerati/Pode/blob/develop/examples/Web-AuthMerged.ps1
-    
+
 .NOTES
     Author: Pode Team
     License: MIT License
@@ -46,10 +46,11 @@ Start-PodeServer -Threads 2 {
 
     # listen on localhost:8081
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http
-    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
 
     # request logging
-    New-PodeLoggingMethod -Terminal -Batch 10 -BatchTimeout 10 | Enable-PodeRequestLogging
+    $batchInfo = New-PodeLogBatchInfo -Size 10 -Timeout 10
+    New-PodeLogTerminalMethod -Batch $batchInfo | Enable-PodeRequestLogging
 
     # setup access
     New-PodeAccessScheme -Type Role | Add-PodeAccess -Name 'Rbac'

--- a/examples/Web-AuthNegotiate.ps1
+++ b/examples/Web-AuthNegotiate.ps1
@@ -43,7 +43,7 @@ Start-PodeServer -Threads 2 {
     Add-PodeEndpoint -Address localhost -Port 8080 -Host 'pode.example.com' -Protocol Http
 
     # enable error logging
-    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogType
 
     # setup negotiate auth
     New-PodeAuthScheme -Negotiate -KeytabPath '.\pode-user.keytab' | Add-PodeAuth -Name 'Login' -Sessionless -ScriptBlock {

--- a/examples/Web-AuthNegotiate.ps1
+++ b/examples/Web-AuthNegotiate.ps1
@@ -43,7 +43,7 @@ Start-PodeServer -Threads 2 {
     Add-PodeEndpoint -Address localhost -Port 8080 -Host 'pode.example.com' -Protocol Http
 
     # enable error logging
-    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
 
     # setup negotiate auth
     New-PodeAuthScheme -Negotiate -KeytabPath '.\pode-user.keytab' | Add-PodeAuth -Name 'Login' -Sessionless -ScriptBlock {

--- a/examples/Web-AuthOauth2.ps1
+++ b/examples/Web-AuthOauth2.ps1
@@ -44,7 +44,7 @@ Start-PodeServer -Threads 2 {
 
     # listen on localhost:8081
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http -Default
-    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
 
     # set the view engine
     Set-PodeViewEngine -Type Pode

--- a/examples/Web-AuthOauth2.ps1
+++ b/examples/Web-AuthOauth2.ps1
@@ -44,7 +44,7 @@ Start-PodeServer -Threads 2 {
 
     # listen on localhost:8081
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http -Default
-    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogType
 
     # set the view engine
     Set-PodeViewEngine -Type Pode

--- a/examples/Web-AuthOauth2Form.ps1
+++ b/examples/Web-AuthOauth2Form.ps1
@@ -44,7 +44,7 @@ Start-PodeServer -Threads 2 {
 
     # listen on localhost:8081
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http -Default
-    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
 
     # set the view engine
     Set-PodeViewEngine -Type Pode

--- a/examples/Web-AuthOauth2Form.ps1
+++ b/examples/Web-AuthOauth2Form.ps1
@@ -44,7 +44,7 @@ Start-PodeServer -Threads 2 {
 
     # listen on localhost:8081
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http -Default
-    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogType
 
     # set the view engine
     Set-PodeViewEngine -Type Pode

--- a/examples/Web-AuthOauth2Oidc.ps1
+++ b/examples/Web-AuthOauth2Oidc.ps1
@@ -44,7 +44,7 @@ Start-PodeServer -Threads 2 {
 
     # listen on localhost:8081
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http -Default
-    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogType
 
     # set the view engine
     Set-PodeViewEngine -Type Pode

--- a/examples/Web-AuthOauth2Oidc.ps1
+++ b/examples/Web-AuthOauth2Oidc.ps1
@@ -14,7 +14,7 @@
 
 .LINK
     https://github.com/Badgerati/Pode/blob/develop/examples/Web-AuthOauth2Oidc.ps1
-    
+
 .NOTES
     Author: Pode Team
     License: MIT License
@@ -44,7 +44,7 @@ Start-PodeServer -Threads 2 {
 
     # listen on localhost:8081
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http -Default
-    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
 
     # set the view engine
     Set-PodeViewEngine -Type Pode

--- a/examples/Web-FuncsToRoutes.ps1
+++ b/examples/Web-FuncsToRoutes.ps1
@@ -58,7 +58,7 @@ Start-PodeServer -Threads 2 {
 
     # listen on localhost:8081
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http
-    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
 
     # make routes for functions - with every route requires authentication
     ConvertTo-PodeRoute -Commands @('Get-ChildItem', 'Get-Host', 'Invoke-Expression') -Authentication Validate -Verbose

--- a/examples/Web-FuncsToRoutes.ps1
+++ b/examples/Web-FuncsToRoutes.ps1
@@ -58,7 +58,7 @@ Start-PodeServer -Threads 2 {
 
     # listen on localhost:8081
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http
-    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogType
 
     # make routes for functions - with every route requires authentication
     ConvertTo-PodeRoute -Commands @('Get-ChildItem', 'Get-Host', 'Invoke-Expression') -Authentication Validate -Verbose

--- a/examples/Web-GzipRequest.ps1
+++ b/examples/Web-GzipRequest.ps1
@@ -41,7 +41,7 @@ Start-PodeServer -Threads 2 {
     # listen on localhost:8081
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http
 
-    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
 
     # GET request that receives gzip'd json
     Add-PodeRoute -Method Post -Path '/users' -ScriptBlock {

--- a/examples/Web-GzipRequest.ps1
+++ b/examples/Web-GzipRequest.ps1
@@ -41,7 +41,7 @@ Start-PodeServer -Threads 2 {
     # listen on localhost:8081
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http
 
-    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogType
 
     # GET request that receives gzip'd json
     Add-PodeRoute -Method Post -Path '/users' -ScriptBlock {

--- a/examples/Web-Hostname.ps1
+++ b/examples/Web-Hostname.ps1
@@ -60,7 +60,7 @@ Start-PodeServer -Threads 2 {
     Add-PodeEndpoint -Hostname pode4.foo.com -Port $Port -Protocol Http -LookupHostname
 
     # logging
-    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogType
 
     # set view engine to pode renderer
     Set-PodeViewEngine -Type Pode

--- a/examples/Web-Hostname.ps1
+++ b/examples/Web-Hostname.ps1
@@ -60,7 +60,7 @@ Start-PodeServer -Threads 2 {
     Add-PodeEndpoint -Hostname pode4.foo.com -Port $Port -Protocol Http -LookupHostname
 
     # logging
-    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
 
     # set view engine to pode renderer
     Set-PodeViewEngine -Type Pode

--- a/examples/Web-Mcp.ps1
+++ b/examples/Web-Mcp.ps1
@@ -39,8 +39,9 @@ Start-PodeServer -Threads 2 {
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http
 
     # request logging
-    New-PodeLoggingMethod -Terminal -Batch 10 -BatchTimeout 10 | Enable-PodeRequestLogging
-    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+    $batchInfo = New-PodeLogBatchInfo -Size 10 -Timeout 10
+    New-PodeLogTerminalMethod -Batch $batchInfo | Enable-PodeRequestLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
 
     # Create a simple default group for MCP tools
     Add-PodeMcpGroup -Name 'Default' -Description 'Default group for MCP tools'

--- a/examples/Web-Mcp.ps1
+++ b/examples/Web-Mcp.ps1
@@ -40,8 +40,8 @@ Start-PodeServer -Threads 2 {
 
     # request logging
     $batchInfo = New-PodeLogBatchInfo -Size 10 -Timeout 10
-    New-PodeLogTerminalMethod -Batch $batchInfo | Enable-PodeRequestLogging
-    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod -Batch $batchInfo | Enable-PodeRequestLogType
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogType
 
     # Create a simple default group for MCP tools
     Add-PodeMcpGroup -Name 'Default' -Description 'Default group for MCP tools'

--- a/examples/Web-McpServices.ps1
+++ b/examples/Web-McpServices.ps1
@@ -39,8 +39,9 @@ Start-PodeServer -Threads 2 {
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http
 
     # request logging
-    New-PodeLoggingMethod -Terminal -Batch 10 -BatchTimeout 10 | Enable-PodeRequestLogging
-    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+    $batchInfo = New-PodeLogBatchInfo -Size 10 -Timeout 10
+    New-PodeLogTerminalMethod -Batch $batchInfo | Enable-PodeRequestLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
 
     # Create a simple default group for MCP tools
     Add-PodeMcpGroup -Name 'Default' -Description 'Default group for MCP tools'

--- a/examples/Web-McpServices.ps1
+++ b/examples/Web-McpServices.ps1
@@ -40,8 +40,8 @@ Start-PodeServer -Threads 2 {
 
     # request logging
     $batchInfo = New-PodeLogBatchInfo -Size 10 -Timeout 10
-    New-PodeLogTerminalMethod -Batch $batchInfo | Enable-PodeRequestLogging
-    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod -Batch $batchInfo | Enable-PodeRequestLogType
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogType
 
     # Create a simple default group for MCP tools
     Add-PodeMcpGroup -Name 'Default' -Description 'Default group for MCP tools'

--- a/examples/Web-Pages.ps1
+++ b/examples/Web-Pages.ps1
@@ -85,19 +85,22 @@ Start-PodeServer -Threads 2 -Verbose {
     # )
 
     # log requests to the terminal
-    New-PodeLoggingMethod -Terminal -Batch 10 -BatchTimeout 10 | Enable-PodeRequestLogging
-    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+    $batchInfo = New-PodeLogBatchInfo -Size 10 -Timeout 10
+    New-PodeLogTerminalMethod -BatchInfo $batchInfo | Enable-PodeRequestLogging
+
+    # log errors to the terminal
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
 
     # set view engine to pode renderer
     Set-PodeViewEngine -Type Pode
 
     # wire up a custom logger
-    $logType = New-PodeLoggingMethod -Custom -ScriptBlock {
+    $logType = New-PodeLogCustomMethod -ScriptBlock {
         param($item)
         $item.HttpMethod | Out-Default
     }
 
-    $logType | Add-PodeLogger -Name 'custom' -ScriptBlock {
+    $logType | Add-PodeLogType -Name 'custom' -ScriptBlock {
         param($item)
         return @{
             HttpMethod = $item.HttpMethod

--- a/examples/Web-Pages.ps1
+++ b/examples/Web-Pages.ps1
@@ -86,10 +86,10 @@ Start-PodeServer -Threads 2 -Verbose {
 
     # log requests to the terminal
     $batchInfo = New-PodeLogBatchInfo -Size 10 -Timeout 10
-    New-PodeLogTerminalMethod -BatchInfo $batchInfo | Enable-PodeRequestLogging
+    New-PodeLogTerminalMethod -BatchInfo $batchInfo | Enable-PodeRequestLogType
 
     # log errors to the terminal
-    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogType
 
     # set view engine to pode renderer
     Set-PodeViewEngine -Type Pode

--- a/examples/Web-Pages.ps1
+++ b/examples/Web-Pages.ps1
@@ -112,7 +112,7 @@ Start-PodeServer -Threads 2 -Verbose {
 
     # GET request for web page on "localhost:8081/"
     Add-PodeRoute -Method Get -Path '/' -ScriptBlock {
-        # $WebEvent.Request | Write-PodeLog -Name 'custom'
+        $WebEvent.Request | Write-PodeLog -Name 'custom'
         Write-PodeViewResponse -Path 'simple' -Data @{ 'numbers' = @(1, 2, 3); }
     }
 
@@ -125,6 +125,11 @@ Start-PodeServer -Threads 2 -Verbose {
     # GET request throws fake "500" server error status code
     Add-PodeRoute -Method Get -Path '/error' -ScriptBlock {
         Set-PodeResponseStatus -Code 500
+    }
+
+    # GET request throws dummy server exception
+    Add-PodeRoute -Method Get -Path '/exception' -ScriptBlock {
+        throw 'this is a dummy exception'
     }
 
     # GET request to page that merely redirects to google

--- a/examples/Web-Pages.ps1
+++ b/examples/Web-Pages.ps1
@@ -84,9 +84,22 @@ Start-PodeServer -Threads 2 -Verbose {
     #     New-PodeLimitMethodComponent -Method Get, Post
     # )
 
+    # wire up a custom logger
+    $customLogMethod = New-PodeLogCustomMethod -ScriptBlock {
+        param($item, $options, $raw)
+        $item.HttpMethod | Out-Default
+    }
+
+    $customLogMethod | Add-PodeLogType -Name 'custom' -ScriptBlock {
+        param($item)
+        return @{
+            HttpMethod = $item.HttpMethod
+        }
+    }
+
     # log requests to the terminal
     $batchInfo = New-PodeLogBatchInfo -Size 10 -Timeout 10
-    New-PodeLogTerminalMethod -BatchInfo $batchInfo | Enable-PodeRequestLogType
+    New-PodeLogTerminalMethod -Batch $batchInfo | Enable-PodeRequestLogType
 
     # log errors to the terminal
     New-PodeLogTerminalMethod | Enable-PodeErrorLogType
@@ -94,19 +107,7 @@ Start-PodeServer -Threads 2 -Verbose {
     # set view engine to pode renderer
     Set-PodeViewEngine -Type Pode
 
-    # wire up a custom logger
-    $logType = New-PodeLogCustomMethod -ScriptBlock {
-        param($item)
-        $item.HttpMethod | Out-Default
-    }
-
-    $logType | Add-PodeLogType -Name 'custom' -ScriptBlock {
-        param($item)
-        return @{
-            HttpMethod = $item.HttpMethod
-        }
-    }
-
+    # load file routes
     Use-PodeRoutes -Path './routes'
 
     # GET request for web page on "localhost:8081/"

--- a/examples/Web-Pages.ps1
+++ b/examples/Web-Pages.ps1
@@ -97,6 +97,9 @@ Start-PodeServer -Threads 2 -Verbose {
         }
     }
 
+    # wire up a custom raw logger
+    New-PodeLogTerminalMethod | Add-PodeLogType -Name 'custom-raw' -Raw
+
     # log requests to the terminal
     $batchInfo = New-PodeLogBatchInfo -Size 10 -Timeout 10
     New-PodeLogTerminalMethod -Batch $batchInfo | Enable-PodeRequestLogType
@@ -113,6 +116,7 @@ Start-PodeServer -Threads 2 -Verbose {
     # GET request for web page on "localhost:8081/"
     Add-PodeRoute -Method Get -Path '/' -ScriptBlock {
         $WebEvent.Request | Write-PodeLog -Name 'custom'
+        $WebEvent.ContextId | Write-PodeLog -Name 'custom-raw'
         Write-PodeViewResponse -Path 'simple' -Data @{ 'numbers' = @(1, 2, 3); }
     }
 

--- a/examples/Web-PagesHttps.ps1
+++ b/examples/Web-PagesHttps.ps1
@@ -50,8 +50,8 @@ catch { throw }
 
 # create a server, flagged to generate a self-signed cert for dev/testing
 Start-PodeServer {
-    New-PodeLogTerminalMethod | Enable-PodeRequestLogging
-    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeRequestLogType
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogType
 
     # bind to ip/port and set as https with self-signed cert
     switch ($CertType) {

--- a/examples/Web-PagesHttps.ps1
+++ b/examples/Web-PagesHttps.ps1
@@ -50,8 +50,8 @@ catch { throw }
 
 # create a server, flagged to generate a self-signed cert for dev/testing
 Start-PodeServer {
-    New-PodeLoggingMethod -Terminal | Enable-PodeRequestLogging
-    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeRequestLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
 
     # bind to ip/port and set as https with self-signed cert
     switch ($CertType) {

--- a/examples/Web-PagesSimple.ps1
+++ b/examples/Web-PagesSimple.ps1
@@ -53,7 +53,7 @@ Start-PodeServer -Threads 2 {
     Add-PodeEndpoint -Address localhost -Port $Port -Protocol Http -Name '8081Address' -RedirectTo '8090Address'
 
     # log errors to the terminal
-    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
 
     # set view engine to pode renderer
     Set-PodeViewEngine -Type Pode

--- a/examples/Web-PagesSimple.ps1
+++ b/examples/Web-PagesSimple.ps1
@@ -53,7 +53,7 @@ Start-PodeServer -Threads 2 {
     Add-PodeEndpoint -Address localhost -Port $Port -Protocol Http -Name '8081Address' -RedirectTo '8090Address'
 
     # log errors to the terminal
-    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogType
 
     # set view engine to pode renderer
     Set-PodeViewEngine -Type Pode

--- a/examples/Web-PagesUsing.ps1
+++ b/examples/Web-PagesUsing.ps1
@@ -69,8 +69,9 @@ Start-PodeServer -Threads 2 {
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http
 
     # log requests to the terminal
-    New-PodeLoggingMethod -Terminal -Batch 10 -BatchTimeout 10 | Enable-PodeRequestLogging
-    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+    $batchInfo = New-PodeLogBatchInfo -Size 10 -Timeout 10
+    New-PodeLogTerminalMethod -Batch $batchInfo | Enable-PodeRequestLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
 
     # set view engine to pode renderer
     Set-PodeViewEngine -Type Pode

--- a/examples/Web-PagesUsing.ps1
+++ b/examples/Web-PagesUsing.ps1
@@ -70,8 +70,8 @@ Start-PodeServer -Threads 2 {
 
     # log requests to the terminal
     $batchInfo = New-PodeLogBatchInfo -Size 10 -Timeout 10
-    New-PodeLogTerminalMethod -Batch $batchInfo | Enable-PodeRequestLogging
-    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod -Batch $batchInfo | Enable-PodeRequestLogType
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogType
 
     # set view engine to pode renderer
     Set-PodeViewEngine -Type Pode

--- a/examples/Web-RestApi.ps1
+++ b/examples/Web-RestApi.ps1
@@ -45,7 +45,8 @@ Start-PodeServer {
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http -DualMode
 
     # request logging
-    New-PodeLoggingMethod -Terminal -Batch 10 -BatchTimeout 10 | Enable-PodeRequestLogging
+    $batchInfo = New-PodeLogBatchInfo -Size 10 -Timeout 10
+    New-PodeLogTerminalMethod -Batch $batchInfo | Enable-PodeRequestLogging
 
     # can be hit by sending a GET request to "localhost:8086/api/test"
     Add-PodeRoute -Method Get -Path '/api/test' -ScriptBlock {

--- a/examples/Web-RestApi.ps1
+++ b/examples/Web-RestApi.ps1
@@ -46,7 +46,7 @@ Start-PodeServer {
 
     # request logging
     $batchInfo = New-PodeLogBatchInfo -Size 10 -Timeout 10
-    New-PodeLogTerminalMethod -Batch $batchInfo | Enable-PodeRequestLogging
+    New-PodeLogTerminalMethod -Batch $batchInfo | Enable-PodeRequestLogType
 
     # can be hit by sending a GET request to "localhost:8086/api/test"
     Add-PodeRoute -Method Get -Path '/api/test' -ScriptBlock {

--- a/examples/Web-RestOpenApi.ps1
+++ b/examples/Web-RestOpenApi.ps1
@@ -44,7 +44,7 @@ Start-PodeServer {
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http -Name 'user'
     Add-PodeEndpoint -Address localhost -Port 8082 -Protocol Http -Name 'admin'
 
-    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogType
 
     Enable-PodeOpenApi -DisableMinimalDefinitions
     Add-PodeOAInfo  -Title 'OpenAPI Example'

--- a/examples/Web-RestOpenApi.ps1
+++ b/examples/Web-RestOpenApi.ps1
@@ -44,7 +44,7 @@ Start-PodeServer {
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http -Name 'user'
     Add-PodeEndpoint -Address localhost -Port 8082 -Protocol Http -Name 'admin'
 
-    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
 
     Enable-PodeOpenApi -DisableMinimalDefinitions
     Add-PodeOAInfo  -Title 'OpenAPI Example'

--- a/examples/Web-RestOpenApiShared.ps1
+++ b/examples/Web-RestOpenApiShared.ps1
@@ -44,7 +44,7 @@ Start-PodeServer {
     Add-PodeEndpoint -Address localhost -Port 8080 -Protocol Http -Name 'user'
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http -Name 'admin'
 
-    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogType
 
     Enable-PodeOpenApi  -DisableMinimalDefinitions
 

--- a/examples/Web-RestOpenApiShared.ps1
+++ b/examples/Web-RestOpenApiShared.ps1
@@ -44,7 +44,7 @@ Start-PodeServer {
     Add-PodeEndpoint -Address localhost -Port 8080 -Protocol Http -Name 'user'
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http -Name 'admin'
 
-    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
 
     Enable-PodeOpenApi  -DisableMinimalDefinitions
 

--- a/examples/Web-RouteGroup.ps1
+++ b/examples/Web-RouteGroup.ps1
@@ -47,7 +47,7 @@ Start-PodeServer -Threads 2 {
 
     # listen on localhost:8081
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http
-    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
 
     $mid1 = New-PodeMiddleware -ScriptBlock {
         'here1' | Out-Default

--- a/examples/Web-RouteGroup.ps1
+++ b/examples/Web-RouteGroup.ps1
@@ -47,7 +47,7 @@ Start-PodeServer -Threads 2 {
 
     # listen on localhost:8081
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http
-    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogType
 
     $mid1 = New-PodeMiddleware -ScriptBlock {
         'here1' | Out-Default

--- a/examples/Web-Secrets.ps1
+++ b/examples/Web-Secrets.ps1
@@ -62,7 +62,7 @@ Start-PodeServer -Threads 2 {
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http
 
     # logging
-    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
 
 
     # secret manage azure keyvault - need to run "Connect-AzAccount" first!

--- a/examples/Web-Secrets.ps1
+++ b/examples/Web-Secrets.ps1
@@ -62,7 +62,7 @@ Start-PodeServer -Threads 2 {
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http
 
     # logging
-    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogType
 
 
     # secret manage azure keyvault - need to run "Connect-AzAccount" first!

--- a/examples/Web-SecretsLocal.ps1
+++ b/examples/Web-SecretsLocal.ps1
@@ -47,7 +47,7 @@ Start-PodeServer -Threads 2 {
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http
 
     # logging
-    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogType
 
 
     # secret manage local vault

--- a/examples/Web-SecretsLocal.ps1
+++ b/examples/Web-SecretsLocal.ps1
@@ -47,7 +47,7 @@ Start-PodeServer -Threads 2 {
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http
 
     # logging
-    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
 
 
     # secret manage local vault

--- a/examples/Web-SelfSigned.ps1
+++ b/examples/Web-SelfSigned.ps1
@@ -30,8 +30,8 @@ catch { throw }
 Start-PodeServer -Threads 6 {
     Add-PodeEndpoint -Address localhost -Port '8081' -Protocol 'Https' -SelfSigned
 
-    New-PodeLoggingMethod -File -Name 'requests' | Enable-PodeRequestLogging
-    New-PodeLoggingMethod -File -Name 'errors' | Enable-PodeErrorLogging
+    New-PodeLogFileMethod -Name 'requests' | Enable-PodeRequestLogging
+    New-PodeLogFileMethod -Name 'errors' | Enable-PodeErrorLogging
 
     Add-PodeRoute -Method Get -Path / -ScriptBlock {
         Write-PodeTextResponse -Value 'Test'

--- a/examples/Web-SelfSigned.ps1
+++ b/examples/Web-SelfSigned.ps1
@@ -30,8 +30,8 @@ catch { throw }
 Start-PodeServer -Threads 6 {
     Add-PodeEndpoint -Address localhost -Port '8081' -Protocol 'Https' -SelfSigned
 
-    New-PodeLogFileMethod -Name 'requests' | Enable-PodeRequestLogging
-    New-PodeLogFileMethod -Name 'errors' | Enable-PodeErrorLogging
+    New-PodeLogFileMethod -Name 'requests' | Enable-PodeRequestLogType
+    New-PodeLogFileMethod -Name 'errors' | Enable-PodeErrorLogType
 
     Add-PodeRoute -Method Get -Path / -ScriptBlock {
         Write-PodeTextResponse -Value 'Test'

--- a/examples/Web-Signal.ps1
+++ b/examples/Web-Signal.ps1
@@ -51,7 +51,7 @@ Start-PodeServer -Threads 3 {
     # Add-PodeEndpoint -Address localhost -Port 8091 -Certificate './certs/pode-cert.pfx' -CertificatePassword '1234' -Protocol Wss
 
     # log errors to the terminal
-    New-PodeLogTerminalMethod | Enable-PodeErrorLogging -Levels Error
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogType -Levels Error
 
     # register a connect event
     Register-PodeSignalEvent -Name '/msg' -Type Connect -EventName 'SignalConnected' -ScriptBlock {

--- a/examples/Web-Signal.ps1
+++ b/examples/Web-Signal.ps1
@@ -51,7 +51,7 @@ Start-PodeServer -Threads 3 {
     # Add-PodeEndpoint -Address localhost -Port 8091 -Certificate './certs/pode-cert.pfx' -CertificatePassword '1234' -Protocol Wss
 
     # log errors to the terminal
-    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging -Levels Error
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogging -Levels Error
 
     # register a connect event
     Register-PodeSignalEvent -Name '/msg' -Type Connect -EventName 'SignalConnected' -ScriptBlock {

--- a/examples/Web-SignalAuthForm.ps1
+++ b/examples/Web-SignalAuthForm.ps1
@@ -52,7 +52,7 @@ Start-PodeServer -Threads 3 {
     Add-PodeEndpoint -Address localhost -Port 8091 -Protocol Ws -NoAutoUpgradeWebSockets
 
     # log errors to the terminal
-    New-PodeLogTerminalMethod | Enable-PodeErrorLogging -Levels Error
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogType -Levels Error
 
     # register a connect event
     Register-PodeSignalEvent -Name 'Msg', 'Local' -Type Connect -EventName 'SignalConnected' -ScriptBlock {

--- a/examples/Web-SignalAuthForm.ps1
+++ b/examples/Web-SignalAuthForm.ps1
@@ -52,7 +52,7 @@ Start-PodeServer -Threads 3 {
     Add-PodeEndpoint -Address localhost -Port 8091 -Protocol Ws -NoAutoUpgradeWebSockets
 
     # log errors to the terminal
-    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging -Levels Error
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogging -Levels Error
 
     # register a connect event
     Register-PodeSignalEvent -Name 'Msg', 'Local' -Type Connect -EventName 'SignalConnected' -ScriptBlock {

--- a/examples/Web-SignalConnection.ps1
+++ b/examples/Web-SignalConnection.ps1
@@ -54,7 +54,7 @@ Start-PodeServer -EnablePool WebSockets {
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http
 
     # log requests to the terminal
-    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging -Levels Error, Debug, Verbose
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogging -Levels Error, Debug, Verbose
 
     # connect to web socket from web-signal.ps1
     Connect-PodeWebSocket -Name 'Example' -Url 'ws://localhost:8091' -ScriptBlock {

--- a/examples/Web-SignalConnection.ps1
+++ b/examples/Web-SignalConnection.ps1
@@ -54,7 +54,7 @@ Start-PodeServer -EnablePool WebSockets {
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http
 
     # log requests to the terminal
-    New-PodeLogTerminalMethod | Enable-PodeErrorLogging -Levels Error, Debug, Verbose
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogType -Levels Error, Debug, Verbose
 
     # connect to web socket from web-signal.ps1
     Connect-PodeWebSocket -Name 'Example' -Url 'ws://localhost:8091' -ScriptBlock {

--- a/examples/Web-SignalManual.ps1
+++ b/examples/Web-SignalManual.ps1
@@ -49,7 +49,7 @@ Start-PodeServer -Threads 3 {
     Add-PodeEndpoint -Address localhost -Port 8091 -Protocol Ws -NoAutoUpgradeWebSockets
 
     # log errors to the terminal
-    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging -Levels Error
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogging -Levels Error
 
     # register a connect event
     Register-PodeSignalEvent -Name 'Msg' -Type Connect -EventName 'SignalConnected' -ScriptBlock {

--- a/examples/Web-SignalManual.ps1
+++ b/examples/Web-SignalManual.ps1
@@ -49,7 +49,7 @@ Start-PodeServer -Threads 3 {
     Add-PodeEndpoint -Address localhost -Port 8091 -Protocol Ws -NoAutoUpgradeWebSockets
 
     # log errors to the terminal
-    New-PodeLogTerminalMethod | Enable-PodeErrorLogging -Levels Error
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogType -Levels Error
 
     # register a connect event
     Register-PodeSignalEvent -Name 'Msg' -Type Connect -EventName 'SignalConnected' -ScriptBlock {

--- a/examples/Web-SimplePages.ps1
+++ b/examples/Web-SimplePages.ps1
@@ -44,7 +44,7 @@ Start-PodeServer -Threads 2 {
 
     # listen on localhost:8081
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http
-    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogType
 
     Add-PodePage -Name Processes -ScriptBlock { Get-Process }
     Add-PodePage -Name Services -ScriptBlock { Get-Service }

--- a/examples/Web-SimplePages.ps1
+++ b/examples/Web-SimplePages.ps1
@@ -19,7 +19,7 @@
 
 .LINK
     https://github.com/Badgerati/Pode/blob/develop/examples/Web-SimplePages.ps1
-    
+
 .NOTES
     Author: Pode Team
     License: MIT License
@@ -44,7 +44,7 @@ Start-PodeServer -Threads 2 {
 
     # listen on localhost:8081
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http
-    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
 
     Add-PodePage -Name Processes -ScriptBlock { Get-Process }
     Add-PodePage -Name Services -ScriptBlock { Get-Service }

--- a/examples/Web-Sockets.ps1
+++ b/examples/Web-Sockets.ps1
@@ -47,7 +47,7 @@ Start-PodeServer -Threads 5 {
     # Add-PodeEndpoint -Address localhost -Port 8081 -SelfSigned -Protocol Https
 
     # log requests to the terminal
-    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
 
     # GET request for web page on "localhost:8085/"
     Add-PodeRoute -Method Get -Path '/' -ScriptBlock {

--- a/examples/Web-Sockets.ps1
+++ b/examples/Web-Sockets.ps1
@@ -47,7 +47,7 @@ Start-PodeServer -Threads 5 {
     # Add-PodeEndpoint -Address localhost -Port 8081 -SelfSigned -Protocol Https
 
     # log requests to the terminal
-    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogType
 
     # GET request for web page on "localhost:8085/"
     Add-PodeRoute -Method Get -Path '/' -ScriptBlock {

--- a/examples/Web-Sse.ps1
+++ b/examples/Web-Sse.ps1
@@ -44,7 +44,7 @@ Start-PodeServer -Threads 3 {
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http
 
     # log errors
-    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging -Levels Error
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogging -Levels Error
 
     # register a connect event
     Register-PodeSseEvent -Name 'Test', 'Data' -Type Connect -EventName 'Connected' -ScriptBlock {

--- a/examples/Web-Sse.ps1
+++ b/examples/Web-Sse.ps1
@@ -44,7 +44,7 @@ Start-PodeServer -Threads 3 {
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http
 
     # log errors
-    New-PodeLogTerminalMethod | Enable-PodeErrorLogging -Levels Error
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogType -Levels Error
 
     # register a connect event
     Register-PodeSseEvent -Name 'Test', 'Data' -Type Connect -EventName 'Connected' -ScriptBlock {

--- a/examples/Web-Static.ps1
+++ b/examples/Web-Static.ps1
@@ -51,8 +51,8 @@ Start-PodeServer -Threads 2 {
 
     # listen on localhost:8081
     Add-PodeEndpoint -Address localhost -Port $port -Protocol Http
-    New-PodeLoggingMethod -Terminal | Enable-PodeRequestLogging
-    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeRequestLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
 
     # set view engine to pode renderer
     Set-PodeViewEngine -Type Pode

--- a/examples/Web-Static.ps1
+++ b/examples/Web-Static.ps1
@@ -51,8 +51,8 @@ Start-PodeServer -Threads 2 {
 
     # listen on localhost:8081
     Add-PodeEndpoint -Address localhost -Port $port -Protocol Http
-    New-PodeLogTerminalMethod | Enable-PodeRequestLogging
-    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeRequestLogType
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogType
 
     # set view engine to pode renderer
     Set-PodeViewEngine -Type Pode

--- a/examples/Web-StaticAuth.ps1
+++ b/examples/Web-StaticAuth.ps1
@@ -45,8 +45,8 @@ Start-PodeServer -Threads 2 {
     # listen on localhost:8081
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http
 
-    New-PodeLoggingMethod -Terminal | Enable-PodeRequestLogging
-    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeRequestLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
 
     # setup basic auth (base64> username:password in header)
     New-PodeAuthScheme -Basic -Realm 'Pode Static Page' | Add-PodeAuth -Name 'Validate' -Sessionless -ScriptBlock {

--- a/examples/Web-StaticAuth.ps1
+++ b/examples/Web-StaticAuth.ps1
@@ -45,8 +45,8 @@ Start-PodeServer -Threads 2 {
     # listen on localhost:8081
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http
 
-    New-PodeLogTerminalMethod | Enable-PodeRequestLogging
-    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeRequestLogType
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogType
 
     # setup basic auth (base64> username:password in header)
     New-PodeAuthScheme -Basic -Realm 'Pode Static Page' | Add-PodeAuth -Name 'Validate' -Sessionless -ScriptBlock {

--- a/examples/Web-TpEPS.ps1
+++ b/examples/Web-TpEPS.ps1
@@ -40,7 +40,7 @@ Start-PodeServer -Threads 2 {
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http
 
     # log requests to the terminal
-    New-PodeLoggingMethod -Terminal | Enable-PodeRequestLogging
+    New-PodeLogTerminalMethod | Enable-PodeRequestLogging
 
     # set view engine to EPS renderer
     Set-PodeViewEngine -Type EPS -ScriptBlock {

--- a/examples/Web-TpEPS.ps1
+++ b/examples/Web-TpEPS.ps1
@@ -40,7 +40,7 @@ Start-PodeServer -Threads 2 {
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http
 
     # log requests to the terminal
-    New-PodeLogTerminalMethod | Enable-PodeRequestLogging
+    New-PodeLogTerminalMethod | Enable-PodeRequestLogType
 
     # set view engine to EPS renderer
     Set-PodeViewEngine -Type EPS -ScriptBlock {

--- a/examples/Web-TpPSHTML.ps1
+++ b/examples/Web-TpPSHTML.ps1
@@ -40,7 +40,7 @@ Start-PodeServer -Threads 2 {
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http
 
     # log requests to the terminal
-    New-PodeLogTerminalMethod | Enable-PodeRequestLogging
+    New-PodeLogTerminalMethod | Enable-PodeRequestLogType
 
     # set view engine to PSHTML renderer
     Set-PodeViewEngine -Type PSHTML -Extension PS1 -ScriptBlock {

--- a/examples/Web-TpPSHTML.ps1
+++ b/examples/Web-TpPSHTML.ps1
@@ -40,7 +40,7 @@ Start-PodeServer -Threads 2 {
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http
 
     # log requests to the terminal
-    New-PodeLoggingMethod -Terminal | Enable-PodeRequestLogging
+    New-PodeLogTerminalMethod | Enable-PodeRequestLogging
 
     # set view engine to PSHTML renderer
     Set-PodeViewEngine -Type PSHTML -Extension PS1 -ScriptBlock {

--- a/examples/Web-Upload.ps1
+++ b/examples/Web-Upload.ps1
@@ -55,7 +55,7 @@ Start-PodeServer -Threads 2 {
     Add-PodeEndpoint -Address localhost -Port $port -Protocol Http
 
     Set-PodeViewEngine -Type HTML
-    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
 
     # GET request for web page on "localhost:8081/"
     Add-PodeRoute -Method Get -Path '/' -ScriptBlock {

--- a/examples/Web-Upload.ps1
+++ b/examples/Web-Upload.ps1
@@ -55,7 +55,7 @@ Start-PodeServer -Threads 2 {
     Add-PodeEndpoint -Address localhost -Port $port -Protocol Http
 
     Set-PodeViewEngine -Type HTML
-    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogType
 
     # GET request for web page on "localhost:8081/"
     Add-PodeRoute -Method Get -Path '/' -ScriptBlock {

--- a/examples/Web-UsePodeAuth.ps1
+++ b/examples/Web-UsePodeAuth.ps1
@@ -67,8 +67,8 @@ Start-PodeServer -Threads 2 {
     # listen on localhost:8081
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http
 
-    New-PodeLoggingMethod -File -Name 'requests' | Enable-PodeRequestLogging
-    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+    New-PodeLogFileMethod -Name 'requests' | Enable-PodeRequestLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
 
     Use-PodeAuth
 

--- a/examples/Web-UsePodeAuth.ps1
+++ b/examples/Web-UsePodeAuth.ps1
@@ -67,8 +67,8 @@ Start-PodeServer -Threads 2 {
     # listen on localhost:8081
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http
 
-    New-PodeLogFileMethod -Name 'requests' | Enable-PodeRequestLogging
-    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+    New-PodeLogFileMethod -Name 'requests' | Enable-PodeRequestLogType
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogType
 
     Use-PodeAuth
 

--- a/examples/WebAuth-ApikeyJWT.ps1
+++ b/examples/WebAuth-ApikeyJWT.ps1
@@ -66,8 +66,8 @@ Start-PodeServer -Threads 2 {
     # listen on localhost:8081
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http
 
-    New-PodeLogFileMethod -Name 'requests' | Enable-PodeRequestLogging
-    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+    New-PodeLogFileMethod -Name 'requests' | Enable-PodeRequestLogType
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogType
 
     # setup bearer auth
     New-PodeAuthScheme -ApiKey -Location $Location -AsJWT | Add-PodeAuth -Name 'Validate' -Sessionless -ScriptBlock {

--- a/examples/WebAuth-ApikeyJWT.ps1
+++ b/examples/WebAuth-ApikeyJWT.ps1
@@ -66,8 +66,8 @@ Start-PodeServer -Threads 2 {
     # listen on localhost:8081
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http
 
-    New-PodeLoggingMethod -File -Name 'requests' | Enable-PodeRequestLogging
-    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+    New-PodeLogFileMethod -Name 'requests' | Enable-PodeRequestLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
 
     # setup bearer auth
     New-PodeAuthScheme -ApiKey -Location $Location -AsJWT | Add-PodeAuth -Name 'Validate' -Sessionless -ScriptBlock {

--- a/examples/WebHook.ps1
+++ b/examples/WebHook.ps1
@@ -61,7 +61,7 @@ Start-PodeServer {
     Set-PodeState -Name 'subscriptions' -Value @{} | Out-Null
 
     # Enable terminal logging for errors
-    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
 
     # Enable OpenAPI documentation
     Enable-PodeOpenApi -Path '/docs/openapi/v3.1' -OpenApiVersion '3.1.0' -DisableMinimalDefinitions -NoDefaultResponses -EnableSchemaValidation

--- a/examples/WebHook.ps1
+++ b/examples/WebHook.ps1
@@ -61,7 +61,7 @@ Start-PodeServer {
     Set-PodeState -Name 'subscriptions' -Value @{} | Out-Null
 
     # Enable terminal logging for errors
-    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogType
 
     # Enable OpenAPI documentation
     Enable-PodeOpenApi -Path '/docs/openapi/v3.1' -OpenApiVersion '3.1.0' -DisableMinimalDefinitions -NoDefaultResponses -EnableSchemaValidation

--- a/examples/scripts/server.ps1
+++ b/examples/scripts/server.ps1
@@ -1,6 +1,6 @@
 {
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http
-    New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
     Set-PodeViewEngine -Type Pode
 
     Add-PodeTimer -Name 'Hi' -Interval 4 -ScriptBlock {

--- a/examples/scripts/server.ps1
+++ b/examples/scripts/server.ps1
@@ -1,6 +1,6 @@
 {
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http
-    New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+    New-PodeLogTerminalMethod | Enable-PodeErrorLogType
     Set-PodeViewEngine -Type Pode
 
     Add-PodeTimer -Name 'Hi' -Interval 4 -ScriptBlock {

--- a/src/Listener/Adapters/Consumers/PodeConsumer.cs
+++ b/src/Listener/Adapters/Consumers/PodeConsumer.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Pode.Utilities;
 using Pode.Protocols.WebSockets;
+using Pode.Utilities.Logging;
 
 namespace Pode.Adapters.Consumers
 {
@@ -95,7 +96,7 @@ namespace Pode.Adapters.Consumers
         protected override void Close()
         {
             // disconnect websockets
-            PodeHelpers.WriteErrorMessage($"Closing client web sockets", this, PodeLoggingLevel.Verbose);
+            PodeHelpers.WriteErrorMessage($"Closing client web sockets", this, PodeLogLevel.Verbose);
 
             foreach (var _webSocket in WebSockets.Values.ToArray())
             {
@@ -103,10 +104,10 @@ namespace Pode.Adapters.Consumers
             }
 
             WebSockets.Clear();
-            PodeHelpers.WriteErrorMessage($"Closed client web sockets", this, PodeLoggingLevel.Verbose);
+            PodeHelpers.WriteErrorMessage($"Closed client web sockets", this, PodeLogLevel.Verbose);
 
             // close existing websocket requests
-            PodeHelpers.WriteErrorMessage($"Closing client web sockets requests", this, PodeLoggingLevel.Verbose);
+            PodeHelpers.WriteErrorMessage($"Closing client web sockets requests", this, PodeLogLevel.Verbose);
 
             foreach (var _req in Requests.ToArray())
             {
@@ -114,7 +115,7 @@ namespace Pode.Adapters.Consumers
             }
 
             Requests.Dispose();
-            PodeHelpers.WriteErrorMessage($"Closed client web requests", this, PodeLoggingLevel.Verbose);
+            PodeHelpers.WriteErrorMessage($"Closed client web requests", this, PodeLogLevel.Verbose);
         }
     }
 }

--- a/src/Listener/Adapters/Consumers/PodeConsumer.cs
+++ b/src/Listener/Adapters/Consumers/PodeConsumer.cs
@@ -15,8 +15,8 @@ namespace Pode.Adapters.Consumers
 
         public PodeItemQueue<PodeWebSocketRequest> Requests { get; private set; }
 
-        public PodeConsumer(PodeAdapterType type, CancellationToken cancellationToken = default)
-            : base(type, cancellationToken)
+        public PodeConsumer(PodeAdapterType type, IPodeLogger logger, CancellationToken cancellationToken = default)
+            : base(type, logger, cancellationToken)
         {
             WebSockets = new Dictionary<string, PodeWebSocket>();
             Requests = new PodeItemQueue<PodeWebSocketRequest>();
@@ -96,7 +96,7 @@ namespace Pode.Adapters.Consumers
         protected override void Close()
         {
             // disconnect websockets
-            PodeHelpers.WriteErrorMessage($"Closing client web sockets", this, PodeLogLevel.Verbose);
+            PodeHelpers.WriteErrorMessage($"Closing client web sockets", PodeLogLevel.Verbose);
 
             foreach (var _webSocket in WebSockets.Values.ToArray())
             {
@@ -104,10 +104,10 @@ namespace Pode.Adapters.Consumers
             }
 
             WebSockets.Clear();
-            PodeHelpers.WriteErrorMessage($"Closed client web sockets", this, PodeLogLevel.Verbose);
+            PodeHelpers.WriteErrorMessage($"Closed client web sockets", PodeLogLevel.Verbose);
 
             // close existing websocket requests
-            PodeHelpers.WriteErrorMessage($"Closing client web sockets requests", this, PodeLogLevel.Verbose);
+            PodeHelpers.WriteErrorMessage($"Closing client web sockets requests", PodeLogLevel.Verbose);
 
             foreach (var _req in Requests.ToArray())
             {
@@ -115,7 +115,7 @@ namespace Pode.Adapters.Consumers
             }
 
             Requests.Dispose();
-            PodeHelpers.WriteErrorMessage($"Closed client web requests", this, PodeLogLevel.Verbose);
+            PodeHelpers.WriteErrorMessage($"Closed client web requests", PodeLogLevel.Verbose);
         }
     }
 }

--- a/src/Listener/Adapters/IPodeAdapter.cs
+++ b/src/Listener/Adapters/IPodeAdapter.cs
@@ -7,8 +7,6 @@ namespace Pode.Adapters
     {
         bool IsConnected { get; }
         bool IsDisposed { get; }
-        bool ErrorLoggingEnabled { get; set; }
-        string[] ErrorLoggingLevels { get; set; }
         CancellationToken CancellationToken { get; }
         PodeAdapterType Type { get; }
 

--- a/src/Listener/Adapters/Listeners/PodeListener.cs
+++ b/src/Listener/Adapters/Listeners/PodeListener.cs
@@ -45,8 +45,8 @@ namespace Pode.Adapters.Listeners
             }
         }
 
-        public PodeListener(PodeAdapterType type, CancellationToken cancellationToken = default)
-            : base(type, cancellationToken)
+        public PodeListener(PodeAdapterType type, IPodeLogger logger, CancellationToken cancellationToken = default)
+            : base(type, logger, cancellationToken)
         {
             Sockets = new List<PodeSocket>();
             Contexts = new PodeItemQueue<PodeContext>();
@@ -106,24 +106,24 @@ namespace Pode.Adapters.Listeners
         protected override void Close()
         {
             // close existing contexts
-            PodeHelpers.WriteErrorMessage($"Closing contexts", this, PodeLogLevel.Verbose);
+            PodeHelpers.WriteErrorMessage($"Closing contexts", PodeLogLevel.Verbose);
             foreach (var _context in Contexts.ToArray())
             {
                 _context.Dispose(true);
             }
 
             Contexts.Dispose();
-            PodeHelpers.WriteErrorMessage($"Closed contexts", this, PodeLogLevel.Verbose);
+            PodeHelpers.WriteErrorMessage($"Closed contexts", PodeLogLevel.Verbose);
 
             // shutdown the sockets
-            PodeHelpers.WriteErrorMessage($"Closing sockets", this, PodeLogLevel.Verbose);
+            PodeHelpers.WriteErrorMessage($"Closing sockets", PodeLogLevel.Verbose);
             for (var i = Sockets.Count - 1; i >= 0; i--)
             {
                 Sockets[i].Dispose();
             }
 
             Sockets.Clear();
-            PodeHelpers.WriteErrorMessage($"Closed sockets", this, PodeLogLevel.Verbose);
+            PodeHelpers.WriteErrorMessage($"Closed sockets", PodeLogLevel.Verbose);
         }
     }
 }

--- a/src/Listener/Adapters/Listeners/PodeListener.cs
+++ b/src/Listener/Adapters/Listeners/PodeListener.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Pode.Transport.Sockets;
 using Pode.Utilities;
 using Pode.Protocols.Common.Contexts;
+using Pode.Utilities.Logging;
 
 namespace Pode.Adapters.Listeners
 {
@@ -105,24 +106,24 @@ namespace Pode.Adapters.Listeners
         protected override void Close()
         {
             // close existing contexts
-            PodeHelpers.WriteErrorMessage($"Closing contexts", this, PodeLoggingLevel.Verbose);
+            PodeHelpers.WriteErrorMessage($"Closing contexts", this, PodeLogLevel.Verbose);
             foreach (var _context in Contexts.ToArray())
             {
                 _context.Dispose(true);
             }
 
             Contexts.Dispose();
-            PodeHelpers.WriteErrorMessage($"Closed contexts", this, PodeLoggingLevel.Verbose);
+            PodeHelpers.WriteErrorMessage($"Closed contexts", this, PodeLogLevel.Verbose);
 
             // shutdown the sockets
-            PodeHelpers.WriteErrorMessage($"Closing sockets", this, PodeLoggingLevel.Verbose);
+            PodeHelpers.WriteErrorMessage($"Closing sockets", this, PodeLogLevel.Verbose);
             for (var i = Sockets.Count - 1; i >= 0; i--)
             {
                 Sockets[i].Dispose();
             }
 
             Sockets.Clear();
-            PodeHelpers.WriteErrorMessage($"Closed sockets", this, PodeLoggingLevel.Verbose);
+            PodeHelpers.WriteErrorMessage($"Closed sockets", this, PodeLogLevel.Verbose);
         }
     }
 }

--- a/src/Listener/Adapters/PodeAdapter.cs
+++ b/src/Listener/Adapters/PodeAdapter.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Threading;
+using Pode.Utilities;
+using Pode.Utilities.Logging;
 
 namespace Pode.Adapters
 {
@@ -7,14 +9,13 @@ namespace Pode.Adapters
     {
         public bool IsConnected { get; private set; }
         public bool IsDisposed { get; private set; }
-        public bool ErrorLoggingEnabled { get; set; }
-        public string[] ErrorLoggingLevels { get; set; }
         public CancellationToken CancellationToken { get; private set; }
         public PodeAdapterType Type { get; private set; }
 
-        public PodeAdapter(PodeAdapterType type, CancellationToken cancellationToken = default)
+        public PodeAdapter(PodeAdapterType type, IPodeLogger logger, CancellationToken cancellationToken = default)
         {
             Type = type;
+            PodeHelpers.SetLogger(logger);
 
             CancellationToken = cancellationToken == default
                 ? cancellationToken

--- a/src/Listener/Adapters/Watchers/PodeWatcher.cs
+++ b/src/Listener/Adapters/Watchers/PodeWatcher.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Pode.Utilities;
 using Pode.Protocols.File;
+using Pode.Utilities.Logging;
 
 namespace Pode.Adapters.Watchers
 {
@@ -53,7 +54,7 @@ namespace Pode.Adapters.Watchers
         protected override void Close()
         {
             // dispose watchers
-            PodeHelpers.WriteErrorMessage($"Closing file watchers", this, PodeLoggingLevel.Verbose);
+            PodeHelpers.WriteErrorMessage($"Closing file watchers", this, PodeLogLevel.Verbose);
 
             foreach (var _watcher in FileWatchers.ToArray())
             {
@@ -61,10 +62,10 @@ namespace Pode.Adapters.Watchers
             }
 
             FileWatchers.Clear();
-            PodeHelpers.WriteErrorMessage($"Closed file watchers", this, PodeLoggingLevel.Verbose);
+            PodeHelpers.WriteErrorMessage($"Closed file watchers", this, PodeLogLevel.Verbose);
 
             // dispose existing file events
-            PodeHelpers.WriteErrorMessage($"Closing file events", this, PodeLoggingLevel.Verbose);
+            PodeHelpers.WriteErrorMessage($"Closing file events", this, PodeLogLevel.Verbose);
 
             foreach (var _evt in FileEvents.ToArray())
             {
@@ -72,7 +73,7 @@ namespace Pode.Adapters.Watchers
             }
 
             FileEvents.Dispose();
-            PodeHelpers.WriteErrorMessage($"Closed file events", this, PodeLoggingLevel.Verbose);
+            PodeHelpers.WriteErrorMessage($"Closed file events", this, PodeLogLevel.Verbose);
         }
     }
 }

--- a/src/Listener/Adapters/Watchers/PodeWatcher.cs
+++ b/src/Listener/Adapters/Watchers/PodeWatcher.cs
@@ -13,8 +13,8 @@ namespace Pode.Adapters.Watchers
 
         public PodeItemQueue<PodeFileEvent> FileEvents { get; private set; }
 
-        public PodeWatcher(PodeAdapterType type, CancellationToken cancellationToken = default)
-            : base(type, cancellationToken)
+        public PodeWatcher(PodeAdapterType type, IPodeLogger logger, CancellationToken cancellationToken = default)
+            : base(type, logger, cancellationToken)
         {
             FileWatchers = new List<PodeFileWatcher>();
             FileEvents = new PodeItemQueue<PodeFileEvent>();
@@ -54,7 +54,7 @@ namespace Pode.Adapters.Watchers
         protected override void Close()
         {
             // dispose watchers
-            PodeHelpers.WriteErrorMessage($"Closing file watchers", this, PodeLogLevel.Verbose);
+            PodeHelpers.WriteErrorMessage($"Closing file watchers", PodeLogLevel.Verbose);
 
             foreach (var _watcher in FileWatchers.ToArray())
             {
@@ -62,10 +62,10 @@ namespace Pode.Adapters.Watchers
             }
 
             FileWatchers.Clear();
-            PodeHelpers.WriteErrorMessage($"Closed file watchers", this, PodeLogLevel.Verbose);
+            PodeHelpers.WriteErrorMessage($"Closed file watchers", PodeLogLevel.Verbose);
 
             // dispose existing file events
-            PodeHelpers.WriteErrorMessage($"Closing file events", this, PodeLogLevel.Verbose);
+            PodeHelpers.WriteErrorMessage($"Closing file events", PodeLogLevel.Verbose);
 
             foreach (var _evt in FileEvents.ToArray())
             {
@@ -73,7 +73,7 @@ namespace Pode.Adapters.Watchers
             }
 
             FileEvents.Dispose();
-            PodeHelpers.WriteErrorMessage($"Closed file events", this, PodeLogLevel.Verbose);
+            PodeHelpers.WriteErrorMessage($"Closed file events", PodeLogLevel.Verbose);
         }
     }
 }

--- a/src/Listener/Protocols/Common/Contexts/PodeContext.cs
+++ b/src/Listener/Protocols/Common/Contexts/PodeContext.cs
@@ -139,8 +139,8 @@ namespace Pode.Protocols.Common.Contexts
         {
             try
             {
-                PodeHelpers.WriteErrorMessage("TimeoutCallback triggered", Listener, PodeLogLevel.Debug, this);
-                PodeHelpers.WriteErrorMessage($"Request timeout reached: {Listener.RequestTimeout} seconds", Listener, PodeLogLevel.Warning, this);
+                PodeHelpers.WriteErrorMessage("TimeoutCallback triggered", PodeLogLevel.Debug, this);
+                PodeHelpers.WriteErrorMessage($"Request timeout reached: {Listener.RequestTimeout} seconds", PodeLogLevel.Warning, this);
 
                 State = PodeContextState.Timeout;
                 ContextTimeoutToken.Cancel();
@@ -149,11 +149,11 @@ namespace Pode.Protocols.Common.Contexts
                 Response.StatusCode = Request.Error.StatusCode;
 
                 Dispose();
-                PodeHelpers.WriteErrorMessage($"Request timeout reached: Dispose", Listener, PodeLogLevel.Debug, this);
+                PodeHelpers.WriteErrorMessage($"Request timeout reached: Dispose", PodeLogLevel.Debug, this);
             }
             catch (Exception ex)
             {
-                PodeHelpers.WriteErrorMessage($"Exception in TimeoutCallback: {ex}", Listener, PodeLogLevel.Error);
+                PodeHelpers.WriteErrorMessage($"Exception in TimeoutCallback: {ex}");
             }
         }
 
@@ -226,7 +226,7 @@ namespace Pode.Protocols.Common.Contexts
 
                 try
                 {
-                    PodeHelpers.WriteErrorMessage($"Receiving request", Listener, PodeLogLevel.Verbose, this);
+                    PodeHelpers.WriteErrorMessage($"Receiving request", PodeLogLevel.Verbose, this);
                     var close = await Request.Receive(ContextTimeoutToken.Token).ConfigureAwait(false);
                     await EndReceive(close).ConfigureAwait(false);
                 }
@@ -240,14 +240,14 @@ namespace Pode.Protocols.Common.Contexts
                 }
                 catch (OperationCanceledException) when (ContextTimeoutToken.IsCancellationRequested)
                 {
-                    PodeHelpers.WriteErrorMessage("Request timed out during receive operation", Listener, PodeLogLevel.Warning, this);
+                    PodeHelpers.WriteErrorMessage("Request timed out during receive operation", PodeLogLevel.Warning, this);
                     State = PodeContextState.Timeout;  // Explicitly set the state to Timeout
                     Request.Timeout();
                 }
             }
             catch (Exception ex)
             {
-                PodeHelpers.WriteException(ex, Listener, PodeLogLevel.Debug);
+                PodeHelpers.WriteException(ex, PodeLogLevel.Debug);
                 State = PodeContextState.Error;
                 await Handle().ConfigureAwait(false);
             }
@@ -281,7 +281,7 @@ namespace Pode.Protocols.Common.Contexts
                     // Check if the request is aborted with a non-StatusCode of 408 (Request Timeout).
                     if (Request?.IsAborted ?? false)
                     {
-                        PodeHelpers.WriteException(Request?.Error, Listener, Request?.Error?.LoggingLevel ?? PodeLogLevel.Error);
+                        PodeHelpers.WriteException(Request?.Error, Request?.Error?.LoggingLevel ?? PodeLogLevel.Error);
                     }
 
                     Dispose(true);
@@ -314,7 +314,7 @@ namespace Pode.Protocols.Common.Contexts
             catch (Exception ex)
             {
                 // Log any exceptions that occur while handling the context.
-                PodeHelpers.WriteException(ex, Listener);
+                PodeHelpers.WriteException(ex);
             }
         }
 
@@ -326,7 +326,7 @@ namespace Pode.Protocols.Common.Contexts
 
         protected virtual void Process()
         {
-            PodeHelpers.WriteErrorMessage($"Received request", Listener, PodeLogLevel.Verbose, this);
+            PodeHelpers.WriteErrorMessage($"Received request", PodeLogLevel.Verbose, this);
             Listener.AddContext(this);
         }
 
@@ -340,7 +340,7 @@ namespace Pode.Protocols.Common.Contexts
 
         protected void StartReceive(bool newResponse)
         {
-            PodeHelpers.WriteErrorMessage($"Re-receiving Request", Listener, PodeLogLevel.Verbose, this);
+            PodeHelpers.WriteErrorMessage($"Re-receiving Request", PodeLogLevel.Verbose, this);
 
             // if (!IsWebSocketUpgraded)
             if (newResponse)
@@ -350,7 +350,7 @@ namespace Pode.Protocols.Common.Contexts
 
             State = PodeContextState.Receiving;
             PodeSocket.StartReceive(this);
-            PodeHelpers.WriteErrorMessage($"Socket listening", Listener, PodeLogLevel.Verbose, this);
+            PodeHelpers.WriteErrorMessage($"Socket listening", PodeLogLevel.Verbose, this);
         }
 
         /// <summary>
@@ -375,7 +375,7 @@ namespace Pode.Protocols.Common.Contexts
 
             lock (Lockable)
             {
-                PodeHelpers.WriteErrorMessage($"Disposing Context", Listener, PodeLogLevel.Verbose, this);
+                PodeHelpers.WriteErrorMessage($"Disposing Context", PodeLogLevel.Verbose, this);
                 Listener.RemoveProcessingContext(this);
 
                 if (IsClosed)
@@ -451,7 +451,7 @@ namespace Pode.Protocols.Common.Contexts
                 }
                 catch (Exception ex)
                 {
-                    PodeHelpers.WriteException(ex, Listener, PodeLogLevel.Error);
+                    PodeHelpers.WriteException(ex);
                 }
                 finally
                 {

--- a/src/Listener/Protocols/Common/Contexts/PodeContext.cs
+++ b/src/Listener/Protocols/Common/Contexts/PodeContext.cs
@@ -280,7 +280,7 @@ namespace Pode.Protocols.Common.Contexts
                     // Check if the request is aborted with a non-StatusCode of 408 (Request Timeout).
                     if (Request?.IsAborted ?? false)
                     {
-                        PodeHelpers.WriteException(Request.Error, Listener, Request.Error.LoggingLevel);
+                        PodeHelpers.WriteException(Request?.Error, Listener, Request?.Error?.LoggingLevel ?? PodeLoggingLevel.Error);
                     }
 
                     Dispose(true);

--- a/src/Listener/Protocols/Common/Contexts/PodeContext.cs
+++ b/src/Listener/Protocols/Common/Contexts/PodeContext.cs
@@ -9,6 +9,7 @@ using Pode.Protocols.Common.Responses;
 using Pode.Adapters.Listeners;
 using Pode.Utilities;
 using Pode.Transport.Sockets;
+using Pode.Utilities.Logging;
 
 namespace Pode.Protocols.Common.Contexts
 {
@@ -138,8 +139,8 @@ namespace Pode.Protocols.Common.Contexts
         {
             try
             {
-                PodeHelpers.WriteErrorMessage("TimeoutCallback triggered", Listener, PodeLoggingLevel.Debug, this);
-                PodeHelpers.WriteErrorMessage($"Request timeout reached: {Listener.RequestTimeout} seconds", Listener, PodeLoggingLevel.Warning, this);
+                PodeHelpers.WriteErrorMessage("TimeoutCallback triggered", Listener, PodeLogLevel.Debug, this);
+                PodeHelpers.WriteErrorMessage($"Request timeout reached: {Listener.RequestTimeout} seconds", Listener, PodeLogLevel.Warning, this);
 
                 State = PodeContextState.Timeout;
                 ContextTimeoutToken.Cancel();
@@ -148,11 +149,11 @@ namespace Pode.Protocols.Common.Contexts
                 Response.StatusCode = Request.Error.StatusCode;
 
                 Dispose();
-                PodeHelpers.WriteErrorMessage($"Request timeout reached: Dispose", Listener, PodeLoggingLevel.Debug, this);
+                PodeHelpers.WriteErrorMessage($"Request timeout reached: Dispose", Listener, PodeLogLevel.Debug, this);
             }
             catch (Exception ex)
             {
-                PodeHelpers.WriteErrorMessage($"Exception in TimeoutCallback: {ex}", Listener, PodeLoggingLevel.Error);
+                PodeHelpers.WriteErrorMessage($"Exception in TimeoutCallback: {ex}", Listener, PodeLogLevel.Error);
             }
         }
 
@@ -225,7 +226,7 @@ namespace Pode.Protocols.Common.Contexts
 
                 try
                 {
-                    PodeHelpers.WriteErrorMessage($"Receiving request", Listener, PodeLoggingLevel.Verbose, this);
+                    PodeHelpers.WriteErrorMessage($"Receiving request", Listener, PodeLogLevel.Verbose, this);
                     var close = await Request.Receive(ContextTimeoutToken.Token).ConfigureAwait(false);
                     await EndReceive(close).ConfigureAwait(false);
                 }
@@ -239,14 +240,14 @@ namespace Pode.Protocols.Common.Contexts
                 }
                 catch (OperationCanceledException) when (ContextTimeoutToken.IsCancellationRequested)
                 {
-                    PodeHelpers.WriteErrorMessage("Request timed out during receive operation", Listener, PodeLoggingLevel.Warning, this);
+                    PodeHelpers.WriteErrorMessage("Request timed out during receive operation", Listener, PodeLogLevel.Warning, this);
                     State = PodeContextState.Timeout;  // Explicitly set the state to Timeout
                     Request.Timeout();
                 }
             }
             catch (Exception ex)
             {
-                PodeHelpers.WriteException(ex, Listener, PodeLoggingLevel.Debug);
+                PodeHelpers.WriteException(ex, Listener, PodeLogLevel.Debug);
                 State = PodeContextState.Error;
                 await Handle().ConfigureAwait(false);
             }
@@ -280,7 +281,7 @@ namespace Pode.Protocols.Common.Contexts
                     // Check if the request is aborted with a non-StatusCode of 408 (Request Timeout).
                     if (Request?.IsAborted ?? false)
                     {
-                        PodeHelpers.WriteException(Request?.Error, Listener, Request?.Error?.LoggingLevel ?? PodeLoggingLevel.Error);
+                        PodeHelpers.WriteException(Request?.Error, Listener, Request?.Error?.LoggingLevel ?? PodeLogLevel.Error);
                     }
 
                     Dispose(true);
@@ -325,7 +326,7 @@ namespace Pode.Protocols.Common.Contexts
 
         protected virtual void Process()
         {
-            PodeHelpers.WriteErrorMessage($"Received request", Listener, PodeLoggingLevel.Verbose, this);
+            PodeHelpers.WriteErrorMessage($"Received request", Listener, PodeLogLevel.Verbose, this);
             Listener.AddContext(this);
         }
 
@@ -339,7 +340,7 @@ namespace Pode.Protocols.Common.Contexts
 
         protected void StartReceive(bool newResponse)
         {
-            PodeHelpers.WriteErrorMessage($"Re-receiving Request", Listener, PodeLoggingLevel.Verbose, this);
+            PodeHelpers.WriteErrorMessage($"Re-receiving Request", Listener, PodeLogLevel.Verbose, this);
 
             // if (!IsWebSocketUpgraded)
             if (newResponse)
@@ -349,7 +350,7 @@ namespace Pode.Protocols.Common.Contexts
 
             State = PodeContextState.Receiving;
             PodeSocket.StartReceive(this);
-            PodeHelpers.WriteErrorMessage($"Socket listening", Listener, PodeLoggingLevel.Verbose, this);
+            PodeHelpers.WriteErrorMessage($"Socket listening", Listener, PodeLogLevel.Verbose, this);
         }
 
         /// <summary>
@@ -374,7 +375,7 @@ namespace Pode.Protocols.Common.Contexts
 
             lock (Lockable)
             {
-                PodeHelpers.WriteErrorMessage($"Disposing Context", Listener, PodeLoggingLevel.Verbose, this);
+                PodeHelpers.WriteErrorMessage($"Disposing Context", Listener, PodeLogLevel.Verbose, this);
                 Listener.RemoveProcessingContext(this);
 
                 if (IsClosed)
@@ -450,7 +451,7 @@ namespace Pode.Protocols.Common.Contexts
                 }
                 catch (Exception ex)
                 {
-                    PodeHelpers.WriteException(ex, Listener, PodeLoggingLevel.Error);
+                    PodeHelpers.WriteException(ex, Listener, PodeLogLevel.Error);
                 }
                 finally
                 {

--- a/src/Listener/Protocols/Common/Requests/PodeRequestException.cs
+++ b/src/Listener/Protocols/Common/Requests/PodeRequestException.cs
@@ -1,5 +1,5 @@
 using System;
-using Pode.Utilities;
+using Pode.Utilities.Logging;
 
 namespace Pode.Protocols.Common.Requests
 {
@@ -18,7 +18,7 @@ namespace Pode.Protocols.Common.Requests
         public virtual bool IsServerError => false;
 
         // the logging level of the exception
-        public PodeLoggingLevel LoggingLevel => IsClientError ? PodeLoggingLevel.Debug : PodeLoggingLevel.Error;
+        public PodeLogLevel LoggingLevel => IsClientError ? PodeLogLevel.Debug : PodeLogLevel.Error;
 
 
         // constructors

--- a/src/Listener/Protocols/Common/Requests/PodeRequestHandler.cs
+++ b/src/Listener/Protocols/Common/Requests/PodeRequestHandler.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Pode.Transport.Sockets;
 using Pode.Utilities;
 using Pode.Protocols.Common.Contexts;
+using Pode.Utilities.Logging;
 
 namespace Pode.Protocols.Common.Requests
 {
@@ -129,11 +130,11 @@ namespace Pode.Protocols.Common.Requests
             {
                 if (ex is AggregateException)
                 {
-                    PodeHelpers.HandleAggregateException(ex as AggregateException, Context.Listener, PodeLoggingLevel.Debug, true);
+                    PodeHelpers.HandleAggregateException(ex as AggregateException, Context.Listener, PodeLogLevel.Debug, true);
                 }
                 else
                 {
-                    PodeHelpers.WriteException(ex, Context.Listener, PodeLoggingLevel.Debug);
+                    PodeHelpers.WriteException(ex, Context.Listener, PodeLogLevel.Debug);
                 }
 
                 State = PodeStreamState.Error;
@@ -182,7 +183,7 @@ namespace Pode.Protocols.Common.Requests
             }
             catch (Exception ex) when (ex is OperationCanceledException || ex is IOException || ex is ObjectDisposedException)
             {
-                PodeHelpers.WriteException(ex, Context.Listener, PodeLoggingLevel.Verbose);
+                PodeHelpers.WriteException(ex, Context.Listener, PodeLogLevel.Verbose);
                 ssl?.Dispose();
                 State = PodeStreamState.Error;
                 SslUpgradeStatus = PodeUpgradeStatus.Failed;
@@ -190,7 +191,7 @@ namespace Pode.Protocols.Common.Requests
             }
             catch (AuthenticationException ex)
             {
-                PodeHelpers.WriteException(ex, Context.Listener, PodeLoggingLevel.Debug);
+                PodeHelpers.WriteException(ex, Context.Listener, PodeLogLevel.Debug);
                 ssl?.Dispose();
                 State = PodeStreamState.Error;
                 SslUpgradeStatus = PodeUpgradeStatus.Failed;
@@ -198,7 +199,7 @@ namespace Pode.Protocols.Common.Requests
             }
             catch (Exception ex)
             {
-                PodeHelpers.WriteException(ex, Context.Listener, PodeLoggingLevel.Error);
+                PodeHelpers.WriteException(ex, Context.Listener, PodeLogLevel.Error);
                 ssl?.Dispose();
                 State = PodeStreamState.Error;
                 SslUpgradeStatus = PodeUpgradeStatus.Failed;
@@ -296,13 +297,13 @@ namespace Pode.Protocols.Common.Requests
             }
             catch (OperationCanceledException ex)
             {
-                PodeHelpers.WriteException(ex, Context.Listener, PodeLoggingLevel.Verbose);
+                PodeHelpers.WriteException(ex, Context.Listener, PodeLogLevel.Verbose);
             }
             catch (ObjectDisposedException ex)
             {
                 if (Context.Listener.IsConnected)
                 {
-                    PodeHelpers.WriteException(ex, Context.Listener, PodeLoggingLevel.Debug);
+                    PodeHelpers.WriteException(ex, Context.Listener, PodeLogLevel.Debug);
                 }
             }
             catch (NullReferenceException ex)
@@ -544,7 +545,7 @@ namespace Pode.Protocols.Common.Requests
             }
             catch (Exception ex)
             {
-                PodeHelpers.WriteException(ex, Context.Listener, PodeLoggingLevel.Error);
+                PodeHelpers.WriteException(ex, Context.Listener, PodeLogLevel.Error);
             }
         }
 
@@ -579,7 +580,7 @@ namespace Pode.Protocols.Common.Requests
                 }
 
                 PartialDispose();
-                PodeHelpers.WriteErrorMessage($"Request disposed", Context.Listener, PodeLoggingLevel.Verbose, Context);
+                PodeHelpers.WriteErrorMessage($"Request disposed", Context.Listener, PodeLogLevel.Verbose, Context);
             }
         }
 

--- a/src/Listener/Protocols/Common/Requests/PodeRequestHandler.cs
+++ b/src/Listener/Protocols/Common/Requests/PodeRequestHandler.cs
@@ -130,11 +130,11 @@ namespace Pode.Protocols.Common.Requests
             {
                 if (ex is AggregateException)
                 {
-                    PodeHelpers.HandleAggregateException(ex as AggregateException, Context.Listener, PodeLogLevel.Debug, true);
+                    PodeHelpers.HandleAggregateException(ex as AggregateException, PodeLogLevel.Debug, handled: true);
                 }
                 else
                 {
-                    PodeHelpers.WriteException(ex, Context.Listener, PodeLogLevel.Debug);
+                    PodeHelpers.WriteException(ex, PodeLogLevel.Debug);
                 }
 
                 State = PodeStreamState.Error;
@@ -183,7 +183,7 @@ namespace Pode.Protocols.Common.Requests
             }
             catch (Exception ex) when (ex is OperationCanceledException || ex is IOException || ex is ObjectDisposedException)
             {
-                PodeHelpers.WriteException(ex, Context.Listener, PodeLogLevel.Verbose);
+                PodeHelpers.WriteException(ex, PodeLogLevel.Verbose);
                 ssl?.Dispose();
                 State = PodeStreamState.Error;
                 SslUpgradeStatus = PodeUpgradeStatus.Failed;
@@ -191,7 +191,7 @@ namespace Pode.Protocols.Common.Requests
             }
             catch (AuthenticationException ex)
             {
-                PodeHelpers.WriteException(ex, Context.Listener, PodeLogLevel.Debug);
+                PodeHelpers.WriteException(ex, PodeLogLevel.Debug);
                 ssl?.Dispose();
                 State = PodeStreamState.Error;
                 SslUpgradeStatus = PodeUpgradeStatus.Failed;
@@ -199,7 +199,7 @@ namespace Pode.Protocols.Common.Requests
             }
             catch (Exception ex)
             {
-                PodeHelpers.WriteException(ex, Context.Listener, PodeLogLevel.Error);
+                PodeHelpers.WriteException(ex);
                 ssl?.Dispose();
                 State = PodeStreamState.Error;
                 SslUpgradeStatus = PodeUpgradeStatus.Failed;
@@ -297,13 +297,13 @@ namespace Pode.Protocols.Common.Requests
             }
             catch (OperationCanceledException ex)
             {
-                PodeHelpers.WriteException(ex, Context.Listener, PodeLogLevel.Verbose);
+                PodeHelpers.WriteException(ex, PodeLogLevel.Verbose);
             }
             catch (ObjectDisposedException ex)
             {
                 if (Context.Listener.IsConnected)
                 {
-                    PodeHelpers.WriteException(ex, Context.Listener, PodeLogLevel.Debug);
+                    PodeHelpers.WriteException(ex, PodeLogLevel.Debug);
                 }
             }
             catch (NullReferenceException ex)
@@ -512,12 +512,12 @@ namespace Pode.Protocols.Common.Requests
             }
             catch (AggregateException aex)
             {
-                PodeHelpers.HandleAggregateException(aex, Context.Listener);
+                PodeHelpers.HandleAggregateException(aex);
                 return false;
             }
             catch (Exception ex)
             {
-                PodeHelpers.WriteException(ex, Context.Listener);
+                PodeHelpers.WriteException(ex);
                 throw;
             }
         }
@@ -545,7 +545,7 @@ namespace Pode.Protocols.Common.Requests
             }
             catch (Exception ex)
             {
-                PodeHelpers.WriteException(ex, Context.Listener, PodeLogLevel.Error);
+                PodeHelpers.WriteException(ex);
             }
         }
 
@@ -580,7 +580,7 @@ namespace Pode.Protocols.Common.Requests
                 }
 
                 PartialDispose();
-                PodeHelpers.WriteErrorMessage($"Request disposed", Context.Listener, PodeLogLevel.Verbose, Context);
+                PodeHelpers.WriteErrorMessage($"Request disposed", PodeLogLevel.Verbose, Context);
             }
         }
 

--- a/src/Listener/Protocols/Common/Requests/PodeRequestStrategy.cs
+++ b/src/Listener/Protocols/Common/Requests/PodeRequestStrategy.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Pode.Utilities;
 using Pode.Protocols.Common.Contexts;
+using Pode.Utilities.Logging;
 
 namespace Pode.Protocols.Common.Requests
 {
@@ -132,7 +133,7 @@ namespace Pode.Protocols.Common.Requests
 
             if (disposing)
             {
-                PodeHelpers.WriteErrorMessage($"Request Strategy disposed", Handler.Context.Listener, PodeLoggingLevel.Verbose, Handler.Context);
+                PodeHelpers.WriteErrorMessage($"Request Strategy disposed", Handler.Context.Listener, PodeLogLevel.Verbose, Handler.Context);
             }
         }
 

--- a/src/Listener/Protocols/Common/Requests/PodeRequestStrategy.cs
+++ b/src/Listener/Protocols/Common/Requests/PodeRequestStrategy.cs
@@ -133,7 +133,7 @@ namespace Pode.Protocols.Common.Requests
 
             if (disposing)
             {
-                PodeHelpers.WriteErrorMessage($"Request Strategy disposed", Handler.Context.Listener, PodeLogLevel.Verbose, Handler.Context);
+                PodeHelpers.WriteErrorMessage($"Request Strategy disposed", PodeLogLevel.Verbose, Handler.Context);
             }
         }
 

--- a/src/Listener/Protocols/Common/Responses/PodeResponse.cs
+++ b/src/Listener/Protocols/Common/Responses/PodeResponse.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Pode.Utilities;
 using Pode.Protocols.Common.Requests;
 using Pode.Protocols.Common.Contexts;
+using Pode.Utilities.Logging;
 
 namespace Pode.Protocols.Common.Responses
 {
@@ -112,7 +113,7 @@ namespace Pode.Protocols.Common.Responses
 
             IsDisposed = true;
             GC.SuppressFinalize(this);
-            PodeHelpers.WriteErrorMessage($"Response disposed", Context.Listener, PodeLoggingLevel.Verbose, Context);
+            PodeHelpers.WriteErrorMessage($"Response disposed", Context.Listener, PodeLogLevel.Verbose, Context);
         }
     }
 }

--- a/src/Listener/Protocols/Common/Responses/PodeResponse.cs
+++ b/src/Listener/Protocols/Common/Responses/PodeResponse.cs
@@ -113,7 +113,7 @@ namespace Pode.Protocols.Common.Responses
 
             IsDisposed = true;
             GC.SuppressFinalize(this);
-            PodeHelpers.WriteErrorMessage($"Response disposed", Context.Listener, PodeLogLevel.Verbose, Context);
+            PodeHelpers.WriteErrorMessage($"Response disposed", PodeLogLevel.Verbose, Context);
         }
     }
 }

--- a/src/Listener/Protocols/File/PodeFileWatcher.cs
+++ b/src/Listener/Protocols/File/PodeFileWatcher.cs
@@ -88,7 +88,7 @@ namespace Pode.Protocols.File
 
         private void FileErrorEventHandler(object _, FileWatcherErrorEventArgs e)
         {
-            PodeHelpers.WriteException(e.Error, Watcher);
+            PodeHelpers.WriteException(e.Error);
         }
     }
 }

--- a/src/Listener/Protocols/Http/Client/PodeClientConnection.cs
+++ b/src/Listener/Protocols/Http/Client/PodeClientConnection.cs
@@ -66,16 +66,16 @@ namespace Pode.Protocols.Http.Client
                 return;
             }
 
-            PodeHelpers.WriteErrorMessage($"Pinging client connection, ClientId: {ClientId}", Context?.Listener, PodeLogLevel.Debug, Context);
+            PodeHelpers.WriteErrorMessage($"Pinging client connection, ClientId: {ClientId}", PodeLogLevel.Debug, Context);
 
             if (await Ping().ConfigureAwait(false))
             {
                 // LastActivity = DateTime.UtcNow;
-                PodeHelpers.WriteErrorMessage($"Ping successful for client connection, ClientId: {ClientId}", Context?.Listener, PodeLogLevel.Debug, Context);
+                PodeHelpers.WriteErrorMessage($"Ping successful for client connection, ClientId: {ClientId}", PodeLogLevel.Debug, Context);
             }
             else
             {
-                PodeHelpers.WriteErrorMessage($"Ping failed for client connection, ClientId: {ClientId}", Context?.Listener, PodeLogLevel.Debug, Context);
+                PodeHelpers.WriteErrorMessage($"Ping failed for client connection, ClientId: {ClientId}", PodeLogLevel.Debug, Context);
             }
         }
 

--- a/src/Listener/Protocols/Http/Client/PodeClientConnection.cs
+++ b/src/Listener/Protocols/Http/Client/PodeClientConnection.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Pode.Utilities;
+using Pode.Utilities.Logging;
 
 namespace Pode.Protocols.Http.Client
 {
@@ -65,16 +66,16 @@ namespace Pode.Protocols.Http.Client
                 return;
             }
 
-            PodeHelpers.WriteErrorMessage($"Pinging client connection, ClientId: {ClientId}", Context?.Listener, PodeLoggingLevel.Debug, Context);
+            PodeHelpers.WriteErrorMessage($"Pinging client connection, ClientId: {ClientId}", Context?.Listener, PodeLogLevel.Debug, Context);
 
             if (await Ping().ConfigureAwait(false))
             {
                 // LastActivity = DateTime.UtcNow;
-                PodeHelpers.WriteErrorMessage($"Ping successful for client connection, ClientId: {ClientId}", Context?.Listener, PodeLoggingLevel.Debug, Context);
+                PodeHelpers.WriteErrorMessage($"Ping successful for client connection, ClientId: {ClientId}", Context?.Listener, PodeLogLevel.Debug, Context);
             }
             else
             {
-                PodeHelpers.WriteErrorMessage($"Ping failed for client connection, ClientId: {ClientId}", Context?.Listener, PodeLoggingLevel.Debug, Context);
+                PodeHelpers.WriteErrorMessage($"Ping failed for client connection, ClientId: {ClientId}", Context?.Listener, PodeLogLevel.Debug, Context);
             }
         }
 

--- a/src/Listener/Protocols/Http/Client/PodeClientConnectionNestedMap.cs
+++ b/src/Listener/Protocols/Http/Client/PodeClientConnectionNestedMap.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.IO;
 using Pode.Utilities;
+using Pode.Utilities.Logging;
 
 namespace Pode.Protocols.Http.Client
 {
@@ -60,7 +61,7 @@ namespace Pode.Protocols.Http.Client
                 return false;
             }
 
-            PodeHelpers.WriteErrorMessage($"Removed {conn.ConnectionType} client connection, ClientId: {conn.ClientId}, Name: {conn.Name}, Group: {conn.Group}", Listener, PodeLoggingLevel.Debug, conn.Context);
+            PodeHelpers.WriteErrorMessage($"Removed {conn.ConnectionType} client connection, ClientId: {conn.ClientId}, Name: {conn.Name}, Group: {conn.Group}", Listener, PodeLogLevel.Debug, conn.Context);
             Listener.AddClientConnectionEvent(conn, PodeClientConnectionEventType.Disconnect);
             return true;
         }
@@ -103,11 +104,11 @@ namespace Pode.Protocols.Http.Client
                 }
                 catch (Exception ex) when (ex is OperationCanceledException || ex is IOException || ex is ObjectDisposedException)
                 {
-                    PodeHelpers.WriteException(ex, Listener, PodeLoggingLevel.Verbose);
+                    PodeHelpers.WriteException(ex, Listener, PodeLogLevel.Verbose);
                 }
                 catch (Exception ex)
                 {
-                    PodeHelpers.WriteException(ex, Listener, PodeLoggingLevel.Error);
+                    PodeHelpers.WriteException(ex, Listener, PodeLogLevel.Error);
                 }
                 finally
                 {
@@ -151,11 +152,11 @@ namespace Pode.Protocols.Http.Client
                 }
                 catch (Exception ex) when (ex is OperationCanceledException || ex is IOException || ex is ObjectDisposedException)
                 {
-                    PodeHelpers.WriteException(ex, Listener, PodeLoggingLevel.Verbose);
+                    PodeHelpers.WriteException(ex, Listener, PodeLogLevel.Verbose);
                 }
                 catch (Exception ex)
                 {
-                    PodeHelpers.WriteException(ex, Listener, PodeLoggingLevel.Error);
+                    PodeHelpers.WriteException(ex, Listener, PodeLogLevel.Error);
                 }
             }, Listener.CancellationToken);
         }

--- a/src/Listener/Protocols/Http/Client/PodeClientConnectionNestedMap.cs
+++ b/src/Listener/Protocols/Http/Client/PodeClientConnectionNestedMap.cs
@@ -61,7 +61,7 @@ namespace Pode.Protocols.Http.Client
                 return false;
             }
 
-            PodeHelpers.WriteErrorMessage($"Removed {conn.ConnectionType} client connection, ClientId: {conn.ClientId}, Name: {conn.Name}, Group: {conn.Group}", Listener, PodeLogLevel.Debug, conn.Context);
+            PodeHelpers.WriteErrorMessage($"Removed {conn.ConnectionType} client connection, ClientId: {conn.ClientId}, Name: {conn.Name}, Group: {conn.Group}", PodeLogLevel.Debug, conn.Context);
             Listener.AddClientConnectionEvent(conn, PodeClientConnectionEventType.Disconnect);
             return true;
         }
@@ -104,11 +104,11 @@ namespace Pode.Protocols.Http.Client
                 }
                 catch (Exception ex) when (ex is OperationCanceledException || ex is IOException || ex is ObjectDisposedException)
                 {
-                    PodeHelpers.WriteException(ex, Listener, PodeLogLevel.Verbose);
+                    PodeHelpers.WriteException(ex, PodeLogLevel.Verbose);
                 }
                 catch (Exception ex)
                 {
-                    PodeHelpers.WriteException(ex, Listener, PodeLogLevel.Error);
+                    PodeHelpers.WriteException(ex);
                 }
                 finally
                 {
@@ -152,11 +152,11 @@ namespace Pode.Protocols.Http.Client
                 }
                 catch (Exception ex) when (ex is OperationCanceledException || ex is IOException || ex is ObjectDisposedException)
                 {
-                    PodeHelpers.WriteException(ex, Listener, PodeLogLevel.Verbose);
+                    PodeHelpers.WriteException(ex, PodeLogLevel.Verbose);
                 }
                 catch (Exception ex)
                 {
-                    PodeHelpers.WriteException(ex, Listener, PodeLogLevel.Error);
+                    PodeHelpers.WriteException(ex);
                 }
             }, Listener.CancellationToken);
         }

--- a/src/Listener/Protocols/Http/Client/Signals/PodeSignal.cs
+++ b/src/Listener/Protocols/Http/Client/Signals/PodeSignal.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Security.Cryptography;
 using System.Threading.Tasks;
 using Pode.Utilities;
+using Pode.Utilities.Logging;
 
 namespace Pode.Protocols.Http.Client.Signals
 {
@@ -172,7 +173,7 @@ namespace Pode.Protocols.Http.Client.Signals
             {
                 // mark as closed, log, dispose
                 IsClosed = true;
-                PodeHelpers.WriteException(ex, Context?.Listener, PodeLoggingLevel.Debug);
+                PodeHelpers.WriteException(ex, Context?.Listener, PodeLogLevel.Debug);
                 Dispose();
             }
             catch (Exception)

--- a/src/Listener/Protocols/Http/Client/Signals/PodeSignal.cs
+++ b/src/Listener/Protocols/Http/Client/Signals/PodeSignal.cs
@@ -173,7 +173,7 @@ namespace Pode.Protocols.Http.Client.Signals
             {
                 // mark as closed, log, dispose
                 IsClosed = true;
-                PodeHelpers.WriteException(ex, Context?.Listener, PodeLogLevel.Debug);
+                PodeHelpers.WriteException(ex, PodeLogLevel.Debug);
                 Dispose();
             }
             catch (Exception)

--- a/src/Listener/Protocols/Http/Client/Sse/PodeServerEvent.cs
+++ b/src/Listener/Protocols/Http/Client/Sse/PodeServerEvent.cs
@@ -149,7 +149,7 @@ namespace Pode.Protocols.Http.Client.Sse
             {
                 // mark as closed, log, dispose
                 IsClosed = true;
-                PodeHelpers.WriteException(ex, Context?.Listener, PodeLogLevel.Debug);
+                PodeHelpers.WriteException(ex, PodeLogLevel.Debug);
                 Dispose();
             }
             catch (Exception)

--- a/src/Listener/Protocols/Http/Client/Sse/PodeServerEvent.cs
+++ b/src/Listener/Protocols/Http/Client/Sse/PodeServerEvent.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.IO;
 using System.Threading.Tasks;
 using Pode.Utilities;
+using Pode.Utilities.Logging;
 
 namespace Pode.Protocols.Http.Client.Sse
 {
@@ -148,7 +149,7 @@ namespace Pode.Protocols.Http.Client.Sse
             {
                 // mark as closed, log, dispose
                 IsClosed = true;
-                PodeHelpers.WriteException(ex, Context?.Listener, PodeLoggingLevel.Debug);
+                PodeHelpers.WriteException(ex, Context?.Listener, PodeLogLevel.Debug);
                 Dispose();
             }
             catch (Exception)

--- a/src/Listener/Protocols/Http/PodeHttpContext.cs
+++ b/src/Listener/Protocols/Http/PodeHttpContext.cs
@@ -71,7 +71,7 @@ namespace Pode.Protocols.Http
         {
             if (IsSSEUpgraded || IsWebSocketUpgraded)
             {
-                PodeHelpers.WriteErrorMessage("Timeout ignored due to SSE/WebSocket", Listener, PodeLogLevel.Debug, this);
+                PodeHelpers.WriteErrorMessage("Timeout ignored due to SSE/WebSocket", PodeLogLevel.Debug, this);
                 return;
             }
 
@@ -138,7 +138,7 @@ namespace Pode.Protocols.Http
         {
             if (IsWebSocketUpgraded)
             {
-                PodeHelpers.WriteErrorMessage($"Received client signal", Listener, PodeLogLevel.Verbose, this);
+                PodeHelpers.WriteErrorMessage($"Received client signal", PodeLogLevel.Verbose, this);
                 HttpListener.AddClientSignal(Request.GetStrategy<PodeSignalRequestStrategy>().NewClientSignal());
                 Dispose();
             }
@@ -169,7 +169,7 @@ namespace Pode.Protocols.Http
                 return null;
             }
 
-            PodeHelpers.WriteErrorMessage($"Upgrading SSE", Listener, PodeLogLevel.Verbose, this);
+            PodeHelpers.WriteErrorMessage($"Upgrading SSE", PodeLogLevel.Verbose, this);
 
             // ensure the HTTP method is GET or POST
             if (Request.GetStrategy<PodeHttpRequestStrategy>().HttpMethod != "GET" && Request.GetStrategy<PodeHttpRequestStrategy>().HttpMethod != "POST")
@@ -197,7 +197,7 @@ namespace Pode.Protocols.Http
             HttpListener.AddSseConnection(SSE);
 
             // return the SSE connection
-            PodeHelpers.WriteErrorMessage($"SSE upgraded for client {clientId}", Listener, PodeLogLevel.Verbose, this);
+            PodeHelpers.WriteErrorMessage($"SSE upgraded for client {clientId}", PodeLogLevel.Verbose, this);
             return SSE;
         }
 
@@ -212,7 +212,7 @@ namespace Pode.Protocols.Http
                 return null;
             }
 
-            PodeHelpers.WriteErrorMessage($"Upgrading Websocket", Listener, PodeLogLevel.Verbose, this);
+            PodeHelpers.WriteErrorMessage($"Upgrading Websocket", PodeLogLevel.Verbose, this);
 
             // ensure the HTTP method is GET
             if (Request.GetStrategy<PodeHttpRequestStrategy>().HttpMethod != "GET")
@@ -245,7 +245,7 @@ namespace Pode.Protocols.Http
             httpStrategy.Dispose();
 
             // return the Signal
-            PodeHelpers.WriteErrorMessage($"WebSocket upgraded for client {clientId}", Listener, PodeLogLevel.Verbose, this);
+            PodeHelpers.WriteErrorMessage($"WebSocket upgraded for client {clientId}", PodeLogLevel.Verbose, this);
             return Signal;
         }
 

--- a/src/Listener/Protocols/Http/PodeHttpContext.cs
+++ b/src/Listener/Protocols/Http/PodeHttpContext.cs
@@ -8,6 +8,7 @@ using Pode.Protocols.Common.Contexts;
 using Pode.Protocols.Http.Client;
 using Pode.Protocols.Http.Client.Sse;
 using Pode.Protocols.Http.Client.Signals;
+using Pode.Utilities.Logging;
 
 namespace Pode.Protocols.Http
 {
@@ -70,7 +71,7 @@ namespace Pode.Protocols.Http
         {
             if (IsSSEUpgraded || IsWebSocketUpgraded)
             {
-                PodeHelpers.WriteErrorMessage("Timeout ignored due to SSE/WebSocket", Listener, PodeLoggingLevel.Debug, this);
+                PodeHelpers.WriteErrorMessage("Timeout ignored due to SSE/WebSocket", Listener, PodeLogLevel.Debug, this);
                 return;
             }
 
@@ -137,7 +138,7 @@ namespace Pode.Protocols.Http
         {
             if (IsWebSocketUpgraded)
             {
-                PodeHelpers.WriteErrorMessage($"Received client signal", Listener, PodeLoggingLevel.Verbose, this);
+                PodeHelpers.WriteErrorMessage($"Received client signal", Listener, PodeLogLevel.Verbose, this);
                 HttpListener.AddClientSignal(Request.GetStrategy<PodeSignalRequestStrategy>().NewClientSignal());
                 Dispose();
             }
@@ -168,7 +169,7 @@ namespace Pode.Protocols.Http
                 return null;
             }
 
-            PodeHelpers.WriteErrorMessage($"Upgrading SSE", Listener, PodeLoggingLevel.Verbose, this);
+            PodeHelpers.WriteErrorMessage($"Upgrading SSE", Listener, PodeLogLevel.Verbose, this);
 
             // ensure the HTTP method is GET or POST
             if (Request.GetStrategy<PodeHttpRequestStrategy>().HttpMethod != "GET" && Request.GetStrategy<PodeHttpRequestStrategy>().HttpMethod != "POST")
@@ -196,7 +197,7 @@ namespace Pode.Protocols.Http
             HttpListener.AddSseConnection(SSE);
 
             // return the SSE connection
-            PodeHelpers.WriteErrorMessage($"SSE upgraded for client {clientId}", Listener, PodeLoggingLevel.Verbose, this);
+            PodeHelpers.WriteErrorMessage($"SSE upgraded for client {clientId}", Listener, PodeLogLevel.Verbose, this);
             return SSE;
         }
 
@@ -211,7 +212,7 @@ namespace Pode.Protocols.Http
                 return null;
             }
 
-            PodeHelpers.WriteErrorMessage($"Upgrading Websocket", Listener, PodeLoggingLevel.Verbose, this);
+            PodeHelpers.WriteErrorMessage($"Upgrading Websocket", Listener, PodeLogLevel.Verbose, this);
 
             // ensure the HTTP method is GET
             if (Request.GetStrategy<PodeHttpRequestStrategy>().HttpMethod != "GET")
@@ -244,7 +245,7 @@ namespace Pode.Protocols.Http
             httpStrategy.Dispose();
 
             // return the Signal
-            PodeHelpers.WriteErrorMessage($"WebSocket upgraded for client {clientId}", Listener, PodeLoggingLevel.Verbose, this);
+            PodeHelpers.WriteErrorMessage($"WebSocket upgraded for client {clientId}", Listener, PodeLogLevel.Verbose, this);
             return Signal;
         }
 

--- a/src/Listener/Protocols/Http/PodeHttpListener.cs
+++ b/src/Listener/Protocols/Http/PodeHttpListener.cs
@@ -6,6 +6,7 @@ using Pode.Protocols.Http.Client;
 using Pode.Protocols.Http.Client.Sse;
 using Pode.Protocols.Http.Client.Signals;
 using Pode.Adapters;
+using Pode.Utilities.Logging;
 
 namespace Pode.Protocols.Http
 {
@@ -138,24 +139,24 @@ namespace Pode.Protocols.Http
         protected override void Close()
         {
             // close connected signals
-            PodeHelpers.WriteErrorMessage($"Closing signals", this, PodeLoggingLevel.Verbose);
+            PodeHelpers.WriteErrorMessage($"Closing signals", this, PodeLogLevel.Verbose);
             foreach (var _signal in Signals.ToArray())
             {
                 _signal.Dispose();
             }
 
             Signals.Dispose();
-            PodeHelpers.WriteErrorMessage($"Closed signals", this, PodeLoggingLevel.Verbose);
+            PodeHelpers.WriteErrorMessage($"Closed signals", this, PodeLogLevel.Verbose);
 
             // close connected server events
-            PodeHelpers.WriteErrorMessage($"Closing server events", this, PodeLoggingLevel.Verbose);
+            PodeHelpers.WriteErrorMessage($"Closing server events", this, PodeLogLevel.Verbose);
             foreach (var _sse in ServerEvents.ToArray())
             {
                 _sse.Dispose();
             }
 
             ServerEvents.Dispose();
-            PodeHelpers.WriteErrorMessage($"Closed server events", this, PodeLoggingLevel.Verbose);
+            PodeHelpers.WriteErrorMessage($"Closed server events", this, PodeLogLevel.Verbose);
 
             // call base close
             base.Close();

--- a/src/Listener/Protocols/Http/PodeHttpListener.cs
+++ b/src/Listener/Protocols/Http/PodeHttpListener.cs
@@ -27,8 +27,8 @@ namespace Pode.Protocols.Http
             }
         }
 
-        public PodeHttpListener(CancellationToken cancellationToken = default)
-            : base(PodeAdapterType.Web, cancellationToken)
+        public PodeHttpListener(IPodeLogger logger, CancellationToken cancellationToken = default)
+            : base(PodeAdapterType.Web, logger, cancellationToken)
         {
             Signals = new PodeClientConnectionNestedMap<PodeSignal>(this);
             ServerEvents = new PodeClientConnectionNestedMap<PodeServerEvent>(this);
@@ -139,24 +139,24 @@ namespace Pode.Protocols.Http
         protected override void Close()
         {
             // close connected signals
-            PodeHelpers.WriteErrorMessage($"Closing signals", this, PodeLogLevel.Verbose);
+            PodeHelpers.WriteErrorMessage($"Closing signals", PodeLogLevel.Verbose);
             foreach (var _signal in Signals.ToArray())
             {
                 _signal.Dispose();
             }
 
             Signals.Dispose();
-            PodeHelpers.WriteErrorMessage($"Closed signals", this, PodeLogLevel.Verbose);
+            PodeHelpers.WriteErrorMessage($"Closed signals", PodeLogLevel.Verbose);
 
             // close connected server events
-            PodeHelpers.WriteErrorMessage($"Closing server events", this, PodeLogLevel.Verbose);
+            PodeHelpers.WriteErrorMessage($"Closing server events", PodeLogLevel.Verbose);
             foreach (var _sse in ServerEvents.ToArray())
             {
                 _sse.Dispose();
             }
 
             ServerEvents.Dispose();
-            PodeHelpers.WriteErrorMessage($"Closed server events", this, PodeLogLevel.Verbose);
+            PodeHelpers.WriteErrorMessage($"Closed server events", PodeLogLevel.Verbose);
 
             // call base close
             base.Close();

--- a/src/Listener/Protocols/Http/PodeHttpRequestStrategy.cs
+++ b/src/Listener/Protocols/Http/PodeHttpRequestStrategy.cs
@@ -122,7 +122,7 @@ namespace Pode.Protocols.Http
                 return;
             }
 
-            PodeHelpers.WriteErrorMessage($"Request reset", Handler.Context.Listener, PodeLogLevel.Verbose, Handler.Context);
+            PodeHelpers.WriteErrorMessage($"Request reset", PodeLogLevel.Verbose, Handler.Context);
 
             HttpMethod = string.Empty;
             QueryString = default;

--- a/src/Listener/Protocols/Http/PodeHttpRequestStrategy.cs
+++ b/src/Listener/Protocols/Http/PodeHttpRequestStrategy.cs
@@ -15,6 +15,7 @@ using Pode.Protocols.Common.Forms;
 using Pode.Protocols.Http.Client;
 using Pode.Protocols.Http.Client.Sse;
 using Pode.Protocols.Http.Client.Signals;
+using Pode.Utilities.Logging;
 
 namespace Pode.Protocols.Http
 {
@@ -121,7 +122,7 @@ namespace Pode.Protocols.Http
                 return;
             }
 
-            PodeHelpers.WriteErrorMessage($"Request reset", Handler.Context.Listener, PodeLoggingLevel.Verbose, Handler.Context);
+            PodeHelpers.WriteErrorMessage($"Request reset", Handler.Context.Listener, PodeLogLevel.Verbose, Handler.Context);
 
             HttpMethod = string.Empty;
             QueryString = default;

--- a/src/Listener/Protocols/Http/PodeHttpResponse.cs
+++ b/src/Listener/Protocols/Http/PodeHttpResponse.cs
@@ -78,23 +78,23 @@ namespace Pode.Protocols.Http
                 return;
             }
 
-            PodeHelpers.WriteErrorMessage($"Sending response", Context.Listener, PodeLogLevel.Verbose, Context);
+            PodeHelpers.WriteErrorMessage($"Sending response", PodeLogLevel.Verbose, Context);
 
             try
             {
                 await SendHeaders(Context.IsTimeout).ConfigureAwait(false);
                 await SendBody(Context.IsTimeout).ConfigureAwait(false);
-                PodeHelpers.WriteErrorMessage($"Response sent", Context.Listener, PodeLogLevel.Verbose, Context);
+                PodeHelpers.WriteErrorMessage($"Response sent", PodeLogLevel.Verbose, Context);
             }
             catch (OperationCanceledException) { }
             catch (IOException) { }
             catch (AggregateException aex)
             {
-                PodeHelpers.HandleAggregateException(aex, Context.Listener);
+                PodeHelpers.HandleAggregateException(aex);
             }
             catch (Exception ex)
             {
-                PodeHelpers.WriteException(ex, Context.Listener);
+                PodeHelpers.WriteException(ex);
                 throw;
             }
             finally
@@ -110,24 +110,24 @@ namespace Pode.Protocols.Http
                 return;
             }
 
-            PodeHelpers.WriteErrorMessage($"Sending response timed-out", Context.Listener, PodeLogLevel.Verbose, Context);
+            PodeHelpers.WriteErrorMessage($"Sending response timed-out", PodeLogLevel.Verbose, Context);
             StatusCode = 408;
 
             try
             {
                 await SendHeaders(true).ConfigureAwait(false);
                 IsSent = true;
-                PodeHelpers.WriteErrorMessage($"Response timed-out sent", Context.Listener, PodeLogLevel.Verbose, Context);
+                PodeHelpers.WriteErrorMessage($"Response timed-out sent", PodeLogLevel.Verbose, Context);
             }
             catch (OperationCanceledException) { }
             catch (IOException) { }
             catch (AggregateException aex)
             {
-                PodeHelpers.HandleAggregateException(aex, Context.Listener);
+                PodeHelpers.HandleAggregateException(aex);
             }
             catch (Exception ex)
             {
-                PodeHelpers.WriteException(ex, Context.Listener);
+                PodeHelpers.WriteException(ex);
                 throw;
             }
             finally

--- a/src/Listener/Protocols/Http/PodeHttpResponse.cs
+++ b/src/Listener/Protocols/Http/PodeHttpResponse.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Pode.Utilities;
 using Pode.Protocols.Common.Responses;
+using Pode.Utilities.Logging;
 
 namespace Pode.Protocols.Http
 {
@@ -77,13 +78,13 @@ namespace Pode.Protocols.Http
                 return;
             }
 
-            PodeHelpers.WriteErrorMessage($"Sending response", Context.Listener, PodeLoggingLevel.Verbose, Context);
+            PodeHelpers.WriteErrorMessage($"Sending response", Context.Listener, PodeLogLevel.Verbose, Context);
 
             try
             {
                 await SendHeaders(Context.IsTimeout).ConfigureAwait(false);
                 await SendBody(Context.IsTimeout).ConfigureAwait(false);
-                PodeHelpers.WriteErrorMessage($"Response sent", Context.Listener, PodeLoggingLevel.Verbose, Context);
+                PodeHelpers.WriteErrorMessage($"Response sent", Context.Listener, PodeLogLevel.Verbose, Context);
             }
             catch (OperationCanceledException) { }
             catch (IOException) { }
@@ -109,14 +110,14 @@ namespace Pode.Protocols.Http
                 return;
             }
 
-            PodeHelpers.WriteErrorMessage($"Sending response timed-out", Context.Listener, PodeLoggingLevel.Verbose, Context);
+            PodeHelpers.WriteErrorMessage($"Sending response timed-out", Context.Listener, PodeLogLevel.Verbose, Context);
             StatusCode = 408;
 
             try
             {
                 await SendHeaders(true).ConfigureAwait(false);
                 IsSent = true;
-                PodeHelpers.WriteErrorMessage($"Response timed-out sent", Context.Listener, PodeLoggingLevel.Verbose, Context);
+                PodeHelpers.WriteErrorMessage($"Response timed-out sent", Context.Listener, PodeLogLevel.Verbose, Context);
             }
             catch (OperationCanceledException) { }
             catch (IOException) { }

--- a/src/Listener/Protocols/Http/PodeSignalRequestStrategy.cs
+++ b/src/Listener/Protocols/Http/PodeSignalRequestStrategy.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Pode.Utilities;
 using Pode.Protocols.Common.Requests;
 using Pode.Protocols.Http.Client.Signals;
+using Pode.Utilities.Logging;
 
 namespace Pode.Protocols.Http
 {
@@ -178,7 +179,7 @@ namespace Pode.Protocols.Http
             catch (Exception ex)
             {
                 // Log the error and return false to indicate failure.
-                PodeHelpers.WriteErrorMessage($"Error decoding WebSocket frame: {ex.Message}", Handler.Context.Listener, PodeLoggingLevel.Error, Handler.Context);
+                PodeHelpers.WriteErrorMessage($"Error decoding WebSocket frame: {ex.Message}", Handler.Context.Listener, PodeLogLevel.Error, Handler.Context);
                 throw;
             }
             finally
@@ -264,7 +265,7 @@ namespace Pode.Protocols.Http
             if (disposing)
             {
                 // Log a message indicating the WebSocket is being closed.
-                PodeHelpers.WriteErrorMessage($"Closing Websocket", Handler.Context.Listener, PodeLoggingLevel.Verbose, Handler.Context);
+                PodeHelpers.WriteErrorMessage($"Closing Websocket", Handler.Context.Listener, PodeLogLevel.Verbose, Handler.Context);
                 Signal.Close().Wait();
 
                 Body = string.Empty;

--- a/src/Listener/Protocols/Http/PodeSignalRequestStrategy.cs
+++ b/src/Listener/Protocols/Http/PodeSignalRequestStrategy.cs
@@ -179,7 +179,7 @@ namespace Pode.Protocols.Http
             catch (Exception ex)
             {
                 // Log the error and return false to indicate failure.
-                PodeHelpers.WriteErrorMessage($"Error decoding WebSocket frame: {ex.Message}", Handler.Context.Listener, PodeLogLevel.Error, Handler.Context);
+                PodeHelpers.WriteErrorMessage($"Error decoding WebSocket frame: {ex.Message}", PodeLogLevel.Error, Handler.Context);
                 throw;
             }
             finally
@@ -265,7 +265,7 @@ namespace Pode.Protocols.Http
             if (disposing)
             {
                 // Log a message indicating the WebSocket is being closed.
-                PodeHelpers.WriteErrorMessage($"Closing Websocket", Handler.Context.Listener, PodeLogLevel.Verbose, Handler.Context);
+                PodeHelpers.WriteErrorMessage($"Closing Websocket", PodeLogLevel.Verbose, Handler.Context);
                 Signal.Close().Wait();
 
                 Body = string.Empty;

--- a/src/Listener/Protocols/Smtp/PodeSmtpListener.cs
+++ b/src/Listener/Protocols/Smtp/PodeSmtpListener.cs
@@ -1,12 +1,13 @@
 using System.Threading;
 using Pode.Adapters.Listeners;
 using Pode.Adapters;
+using Pode.Utilities.Logging;
 
 namespace Pode.Protocols.Smtp
 {
     public class PodeSmtpListener : PodeListener
     {
-        public PodeSmtpListener(CancellationToken cancellationToken = default)
-            : base(PodeAdapterType.Smtp, cancellationToken) { }
+        public PodeSmtpListener(IPodeLogger logger, CancellationToken cancellationToken = default)
+            : base(PodeAdapterType.Smtp, logger, cancellationToken) { }
     }
 }

--- a/src/Listener/Protocols/Smtp/PodeSmtpRequestStrategy.cs
+++ b/src/Listener/Protocols/Smtp/PodeSmtpRequestStrategy.cs
@@ -267,7 +267,7 @@ namespace Pode.Protocols.Smtp
                 return;
             }
 
-            PodeHelpers.WriteErrorMessage($"Request reset", Handler.Context.Listener, PodeLogLevel.Verbose, Handler.Context);
+            PodeHelpers.WriteErrorMessage($"Request reset", PodeLogLevel.Verbose, Handler.Context);
 
             _canProcess = false;
             Headers = new Hashtable(StringComparer.InvariantCultureIgnoreCase);

--- a/src/Listener/Protocols/Smtp/PodeSmtpRequestStrategy.cs
+++ b/src/Listener/Protocols/Smtp/PodeSmtpRequestStrategy.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using Pode.Utilities;
 using Pode.Protocols.Common.Requests;
 using Pode.Protocols.Common.Forms;
+using Pode.Utilities.Logging;
 
 namespace Pode.Protocols.Smtp
 {
@@ -266,7 +267,7 @@ namespace Pode.Protocols.Smtp
                 return;
             }
 
-            PodeHelpers.WriteErrorMessage($"Request reset", Handler.Context.Listener, PodeLoggingLevel.Verbose, Handler.Context);
+            PodeHelpers.WriteErrorMessage($"Request reset", Handler.Context.Listener, PodeLogLevel.Verbose, Handler.Context);
 
             _canProcess = false;
             Headers = new Hashtable(StringComparer.InvariantCultureIgnoreCase);

--- a/src/Listener/Protocols/Tcp/PodeTcpListener.cs
+++ b/src/Listener/Protocols/Tcp/PodeTcpListener.cs
@@ -1,12 +1,13 @@
 using System.Threading;
 using Pode.Adapters.Listeners;
 using Pode.Adapters;
+using Pode.Utilities.Logging;
 
 namespace Pode.Protocols.Tcp
 {
     public class PodeTcpListener : PodeListener
     {
-        public PodeTcpListener(CancellationToken cancellationToken = default)
-            : base(PodeAdapterType.Tcp, cancellationToken) { }
+        public PodeTcpListener(IPodeLogger logger, CancellationToken cancellationToken = default)
+            : base(PodeAdapterType.Tcp, logger, cancellationToken) { }
     }
 }

--- a/src/Listener/Protocols/Tcp/PodeTcpRequestStrategy.cs
+++ b/src/Listener/Protocols/Tcp/PodeTcpRequestStrategy.cs
@@ -75,7 +75,7 @@ namespace Pode.Protocols.Tcp
                 return;
             }
 
-            PodeHelpers.WriteErrorMessage($"Request reset", Handler.Context.Listener, PodeLogLevel.Verbose, Handler.Context);
+            PodeHelpers.WriteErrorMessage($"Request reset", PodeLogLevel.Verbose, Handler.Context);
             _body = string.Empty;
             RawBody = default;
         }

--- a/src/Listener/Protocols/Tcp/PodeTcpRequestStrategy.cs
+++ b/src/Listener/Protocols/Tcp/PodeTcpRequestStrategy.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Pode.Utilities;
 using Pode.Protocols.Common.Requests;
+using Pode.Utilities.Logging;
 
 namespace Pode.Protocols.Tcp
 {
@@ -74,7 +75,7 @@ namespace Pode.Protocols.Tcp
                 return;
             }
 
-            PodeHelpers.WriteErrorMessage($"Request reset", Handler.Context.Listener, PodeLoggingLevel.Verbose, Handler.Context);
+            PodeHelpers.WriteErrorMessage($"Request reset", Handler.Context.Listener, PodeLogLevel.Verbose, Handler.Context);
             _body = string.Empty;
             RawBody = default;
         }

--- a/src/Listener/Protocols/WebSockets/PodeWebSocket.cs
+++ b/src/Listener/Protocols/WebSockets/PodeWebSocket.cs
@@ -108,7 +108,7 @@ namespace Pode.Protocols.WebSockets
             catch (IOException) { }
             catch (WebSocketException ex)
             {
-                PodeHelpers.WriteException(ex, Consumer, PodeLogLevel.Debug);
+                PodeHelpers.WriteException(ex, PodeLogLevel.Debug);
                 Dispose();
             }
             finally
@@ -142,7 +142,7 @@ namespace Pode.Protocols.WebSockets
 
             if (IsConnected)
             {
-                PodeHelpers.WriteErrorMessage($"Closing client web socket: {Name}", Consumer, PodeLogLevel.Verbose);
+                PodeHelpers.WriteErrorMessage($"Closing client web socket: {Name}", PodeLogLevel.Verbose);
 
                 // only close output in client closing
                 if (closeFrom == PodeWebSocketCloseFrom.Client)
@@ -156,12 +156,12 @@ namespace Pode.Protocols.WebSockets
                     await WebSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, CancellationToken.None).ConfigureAwait(false);
                 }
 
-                PodeHelpers.WriteErrorMessage($"Closed client web socket: {Name}", Consumer, PodeLogLevel.Verbose);
+                PodeHelpers.WriteErrorMessage($"Closed client web socket: {Name}", PodeLogLevel.Verbose);
             }
 
             WebSocket.Dispose();
             WebSocket = default;
-            PodeHelpers.WriteErrorMessage($"Disconnected client web socket: {Name}", Consumer, PodeLogLevel.Verbose);
+            PodeHelpers.WriteErrorMessage($"Disconnected client web socket: {Name}", PodeLogLevel.Verbose);
         }
 
         public void Dispose()

--- a/src/Listener/Protocols/WebSockets/PodeWebSocket.cs
+++ b/src/Listener/Protocols/WebSockets/PodeWebSocket.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Linq; // needed for netstandard2.0
 using Pode.Adapters.Consumers;
 using Pode.Utilities;
+using Pode.Utilities.Logging;
 
 namespace Pode.Protocols.WebSockets
 {
@@ -107,7 +108,7 @@ namespace Pode.Protocols.WebSockets
             catch (IOException) { }
             catch (WebSocketException ex)
             {
-                PodeHelpers.WriteException(ex, Consumer, PodeLoggingLevel.Debug);
+                PodeHelpers.WriteException(ex, Consumer, PodeLogLevel.Debug);
                 Dispose();
             }
             finally
@@ -141,7 +142,7 @@ namespace Pode.Protocols.WebSockets
 
             if (IsConnected)
             {
-                PodeHelpers.WriteErrorMessage($"Closing client web socket: {Name}", Consumer, PodeLoggingLevel.Verbose);
+                PodeHelpers.WriteErrorMessage($"Closing client web socket: {Name}", Consumer, PodeLogLevel.Verbose);
 
                 // only close output in client closing
                 if (closeFrom == PodeWebSocketCloseFrom.Client)
@@ -155,12 +156,12 @@ namespace Pode.Protocols.WebSockets
                     await WebSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, CancellationToken.None).ConfigureAwait(false);
                 }
 
-                PodeHelpers.WriteErrorMessage($"Closed client web socket: {Name}", Consumer, PodeLoggingLevel.Verbose);
+                PodeHelpers.WriteErrorMessage($"Closed client web socket: {Name}", Consumer, PodeLogLevel.Verbose);
             }
 
             WebSocket.Dispose();
             WebSocket = default;
-            PodeHelpers.WriteErrorMessage($"Disconnected client web socket: {Name}", Consumer, PodeLoggingLevel.Verbose);
+            PodeHelpers.WriteErrorMessage($"Disconnected client web socket: {Name}", Consumer, PodeLogLevel.Verbose);
         }
 
         public void Dispose()

--- a/src/Listener/Transport/Sockets/PodeSocket.cs
+++ b/src/Listener/Transport/Sockets/PodeSocket.cs
@@ -11,6 +11,7 @@ using System.IO;
 using Pode.Adapters.Listeners;
 using Pode.Utilities;
 using Pode.Protocols.Common.Contexts;
+using Pode.Utilities.Logging;
 
 namespace Pode.Transport.Sockets
 {
@@ -185,7 +186,7 @@ namespace Pode.Transport.Sockets
 
             // Create the context for the connection.
             var context = PodeContextFactory.Create(Type, acceptedSocket, this, Listener);
-            PodeHelpers.WriteErrorMessage($"Opening Receive", Listener, PodeLoggingLevel.Verbose, context);
+            PodeHelpers.WriteErrorMessage($"Opening Receive", Listener, PodeLogLevel.Verbose, context);
 
             // Initialize the context.
             await context.Initialise().ConfigureAwait(false);
@@ -205,7 +206,7 @@ namespace Pode.Transport.Sockets
         /// <param name="context">The context to start receiving for.</param>
         public void StartReceive(IPodeContext context)
         {
-            PodeHelpers.WriteErrorMessage($"Starting Receive", Listener, PodeLoggingLevel.Verbose, context);
+            PodeHelpers.WriteErrorMessage($"Starting Receive", Listener, PodeLogLevel.Verbose, context);
 
             try
             {
@@ -215,17 +216,17 @@ namespace Pode.Transport.Sockets
             catch (OperationCanceledException ex)
             {
                 // Handle cancellation.
-                PodeHelpers.WriteException(ex, Listener, PodeLoggingLevel.Verbose);
+                PodeHelpers.WriteException(ex, Listener, PodeLogLevel.Verbose);
             }
             catch (IOException ex)
             {
                 // Handle I/O exceptions.
-                PodeHelpers.WriteException(ex, Listener, PodeLoggingLevel.Verbose);
+                PodeHelpers.WriteException(ex, Listener, PodeLogLevel.Verbose);
             }
             catch (AggregateException aex)
             {
                 // Handle aggregated exceptions.
-                PodeHelpers.HandleAggregateException(aex, Listener, PodeLoggingLevel.Error, true);
+                PodeHelpers.HandleAggregateException(aex, Listener, PodeLogLevel.Error, true);
                 context.Socket.Close();
             }
             catch (Exception ex)
@@ -255,7 +256,7 @@ namespace Pode.Transport.Sockets
             {
                 if (error != SocketError.Success)
                 {
-                    PodeHelpers.WriteErrorMessage($"Closing accepting socket: {error}", Listener, PodeLoggingLevel.Debug);
+                    PodeHelpers.WriteErrorMessage($"Closing accepting socket: {error}", Listener, PodeLogLevel.Debug);
                 }
 
                 // Close socket if it was accepted but there's an error.
@@ -274,17 +275,17 @@ namespace Pode.Transport.Sockets
                 catch (OperationCanceledException ex)
                 {
                     // Handle cancellation.
-                    PodeHelpers.WriteException(ex, Listener, PodeLoggingLevel.Verbose);
+                    PodeHelpers.WriteException(ex, Listener, PodeLogLevel.Verbose);
                 }
                 catch (IOException ex)
                 {
                     // Handle I/O exceptions.
-                    PodeHelpers.WriteException(ex, Listener, PodeLoggingLevel.Verbose);
+                    PodeHelpers.WriteException(ex, Listener, PodeLogLevel.Verbose);
                 }
                 catch (AggregateException aex)
                 {
                     // Handle aggregated exceptions.
-                    PodeHelpers.HandleAggregateException(aex, Listener, PodeLoggingLevel.Error, true);
+                    PodeHelpers.HandleAggregateException(aex, Listener, PodeLogLevel.Error, true);
                 }
                 catch (Exception ex)
                 {

--- a/src/Listener/Transport/Sockets/PodeSocket.cs
+++ b/src/Listener/Transport/Sockets/PodeSocket.cs
@@ -186,7 +186,7 @@ namespace Pode.Transport.Sockets
 
             // Create the context for the connection.
             var context = PodeContextFactory.Create(Type, acceptedSocket, this, Listener);
-            PodeHelpers.WriteErrorMessage($"Opening Receive", Listener, PodeLogLevel.Verbose, context);
+            PodeHelpers.WriteErrorMessage($"Opening Receive", PodeLogLevel.Verbose, context);
 
             // Initialize the context.
             await context.Initialise().ConfigureAwait(false);
@@ -206,7 +206,7 @@ namespace Pode.Transport.Sockets
         /// <param name="context">The context to start receiving for.</param>
         public void StartReceive(IPodeContext context)
         {
-            PodeHelpers.WriteErrorMessage($"Starting Receive", Listener, PodeLogLevel.Verbose, context);
+            PodeHelpers.WriteErrorMessage($"Starting Receive", PodeLogLevel.Verbose, context);
 
             try
             {
@@ -216,23 +216,23 @@ namespace Pode.Transport.Sockets
             catch (OperationCanceledException ex)
             {
                 // Handle cancellation.
-                PodeHelpers.WriteException(ex, Listener, PodeLogLevel.Verbose);
+                PodeHelpers.WriteException(ex, PodeLogLevel.Verbose);
             }
             catch (IOException ex)
             {
                 // Handle I/O exceptions.
-                PodeHelpers.WriteException(ex, Listener, PodeLogLevel.Verbose);
+                PodeHelpers.WriteException(ex, PodeLogLevel.Verbose);
             }
             catch (AggregateException aex)
             {
                 // Handle aggregated exceptions.
-                PodeHelpers.HandleAggregateException(aex, Listener, PodeLogLevel.Error, true);
+                PodeHelpers.HandleAggregateException(aex, handled: true);
                 context.Socket.Close();
             }
             catch (Exception ex)
             {
                 // Handle any other exceptions.
-                PodeHelpers.WriteException(ex, Listener);
+                PodeHelpers.WriteException(ex);
                 context.Socket.Close();
             }
         }
@@ -256,7 +256,7 @@ namespace Pode.Transport.Sockets
             {
                 if (error != SocketError.Success)
                 {
-                    PodeHelpers.WriteErrorMessage($"Closing accepting socket: {error}", Listener, PodeLogLevel.Debug);
+                    PodeHelpers.WriteErrorMessage($"Closing accepting socket: {error}", PodeLogLevel.Debug);
                 }
 
                 // Close socket if it was accepted but there's an error.
@@ -275,22 +275,22 @@ namespace Pode.Transport.Sockets
                 catch (OperationCanceledException ex)
                 {
                     // Handle cancellation.
-                    PodeHelpers.WriteException(ex, Listener, PodeLogLevel.Verbose);
+                    PodeHelpers.WriteException(ex, PodeLogLevel.Verbose);
                 }
                 catch (IOException ex)
                 {
                     // Handle I/O exceptions.
-                    PodeHelpers.WriteException(ex, Listener, PodeLogLevel.Verbose);
+                    PodeHelpers.WriteException(ex, PodeLogLevel.Verbose);
                 }
                 catch (AggregateException aex)
                 {
                     // Handle aggregated exceptions.
-                    PodeHelpers.HandleAggregateException(aex, Listener, PodeLogLevel.Error, true);
+                    PodeHelpers.HandleAggregateException(aex, handled: true);
                 }
                 catch (Exception ex)
                 {
                     // Handle any other exceptions.
-                    PodeHelpers.WriteException(ex, Listener);
+                    PodeHelpers.WriteException(ex);
                 }
             }
 
@@ -400,7 +400,7 @@ namespace Pode.Transport.Sockets
                 }
                 catch (Exception ex)
                 {
-                    PodeHelpers.WriteException(ex, Listener);
+                    PodeHelpers.WriteException(ex);
                 }
             }
             finally

--- a/src/Listener/Utilities/Logging/IPodeLogEvent.cs
+++ b/src/Listener/Utilities/Logging/IPodeLogEvent.cs
@@ -1,0 +1,9 @@
+namespace Pode.Utilities.Logging
+{
+    public interface IPodeLogEvent
+    {
+        string Name { get; }
+        PodeLogLevel Level { get; }
+        object Item { get; }
+    }
+}

--- a/src/Listener/Utilities/Logging/IPodeLogItem.cs
+++ b/src/Listener/Utilities/Logging/IPodeLogItem.cs
@@ -1,0 +1,8 @@
+namespace Pode.Utilities.Logging
+{
+    public interface IPodeLogItem
+    {
+        object Items { get; set; }
+        object RawItems { get; set; }
+    }
+}

--- a/src/Listener/Utilities/Logging/IPodeLogQueue.cs
+++ b/src/Listener/Utilities/Logging/IPodeLogQueue.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Threading;
+
+namespace Pode.Utilities.Logging
+{
+    public interface IPodeLogQueue<T> : IDisposable
+    {
+        bool IsDisposed { get; }
+        int Count { get; }
+
+        void Add(T logItem);
+        bool TryTake(out T logItem, CancellationToken cancellationToken);
+    }
+}

--- a/src/Listener/Utilities/Logging/IPodeLogType.cs
+++ b/src/Listener/Utilities/Logging/IPodeLogType.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+
+namespace Pode.Utilities.Logging
+{
+    public interface IPodeLogType
+    {
+        string Name { get; }
+        HashSet<PodeLogLevel> Levels { get; }
+
+        bool IsLevelEnabled(PodeLogLevel level);
+    }
+}

--- a/src/Listener/Utilities/Logging/IPodeLogger.cs
+++ b/src/Listener/Utilities/Logging/IPodeLogger.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Threading;
+
+namespace Pode.Utilities.Logging
+{
+    public interface IPodeLogger : IDisposable
+    {
+        bool IsDisposed { get; }
+        int Count { get; }
+
+        bool IsEnabled { get; set; }
+        bool IsRequestLoggingEnabled { get; }
+        bool IsErrorLoggingEnabled { get; }
+
+        void RegisterType(IPodeLogType logType);
+        void UnregisterType(IPodeLogType logType);
+        void Add(string name, PodeLogLevel level, object item);
+        void Add(IPodeLogEvent logEvent);
+        void AddException(Exception exception, string contextId, PodeLogLevel level, int threadId = 0);
+        void AddException(string message, string contextId, PodeLogLevel level, int threadId = 0);
+        void AddException(string category, string message, string stackTrace, string contextId, PodeLogLevel level, int threadId = 0);
+        bool TryTake(out IPodeLogEvent logEvent, CancellationToken cancellationToken);
+    }
+}

--- a/src/Listener/Utilities/Logging/IPodeLogger.cs
+++ b/src/Listener/Utilities/Logging/IPodeLogger.cs
@@ -20,5 +20,6 @@ namespace Pode.Utilities.Logging
         void AddException(string message, string contextId, PodeLogLevel level, int threadId = 0);
         void AddException(string category, string message, string stackTrace, string contextId, PodeLogLevel level, int threadId = 0);
         bool TryTake(out IPodeLogEvent logEvent, CancellationToken cancellationToken);
+        void Reset();
     }
 }

--- a/src/Listener/Utilities/Logging/IPodeLogger.cs
+++ b/src/Listener/Utilities/Logging/IPodeLogger.cs
@@ -13,7 +13,7 @@ namespace Pode.Utilities.Logging
         bool IsErrorLoggingEnabled { get; }
 
         void RegisterType(IPodeLogType logType);
-        void UnregisterType(IPodeLogType logType);
+        void UnregisterType(string name);
         void Add(string name, PodeLogLevel level, object item);
         void Add(IPodeLogEvent logEvent);
         void AddException(Exception exception, string contextId, PodeLogLevel level, int threadId = 0);

--- a/src/Listener/Utilities/Logging/PodeLogEvent.cs
+++ b/src/Listener/Utilities/Logging/PodeLogEvent.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace Pode.Utilities.Logging
+{
+    public class PodeLogEvent : IPodeLogEvent
+    {
+        public string Name { get; private set; }
+        public PodeLogLevel Level { get; private set; }
+        public object Item { get; private set; }
+
+        public PodeLogEvent(string name, PodeLogLevel level, object item)
+        {
+            if (string.IsNullOrEmpty(name))
+            {
+                throw new ArgumentException("Log item name cannot be null or empty.", nameof(name));
+            }
+
+            Name = name;
+            Level = level;
+            Item = item;
+        }
+    }
+}

--- a/src/Listener/Utilities/Logging/PodeLogItem.cs
+++ b/src/Listener/Utilities/Logging/PodeLogItem.cs
@@ -1,23 +1,14 @@
-using System;
-
 namespace Pode.Utilities.Logging
 {
-    public class PodeLogItem
+    public class PodeLogItem : IPodeLogItem
     {
-        public string Name { get; private set; }
-        public PodeLogLevel Level { get; private set; }
-        public object Item { get; private set; }
+        public object Items { get; set; }
+        public object RawItems { get; set; }
 
-        public PodeLogItem(string name, PodeLogLevel level, object item)
+        public PodeLogItem(object items, object rawItems)
         {
-            if (string.IsNullOrEmpty(name))
-            {
-                throw new ArgumentException("Log item name cannot be null or empty.", nameof(name));
-            }
-
-            Name = name;
-            Level = level;
-            Item = item;
+            Items = items;
+            RawItems = rawItems;
         }
     }
 }

--- a/src/Listener/Utilities/Logging/PodeLogItem.cs
+++ b/src/Listener/Utilities/Logging/PodeLogItem.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace Pode.Utilities.Logging
+{
+    public class PodeLogItem
+    {
+        public string Name { get; private set; }
+        public PodeLogLevel Level { get; private set; }
+        public object Item { get; private set; }
+
+        public PodeLogItem(string name, PodeLogLevel level, object item)
+        {
+            if (string.IsNullOrEmpty(name))
+            {
+                throw new ArgumentException("Log item name cannot be null or empty.", nameof(name));
+            }
+
+            Name = name;
+            Level = level;
+            Item = item;
+        }
+    }
+}

--- a/src/Listener/Utilities/Logging/PodeLogLevel.cs
+++ b/src/Listener/Utilities/Logging/PodeLogLevel.cs
@@ -1,6 +1,6 @@
-namespace Pode.Utilities
+namespace Pode.Utilities.Logging
 {
-    public enum PodeLoggingLevel
+    public enum PodeLogLevel
     {
         Error,
         Warning,

--- a/src/Listener/Utilities/Logging/PodeLogQueue.cs
+++ b/src/Listener/Utilities/Logging/PodeLogQueue.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+
+namespace Pode.Utilities.Logging
+{
+    public class PodeLogQueue<T> : IPodeLogQueue<T>
+    {
+        private readonly BlockingCollection<T> Queue;
+
+        public bool IsDisposed { get; private set; } = false;
+        public int Count => Queue.Count;
+
+        public PodeLogQueue()
+        {
+            Queue = new BlockingCollection<T>();
+        }
+
+        public void Add(T logItem)
+        {
+            if (IsDisposed)
+            {
+                return;
+            }
+
+            // add the log item to the queue
+            Queue.Add(logItem);
+        }
+
+        public bool TryTake(out T logItem, CancellationToken cancellationToken)
+        {
+            if (IsDisposed)
+            {
+                logItem = default;
+                return false;
+            }
+
+            return Queue.TryTake(out logItem, 5000, cancellationToken);
+        }
+
+        public void Dispose()
+        {
+            if (IsDisposed)
+            {
+                return;
+            }
+            IsDisposed = true;
+
+            // dispose the queue
+            Queue.Dispose();
+
+            // suppress finalization
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/src/Listener/Utilities/Logging/PodeLogType.cs
+++ b/src/Listener/Utilities/Logging/PodeLogType.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Pode.Utilities.Logging
 {
-    public class PodeLogType
+    public class PodeLogType : IPodeLogType
     {
         public string Name { get; private set; }
         public HashSet<PodeLogLevel> Levels { get; private set; }

--- a/src/Listener/Utilities/Logging/PodeLogType.cs
+++ b/src/Listener/Utilities/Logging/PodeLogType.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+
+namespace Pode.Utilities.Logging
+{
+    public class PodeLogType
+    {
+        public string Name { get; private set; }
+        public HashSet<PodeLogLevel> Levels { get; private set; }
+
+        public PodeLogType(string name, HashSet<PodeLogLevel> levels)
+        {
+            if (string.IsNullOrEmpty(name))
+            {
+                throw new ArgumentException("Log type name cannot be null or empty.", nameof(name));
+            }
+
+            Name = name;
+            Levels = levels;
+        }
+
+        public bool IsLevelEnabled(PodeLogLevel level)
+        {
+            return Levels.Contains(level);
+        }
+    }
+}

--- a/src/Listener/Utilities/Logging/PodeLogger.cs
+++ b/src/Listener/Utilities/Logging/PodeLogger.cs
@@ -1,0 +1,165 @@
+using System;
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Net;
+using System.Threading;
+
+namespace Pode.Utilities.Logging
+{
+    public class PodeLogger : IDisposable
+    {
+        public const string REQUEST_LOG_TYPE_NAME = "__pode_log_requests__";
+        public const string ERROR_LOG_TYPE_NAME = "__pode_log_errors__";
+
+        private readonly BlockingCollection<PodeLogItem> Queue;
+        private readonly Dictionary<string, PodeLogType> LogTypes;
+
+        public bool IsDisposed { get; private set; } = false;
+        public int Count => Queue.Count;
+
+        private bool _isEnabled = true;
+        public bool IsEnabled
+        {
+            get => !IsDisposed && _isEnabled;
+            set => _isEnabled = value;
+        }
+
+        public bool IsRequestLoggingEnabled => IsEnabled && (LogTypes?.ContainsKey(REQUEST_LOG_TYPE_NAME) ?? false);
+        public bool IsErrorLoggingEnabled => IsEnabled && (LogTypes?.ContainsKey(ERROR_LOG_TYPE_NAME) ?? false);
+
+        public PodeLogger()
+        {
+            LogTypes = new Dictionary<string, PodeLogType>();
+            Queue = new BlockingCollection<PodeLogItem>();
+        }
+
+        public void RegisterType(PodeLogType logType)
+        {
+            if (IsDisposed || !IsEnabled)
+            {
+                return;
+            }
+
+            LogTypes.Add(logType.Name, logType);
+        }
+
+        public void UnregisterType(PodeLogType logType)
+        {
+            if (IsDisposed || !IsEnabled)
+            {
+                return;
+            }
+
+            LogTypes.Remove(logType.Name);
+        }
+
+        public void Add(string name, PodeLogLevel level, object item)
+        {
+            if (IsDisposed || !IsEnabled)
+            {
+                return;
+            }
+
+            Add(new PodeLogItem(name, level, item));
+        }
+
+        public void Add(PodeLogItem logItem)
+        {
+            if (IsDisposed || !IsEnabled)
+            {
+                return;
+            }
+
+            // does the log type exist?
+            if (!LogTypes.TryGetValue(logItem.Name, out PodeLogType logType))
+            {
+                return;
+            }
+
+            // is the log level enabled for the log type?
+            if (!logType.IsLevelEnabled(logItem.Level))
+            {
+                return;
+            }
+
+            // add the log item to the queue
+            Queue.Add(logItem);
+        }
+
+        public void AddException(Exception exception, PodeLogLevel level, int threadId = -1)
+        {
+            if (exception == null)
+            {
+                return;
+            }
+
+            AddException(exception.Source, exception.Message, exception.StackTrace, level, threadId);
+        }
+
+        public void AddException(string category, string message, string stackTrace, PodeLogLevel level, int threadId = -1)
+        {
+            if (IsDisposed || !IsEnabled)
+            {
+                return;
+            }
+
+            // does the log type exist?
+            if (!LogTypes.TryGetValue(ERROR_LOG_TYPE_NAME, out PodeLogType logType))
+            {
+                return;
+            }
+
+            // is the log level enabled for the log type?
+            if (!logType.IsLevelEnabled(level))
+            {
+                return;
+            }
+
+            // convert the exception to a log item
+            var item = new Hashtable(StringComparer.InvariantCultureIgnoreCase)
+            {
+                { "Category", category },
+                { "Message", message },
+                { "StackTrace", stackTrace },
+                { "Server", Dns.GetHostName() },
+                { "Level", level.ToString() },
+                { "Date", DateTime.Now },
+                { "ThreadId", threadId == -1 ? Environment.CurrentManagedThreadId : threadId }
+            };
+
+            // add the log item to the queue
+            Queue.Add(new PodeLogItem(ERROR_LOG_TYPE_NAME, level, item));
+        }
+
+        public bool TryTake(out PodeLogItem logItem, CancellationToken cancellationToken)
+        {
+            if (IsDisposed || !IsEnabled)
+            {
+                logItem = null;
+                return false;
+            }
+
+            return Queue.TryTake(out logItem, 5000, cancellationToken);
+        }
+
+        public void Dispose()
+        {
+            if (IsDisposed)
+            {
+                return;
+            }
+            IsDisposed = true;
+            IsEnabled = false;
+
+            // dispose the queue
+            Queue.Dispose();
+
+            // clear the log types
+            LogTypes.Clear();
+
+            // suppress finalization
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/src/Listener/Utilities/Logging/PodeLogger.cs
+++ b/src/Listener/Utilities/Logging/PodeLogger.cs
@@ -1,19 +1,18 @@
 using System;
 using System.Collections;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Net;
 using System.Threading;
 
 namespace Pode.Utilities.Logging
 {
-    public class PodeLogger : IDisposable
+    public class PodeLogger : IPodeLogger
     {
         public const string REQUEST_LOG_TYPE_NAME = "__pode_log_requests__";
         public const string ERROR_LOG_TYPE_NAME = "__pode_log_errors__";
 
-        private readonly BlockingCollection<PodeLogItem> Queue;
-        private readonly Dictionary<string, PodeLogType> LogTypes;
+        private readonly PodeLogQueue<IPodeLogEvent> Queue;
+        private readonly Dictionary<string, IPodeLogType> LogTypes;
 
         public bool IsDisposed { get; private set; } = false;
         public int Count => Queue.Count;
@@ -30,11 +29,11 @@ namespace Pode.Utilities.Logging
 
         public PodeLogger()
         {
-            LogTypes = new Dictionary<string, PodeLogType>();
-            Queue = new BlockingCollection<PodeLogItem>();
+            LogTypes = new Dictionary<string, IPodeLogType>();
+            Queue = new PodeLogQueue<IPodeLogEvent>();
         }
 
-        public void RegisterType(PodeLogType logType)
+        public void RegisterType(IPodeLogType logType)
         {
             if (IsDisposed || !IsEnabled)
             {
@@ -44,7 +43,7 @@ namespace Pode.Utilities.Logging
             LogTypes.Add(logType.Name, logType);
         }
 
-        public void UnregisterType(PodeLogType logType)
+        public void UnregisterType(IPodeLogType logType)
         {
             if (IsDisposed || !IsEnabled)
             {
@@ -61,10 +60,10 @@ namespace Pode.Utilities.Logging
                 return;
             }
 
-            Add(new PodeLogItem(name, level, item));
+            Add(new PodeLogEvent(name, level, item));
         }
 
-        public void Add(PodeLogItem logItem)
+        public void Add(IPodeLogEvent logEvent)
         {
             if (IsDisposed || !IsEnabled)
             {
@@ -72,32 +71,37 @@ namespace Pode.Utilities.Logging
             }
 
             // does the log type exist?
-            if (!LogTypes.TryGetValue(logItem.Name, out PodeLogType logType))
+            if (!LogTypes.TryGetValue(logEvent.Name, out IPodeLogType logType))
             {
                 return;
             }
 
             // is the log level enabled for the log type?
-            if (!logType.IsLevelEnabled(logItem.Level))
+            if (!logType.IsLevelEnabled(logEvent.Level))
             {
                 return;
             }
 
-            // add the log item to the queue
-            Queue.Add(logItem);
+            // add the log event to the queue
+            Queue.Add(logEvent);
         }
 
-        public void AddException(Exception exception, PodeLogLevel level, int threadId = -1)
+        public void AddException(Exception exception, string contextId, PodeLogLevel level, int threadId = 0)
         {
             if (exception == null)
             {
                 return;
             }
 
-            AddException(exception.Source, exception.Message, exception.StackTrace, level, threadId);
+            AddException(exception.Source, exception.Message, exception.StackTrace, contextId, level, threadId);
         }
 
-        public void AddException(string category, string message, string stackTrace, PodeLogLevel level, int threadId = -1)
+        public void AddException(string message, string contextId, PodeLogLevel level, int threadId = 0)
+        {
+            AddException(string.Empty, message, string.Empty, contextId, level, threadId);
+        }
+
+        public void AddException(string category, string message, string stackTrace, string contextId, PodeLogLevel level, int threadId = 0)
         {
             if (IsDisposed || !IsEnabled)
             {
@@ -105,7 +109,7 @@ namespace Pode.Utilities.Logging
             }
 
             // does the log type exist?
-            if (!LogTypes.TryGetValue(ERROR_LOG_TYPE_NAME, out PodeLogType logType))
+            if (!LogTypes.TryGetValue(ERROR_LOG_TYPE_NAME, out IPodeLogType logType))
             {
                 return;
             }
@@ -114,6 +118,20 @@ namespace Pode.Utilities.Logging
             if (!logType.IsLevelEnabled(level))
             {
                 return;
+            }
+
+            // set a category to calling class and method if not set
+            if (string.IsNullOrWhiteSpace(category))
+            {
+                var diag = new System.Diagnostics.StackTrace();
+                if (diag.FrameCount > 3)
+                {
+                    var frame = diag.GetFrame(3);
+                    var method = frame.GetMethod();
+                    var className = method.DeclaringType?.Name;
+                    var methodName = method.Name;
+                    category = $"{className}.{methodName}";
+                }
             }
 
             // convert the exception to a log item
@@ -125,22 +143,23 @@ namespace Pode.Utilities.Logging
                 { "Server", Dns.GetHostName() },
                 { "Level", level.ToString() },
                 { "Date", DateTime.Now },
-                { "ThreadId", threadId == -1 ? Environment.CurrentManagedThreadId : threadId }
+                { "ThreadId", threadId == 0 ? Environment.CurrentManagedThreadId : threadId },
+                { "ContextId", contextId }
             };
 
-            // add the log item to the queue
-            Queue.Add(new PodeLogItem(ERROR_LOG_TYPE_NAME, level, item));
+            // add the log event to the queue
+            Queue.Add(new PodeLogEvent(ERROR_LOG_TYPE_NAME, level, item));
         }
 
-        public bool TryTake(out PodeLogItem logItem, CancellationToken cancellationToken)
+        public bool TryTake(out IPodeLogEvent logEvent, CancellationToken cancellationToken)
         {
             if (IsDisposed || !IsEnabled)
             {
-                logItem = null;
+                logEvent = null;
                 return false;
             }
 
-            return Queue.TryTake(out logItem, 5000, cancellationToken);
+            return Queue.TryTake(out logEvent, cancellationToken);
         }
 
         public void Dispose()

--- a/src/Listener/Utilities/Logging/PodeLogger.cs
+++ b/src/Listener/Utilities/Logging/PodeLogger.cs
@@ -162,6 +162,17 @@ namespace Pode.Utilities.Logging
             return Queue.TryTake(out logEvent, cancellationToken);
         }
 
+        public void Reset()
+        {
+            if (IsDisposed)
+            {
+                return;
+            }
+
+            // clear log types
+            LogTypes.Clear();
+        }
+
         public void Dispose()
         {
             if (IsDisposed)

--- a/src/Listener/Utilities/Logging/PodeLogger.cs
+++ b/src/Listener/Utilities/Logging/PodeLogger.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Net;
 using System.Threading;
 
@@ -12,7 +12,7 @@ namespace Pode.Utilities.Logging
         public const string ERROR_LOG_TYPE_NAME = "__pode_log_errors__";
 
         private readonly PodeLogQueue<IPodeLogEvent> Queue;
-        private readonly Dictionary<string, IPodeLogType> LogTypes;
+        private readonly ConcurrentDictionary<string, IPodeLogType> LogTypes;
 
         public bool IsDisposed { get; private set; } = false;
         public int Count => Queue.Count;
@@ -29,7 +29,7 @@ namespace Pode.Utilities.Logging
 
         public PodeLogger()
         {
-            LogTypes = new Dictionary<string, IPodeLogType>();
+            LogTypes = new ConcurrentDictionary<string, IPodeLogType>();
             Queue = new PodeLogQueue<IPodeLogEvent>();
         }
 
@@ -40,17 +40,17 @@ namespace Pode.Utilities.Logging
                 return;
             }
 
-            LogTypes.Add(logType.Name, logType);
+            LogTypes.TryAdd(logType.Name, logType);
         }
 
-        public void UnregisterType(IPodeLogType logType)
+        public void UnregisterType(string name)
         {
             if (IsDisposed || !IsEnabled)
             {
                 return;
             }
 
-            LogTypes.Remove(logType.Name);
+            LogTypes.TryRemove(name, out _);
         }
 
         public void Add(string name, PodeLogLevel level, object item)
@@ -71,7 +71,7 @@ namespace Pode.Utilities.Logging
             }
 
             // does the log type exist?
-            if (!LogTypes.TryGetValue(logEvent.Name, out IPodeLogType logType))
+            if (!LogTypes.TryGetValue(logEvent.Name, out var logType))
             {
                 return;
             }
@@ -109,7 +109,7 @@ namespace Pode.Utilities.Logging
             }
 
             // does the log type exist?
-            if (!LogTypes.TryGetValue(ERROR_LOG_TYPE_NAME, out IPodeLogType logType))
+            if (!LogTypes.TryGetValue(ERROR_LOG_TYPE_NAME, out var logType))
             {
                 return;
             }
@@ -159,7 +159,16 @@ namespace Pode.Utilities.Logging
                 return false;
             }
 
-            return Queue.TryTake(out logEvent, cancellationToken);
+            var found = Queue.TryTake(out var _event, cancellationToken);
+
+            if (!found || string.IsNullOrEmpty(_event?.Name) || !LogTypes.ContainsKey(_event?.Name))
+            {
+                logEvent = null;
+                return false;
+            }
+
+            logEvent = _event;
+            return found;
         }
 
         public void Reset()

--- a/src/Listener/Utilities/PodeHelpers.cs
+++ b/src/Listener/Utilities/PodeHelpers.cs
@@ -9,13 +9,12 @@ using System.Threading.Tasks;
 using System.Threading;
 using System.Text;
 using System.IO.Compression;
-using Pode.Adapters;
 using Pode.Protocols.Common.Contexts;
 using Pode.Utilities.Logging;
 
 namespace Pode.Utilities
 {
-    public class PodeHelpers
+    public static class PodeHelpers
     {
         public static readonly string[] HTTP_METHODS = new string[] { "CONNECT", "DELETE", "GET", "HEAD", "MERGE", "OPTIONS", "PATCH", "POST", "PUT", "TRACE" };
         public const string WEB_SOCKET_MAGIC_KEY = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
@@ -48,34 +47,40 @@ namespace Pode.Utilities
             }
         }
 
-        public static void WriteException(Exception ex, IPodeAdapter adapter = default, PodeLogLevel level = PodeLogLevel.Error)
+        public static IPodeLogger Logger { get; private set; }
+
+        public static void SetLogger(IPodeLogger logger)
         {
-            if (ex == default(Exception))
+            Logger = logger;
+        }
+
+        public static void WriteException(Exception ex, PodeLogLevel level = PodeLogLevel.Error, IPodeContext context = default)
+        {
+            // do nothing if no exception, or no logger
+            if (ex == default(Exception) || Logger == default(IPodeLogger))
             {
                 return;
             }
 
-            // return if logging disabled, or if level isn't being logged
-            if (adapter != default && (!adapter.ErrorLoggingEnabled || !adapter.ErrorLoggingLevels.Contains(level.ToString(), StringComparer.InvariantCultureIgnoreCase)))
-            {
-                return;
-            }
-
-            // write the exception to terminal
-            Console.WriteLine($"[{level}] {ex.GetType().Name}: {ex.Message}");
-            Console.WriteLine(string.IsNullOrEmpty(ex.StackTrace) ? "   [No Stack Trace]" : ex.StackTrace);
-
+            // add the exception to the logger
+            Logger.AddException(ex, context?.ID, level);
             if (ex.InnerException != null)
             {
-                Console.WriteLine($"[{level}] {ex.InnerException.GetType().Name}: {ex.InnerException.Message}");
-                Console.WriteLine(string.IsNullOrEmpty(ex.InnerException.StackTrace) ? "   [No Stack Trace]" : ex.InnerException.StackTrace);
+                Logger.AddException(ex.InnerException, context?.ID, level);
             }
         }
 
-        public static void HandleAggregateException(AggregateException aex, IPodeAdapter adapter = default, PodeLogLevel level = PodeLogLevel.Error, bool handled = false)
+        public static void HandleAggregateException(AggregateException aex, PodeLogLevel level = PodeLogLevel.Error, IPodeContext context = default, bool handled = false)
         {
+            // do nothing if no exception, or no logger
+            if (aex == default(AggregateException) || Logger == default(IPodeLogger))
+            {
+                return;
+            }
+
             try
             {
+                // handle the exception, and ignore if it's an IO or OperationCanceled exception
                 aex.Handle((ex) =>
                 {
                     if (ex is IOException || ex is OperationCanceledException)
@@ -83,12 +88,13 @@ namespace Pode.Utilities
                         return true;
                     }
 
-                    WriteException(ex, adapter, level);
+                    WriteException(ex, level, context);
                     return false;
                 });
             }
             catch
             {
+                // rethrow the exception if it wasn't handled
                 if (!handled)
                 {
                     throw;
@@ -96,35 +102,16 @@ namespace Pode.Utilities
             }
         }
 
-        public static void WriteErrorMessage(string message, IPodeAdapter adapter = default, PodeLogLevel level = PodeLogLevel.Error, IPodeContext context = default)
+        public static void WriteErrorMessage(string message, PodeLogLevel level = PodeLogLevel.Error, IPodeContext context = default)
         {
-            // do nothing if no message
-            if (string.IsNullOrWhiteSpace(message))
+            // do nothing if no message, or no logger
+            if (string.IsNullOrWhiteSpace(message) || Logger == default(IPodeLogger))
             {
                 return;
             }
 
-            // return if logging disabled, or if level isn't being logged
-            if (adapter != default && (!adapter.ErrorLoggingEnabled || !adapter.ErrorLoggingLevels.Contains(level.ToString(), StringComparer.InvariantCultureIgnoreCase)))
-            {
-                return;
-            }
-
-            // return if no adapter, and level is not error or higher
-            if (adapter == default && level != PodeLogLevel.Error)
-            {
-                return;
-            }
-
-            // write the message to terminal
-            if (context == default)
-            {
-                Console.WriteLine($"[{level}]: {message}");
-            }
-            else
-            {
-                Console.WriteLine($"[{level}]: [ContextId: {context.ID}] {message}");
-            }
+            // add the error message to the logger
+            Logger.AddException(message, context?.ID, level);
         }
 
         public static string NewGuid(int length = 16)

--- a/src/Listener/Utilities/PodeHelpers.cs
+++ b/src/Listener/Utilities/PodeHelpers.cs
@@ -11,6 +11,7 @@ using System.Text;
 using System.IO.Compression;
 using Pode.Adapters;
 using Pode.Protocols.Common.Contexts;
+using Pode.Utilities.Logging;
 
 namespace Pode.Utilities
 {
@@ -47,7 +48,7 @@ namespace Pode.Utilities
             }
         }
 
-        public static void WriteException(Exception ex, IPodeAdapter adapter = default, PodeLoggingLevel level = PodeLoggingLevel.Error)
+        public static void WriteException(Exception ex, IPodeAdapter adapter = default, PodeLogLevel level = PodeLogLevel.Error)
         {
             if (ex == default(Exception))
             {
@@ -71,7 +72,7 @@ namespace Pode.Utilities
             }
         }
 
-        public static void HandleAggregateException(AggregateException aex, IPodeAdapter adapter = default, PodeLoggingLevel level = PodeLoggingLevel.Error, bool handled = false)
+        public static void HandleAggregateException(AggregateException aex, IPodeAdapter adapter = default, PodeLogLevel level = PodeLogLevel.Error, bool handled = false)
         {
             try
             {
@@ -95,7 +96,7 @@ namespace Pode.Utilities
             }
         }
 
-        public static void WriteErrorMessage(string message, IPodeAdapter adapter = default, PodeLoggingLevel level = PodeLoggingLevel.Error, IPodeContext context = default)
+        public static void WriteErrorMessage(string message, IPodeAdapter adapter = default, PodeLogLevel level = PodeLogLevel.Error, IPodeContext context = default)
         {
             // do nothing if no message
             if (string.IsNullOrWhiteSpace(message))
@@ -110,7 +111,7 @@ namespace Pode.Utilities
             }
 
             // return if no adapter, and level is not error or higher
-            if (adapter == default && level != PodeLoggingLevel.Error)
+            if (adapter == default && level != PodeLogLevel.Error)
             {
                 return;
             }

--- a/src/Listener/Utilities/PodeItemQueue.cs
+++ b/src/Listener/Utilities/PodeItemQueue.cs
@@ -106,9 +106,11 @@ namespace Pode.Utilities
 
             IsDisposed = true;
 
+            // dispose the queue
             Items.Dispose();
             Items = null;
 
+            // clear the processing items
             ProcessingItems.Clear();
             ProcessingItems = null;
 

--- a/src/Listener/Utilities/PodeItemQueue.cs
+++ b/src/Listener/Utilities/PodeItemQueue.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Pode.Utilities
 {
-    public class PodeItemQueue<T>
+    public class PodeItemQueue<T> : IDisposable
     {
         private BlockingCollection<T> Items = default;
         private List<T> ProcessingItems = default;
@@ -111,6 +111,8 @@ namespace Pode.Utilities
 
             ProcessingItems.Clear();
             ProcessingItems = null;
+
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/Locales/ar/Pode.psd1
+++ b/src/Locales/ar/Pode.psd1
@@ -347,4 +347,5 @@
     mcpToolAlreadyExistsExceptionMessage                              = "أداة MCP '{0}' موجودة بالفعل."
     mcpToolGroupAlreadyExistsExceptionMessage                         = "مجموعة أدوات MCP '{0}' موجودة بالفعل."
     staticRouteDefaultCannotBeRootedExceptionMessage                  = "لا يمكن أن تكون القيم الافتراضية للمسار الثابت مسارات جذرية. القيمة الافتراضية غير صالحة: '{0}'"
+    deprecatedFunctionWarningMessage                                  = "تحذير: الدالة '{0}' لم تعد مدعومة وسيتم إزالتها في الإصدارات المستقبلية. يرجى استخدام الدالة '{1}' بدلاً منها."
 }

--- a/src/Locales/ar/Pode.psd1
+++ b/src/Locales/ar/Pode.psd1
@@ -348,4 +348,5 @@
     mcpToolGroupAlreadyExistsExceptionMessage                         = "مجموعة أدوات MCP '{0}' موجودة بالفعل."
     staticRouteDefaultCannotBeRootedExceptionMessage                  = "لا يمكن أن تكون القيم الافتراضية للمسار الثابت مسارات جذرية. القيمة الافتراضية غير صالحة: '{0}'"
     deprecatedFunctionWarningMessage                                  = "تحذير: الدالة '{0}' لم تعد مدعومة وسيتم إزالتها في الإصدارات المستقبلية. يرجى استخدام الدالة '{1}' بدلاً منها."
+    loggingMethodDoesNotExistExceptionMessage                         = "طريقة التسجيل '{0}' غير موجودة."
 }

--- a/src/Locales/de/Pode.psd1
+++ b/src/Locales/de/Pode.psd1
@@ -347,4 +347,5 @@
     mcpToolAlreadyExistsExceptionMessage                              = "Das MCP-Tool '{0}' existiert bereits."
     mcpToolGroupAlreadyExistsExceptionMessage                         = "Die MCP-Toolgruppe '{0}' existiert bereits."
     staticRouteDefaultCannotBeRootedExceptionMessage                  = "Die Standardwerte für statische Routen können keine gerooteten Pfade sein. Ungültiger Standardwert: '{0}'"
+    deprecatedFunctionWarningMessage                                  = "WARNUNG: Die Funktion '{0}' ist veraltet und wird in zukünftigen Versionen entfernt. Bitte verwenden Sie stattdessen die Funktion '{1}'."
 }

--- a/src/Locales/de/Pode.psd1
+++ b/src/Locales/de/Pode.psd1
@@ -348,4 +348,5 @@
     mcpToolGroupAlreadyExistsExceptionMessage                         = "Die MCP-Toolgruppe '{0}' existiert bereits."
     staticRouteDefaultCannotBeRootedExceptionMessage                  = "Die Standardwerte für statische Routen können keine gerooteten Pfade sein. Ungültiger Standardwert: '{0}'"
     deprecatedFunctionWarningMessage                                  = "WARNUNG: Die Funktion '{0}' ist veraltet und wird in zukünftigen Versionen entfernt. Bitte verwenden Sie stattdessen die Funktion '{1}'."
+    loggingMethodDoesNotExistExceptionMessage                         = "Die Protokollierungsmethode '{0}' existiert nicht."
 }

--- a/src/Locales/en-us/Pode.psd1
+++ b/src/Locales/en-us/Pode.psd1
@@ -347,4 +347,5 @@
     mcpToolAlreadyExistsExceptionMessage                              = "The MCP tool '{0}' already exists."
     mcpToolGroupAlreadyExistsExceptionMessage                         = "The MCP tool group '{0}' already exists."
     staticRouteDefaultCannotBeRootedExceptionMessage                  = "Static route defaults cannot be rooted paths. Invalid default: '{0}'"
+    deprecatedFunctionWarningMessage                                  = "WARNING: The function '{0}' is deprecated and will be removed in future releases. Please use the '{1}' function instead."
 }

--- a/src/Locales/en-us/Pode.psd1
+++ b/src/Locales/en-us/Pode.psd1
@@ -348,4 +348,5 @@
     mcpToolGroupAlreadyExistsExceptionMessage                         = "The MCP tool group '{0}' already exists."
     staticRouteDefaultCannotBeRootedExceptionMessage                  = "Static route defaults cannot be rooted paths. Invalid default: '{0}'"
     deprecatedFunctionWarningMessage                                  = "WARNING: The function '{0}' is deprecated and will be removed in future releases. Please use the '{1}' function instead."
+    loggingMethodDoesNotExistExceptionMessage                         = "The logging method '{0}' does not exist."
 }

--- a/src/Locales/en/Pode.psd1
+++ b/src/Locales/en/Pode.psd1
@@ -347,4 +347,5 @@
     mcpToolAlreadyExistsExceptionMessage                              = "The MCP tool '{0}' already exists."
     mcpToolGroupAlreadyExistsExceptionMessage                         = "The MCP tool group '{0}' already exists."
     staticRouteDefaultCannotBeRootedExceptionMessage                  = "Static route defaults cannot be rooted paths. Invalid default: '{0}'"
+    deprecatedFunctionWarningMessage                                  = "WARNING: The function '{0}' is deprecated and will be removed in future releases. Please use the '{1}' function instead."
 }

--- a/src/Locales/en/Pode.psd1
+++ b/src/Locales/en/Pode.psd1
@@ -348,4 +348,5 @@
     mcpToolGroupAlreadyExistsExceptionMessage                         = "The MCP tool group '{0}' already exists."
     staticRouteDefaultCannotBeRootedExceptionMessage                  = "Static route defaults cannot be rooted paths. Invalid default: '{0}'"
     deprecatedFunctionWarningMessage                                  = "WARNING: The function '{0}' is deprecated and will be removed in future releases. Please use the '{1}' function instead."
+    loggingMethodDoesNotExistExceptionMessage                         = "The logging method '{0}' does not exist."
 }

--- a/src/Locales/es/Pode.psd1
+++ b/src/Locales/es/Pode.psd1
@@ -347,4 +347,5 @@
     mcpToolAlreadyExistsExceptionMessage                              = "La herramienta MCP '{0}' ya existe."
     mcpToolGroupAlreadyExistsExceptionMessage                         = "El grupo de herramientas MCP '{0}' ya existe."
     staticRouteDefaultCannotBeRootedExceptionMessage                  = "Los valores predeterminados de las rutas estáticas no pueden ser rutas absolutas. Valor predeterminado no válido: '{0}'"
+    deprecatedFunctionWarningMessage                                  = "ADVERTENCIA: La función '{0}' está obsoleta y se eliminará en futuras versiones. Por favor, use la función '{1}' en su lugar."
 }

--- a/src/Locales/es/Pode.psd1
+++ b/src/Locales/es/Pode.psd1
@@ -348,4 +348,5 @@
     mcpToolGroupAlreadyExistsExceptionMessage                         = "El grupo de herramientas MCP '{0}' ya existe."
     staticRouteDefaultCannotBeRootedExceptionMessage                  = "Los valores predeterminados de las rutas estáticas no pueden ser rutas absolutas. Valor predeterminado no válido: '{0}'"
     deprecatedFunctionWarningMessage                                  = "ADVERTENCIA: La función '{0}' está obsoleta y se eliminará en futuras versiones. Por favor, use la función '{1}' en su lugar."
+    loggingMethodDoesNotExistExceptionMessage                         = "El método de registro '{0}' no existe."
 }

--- a/src/Locales/fr/Pode.psd1
+++ b/src/Locales/fr/Pode.psd1
@@ -347,4 +347,5 @@
     mcpToolAlreadyExistsExceptionMessage                              = "L'outil MCP '{0}' existe déjà."
     mcpToolGroupAlreadyExistsExceptionMessage                         = "Le groupe d'outils MCP '{0}' existe déjà."
     staticRouteDefaultCannotBeRootedExceptionMessage                  = "Les valeurs par défaut des routes statiques ne peuvent pas être des chemins absolus. Valeur par défaut non valide : '{0}'"
+    deprecatedFunctionWarningMessage                                  = "AVERTISSEMENT : La fonction '{0}' est obsolète et sera supprimée dans les futures versions. Veuillez utiliser la fonction '{1}' à la place."
 }

--- a/src/Locales/fr/Pode.psd1
+++ b/src/Locales/fr/Pode.psd1
@@ -348,4 +348,5 @@
     mcpToolGroupAlreadyExistsExceptionMessage                         = "Le groupe d'outils MCP '{0}' existe déjà."
     staticRouteDefaultCannotBeRootedExceptionMessage                  = "Les valeurs par défaut des routes statiques ne peuvent pas être des chemins absolus. Valeur par défaut non valide : '{0}'"
     deprecatedFunctionWarningMessage                                  = "AVERTISSEMENT : La fonction '{0}' est obsolète et sera supprimée dans les futures versions. Veuillez utiliser la fonction '{1}' à la place."
+    loggingMethodDoesNotExistExceptionMessage                         = "La méthode de journalisation '{0}' n'existe pas."
 }

--- a/src/Locales/it/Pode.psd1
+++ b/src/Locales/it/Pode.psd1
@@ -347,4 +347,5 @@
     mcpToolAlreadyExistsExceptionMessage                              = "Lo strumento MCP '{0}' esiste già."
     mcpToolGroupAlreadyExistsExceptionMessage                         = "Il gruppo di strumenti MCP '{0}' esiste già."
     staticRouteDefaultCannotBeRootedExceptionMessage                  = "I valori predefiniti delle route statiche non possono essere percorsi assoluti. Valore predefinito non valido: '{0}'"
+    deprecatedFunctionWarningMessage                                  = "AVVERTENZA: La funzione '{0}' è obsoleta e sarà rimossa nelle versioni future. Si prega di utilizzare la funzione '{1}' invece."
 }

--- a/src/Locales/it/Pode.psd1
+++ b/src/Locales/it/Pode.psd1
@@ -348,4 +348,5 @@
     mcpToolGroupAlreadyExistsExceptionMessage                         = "Il gruppo di strumenti MCP '{0}' esiste già."
     staticRouteDefaultCannotBeRootedExceptionMessage                  = "I valori predefiniti delle route statiche non possono essere percorsi assoluti. Valore predefinito non valido: '{0}'"
     deprecatedFunctionWarningMessage                                  = "AVVERTENZA: La funzione '{0}' è obsoleta e sarà rimossa nelle versioni future. Si prega di utilizzare la funzione '{1}' invece."
+    loggingMethodDoesNotExistExceptionMessage                         = "Il metodo di registrazione '{0}' non esiste."
 }

--- a/src/Locales/ja/Pode.psd1
+++ b/src/Locales/ja/Pode.psd1
@@ -347,4 +347,5 @@
     mcpToolAlreadyExistsExceptionMessage                              = 'MCPツール「{0}」は既に存在します。'
     mcpToolGroupAlreadyExistsExceptionMessage                         = 'MCPツールグループ「{0}」は既に存在します。'
     staticRouteDefaultCannotBeRootedExceptionMessage                  = "静的ルートのデフォルトはルートパスにできません。無効なデフォルト: '{0}'"
+    deprecatedFunctionWarningMessage                                  = "警告: 関数 '{0}' は非推奨であり、将来のリリースで削除されます。代わりに '{1}' 関数を使用してください。"
 }

--- a/src/Locales/ja/Pode.psd1
+++ b/src/Locales/ja/Pode.psd1
@@ -348,4 +348,5 @@
     mcpToolGroupAlreadyExistsExceptionMessage                         = 'MCPツールグループ「{0}」は既に存在します。'
     staticRouteDefaultCannotBeRootedExceptionMessage                  = "静的ルートのデフォルトはルートパスにできません。無効なデフォルト: '{0}'"
     deprecatedFunctionWarningMessage                                  = "警告: 関数 '{0}' は非推奨であり、将来のリリースで削除されます。代わりに '{1}' 関数を使用してください。"
+    loggingMethodDoesNotExistExceptionMessage                         = "ログ方法 '{0}' は存在しません。"
 }

--- a/src/Locales/ko/Pode.psd1
+++ b/src/Locales/ko/Pode.psd1
@@ -347,4 +347,5 @@
     mcpToolAlreadyExistsExceptionMessage                              = "MCP 도구 '{0}'은 이미 존재합니다."
     mcpToolGroupAlreadyExistsExceptionMessage                         = "MCP 도구 그룹 '{0}'은 이미 존재합니다."
     staticRouteDefaultCannotBeRootedExceptionMessage                  = "정적 경로의 기본값은 루트 경로일 수 없습니다. 잘못된 기본값: '{0}'"
+    deprecatedFunctionWarningMessage                                  = "경고: 함수 '{0}'는 더 이상 사용되지 않으며 향후 릴리스에서 제거될 예정입니다. 대신 '{1}' 함수를 사용하십시오."
 }

--- a/src/Locales/ko/Pode.psd1
+++ b/src/Locales/ko/Pode.psd1
@@ -348,4 +348,5 @@
     mcpToolGroupAlreadyExistsExceptionMessage                         = "MCP 도구 그룹 '{0}'은 이미 존재합니다."
     staticRouteDefaultCannotBeRootedExceptionMessage                  = "정적 경로의 기본값은 루트 경로일 수 없습니다. 잘못된 기본값: '{0}'"
     deprecatedFunctionWarningMessage                                  = "경고: 함수 '{0}'는 더 이상 사용되지 않으며 향후 릴리스에서 제거될 예정입니다. 대신 '{1}' 함수를 사용하십시오."
+    loggingMethodDoesNotExistExceptionMessage                         = "로그 방법 '{0}'은 존재하지 않습니다."
 }

--- a/src/Locales/nl/Pode.psd1
+++ b/src/Locales/nl/Pode.psd1
@@ -347,4 +347,5 @@
     mcpToolAlreadyExistsExceptionMessage                              = "De MCP-tool '{0}' bestaat al."
     mcpToolGroupAlreadyExistsExceptionMessage                         = "De MCP-toolgroep '{0}' bestaat al."
     staticRouteDefaultCannotBeRootedExceptionMessage                  = "Statische route-standaarden kunnen geen geroot pad zijn. Ongeldige standaard: '{0}'"
+    deprecatedFunctionWarningMessage                                  = "WAARSCHUWING: De functie '{0}' is verouderd en zal in toekomstige versies worden verwijderd. Gebruik in plaats daarvan de functie '{1}'."
 }

--- a/src/Locales/nl/Pode.psd1
+++ b/src/Locales/nl/Pode.psd1
@@ -348,4 +348,5 @@
     mcpToolGroupAlreadyExistsExceptionMessage                         = "De MCP-toolgroep '{0}' bestaat al."
     staticRouteDefaultCannotBeRootedExceptionMessage                  = "Statische route-standaarden kunnen geen geroot pad zijn. Ongeldige standaard: '{0}'"
     deprecatedFunctionWarningMessage                                  = "WAARSCHUWING: De functie '{0}' is verouderd en zal in toekomstige versies worden verwijderd. Gebruik in plaats daarvan de functie '{1}'."
+    loggingMethodDoesNotExistExceptionMessage                         = "De logmethode '{0}' bestaat niet."
 }

--- a/src/Locales/pl/Pode.psd1
+++ b/src/Locales/pl/Pode.psd1
@@ -347,4 +347,5 @@
     mcpToolAlreadyExistsExceptionMessage                              = "Narzędzie MCP '{0}' już istnieje."
     mcpToolGroupAlreadyExistsExceptionMessage                         = "Grupa narzędzi MCP '{0}' już istnieje."
     staticRouteDefaultCannotBeRootedExceptionMessage                  = "Domyślne wartości statycznej trasy nie mogą być ścieżkami zrootowanymi. Nieprawidłowa wartość domyślna: '{0}'"
+    deprecatedFunctionWarningMessage                                  = "UWAGA: Funkcja '{0}' jest przestarzała i zostanie usunięta w przyszłych wersjach. Proszę użyć funkcji '{1}' zamiast niej."
 }

--- a/src/Locales/pl/Pode.psd1
+++ b/src/Locales/pl/Pode.psd1
@@ -348,4 +348,5 @@
     mcpToolGroupAlreadyExistsExceptionMessage                         = "Grupa narzędzi MCP '{0}' już istnieje."
     staticRouteDefaultCannotBeRootedExceptionMessage                  = "Domyślne wartości statycznej trasy nie mogą być ścieżkami zrootowanymi. Nieprawidłowa wartość domyślna: '{0}'"
     deprecatedFunctionWarningMessage                                  = "UWAGA: Funkcja '{0}' jest przestarzała i zostanie usunięta w przyszłych wersjach. Proszę użyć funkcji '{1}' zamiast niej."
+    loggingMethodDoesNotExistExceptionMessage                         = "Metoda logowania '{0}' nie istnieje."
 }

--- a/src/Locales/pt/Pode.psd1
+++ b/src/Locales/pt/Pode.psd1
@@ -347,4 +347,5 @@
     mcpToolAlreadyExistsExceptionMessage                              = "A ferramenta MCP '{0}' já existe."
     mcpToolGroupAlreadyExistsExceptionMessage                         = "O grupo de ferramentas MCP '{0}' já existe."
     staticRouteDefaultCannotBeRootedExceptionMessage                  = "Os valores padrão da rota estática não podem ser caminhos raiz. Valor padrão inválido: '{0}'"
+    deprecatedFunctionWarningMessage                                  = "AVISO: A função '{0}' está obsoleta e será removida em versões futuras. Por favor, use a função '{1}' em vez disso."
 }

--- a/src/Locales/pt/Pode.psd1
+++ b/src/Locales/pt/Pode.psd1
@@ -348,4 +348,5 @@
     mcpToolGroupAlreadyExistsExceptionMessage                         = "O grupo de ferramentas MCP '{0}' já existe."
     staticRouteDefaultCannotBeRootedExceptionMessage                  = "Os valores padrão da rota estática não podem ser caminhos raiz. Valor padrão inválido: '{0}'"
     deprecatedFunctionWarningMessage                                  = "AVISO: A função '{0}' está obsoleta e será removida em versões futuras. Por favor, use a função '{1}' em vez disso."
+    loggingMethodDoesNotExistExceptionMessage                         = "O método de registro '{0}' não existe."
 }

--- a/src/Locales/zh/Pode.psd1
+++ b/src/Locales/zh/Pode.psd1
@@ -347,4 +347,5 @@
     mcpToolAlreadyExistsExceptionMessage                              = "MCP工具'{0}'已经存在。"
     mcpToolGroupAlreadyExistsExceptionMessage                         = "MCP工具组'{0}'已经存在。"
     staticRouteDefaultCannotBeRootedExceptionMessage                  = "静态路由的默认值不能是根路径。无效的默认值: '{0}'"
+    deprecatedFunctionWarningMessage                                  = "警告: 函数 '{0}' 已被弃用，并将在未来版本中移除。请改用 '{1}' 函数。"
 }

--- a/src/Locales/zh/Pode.psd1
+++ b/src/Locales/zh/Pode.psd1
@@ -348,4 +348,5 @@
     mcpToolGroupAlreadyExistsExceptionMessage                         = "MCP工具组'{0}'已经存在。"
     staticRouteDefaultCannotBeRootedExceptionMessage                  = "静态路由的默认值不能是根路径。无效的默认值: '{0}'"
     deprecatedFunctionWarningMessage                                  = "警告: 函数 '{0}' 已被弃用，并将在未来版本中移除。请改用 '{1}' 函数。"
+    loggingMethodDoesNotExistExceptionMessage                         = "日志方法 '{0}' 不存在。"
 }

--- a/src/Pode.psd1
+++ b/src/Pode.psd1
@@ -324,13 +324,18 @@
         'Enable-PodeErrorLogging',
         'Disable-PodeRequestLogging',
         'Disable-PodeErrorLogging',
-        'Add-PodeLogger',
+        'Add-PodeLogType',
         'Remove-PodeLogger',
         'Clear-PodeLoggers',
         'Write-PodeErrorLog',
         'Write-PodeLog',
         'Protect-PodeLogItem',
         'Use-PodeLogging',
+        'New-PodeLogBatchInfo',
+        'New-PodeLogTerminalMethod',
+        'New-PodeLogFileMethod',
+        'New-PodeLogEventViewerMethod',
+        'New-PodeLogCustomMethod',
 
         # core
         'Start-PodeServer',
@@ -608,7 +613,8 @@
         'Enable-PodeOpenApiViewer',
         'Enable-PodeOA',
         'Get-PodeOpenApiDefinition',
-        'New-PodeOASchemaProperty'
+        'New-PodeOASchemaProperty',
+        'Add-PodeLogger'
     )
 
     # Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.

--- a/src/Pode.psd1
+++ b/src/Pode.psd1
@@ -320,13 +320,13 @@
 
         # logging
         'New-PodeLoggingMethod',
-        'Enable-PodeRequestLogging',
-        'Enable-PodeErrorLogging',
-        'Disable-PodeRequestLogging',
-        'Disable-PodeErrorLogging',
+        'Enable-PodeRequestLogType',
+        'Enable-PodeErrorLogType',
+        'Disable-PodeRequestLogType',
+        'Disable-PodeErrorLogType',
         'Add-PodeLogType',
-        'Remove-PodeLogger',
-        'Clear-PodeLoggers',
+        'Remove-PodeLogType',
+        'Clear-PodeLogTypes',
         'Write-PodeErrorLog',
         'Write-PodeLog',
         'Protect-PodeLogItem',
@@ -614,7 +614,13 @@
         'Enable-PodeOA',
         'Get-PodeOpenApiDefinition',
         'New-PodeOASchemaProperty',
-        'Add-PodeLogger'
+        'Add-PodeLogger',
+        'Remove-PodeLogger',
+        'Clear-PodeLoggers',
+        'Enable-PodeRequestLogging',
+        'Disable-PodeRequestLogging',
+        'Enable-PodeErrorLogging',
+        'Disable-PodeErrorLogging'
     )
 
     # Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.

--- a/src/Pode.psd1
+++ b/src/Pode.psd1
@@ -338,6 +338,8 @@
         'New-PodeLogFileMethod',
         'New-PodeLogEventViewerMethod',
         'New-PodeLogCustomMethod',
+        'Clear-PodeLogMethods',
+        'Remove-PodeLogMethod',
 
         # core
         'Start-PodeServer',

--- a/src/Private/Authentication.ps1
+++ b/src/Private/Authentication.ps1
@@ -1204,6 +1204,7 @@ function Invoke-PodeAuthValidation {
                 $results[$authName] = $result
             }
         }
+
         # if the last auth failed, and we only need one auth to pass, set failure and return
         if (!$result.Success -and $auth.PassOne) {
             return $result
@@ -1233,7 +1234,7 @@ function Invoke-PodeAuthValidation {
     }
 
     # main auth validation logic
-    $result = (Test-PodeAuthValidation -Name $Name)
+    $result = Test-PodeAuthValidation -Name $Name
     $result.Auth = $Name
     return $result
 }
@@ -1278,7 +1279,7 @@ function Test-PodeAuthValidation {
                 $_tmp_args = @(Merge-PodeScriptblockArguments -ArgumentList $_inner[$i].Arguments -UsingVariables $_inner[$i].ScriptBlock.UsingVariables)
 
                 $_tmp_args += , $schemes
-                $result = (Invoke-PodeScriptBlock -ScriptBlock $_inner[$i].ScriptBlock.Script -Arguments $_tmp_args -Return -Splat)
+                $result = Invoke-PodeScriptBlock -ScriptBlock $_inner[$i].ScriptBlock.Script -Arguments $_tmp_args -Return -Splat
                 if ($result -is [hashtable]) {
                     break
                 }
@@ -1291,7 +1292,7 @@ function Test-PodeAuthValidation {
         }
 
         if ($null -eq $result) {
-            $result = (Invoke-PodeScriptBlock -ScriptBlock $auth.Scheme.ScriptBlock.Script -Arguments $_args -Return -Splat)
+            $result = Invoke-PodeScriptBlock -ScriptBlock $auth.Scheme.ScriptBlock.Script -Arguments $_args -Return -Splat
         }
 
         # if data is a hashtable, then don't call validator (parser either failed, or forced a success)
@@ -1299,12 +1300,12 @@ function Test-PodeAuthValidation {
             $original = $result
 
             $_args = @($result) + @($auth.Arguments)
-            $result = (Invoke-PodeScriptBlock -ScriptBlock $auth.ScriptBlock -Arguments $_args -UsingVariables $auth.UsingVariables -Return -Splat)
+            $result = Invoke-PodeScriptBlock -ScriptBlock $auth.ScriptBlock -Arguments $_args -UsingVariables $auth.UsingVariables -Return -Splat
 
             # if we have user, then run post validator if present
             if ([string]::IsNullOrEmpty($result.Code) -and ($null -ne $auth.Scheme.PostValidator.Script)) {
                 $_args = @($original) + @($result) + @($auth.Scheme.Arguments)
-                $result = (Invoke-PodeScriptBlock -ScriptBlock $auth.Scheme.PostValidator.Script -Arguments $_args -UsingVariables $auth.Scheme.PostValidator.UsingVariables -Return -Splat)
+                $result = Invoke-PodeScriptBlock -ScriptBlock $auth.Scheme.PostValidator.Script -Arguments $_args -UsingVariables $auth.Scheme.PostValidator.UsingVariables -Return -Splat
             }
         }
 
@@ -1318,10 +1319,10 @@ function Test-PodeAuthValidation {
 
         # if there's no result, or no user, then the auth failed - but allow auth if anon enabled
         if (($null -eq $result) -or ($result.Count -eq 0) -or (Test-PodeIsEmpty $result.User)) {
-            $code = (Protect-PodeValue -Value $result.Code -Default 401)
+            $code = Protect-PodeValue -Value $result.Code -Default 401
 
             # set the www-auth header
-            $validCode = (($code -eq 401) -or ![string]::IsNullOrEmpty($result.Challenge))
+            $validCode = ($code -eq 401) -or ![string]::IsNullOrEmpty($result.Challenge)
 
             if ($validCode) {
                 if ($null -eq $result) {

--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -602,7 +602,7 @@ function New-PodeRunspacePool {
         $threadsCounts.Schedule = 0
     }
 
-    if (!(Test-PodeLoggersExist)) {
+    if (!(Test-PodeLogTypesExist)) {
         $threadsCounts.Log = 0
     }
 

--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -589,10 +589,6 @@ function New-PodeRunspacePool {
         $threadsCounts.Schedule = 0
     }
 
-    if (!(Test-PodeLogTypesExist)) {
-        $threadsCounts.Log = 0
-    }
-
     # main runspace - for timers, schedules, etc
     $totalThreadCount = ($threadsCounts.Values | Measure-Object -Sum).Sum
     $PodeContext.RunspacePools.Main = @{

--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -1,4 +1,5 @@
 using namespace Pode.Utilities
+using namespace Pode.Utilities.Logging
 
 function New-PodeContext {
     [CmdletBinding()]
@@ -78,7 +79,6 @@ function New-PodeContext {
         Runspaces     = $null
         RunspaceState = $null
         Tokens        = @{}
-        LogsToProcess = $null
         Threading     = @{}
         Server        = @{}
         Metrics       = @{}
@@ -134,7 +134,7 @@ function New-PodeContext {
 
     # basic logging setup
     $ctx.Server.Logging = @{
-        Enabled = $true
+        Logger  = [PodeLogger]::new()
         Masking = @{}
         Methods = @{}
         Types   = @{}
@@ -468,9 +468,6 @@ function New-PodeContext {
 
     # create new cancellation tokens
     $ctx.Tokens = Initialize-PodeCancellationToken
-
-    # requests that should be logged
-    $ctx.LogsToProcess = [System.Collections.Concurrent.BlockingCollection[hashtable]]::new()
 
     # middleware that needs to run
     $ctx.Server.Middleware = @()
@@ -867,7 +864,6 @@ function New-PodeStateContext {
         RunspacePools = $Context.RunspacePools
         Tokens        = $Context.Tokens
         Metrics       = $Context.Metrics
-        LogsToProcess = $Context.LogsToProcess
         Threading     = $Context.Threading
         Server        = $Context.Server
     }
@@ -985,7 +981,7 @@ function Set-PodeServerConfiguration {
     }
 
     # logging
-    $Context.Server.Logging.Enabled = ($null -eq $Configuration.Logging.Enable) -or [bool]$Configuration.Logging.Enable
+    $Context.Server.Logging.Logger.IsEnabled = ($null -eq $Configuration.Logging.Enable) -or [bool]$Configuration.Logging.Enable
     $Context.Server.Logging.Masking = @{
         Patterns = Remove-PodeEmptyItemsFromArray -Array @($Configuration.Logging.Masking.Patterns)
         Mask     = Protect-PodeValue -Value $Configuration.Logging.Masking.Mask -Default '********'

--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -135,6 +135,8 @@ function New-PodeContext {
     # basic logging setup
     $ctx.Server.Logging = @{
         Enabled = $true
+        Masking = @{}
+        Methods = @{}
         Types   = @{}
     }
 
@@ -976,21 +978,17 @@ function Set-PodeServerConfiguration {
     # file monitoring
     $Context.Server.FileMonitor = @{
         Enabled   = [bool]$Configuration.FileMonitor.Enable
-        Exclude   = (Convert-PodePathPatternsToRegex -Paths @($Configuration.FileMonitor.Exclude))
-        Include   = (Convert-PodePathPatternsToRegex -Paths @($Configuration.FileMonitor.Include))
+        Exclude   = Convert-PodePathPatternsToRegex -Paths @($Configuration.FileMonitor.Exclude)
+        Include   = Convert-PodePathPatternsToRegex -Paths @($Configuration.FileMonitor.Include)
         ShowFiles = [bool]$Configuration.FileMonitor.ShowFiles
         Files     = @()
     }
 
     # logging
-    $Context.Server.Logging = @{
-        Enabled = (($null -eq $Configuration.Logging.Enable) -or [bool]$Configuration.Logging.Enable)
-        Masking = @{
-            Patterns = (Remove-PodeEmptyItemsFromArray -Array @($Configuration.Logging.Masking.Patterns))
-            Mask     = (Protect-PodeValue -Value $Configuration.Logging.Masking.Mask -Default '********')
-        }
-        Methods = @{}
-        Types   = @{}
+    $Context.Server.Logging.Enabled = ($null -eq $Configuration.Logging.Enable) -or [bool]$Configuration.Logging.Enable
+    $Context.Server.Logging.Masking = @{
+        Patterns = Remove-PodeEmptyItemsFromArray -Array @($Configuration.Logging.Masking.Patterns)
+        Mask     = Protect-PodeValue -Value $Configuration.Logging.Masking.Mask -Default '********'
     }
 
     # sockets
@@ -1078,8 +1076,6 @@ function Set-PodeServerConfiguration {
             MetricsHeader     = Protect-PodeValue -Value $Configuration.Console.Colors.MetricsHeader -Default $Context.Server.Console.Colors.MetricsHeader -EnumType ([type][System.ConsoleColor])
             MetricsLabel      = Protect-PodeValue -Value $Configuration.Console.Colors.MetricsLabel -Default $Context.Server.Console.Colors.MetricsLabel -EnumType ([type][System.ConsoleColor])
             MetricsValue      = Protect-PodeValue -Value $Configuration.Console.Colors.MetricsValue -Default $Context.Server.Console.Colors.MetricsValue -EnumType ([type][System.ConsoleColor])
-
-
         }
         KeyBindings         = @{
             Browser   = Protect-PodeValue -Value $Configuration.Console.KeyBindings.Browser -Default $Context.Server.Console.KeyBindings.Browser -EnumType ([type][System.ConsoleKey])

--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -480,7 +480,7 @@ function New-PodeContext {
     $ctx.Tokens = Initialize-PodeCancellationToken
 
     # requests that should be logged
-    $ctx.LogsToProcess = [System.Collections.ArrayList]::new()
+    $ctx.LogsToProcess = [System.Collections.Concurrent.BlockingCollection[hashtable]]::new()
 
     # middleware that needs to run
     $ctx.Server.Middleware = @()

--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -494,6 +494,7 @@ function New-PodeContext {
         Tasks     = $null
         Files     = $null
         Timers    = $null
+        Logs      = $null
     }
 
     # threading locks, etc.
@@ -581,7 +582,6 @@ function New-PodeRunspacePool {
     # setup main runspace pool
     $threadsCounts = @{
         Default  = 3
-        Log      = 1
         Schedule = 1
         Misc     = 1
     }
@@ -598,6 +598,13 @@ function New-PodeRunspacePool {
     $totalThreadCount = ($threadsCounts.Values | Measure-Object -Sum).Sum
     $PodeContext.RunspacePools.Main = @{
         Pool   = [runspacefactory]::CreateRunspacePool(1, $totalThreadCount, $PodeContext.RunspaceState, $Host)
+        State  = 'Waiting'
+        LastId = 0
+    }
+
+    # logs runspace - for processing logs
+    $PodeContext.RunspacePools.Logs = @{
+        Pool   = [runspacefactory]::CreateRunspacePool(1, 1, $PodeContext.RunspaceState, $Host)
         State  = 'Waiting'
         LastId = 0
     }
@@ -982,6 +989,7 @@ function Set-PodeServerConfiguration {
             Patterns = (Remove-PodeEmptyItemsFromArray -Array @($Configuration.Logging.Masking.Patterns))
             Mask     = (Protect-PodeValue -Value $Configuration.Logging.Masking.Mask -Default '********')
         }
+        Methods = @{}
         Types   = @{}
     }
 

--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -135,9 +135,10 @@ function New-PodeContext {
     # basic logging setup
     $ctx.Server.Logging = @{
         Logger  = [PodeLogger]::new()
+        Running = $false
         Masking = @{}
-        Methods = @{}
-        Types   = @{}
+        Methods = [hashtable]::Synchronized(@{})
+        Types   = [hashtable]::Synchronized(@{})
     }
 
     # set thread counts

--- a/src/Private/FileWatchers.ps1
+++ b/src/Private/FileWatchers.ps1
@@ -16,7 +16,7 @@ function New-PodeFileWatcher {
     param()
 
     $watcher = [PodeWatcher]::new([PodeAdapterType]::File, $PodeContext.Tokens.Cancellation.Token)
-    $watcher.ErrorLoggingEnabled = (Test-PodeErrorLoggingEnabled)
+    $watcher.ErrorLoggingEnabled = Test-PodeErrorLogTypeEnabled
     $watcher.ErrorLoggingLevels = @(Get-PodeErrorLoggingLevel)
     return $watcher
 }

--- a/src/Private/FileWatchers.ps1
+++ b/src/Private/FileWatchers.ps1
@@ -17,7 +17,7 @@ function New-PodeFileWatcher {
 
     $watcher = [PodeWatcher]::new([PodeAdapterType]::File, $PodeContext.Tokens.Cancellation.Token)
     $watcher.ErrorLoggingEnabled = Test-PodeErrorLogTypeEnabled
-    $watcher.ErrorLoggingLevels = @(Get-PodeErrorLoggingLevel)
+    $watcher.ErrorLoggingLevels = @(Get-PodeLogTypeLogLevel -Name (Get-PodeErrorLogTypeName))
     return $watcher
 }
 

--- a/src/Private/FileWatchers.ps1
+++ b/src/Private/FileWatchers.ps1
@@ -1,6 +1,7 @@
 using namespace Pode.Adapters
 using namespace Pode.Adapters.Watchers
 using namespace Pode.Protocols.File
+using namespace Pode.Utilities.Logging
 
 function Test-PodeFileWatchersExist {
     [CmdletBinding()]
@@ -17,7 +18,7 @@ function New-PodeFileWatcher {
 
     $watcher = [PodeWatcher]::new([PodeAdapterType]::File, $PodeContext.Tokens.Cancellation.Token)
     $watcher.ErrorLoggingEnabled = Test-PodeErrorLogTypeEnabled
-    $watcher.ErrorLoggingLevels = @(Get-PodeLogTypeLogLevel -Name (Get-PodeErrorLogTypeName))
+    $watcher.ErrorLoggingLevels = @(Get-PodeLogTypeLogLevel -Name [PodeLogger]::ERROR_LOG_TYPE_NAME)
     return $watcher
 }
 

--- a/src/Private/FileWatchers.ps1
+++ b/src/Private/FileWatchers.ps1
@@ -16,10 +16,7 @@ function New-PodeFileWatcher {
     [OutputType([Pode.Adapters.Watchers.PodeWatcher])]
     param()
 
-    $watcher = [PodeWatcher]::new([PodeAdapterType]::File, $PodeContext.Tokens.Cancellation.Token)
-    $watcher.ErrorLoggingEnabled = Test-PodeErrorLogTypeEnabled
-    $watcher.ErrorLoggingLevels = @(Get-PodeLogTypeLogLevel -Name [PodeLogger]::ERROR_LOG_TYPE_NAME)
-    return $watcher
+    return [PodeWatcher]::new([PodeAdapterType]::File, $PodeContext.Server.Logging.Logger, $PodeContext.Tokens.Cancellation.Token)
 }
 
 function Start-PodeFileWatcherRunspace {
@@ -51,9 +48,8 @@ function Start-PodeFileWatcherRunspace {
     }
     catch {
         $_ | Write-PodeErrorLog
-        $_.Exception | Write-PodeErrorLog -CheckInnerException
         Close-PodeDisposable -Disposable $watcher
-        throw $_.Exception
+        throw
     }
 
     $watchScript = {
@@ -120,7 +116,6 @@ function Start-PodeFileWatcherRunspace {
                         }
                         catch {
                             $_ | Write-PodeErrorLog
-                            $_.Exception | Write-PodeErrorLog -CheckInnerException
                         }
                     }
                     finally {
@@ -134,8 +129,7 @@ function Start-PodeFileWatcherRunspace {
             }
             catch {
                 $_ | Write-PodeErrorLog
-                $_.Exception | Write-PodeErrorLog -CheckInnerException
-                throw $_.Exception
+                throw
             }
 
             # end do-while
@@ -165,8 +159,7 @@ function Start-PodeFileWatcherRunspace {
         }
         catch {
             $_ | Write-PodeErrorLog
-            $_.Exception | Write-PodeErrorLog -CheckInnerException
-            throw $_.Exception
+            throw
         }
         finally {
             Close-PodeDisposable -Disposable $Watcher

--- a/src/Private/Gui.ps1
+++ b/src/Private/Gui.ps1
@@ -131,7 +131,7 @@ function Start-PodeGuiRunspace {
         }
         catch {
             $_ | Write-PodeErrorLog
-            throw $_.Exception
+            throw
         }
         finally {
             # invoke the cancellation token to close the server

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -192,7 +192,7 @@ function Test-PodeIsAdminUser {
 
         return $principal.IsInRole([System.Security.Principal.WindowsBuiltInRole]::Administrator)
     }
-    catch [exception] {
+    catch {
         Write-PodeHost 'Error checking user administrator privileges' -ForegroundColor Red
         Write-PodeHost $_.Exception.Message -ForegroundColor Red
         return $false
@@ -323,7 +323,7 @@ function Test-PodeIPAddress {
         $null = [System.Net.IPAddress]::Parse($IP)
         return $true
     }
-    catch [exception] {
+    catch {
         return $false
     }
 }

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -655,17 +655,15 @@ function Close-PodeServerInternal {
         # remove all of the pode temp drives
         Write-Verbose 'Removing internal PSDrives'
         Remove-PodePSDrive
+
+        # remove logging queues
+        Write-Verbose 'Clearing logging queues'
+        Close-PodeLogging
     }
     finally {
         if ($null -ne $PodeContext) {
             # Remove any tokens
             $PodeContext.Tokens = $null
-
-            # Dispose of the logs to process collection
-            if ($null -ne $PodeContext.LogsToProcess) {
-                $PodeContext.LogsToProcess.Dispose()
-                $PodeContext.LogsToProcess = $null
-            }
         }
     }
 }

--- a/src/Private/Helpers.ps1
+++ b/src/Private/Helpers.ps1
@@ -660,9 +660,14 @@ function Close-PodeServerInternal {
         if ($null -ne $PodeContext) {
             # Remove any tokens
             $PodeContext.Tokens = $null
+
+            # Dispose of the logs to process collection
+            if ($null -ne $PodeContext.LogsToProcess) {
+                $PodeContext.LogsToProcess.Dispose()
+                $PodeContext.LogsToProcess = $null
+            }
         }
     }
-
 }
 
 function New-PodePSDrive {

--- a/src/Private/Logging.ps1
+++ b/src/Private/Logging.ps1
@@ -200,32 +200,15 @@ function Get-PodeLoggingInbuiltType {
     return $script
 }
 
-function Get-PodeRequestLoggingName {
+function Get-PodeRequestLogTypeName {
     return '__pode_log_requests__'
 }
 
-function Get-PodeErrorLoggingName {
+function Get-PodeErrorLogTypeName {
     return '__pode_log_errors__'
 }
 
-<#
-.SYNOPSIS
-    Retrieves a Pode logger by name.
-
-.DESCRIPTION
-    This function allows you to retrieve a Pode logger by specifying its name. It returns the logger object associated with the given name.
-
-.PARAMETER Name
-    The name of the Pode logger to retrieve.
-
-.OUTPUTS
-    A Pode logger object.
-
-.NOTES
-    This is an internal function and may change in future releases of Pode.
-#>
-function Get-PodeLogger {
-    [CmdletBinding()]
+function Get-PodeLogType {
     [OutputType([hashtable])]
     param(
         [Parameter(Mandatory = $true)]
@@ -236,7 +219,7 @@ function Get-PodeLogger {
     return $PodeContext.Server.Logging.Types[$Name]
 }
 
-function Test-PodeLoggerEnabled {
+function Test-PodeLogTypeEnabled {
     param(
         [Parameter(Mandatory = $true)]
         [string]
@@ -246,32 +229,16 @@ function Test-PodeLoggerEnabled {
     return ($PodeContext.Server.Logging.Enabled -and $PodeContext.Server.Logging.Types.ContainsKey($Name))
 }
 
-<#
-.SYNOPSIS
-    Gets the error logging levels for Pode.
-
-.DESCRIPTION
-    This function retrieves the error logging levels configured for Pode. It returns an array of available error levels.
-
-.PARAMETER Name
-    The name of the Pode logger to retrieve.
-
-.OUTPUTS
-    An array of error logging levels.
-
-.NOTES
-    This is an internal function and may change in future releases of Pode.
-#>
 function Get-PodeErrorLoggingLevel {
-    return (Get-PodeLogger -Name (Get-PodeErrorLoggingName)).Arguments.Levels
+    return (Get-PodeLogType -Name (Get-PodeErrorLogTypeName)).Arguments.Levels
 }
 
-function Test-PodeErrorLoggingEnabled {
-    return (Test-PodeLoggerEnabled -Name (Get-PodeErrorLoggingName))
+function Test-PodeErrorLogTypeEnabled {
+    return (Test-PodeLogTypeEnabled -Name (Get-PodeErrorLogTypeName))
 }
 
-function Test-PodeRequestLoggingEnabled {
-    return (Test-PodeLoggerEnabled -Name (Get-PodeRequestLoggingName))
+function Test-PodeRequestLogTypeEnabled {
+    return (Test-PodeLogTypeEnabled -Name (Get-PodeRequestLogTypeName))
 }
 
 function Write-PodeRequestLog {
@@ -288,8 +255,8 @@ function Write-PodeRequestLog {
     )
 
     # do nothing if logging is disabled, or request logging isn't setup
-    $name = Get-PodeRequestLoggingName
-    if (!(Test-PodeLoggerEnabled -Name $name)) {
+    $name = Get-PodeRequestLogTypeName
+    if (!(Test-PodeLogTypeEnabled -Name $name)) {
         return
     }
 
@@ -324,7 +291,7 @@ function Write-PodeRequestLog {
 
     # set username - dot spaces
     if (Test-PodeAuthUser -IgnoreSession) {
-        $userProps = (Get-PodeLogger -Name $name).Properties.Username.Split('.')
+        $userProps = (Get-PodeLogType -Name $name).Properties.Username.Split('.')
 
         $user = $WebEvent.Auth.User
         foreach ($atom in $userProps) {
@@ -351,8 +318,8 @@ function Add-PodeRequestLogEndware {
     )
 
     # do nothing if logging is disabled, or request logging isn't setup
-    $name = Get-PodeRequestLoggingName
-    if (!(Test-PodeLoggerEnabled -Name $name)) {
+    $name = Get-PodeRequestLogTypeName
+    if (!(Test-PodeLogTypeEnabled -Name $name)) {
         return
     }
 
@@ -400,8 +367,12 @@ function Start-PodeLoggingRunspace {
                             return $log
                         })
 
+                    if ($null -eq $log) {
+                        continue
+                    }
+
                     # run the log item through the appropriate method
-                    $logger = Get-PodeLogger -Name $log.Name
+                    $logger = Get-PodeLogType -Name $log.Name
                     $now = [datetime]::Now
 
                     # if the log is null, check batch then sleep and skip

--- a/src/Private/Logging.ps1
+++ b/src/Private/Logging.ps1
@@ -494,3 +494,23 @@ function Test-PodeLoggerBatch {
         }
     }
 }
+
+function New-PodeLogBatchConfig {
+    param(
+        [Parameter(ValueFromPipeline = $true)]
+        [hashtable]
+        $BatchInfo = $null
+    )
+
+    if ($null -eq $BatchInfo) {
+        $BatchInfo = New-PodeLogBatchInfo
+    }
+
+    return @{
+        Size       = $BatchInfo.Size
+        Timeout    = $BatchInfo.Timeout
+        LastUpdate = $null
+        Items      = @()
+        RawItems   = @()
+    }
+}

--- a/src/Private/Logging.ps1
+++ b/src/Private/Logging.ps1
@@ -544,8 +544,7 @@ function Start-PodeLoggingRunspace {
 
         try {
             while (!(Test-PodeCancellationTokenRequest -Type Terminate)) {
-
-                # Check for suspension token and wait for the debugger to reset if active
+                # check for suspension
                 Test-PodeSuspensionToken
 
                 try {
@@ -583,12 +582,11 @@ function Start-PodeLoggingRunspace {
 
                             # if the current amount of items matches the batch, send to log method and reset batch
                             if ($batch.Items.Length -ge $batch.Size) {
-                                #TODO: add item/rawItem to method queue
                                 $logMethod.Queue.Add(@{
                                         Items    = $batch.Items
                                         RawItems = $batch.RawItems
                                     })
-                                # Invoke-PodeLogMethod -Method $logMethod -Item $batch.Items -RawItem $batch.RawItems
+
                                 $batch.Items = @()
                                 $batch.RawItems = @()
                             }
@@ -596,12 +594,10 @@ function Start-PodeLoggingRunspace {
 
                         # send log item to log method
                         else {
-                            #TODO: add item/rawItem to method queue
                             $logMethod.Queue.Add(@{
                                     Items    = $result
                                     RawItems = $log.Item
                                 })
-                            # Invoke-PodeLogMethod -Method $logMethod -Item $result -RawItem $log.Item
                         }
                     }
 
@@ -661,9 +657,12 @@ function Add-PodeLogMethod {
 
     # check if method already exists
     if (Test-PodeLogMethod -Id $Id) {
-        #TODO: A logging method with the same ID already exists
+        # A logging method with the same ID already exists
         throw ($PodeLocale.loggingMethodAlreadyDefinedExceptionMessage -f $Id)
     }
+
+    # empty list of log types for later associations
+    $Metadata.Types = @()
 
     # add batching info to metadata
     $Metadata.Batch = $BatchInfo | New-PodeLogBatchConfig
@@ -676,6 +675,54 @@ function Add-PodeLogMethod {
 
     # return the method ID
     return $Id
+}
+
+function Register-PodeLogTypeToMethod {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]
+        $TypeName,
+
+        [Parameter(Mandatory = $true)]
+        [string]
+        $MethodId
+    )
+
+    $method = Get-PodeLogMethod -Id $MethodId
+
+    if ($method.Types -inotcontains $TypeName) {
+        $method.Types += $TypeName
+    }
+}
+
+function Unregister-PodeLogTypeFromMethod {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]
+        $TypeName,
+
+        [Parameter(Mandatory = $true)]
+        [string]
+        $MethodId
+    )
+
+    $method = Get-PodeLogMethod -Id $MethodId
+    $method.Types = @($method.Types | Where-Object { $_ -ine $TypeName })
+}
+
+function Unregister-PodeLogMethodFromType {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]
+        $TypeName,
+
+        [Parameter(Mandatory = $true)]
+        [string]
+        $MethodId
+    )
+
+    $type = Get-PodeLogType -Name $TypeName
+    $type.Method = @($type.Method | Where-Object { $_ -ine $MethodId })
 }
 
 function Test-PodeLogTypeBatchTimeout {
@@ -698,36 +745,16 @@ function Test-PodeLogTypeBatchTimeout {
             }
 
             # send batch to log method and reset batch
-            #TODO: add item/rawItem to method queue
             $logMethod.Queue.Add(@{
                     Items    = $batch.Items
                     RawItems = $batch.RawItems
                 })
-            # Invoke-PodeLogMethod -Method $logMethod -Item $batch.Items -RawItem $batch.RawItems
+
             $batch.Items = @()
             $batch.RawItems = @()
         }
     }
 }
-
-# function Invoke-PodeLogMethod {
-#     param(
-#         [Parameter(Mandatory = $true)]
-#         [hashtable]
-#         $Method,
-
-#         [Parameter(Mandatory = $true)]
-#         [object[]]
-#         $Item,
-
-#         [Parameter()]
-#         [object[]]
-#         $RawItem
-#     )
-
-#     $_args = @(, $Item) + @($Method.Arguments) + @(, $RawItem)
-#     $null = Invoke-PodeScriptBlock -ScriptBlock $Method.ScriptBlock -Arguments $_args -UsingVariables $Method.UsingVariables -Splat
-# }
 
 function New-PodeLogBatchConfig {
     param(

--- a/src/Private/Logging.ps1
+++ b/src/Private/Logging.ps1
@@ -1,111 +1,281 @@
 function Get-PodeLoggingTerminalMethod {
     return {
-        param($item, $options)
+        param(
+            [Parameter(Mandatory = $true)]
+            [string]
+            $MethodId
+        )
 
         if ($PodeContext.Server.Quiet) {
             return
         }
 
-        # check if it's an array from batching
-        if ($item -is [array]) {
-            $item = ($item -join [System.Environment]::NewLine)
-        }
+        # wait for the server to fully start
+        Wait-PodeCancellationTokenRequest -Type Start
 
-        # protect then write
-        $item = ($item | Protect-PodeLogItem)
-        $item.ToString() | Out-PodeHost
+        try {
+            $method = $PodeContext.Server.Logging.Methods[$MethodId]
+
+            while (!(Test-PodeCancellationTokenRequest -Type Terminate)) {
+                # check for suspension
+                Test-PodeSuspensionToken
+
+                try {
+                    # try and get a log item
+                    $log = $null
+                    $found = $method.Queue.TryTake([ref]$log, 5000, $PodeContext.Tokens.Cancellation.Token)
+
+                    if (!$found -or ($null -eq $log)) {
+                        continue
+                    }
+
+                    # check if it's an array from batching
+                    if ($log.Items -is [array]) {
+                        $log.Items = $log.Items -join [System.Environment]::NewLine
+                    }
+
+                    # protect then write
+                    $log.Items = ($log.Items | Protect-PodeLogItem)
+                    $log.Items.ToString() | Out-PodeHost
+                }
+                catch [System.OperationCanceledException] {
+                    $_ | Write-PodeErrorLog -Level Debug
+                }
+                catch {
+                    $_ | Write-PodeErrorLog
+                }
+            }
+        }
+        catch [System.OperationCanceledException] {
+            $_ | Write-PodeErrorLog -Level Debug
+        }
+        catch {
+            $_ | Write-PodeErrorLog
+            throw $_.Exception
+        }
     }
 }
 
 function Get-PodeLoggingFileMethod {
     return {
-        param($item, $options)
+        param(
+            [Parameter(Mandatory = $true)]
+            [string]
+            $MethodId
+        )
 
-        # check if it's an array from batching
-        if ($item -is [array]) {
-            $item = ($item -join [System.Environment]::NewLine)
-        }
+        # wait for the server to fully start
+        Wait-PodeCancellationTokenRequest -Type Start
 
-        # mask values
-        $item = ($item | Protect-PodeLogItem)
+        try {
+            $method = $PodeContext.Server.Logging.Methods[$MethodId]
 
-        # variables
-        $date = [DateTime]::Now.ToString('yyyy-MM-dd')
+            while (!(Test-PodeCancellationTokenRequest -Type Terminate)) {
+                # check for suspension
+                Test-PodeSuspensionToken
 
-        # do we need to reset the fileId?
-        if ($options.Date -ine $date) {
-            $options.Date = $date
-            $options.FileId = 0
-        }
+                try {
+                    # try and get a log item
+                    $log = $null
+                    $found = $method.Queue.TryTake([ref]$log, 5000, $PodeContext.Tokens.Cancellation.Token)
 
-        # get the fileId
-        if ($options.FileId -eq 0) {
-            $path = [System.IO.Path]::Combine($options.Path, "$($options.Name)_$($date)_*.log")
-            $options.FileId = (@(Get-ChildItem -Path $path)).Length
-            if ($options.FileId -eq 0) {
-                $options.FileId = 1
+                    if (!$found -or ($null -eq $log)) {
+                        continue
+                    }
+
+                    # check if it's an array from batching
+                    if ($log.Items -is [array]) {
+                        $log.Items = $log.Items -join [System.Environment]::NewLine
+                    }
+
+                    # mask values
+                    $log.Items = $log.Items | Protect-PodeLogItem
+
+                    # current date
+                    $date = [DateTime]::Now.ToString('yyyy-MM-dd')
+
+                    # do we need to reset the fileId?
+                    if ($method.Arguments.Date -ine $date) {
+                        $method.Arguments.Date = $date
+                        $method.Arguments.FileId = 0
+                    }
+
+                    # get the fileId
+                    if ($method.Arguments.FileId -eq 0) {
+                        $path = [System.IO.Path]::Combine($method.Arguments.Path, "$($method.Arguments.Name)_$($date)_*.log")
+                        $method.Arguments.FileId = (@(Get-ChildItem -Path $path)).Length
+                        if ($method.Arguments.FileId -eq 0) {
+                            $method.Arguments.FileId = 1
+                        }
+                    }
+
+                    $id = "$($method.Arguments.FileId)".PadLeft(3, '0')
+                    if ($method.Arguments.MaxSize -gt 0) {
+                        $path = [System.IO.Path]::Combine($method.Arguments.Path, "$($method.Arguments.Name)_$($date)_$($id).log")
+                        if ((Get-Item -Path $path -Force).Length -ge $method.Arguments.MaxSize) {
+                            $method.Arguments.FileId++
+                            $id = "$($method.Arguments.FileId)".PadLeft(3, '0')
+                        }
+                    }
+
+                    # get the file to write to
+                    $path = [System.IO.Path]::Combine($method.Arguments.Path, "$($method.Arguments.Name)_$($date)_$($id).log")
+
+                    # write the item to the file
+                    $log.Items.ToString() | Out-File -FilePath $path -Encoding utf8 -Append -Force
+
+                    # if set, remove log files beyond days set (ensure this is only run once a day)
+                    if (($method.Arguments.MaxDays -gt 0) -and ($method.Arguments.NextClearDown -le [DateTime]::Now.Date)) {
+                        $date = [DateTime]::Now.Date.AddDays(-$method.Arguments.MaxDays)
+
+                        $null = Get-ChildItem -Path $method.Arguments.Path -Filter "$($method.Arguments.Name)_*.log" -Force |
+                            Where-Object { $_.CreationTime -lt $date } |
+                            Remove-Item -Force
+
+                        $method.Arguments.NextClearDown = [DateTime]::Now.Date.AddDays(1)
+                    }
+                }
+                catch [System.OperationCanceledException] {
+                    $_ | Write-PodeErrorLog -Level Debug
+                }
+                catch {
+                    $_ | Write-PodeErrorLog
+                }
             }
         }
-
-        $id = "$($options.FileId)".PadLeft(3, '0')
-        if ($options.MaxSize -gt 0) {
-            $path = [System.IO.Path]::Combine($options.Path, "$($options.Name)_$($date)_$($id).log")
-            if ((Get-Item -Path $path -Force).Length -ge $options.MaxSize) {
-                $options.FileId++
-                $id = "$($options.FileId)".PadLeft(3, '0')
-            }
+        catch [System.OperationCanceledException] {
+            $_ | Write-PodeErrorLog -Level Debug
         }
-
-        # get the file to write to
-        $path = [System.IO.Path]::Combine($options.Path, "$($options.Name)_$($date)_$($id).log")
-
-        # write the item to the file
-        $item.ToString() | Out-File -FilePath $path -Encoding utf8 -Append -Force
-
-        # if set, remove log files beyond days set (ensure this is only run once a day)
-        if (($options.MaxDays -gt 0) -and ($options.NextClearDown -le [DateTime]::Now.Date)) {
-            $date = [DateTime]::Now.Date.AddDays(-$options.MaxDays)
-
-            $null = Get-ChildItem -Path $options.Path -Filter "$($options.Name)_*.log" -Force |
-                Where-Object { $_.CreationTime -lt $date } |
-                Remove-Item -Force
-
-            $options.NextClearDown = [DateTime]::Now.Date.AddDays(1)
+        catch {
+            $_ | Write-PodeErrorLog
         }
     }
 }
 
 function Get-PodeLoggingEventViewerMethod {
     return {
-        param($item, $options, $rawItem)
+        param(
+            [Parameter(Mandatory = $true)]
+            [string]
+            $MethodId
+        )
 
-        if ($item -isnot [array]) {
-            $item = @($item)
-        }
+        # wait for the server to fully start
+        Wait-PodeCancellationTokenRequest -Type Start
 
-        if ($rawItem -isnot [array]) {
-            $rawItem = @($rawItem)
-        }
+        try {
+            $method = $PodeContext.Server.Logging.Methods[$MethodId]
 
-        for ($i = 0; $i -lt $item.Length; $i++) {
-            # convert log level - info if no level present
-            $entryType = ConvertTo-PodeEventViewerLevel -Level $rawItem[$i].Level
+            while (!(Test-PodeCancellationTokenRequest -Type Terminate)) {
+                # check for suspension
+                Test-PodeSuspensionToken
 
-            # create log instance
-            $entryInstance = [System.Diagnostics.EventInstance]::new($options.ID, 0, $entryType)
+                try {
+                    # try and get a log item
+                    $log = $null
+                    $found = $method.Queue.TryTake([ref]$log, 5000, $PodeContext.Tokens.Cancellation.Token)
 
-            # create event log
-            $entryLog = [System.Diagnostics.EventLog]::new()
-            $entryLog.Log = $options.LogName
-            $entryLog.Source = $options.Source
+                    if (!$found -or ($null -eq $log)) {
+                        continue
+                    }
 
-            try {
-                $message = ($item[$i] | Protect-PodeLogItem)
-                $entryLog.WriteEvent($entryInstance, $message)
+                    # check if it's an array from batching
+                    if ($log.Items -isnot [array]) {
+                        $log.Items = @($log.Items)
+                    }
+
+                    if ($log.RawItems -isnot [array]) {
+                        $log.RawItems = @($log.RawItems)
+                    }
+
+                    for ($i = 0; $i -lt $log.Items.Length; $i++) {
+                        # convert log level - info if no level present
+                        $entryType = ConvertTo-PodeEventViewerLevel -Level $log.RawItems[$i].Level
+
+                        # create log instance
+                        $entryInstance = [System.Diagnostics.EventInstance]::new($method.Arguments.ID, 0, $entryType)
+
+                        # create event log
+                        $entryLog = [System.Diagnostics.EventLog]::new()
+                        $entryLog.Log = $method.Arguments.LogName
+                        $entryLog.Source = $method.Arguments.Source
+
+                        try {
+                            $message = ($log.Items[$i] | Protect-PodeLogItem)
+                            $entryLog.WriteEvent($entryInstance, $message)
+                        }
+                        catch {
+                            $_ | Write-PodeErrorLog -Level Debug
+                        }
+                    }
+                }
+                catch [System.OperationCanceledException] {
+                    $_ | Write-PodeErrorLog -Level Debug
+                }
+                catch {
+                    $_ | Write-PodeErrorLog
+                }
             }
-            catch {
-                $_ | Write-PodeErrorLog -Level Debug
+        }
+        catch [System.OperationCanceledException] {
+            $_ | Write-PodeErrorLog -Level Debug
+        }
+        catch {
+            $_ | Write-PodeErrorLog
+            throw $_.Exception
+        }
+    }
+}
+
+function Get-PodeLoggingCustomMethod {
+    return {
+        param(
+            [Parameter(Mandatory = $true)]
+            [string]
+            $MethodId
+        )
+
+        # wait for the server to fully start
+        Wait-PodeCancellationTokenRequest -Type Start
+
+        try {
+            $method = $PodeContext.Server.Logging.Methods[$MethodId]
+
+            while (!(Test-PodeCancellationTokenRequest -Type Terminate)) {
+                # check for suspension
+                Test-PodeSuspensionToken
+
+                try {
+                    # try and get a log item
+                    $log = $null
+                    $found = $method.Queue.TryTake([ref]$log, 5000, $PodeContext.Tokens.Cancellation.Token)
+
+                    if (!$found -or ($null -eq $log)) {
+                        continue
+                    }
+
+                    # invoke the custom scriptblock
+                    $_args = @(, $log.Items) + @($method.Arguments) + @(, $log.RawItems)
+                    $null = Invoke-PodeScriptBlock `
+                        -ScriptBlock $method.Custom.ScriptBlock `
+                        -Arguments $_args `
+                        -UsingVariables $method.Custom.UsingVariables `
+                        -Splat
+                }
+                catch [System.OperationCanceledException] {
+                    $_ | Write-PodeErrorLog -Level Debug
+                }
+                catch {
+                    $_ | Write-PodeErrorLog
+                }
             }
+        }
+        catch [System.OperationCanceledException] {
+            $_ | Write-PodeErrorLog -Level Debug
+        }
+        catch {
+            $_ | Write-PodeErrorLog
+            throw $_.Exception
         }
     }
 }
@@ -214,6 +384,28 @@ function Get-PodeLogType {
     return $PodeContext.Server.Logging.Types[$Name]
 }
 
+function Get-PodeLogMethod {
+    [OutputType([hashtable])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Id
+    )
+
+    return $PodeContext.Server.Logging.Methods[$Id]
+}
+
+function Test-PodeLogMethod {
+    [OutputType([hashtable])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Id
+    )
+
+    return $PodeContext.Server.Logging.Methods.ContainsKey($Id)
+}
+
 function Test-PodeLogTypeEnabled {
     param(
         [Parameter(Mandatory = $true)]
@@ -221,7 +413,7 @@ function Test-PodeLogTypeEnabled {
         $Name
     )
 
-    return ($PodeContext.Server.Logging.Enabled -and $PodeContext.Server.Logging.Types.ContainsKey($Name))
+    return $PodeContext.Server.Logging.Enabled -and $PodeContext.Server.Logging.Types.ContainsKey($Name)
 }
 
 function Get-PodeLogTypeLogLevel {
@@ -370,7 +562,7 @@ function Start-PodeLoggingRunspace {
                     $logType = Get-PodeLogType -Name $log.Name
                     $now = [datetime]::Now
 
-                    # convert to log item into a writeable format
+                    # transform the log item into a writeable format
                     $_args = @($log.Item) + @($logType.Arguments)
                     $result = @(Invoke-PodeScriptBlock -ScriptBlock $logType.ScriptBlock -Arguments $_args -UsingVariables $logType.UsingVariables -Return -Splat)
                     if ($null -eq $result) {
@@ -379,7 +571,8 @@ function Start-PodeLoggingRunspace {
                     }
 
                     # loop through each log method available to the log type
-                    foreach ($logMethod in $logType.Method) {
+                    foreach ($logMethodId in $logType.Method) {
+                        $logMethod = Get-PodeLogMethod -Id $logMethodId
                         $batch = $logMethod.Batch
 
                         if ($batch.Size -gt 1) {
@@ -390,7 +583,12 @@ function Start-PodeLoggingRunspace {
 
                             # if the current amount of items matches the batch, send to log method and reset batch
                             if ($batch.Items.Length -ge $batch.Size) {
-                                Invoke-PodeLogMethod -Method $logMethod -Item $batch.Items -RawItem $batch.RawItems
+                                #TODO: add item/rawItem to method queue
+                                $logMethod.Queue.Add(@{
+                                        Items    = $batch.Items
+                                        RawItems = $batch.RawItems
+                                    })
+                                # Invoke-PodeLogMethod -Method $logMethod -Item $batch.Items -RawItem $batch.RawItems
                                 $batch.Items = @()
                                 $batch.RawItems = @()
                             }
@@ -398,7 +596,12 @@ function Start-PodeLoggingRunspace {
 
                         # send log item to log method
                         else {
-                            Invoke-PodeLogMethod -Method $logMethod -Item $result -RawItem $log.Item
+                            #TODO: add item/rawItem to method queue
+                            $logMethod.Queue.Add(@{
+                                    Items    = $result
+                                    RawItems = $log.Item
+                                })
+                            # Invoke-PodeLogMethod -Method $logMethod -Item $result -RawItem $log.Item
                         }
                     }
 
@@ -422,8 +625,57 @@ function Start-PodeLoggingRunspace {
         }
     }
 
-    Write-Verbose 'Starting the Logging runspace...'
-    Add-PodeRunspace -Type Main -Name 'Logging' -ScriptBlock $script
+    # create and start log method runspaces
+    Write-Verbose 'Starting log method runspaces...'
+    $null = $PodeContext.RunspacePools.Logs.Pool.SetMaxRunspaces($PodeContext.Server.Logging.Methods.Count + 1)
+
+    foreach ($methodId in $PodeContext.Server.Logging.Methods.Keys) {
+        $method = Get-PodeLogMethod -Id $methodId
+        $method.Runspace = Add-PodeRunspace -Type Logs -Name "Method_$($method.Type)" -ScriptBlock $method.ScriptBlock -Parameters @{ MethodId = $methodId } -PassThru
+    }
+
+    # start the log dispatcher runspace
+    Write-Verbose 'Starting the Log Dispatcher runspace...'
+    Add-PodeRunspace -Type Logs -Name 'Dispatcher' -ScriptBlock $script
+}
+
+function Add-PodeLogMethod {
+    param(
+        [Parameter()]
+        [string]
+        $Id,
+
+        [Parameter()]
+        [hashtable]
+        $BatchInfo = $null,
+
+        [Parameter(Mandatory = $true)]
+        [hashtable]
+        $Metadata
+    )
+
+    # generate an ID if not supplied
+    if ([string]::IsNullOrWhiteSpace($Id)) {
+        $Id = New-PodeGuid
+    }
+
+    # check if method already exists
+    if (Test-PodeLogMethod -Id $Id) {
+        #TODO: A logging method with the same ID already exists
+        throw ($PodeLocale.loggingMethodAlreadyDefinedExceptionMessage -f $Id)
+    }
+
+    # add batching info to metadata
+    $Metadata.Batch = $BatchInfo | New-PodeLogBatchConfig
+
+    # create queue for the method's log items
+    $Metadata.Queue = [System.Collections.Concurrent.BlockingCollection[hashtable]]::new()
+
+    # add method to server
+    $PodeContext.Server.Logging.Methods[$Id] = $Metadata
+
+    # return the method ID
+    return $Id
 }
 
 function Test-PodeLogTypeBatchTimeout {
@@ -431,7 +683,8 @@ function Test-PodeLogTypeBatchTimeout {
 
     # check each log Type, and see if its batch needs to be outputted due to timeout
     foreach ($logType in $PodeContext.Server.Logging.Types.Values) {
-        foreach ($logMethod in $logType.Method) {
+        foreach ($logMethodId in $logType.Method) {
+            $logMethod = Get-PodeLogMethod -Id $logMethodId
             $batch = $logMethod.Batch
 
             # do nothing if not batching, or no items
@@ -445,31 +698,36 @@ function Test-PodeLogTypeBatchTimeout {
             }
 
             # send batch to log method and reset batch
-            Invoke-PodeLogMethod -Method $logMethod -Item $batch.Items -RawItem $batch.RawItems
+            #TODO: add item/rawItem to method queue
+            $logMethod.Queue.Add(@{
+                    Items    = $batch.Items
+                    RawItems = $batch.RawItems
+                })
+            # Invoke-PodeLogMethod -Method $logMethod -Item $batch.Items -RawItem $batch.RawItems
             $batch.Items = @()
             $batch.RawItems = @()
         }
     }
 }
 
-function Invoke-PodeLogMethod {
-    param(
-        [Parameter(Mandatory = $true)]
-        [hashtable]
-        $Method,
+# function Invoke-PodeLogMethod {
+#     param(
+#         [Parameter(Mandatory = $true)]
+#         [hashtable]
+#         $Method,
 
-        [Parameter(Mandatory = $true)]
-        [object[]]
-        $Item,
+#         [Parameter(Mandatory = $true)]
+#         [object[]]
+#         $Item,
 
-        [Parameter()]
-        [object[]]
-        $RawItem
-    )
+#         [Parameter()]
+#         [object[]]
+#         $RawItem
+#     )
 
-    $_args = @(, $Item) + @($Method.Arguments) + @(, $RawItem)
-    $null = Invoke-PodeScriptBlock -ScriptBlock $Method.ScriptBlock -Arguments $_args -UsingVariables $Method.UsingVariables -Splat
-}
+#     $_args = @(, $Item) + @($Method.Arguments) + @(, $RawItem)
+#     $null = Invoke-PodeScriptBlock -ScriptBlock $Method.ScriptBlock -Arguments $_args -UsingVariables $Method.UsingVariables -Splat
+# }
 
 function New-PodeLogBatchConfig {
     param(
@@ -488,5 +746,21 @@ function New-PodeLogBatchConfig {
         LastUpdate = $null
         Items      = @()
         RawItems   = @()
+    }
+}
+
+function Close-PodeLogging {
+    # Dispose of the logs to process collection
+    if ($null -ne $PodeContext.LogsToProcess) {
+        $PodeContext.LogsToProcess.Dispose()
+        $PodeContext.LogsToProcess = $null
+    }
+
+    # Dispose log method queues
+    foreach ($method in $PodeContext.Server.Logging.Methods.Values) {
+        if ($null -ne $method.Queue) {
+            $method.Queue.Dispose()
+            $method.Queue = $null
+        }
     }
 }

--- a/src/Private/Logging.ps1
+++ b/src/Private/Logging.ps1
@@ -1,3 +1,5 @@
+using namespace Pode.Utilities.Logging
+
 function Get-PodeLoggingTerminalMethod {
     return {
         param(
@@ -365,14 +367,6 @@ function Get-PodeLoggingInbuiltType {
     return $script
 }
 
-function Get-PodeRequestLogTypeName {
-    return '__pode_log_requests__'
-}
-
-function Get-PodeErrorLogTypeName {
-    return '__pode_log_errors__'
-}
-
 function Get-PodeLogType {
     [OutputType([hashtable])]
     param(
@@ -413,7 +407,7 @@ function Test-PodeLogTypeEnabled {
         $Name
     )
 
-    return $PodeContext.Server.Logging.Enabled -and $PodeContext.Server.Logging.Types.ContainsKey($Name)
+    return $PodeContext.Server.Logging.Logger.IsEnabled -and $PodeContext.Server.Logging.Types.ContainsKey($Name)
 }
 
 function Get-PodeLogTypeLogLevel {
@@ -427,11 +421,11 @@ function Get-PodeLogTypeLogLevel {
 }
 
 function Test-PodeErrorLogTypeEnabled {
-    return (Test-PodeLogTypeEnabled -Name (Get-PodeErrorLogTypeName))
+    return Test-PodeLogTypeEnabled -Name [PodeLogger]::ERROR_LOG_TYPE_NAME
 }
 
 function Test-PodeRequestLogTypeEnabled {
-    return (Test-PodeLogTypeEnabled -Name (Get-PodeRequestLogTypeName))
+    return Test-PodeLogTypeEnabled -Name [PodeLogger]::REQUEST_LOG_TYPE_NAME
 }
 
 function Write-PodeRequestLog {
@@ -447,9 +441,8 @@ function Write-PodeRequestLog {
         $Path
     )
 
-    # do nothing if logging is disabled, or request logging isn't setup
-    $name = Get-PodeRequestLogTypeName
-    if (!(Test-PodeLogTypeEnabled -Name $name)) {
+    # do nothing if request logging isn't setup
+    if (!$PodeContext.Server.Logging.Logger.IsRequestLoggingEnabled) {
         return
     }
 
@@ -484,7 +477,7 @@ function Write-PodeRequestLog {
 
     # set username - dot spaces
     if (Test-PodeAuthUser -IgnoreSession) {
-        $userProps = (Get-PodeLogType -Name $name).Properties.Username.Split('.')
+        $userProps = (Get-PodeLogType -Name [PodeLogger]::REQUEST_LOG_TYPE_NAME).Properties.Username.Split('.')
 
         $user = $WebEvent.Auth.User
         foreach ($atom in $userProps) {
@@ -497,10 +490,7 @@ function Write-PodeRequestLog {
     }
 
     # add the item to be processed
-    $null = $PodeContext.LogsToProcess.Add(@{
-            Name = $name
-            Item = $item
-        })
+    $PodeContext.Server.Logging.Logger.Add([PodeLogger]::REQUEST_LOG_TYPE_NAME, [PodeLogLevel]::Informational, $item)
 }
 
 function Add-PodeRequestLogEndware {
@@ -511,7 +501,7 @@ function Add-PodeRequestLogEndware {
     )
 
     # do nothing if logging is disabled, or request logging isn't setup
-    $name = Get-PodeRequestLogTypeName
+    $name = [PodeLogger]::REQUEST_LOG_TYPE_NAME
     if (!(Test-PodeLogTypeEnabled -Name $name)) {
         return
     }
@@ -529,7 +519,7 @@ function Test-PodeLogTypesExist {
         return $false
     }
 
-    return (($PodeContext.Server.Logging.Types.Count -gt 0) -or ($PodeContext.Server.Logging.Enabled))
+    return (($PodeContext.Server.Logging.Types.Count -gt 0) -or ($PodeContext.Server.Logging.Logger.IsEnabled))
 }
 
 function Start-PodeLoggingRunspace {
@@ -550,7 +540,7 @@ function Start-PodeLoggingRunspace {
                 try {
                     # try and remove an item from the queue, if none check batches then continue
                     $log = $null
-                    $found = $PodeContext.LogsToProcess.TryTake([ref]$log, 5000, $PodeContext.Tokens.Cancellation.Token)
+                    $found = $PodeContext.Server.Logging.Logger.TryTake([ref]$log, $PodeContext.Tokens.Cancellation.Token)
 
                     if (!$found -or ($null -eq $log)) {
                         Test-PodeLogTypeBatchTimeout
@@ -668,6 +658,7 @@ function Add-PodeLogMethod {
     $Metadata.Batch = $BatchInfo | New-PodeLogBatchConfig
 
     # create queue for the method's log items
+    #TODO: new PodeLogQueue?
     $Metadata.Queue = [System.Collections.Concurrent.BlockingCollection[hashtable]]::new()
 
     # add method to server
@@ -778,9 +769,9 @@ function New-PodeLogBatchConfig {
 
 function Close-PodeLogging {
     # Dispose of the logs to process collection
-    if ($null -ne $PodeContext.LogsToProcess) {
-        $PodeContext.LogsToProcess.Dispose()
-        $PodeContext.LogsToProcess = $null
+    if ($null -ne $PodeContext.Server.Logging.Logger) {
+        $PodeContext.Server.Logging.Logger.Dispose()
+        $PodeContext.Server.Logging.Logger = $null
     }
 
     # Dispose log method queues

--- a/src/Private/Logging.ps1
+++ b/src/Private/Logging.ps1
@@ -346,6 +346,9 @@ function Start-PodeLoggingRunspace {
     }
 
     $script = {
+        # Waits for the Pode server to fully start before proceeding with further operations.
+        Wait-PodeCancellationTokenRequest -Type Start
+
         try {
             while (!(Test-PodeCancellationTokenRequest -Type Terminate)) {
 
@@ -353,21 +356,12 @@ function Start-PodeLoggingRunspace {
                 Test-PodeSuspensionToken
 
                 try {
-                    # if there are no logs to process, just sleep for a few seconds - but after checking the batch
-                    if ($PodeContext.LogsToProcess.Count -eq 0) {
+                    # try and remove an item from the queue, if none check batches then continue
+                    $log = $null
+                    $found = $PodeContext.LogsToProcess.TryTake([ref]$log, 5000, $PodeContext.Tokens.Cancellation.Token)
+
+                    if (!$found -or ($null -eq $log)) {
                         Test-PodeLoggerBatch
-                        Start-Sleep -Seconds 5
-                        continue
-                    }
-
-                    # safely pop off the first log from the array
-                    $log = (Lock-PodeObject -Return -Object $PodeContext.LogsToProcess -ScriptBlock {
-                            $log = $PodeContext.LogsToProcess[0]
-                            $null = $PodeContext.LogsToProcess.RemoveAt(0)
-                            return $log
-                        })
-
-                    if ($null -eq $log) {
                         continue
                     }
 
@@ -414,8 +408,11 @@ function Start-PodeLoggingRunspace {
                         $null = Invoke-PodeScriptBlock -ScriptBlock $logger.Method.ScriptBlock -Arguments $_args -UsingVariables $logger.Method.UsingVariables -Splat
                     }
 
-                    # small sleep to lower cpu usage
+                    # small sleep to lower cpu usage when there are lots of logs to process
                     Start-Sleep -Milliseconds 100
+                }
+                catch [System.OperationCanceledException] {
+                    $_ | Write-PodeErrorLog -Level Debug
                 }
                 catch {
                     $_ | Write-PodeErrorLog

--- a/src/Private/Logging.ps1
+++ b/src/Private/Logging.ps1
@@ -317,11 +317,7 @@ function Get-PodeLoggingInbuiltType {
             $script = {
                 param($item, $options)
 
-                # just return the item if Raw is set
-                if ($options.Raw) {
-                    return $item
-                }
-
+                # safeguard for null or whitespace values
                 function sg($value) {
                     if ([string]::IsNullOrWhiteSpace($value)) {
                         return '-'
@@ -341,11 +337,6 @@ function Get-PodeLoggingInbuiltType {
         'errors' {
             $script = {
                 param($item, $options)
-
-                # just return the item if Raw is set
-                if ($options.Raw) {
-                    return $item
-                }
 
                 # build the exception details
                 $row = @(
@@ -524,8 +515,14 @@ function Start-PodeLoggingRunspace {
                     $now = [datetime]::Now
 
                     # transform the log item into a writeable format
-                    $_args = @($log.Item) + @($logType.Arguments)
-                    $result = @(Invoke-PodeScriptBlock -ScriptBlock $logType.ScriptBlock -Arguments $_args -UsingVariables $logType.UsingVariables -Return -Splat)
+                    if ($logType.Raw) {
+                        $result = $log.Item
+                    }
+                    else {
+                        $_args = @($log.Item) + @($logType.Arguments)
+                        $result = @(Invoke-PodeScriptBlock -ScriptBlock $logType.ScriptBlock -Arguments $_args -UsingVariables $logType.UsingVariables -Return -Splat)
+                    }
+
                     if ($null -eq $result) {
                         Start-Sleep -Milliseconds 100
                         continue

--- a/src/Private/Logging.ps1
+++ b/src/Private/Logging.ps1
@@ -25,7 +25,7 @@ function Get-PodeLoggingTerminalMethod {
                 try {
                     # try and get a log item
                     $log = $null
-                    $found = $method.Queue.TryTake([ref]$log, 5000, $PodeContext.Tokens.Cancellation.Token)
+                    $found = $method.Queue.TryTake([ref]$log, $PodeContext.Tokens.Cancellation.Token)
 
                     if (!$found -or ($null -eq $log)) {
                         continue
@@ -44,7 +44,7 @@ function Get-PodeLoggingTerminalMethod {
                     $_ | Write-PodeErrorLog -Level Debug
                 }
                 catch {
-                    $_ | Write-PodeErrorLog
+                    $_ | Out-Default
                 }
             }
         }
@@ -52,8 +52,8 @@ function Get-PodeLoggingTerminalMethod {
             $_ | Write-PodeErrorLog -Level Debug
         }
         catch {
-            $_ | Write-PodeErrorLog
-            throw $_.Exception
+            $_ | Out-Default
+            throw
         }
     }
 }
@@ -79,7 +79,7 @@ function Get-PodeLoggingFileMethod {
                 try {
                     # try and get a log item
                     $log = $null
-                    $found = $method.Queue.TryTake([ref]$log, 5000, $PodeContext.Tokens.Cancellation.Token)
+                    $found = $method.Queue.TryTake([ref]$log, $PodeContext.Tokens.Cancellation.Token)
 
                     if (!$found -or ($null -eq $log)) {
                         continue
@@ -141,7 +141,7 @@ function Get-PodeLoggingFileMethod {
                     $_ | Write-PodeErrorLog -Level Debug
                 }
                 catch {
-                    $_ | Write-PodeErrorLog
+                    $_ | Out-Default
                 }
             }
         }
@@ -149,7 +149,7 @@ function Get-PodeLoggingFileMethod {
             $_ | Write-PodeErrorLog -Level Debug
         }
         catch {
-            $_ | Write-PodeErrorLog
+            $_ | Out-Default
         }
     }
 }
@@ -175,7 +175,7 @@ function Get-PodeLoggingEventViewerMethod {
                 try {
                     # try and get a log item
                     $log = $null
-                    $found = $method.Queue.TryTake([ref]$log, 5000, $PodeContext.Tokens.Cancellation.Token)
+                    $found = $method.Queue.TryTake([ref]$log, $PodeContext.Tokens.Cancellation.Token)
 
                     if (!$found -or ($null -eq $log)) {
                         continue
@@ -215,7 +215,7 @@ function Get-PodeLoggingEventViewerMethod {
                     $_ | Write-PodeErrorLog -Level Debug
                 }
                 catch {
-                    $_ | Write-PodeErrorLog
+                    $_ | Out-Default
                 }
             }
         }
@@ -223,8 +223,8 @@ function Get-PodeLoggingEventViewerMethod {
             $_ | Write-PodeErrorLog -Level Debug
         }
         catch {
-            $_ | Write-PodeErrorLog
-            throw $_.Exception
+            $_ | Out-Default
+            throw
         }
     }
 }
@@ -250,7 +250,7 @@ function Get-PodeLoggingCustomMethod {
                 try {
                     # try and get a log item
                     $log = $null
-                    $found = $method.Queue.TryTake([ref]$log, 5000, $PodeContext.Tokens.Cancellation.Token)
+                    $found = $method.Queue.TryTake([ref]$log, $PodeContext.Tokens.Cancellation.Token)
 
                     if (!$found -or ($null -eq $log)) {
                         continue
@@ -268,7 +268,7 @@ function Get-PodeLoggingCustomMethod {
                     $_ | Write-PodeErrorLog -Level Debug
                 }
                 catch {
-                    $_ | Write-PodeErrorLog
+                    $_ | Out-Default
                 }
             }
         }
@@ -276,8 +276,8 @@ function Get-PodeLoggingCustomMethod {
             $_ | Write-PodeErrorLog -Level Debug
         }
         catch {
-            $_ | Write-PodeErrorLog
-            throw $_.Exception
+            $_ | Out-Default
+            throw
         }
     }
 }
@@ -352,6 +352,7 @@ function Get-PodeLoggingInbuiltType {
                     "Date: $($item.Date.ToString('yyyy-MM-dd HH:mm:ss'))",
                     "Level: $($item.Level)",
                     "ThreadId: $($item.ThreadId)",
+                    "ContextId: $($item.ContextId)",
                     "Server: $($item.Server)",
                     "Category: $($item.Category)",
                     "Message: $($item.Message)",
@@ -398,34 +399,6 @@ function Test-PodeLogMethod {
     )
 
     return $PodeContext.Server.Logging.Methods.ContainsKey($Id)
-}
-
-function Test-PodeLogTypeEnabled {
-    param(
-        [Parameter(Mandatory = $true)]
-        [string]
-        $Name
-    )
-
-    return $PodeContext.Server.Logging.Logger.IsEnabled -and $PodeContext.Server.Logging.Types.ContainsKey($Name)
-}
-
-function Get-PodeLogTypeLogLevel {
-    param(
-        [Parameter(Mandatory = $true)]
-        [string]
-        $Name
-    )
-
-    return (Get-PodeLogType -Name $Name).Levels
-}
-
-function Test-PodeErrorLogTypeEnabled {
-    return Test-PodeLogTypeEnabled -Name [PodeLogger]::ERROR_LOG_TYPE_NAME
-}
-
-function Test-PodeRequestLogTypeEnabled {
-    return Test-PodeLogTypeEnabled -Name [PodeLogger]::REQUEST_LOG_TYPE_NAME
 }
 
 function Write-PodeRequestLog {
@@ -501,8 +474,7 @@ function Add-PodeRequestLogEndware {
     )
 
     # do nothing if logging is disabled, or request logging isn't setup
-    $name = [PodeLogger]::REQUEST_LOG_TYPE_NAME
-    if (!(Test-PodeLogTypeEnabled -Name $name)) {
+    if (!$PodeContext.Server.Logging.Logger.IsRequestLoggingEnabled) {
         return
     }
 
@@ -538,7 +510,7 @@ function Start-PodeLoggingRunspace {
                 Test-PodeSuspensionToken
 
                 try {
-                    # try and remove an item from the queue, if none check batches then continue
+                    # try and remove an event from the queue, if none check batches then continue
                     $log = $null
                     $found = $PodeContext.Server.Logging.Logger.TryTake([ref]$log, $PodeContext.Tokens.Cancellation.Token)
 
@@ -572,22 +544,15 @@ function Start-PodeLoggingRunspace {
 
                             # if the current amount of items matches the batch, send to log method and reset batch
                             if ($batch.Items.Length -ge $batch.Size) {
-                                $logMethod.Queue.Add(@{
-                                        Items    = $batch.Items
-                                        RawItems = $batch.RawItems
-                                    })
-
+                                $logMethod.Queue.Add([Pode.Utilities.Logging.PodeLogItem]::new($batch.Items, $batch.RawItems))
                                 $batch.Items = @()
                                 $batch.RawItems = @()
                             }
                         }
 
-                        # send log item to log method
+                        # send log message to log method
                         else {
-                            $logMethod.Queue.Add(@{
-                                    Items    = $result
-                                    RawItems = $log.Item
-                                })
+                            $logMethod.Queue.Add([Pode.Utilities.Logging.PodeLogItem]::new($result, $log.Item))
                         }
                     }
 
@@ -598,6 +563,7 @@ function Start-PodeLoggingRunspace {
                     $_ | Write-PodeErrorLog -Level Debug
                 }
                 catch {
+                    $_ | Out-Default
                     $_ | Write-PodeErrorLog
                 }
             }
@@ -607,7 +573,7 @@ function Start-PodeLoggingRunspace {
         }
         catch {
             $_ | Write-PodeErrorLog
-            throw $_.Exception
+            throw
         }
     }
 
@@ -658,8 +624,7 @@ function Add-PodeLogMethod {
     $Metadata.Batch = $BatchInfo | New-PodeLogBatchConfig
 
     # create queue for the method's log items
-    #TODO: new PodeLogQueue?
-    $Metadata.Queue = [System.Collections.Concurrent.BlockingCollection[hashtable]]::new()
+    $Metadata.Queue = [Pode.Utilities.Logging.PodeLogQueue[Pode.Utilities.Logging.IPodeLogItem]]::new()
 
     # add method to server
     $PodeContext.Server.Logging.Methods[$Id] = $Metadata
@@ -736,10 +701,7 @@ function Test-PodeLogTypeBatchTimeout {
             }
 
             # send batch to log method and reset batch
-            $logMethod.Queue.Add(@{
-                    Items    = $batch.Items
-                    RawItems = $batch.RawItems
-                })
+            $logMethod.Queue.Add([Pode.Utilities.Logging.PodeLogItem]::new($batch.Items, $batch.RawItems))
 
             $batch.Items = @()
             $batch.RawItems = @()
@@ -781,4 +743,24 @@ function Close-PodeLogging {
             $method.Queue = $null
         }
     }
+}
+
+function Get-PodeLoggingContextId {
+    if ($null -ne $WebEvent) {
+        return $WebEvent.ContextId
+    }
+
+    if ($null -ne $SignalEvent) {
+        return $SignalEvent.ContextId
+    }
+
+    if ($null -ne $script:SmtpEvent) {
+        return $script:SmtpEvent.ContextId
+    }
+
+    if ($null -ne $TcpEvent) {
+        return $TcpEvent.ContextId
+    }
+
+    return [string]::Empty
 }

--- a/src/Private/Logging.ps1
+++ b/src/Private/Logging.ps1
@@ -170,11 +170,6 @@ function Get-PodeLoggingInbuiltType {
             $script = {
                 param($item, $options)
 
-                # do nothing if the error level isn't present
-                if (@($options.Levels) -inotcontains $item.Level) {
-                    return
-                }
-
                 # just return the item if Raw is set
                 if ($options.Raw) {
                     return $item
@@ -229,8 +224,14 @@ function Test-PodeLogTypeEnabled {
     return ($PodeContext.Server.Logging.Enabled -and $PodeContext.Server.Logging.Types.ContainsKey($Name))
 }
 
-function Get-PodeErrorLoggingLevel {
-    return (Get-PodeLogType -Name (Get-PodeErrorLogTypeName)).Arguments.Levels
+function Get-PodeLogTypeLogLevel {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Name
+    )
+
+    return (Get-PodeLogType -Name $Name).Levels
 }
 
 function Test-PodeErrorLogTypeEnabled {

--- a/src/Private/Logging.ps1
+++ b/src/Private/Logging.ps1
@@ -331,7 +331,7 @@ function Add-PodeRequestLogEndware {
     }
 }
 
-function Test-PodeLoggersExist {
+function Test-PodeLogTypesExist {
     if (($null -eq $PodeContext.Server.Logging) -or ($null -eq $PodeContext.Server.Logging.Types)) {
         return $false
     }
@@ -340,8 +340,8 @@ function Test-PodeLoggersExist {
 }
 
 function Start-PodeLoggingRunspace {
-    # skip if there are no loggers configured, or logging is disabled
-    if (!(Test-PodeLoggersExist)) {
+    # skip if there are no log types configured, or logging is disabled
+    if (!(Test-PodeLogTypesExist)) {
         return
     }
 
@@ -361,51 +361,44 @@ function Start-PodeLoggingRunspace {
                     $found = $PodeContext.LogsToProcess.TryTake([ref]$log, 5000, $PodeContext.Tokens.Cancellation.Token)
 
                     if (!$found -or ($null -eq $log)) {
-                        Test-PodeLoggerBatch
+                        Test-PodeLogTypeBatchTimeout
                         continue
                     }
 
                     # run the log item through the appropriate method
-                    $logger = Get-PodeLogType -Name $log.Name
+                    $logType = Get-PodeLogType -Name $log.Name
                     $now = [datetime]::Now
 
-                    # if the log is null, check batch then sleep and skip
-                    if ($null -eq $log) {
+                    # convert to log item into a writeable format
+                    $_args = @($log.Item) + @($logType.Arguments)
+                    $result = @(Invoke-PodeScriptBlock -ScriptBlock $logType.ScriptBlock -Arguments $_args -UsingVariables $logType.UsingVariables -Return -Splat)
+                    if ($null -eq $result) {
                         Start-Sleep -Milliseconds 100
                         continue
                     }
 
-                    # convert to log item into a writeable format
-                    $rawItems = $log.Item
-                    $_args = @($log.Item) + @($logger.Arguments)
-                    $result = @(Invoke-PodeScriptBlock -ScriptBlock $logger.ScriptBlock -Arguments $_args -UsingVariables $logger.UsingVariables -Return -Splat)
+                    # loop through each log method available to the log type
+                    foreach ($logMethod in $logType.Method) {
+                        $batch = $logMethod.Batch
 
-                    # check batching
-                    $batch = $logger.Method.Batch
-                    if ($batch.Size -gt 1) {
-                        # add current item to batch
-                        $batch.Items += $result
-                        $batch.RawItems += $log.Item
-                        $batch.LastUpdate = $now
+                        if ($batch.Size -gt 1) {
+                            # add current item to batch
+                            $batch.Items += $result
+                            $batch.RawItems += $log.Item
+                            $batch.LastUpdate = $now
 
-                        # if the current amount of items matches the batch, write
-                        $result = $null
-                        if ($batch.Items.Length -ge $batch.Size) {
-                            $result = $batch.Items
-                            $rawItems = $batch.RawItems
+                            # if the current amount of items matches the batch, send to log method and reset batch
+                            if ($batch.Items.Length -ge $batch.Size) {
+                                Invoke-PodeLogMethod -Method $logMethod -Item $batch.Items -RawItem $batch.RawItems
+                                $batch.Items = @()
+                                $batch.RawItems = @()
+                            }
                         }
 
-                        # if we're writing, reset the items
-                        if ($null -ne $result) {
-                            $batch.Items = @()
-                            $batch.RawItems = @()
+                        # send log item to log method
+                        else {
+                            Invoke-PodeLogMethod -Method $logMethod -Item $result -RawItem $log.Item
                         }
-                    }
-
-                    # send the writeable log item off to the log writer
-                    if ($null -ne $result) {
-                        $_args = @(, $result) + @($logger.Method.Arguments) + @(, $rawItems)
-                        $null = Invoke-PodeScriptBlock -ScriptBlock $logger.Method.ScriptBlock -Arguments $_args -UsingVariables $logger.Method.UsingVariables -Splat
                     }
 
                     # small sleep to lower cpu usage when there are lots of logs to process
@@ -432,35 +425,49 @@ function Start-PodeLoggingRunspace {
     Add-PodeRunspace -Type Main -Name 'Logging' -ScriptBlock $script
 }
 
-<#
-.SYNOPSIS
-    Tests whether Pode logger batches need to be written.
-
-.DESCRIPTION
-    This function checks each Pode logger and determines if its batch needs to be written. It evaluates the batch size, timeout, and last update timestamp to decide whether to process the batch and write the log entries.
-
-.NOTES
-    This is an internal function and may change in future releases of Pode.
-#>
-function Test-PodeLoggerBatch {
+function Test-PodeLogTypeBatchTimeout {
     $now = [datetime]::Now
 
-    # check each logger, and see if its batch needs to be written
-    foreach ($logger in $PodeContext.Server.Logging.Types.Values) {
-        $batch = $logger.Method.Batch
-        if (($batch.Size -gt 1) -and ($batch.Items.Length -gt 0) -and ($batch.Timeout -gt 0) `
-                -and ($null -ne $batch.LastUpdate) -and ($batch.LastUpdate.AddSeconds($batch.Timeout) -le $now)
-        ) {
-            $result = $batch.Items
-            $rawItems = $batch.RawItems
+    # check each log Type, and see if its batch needs to be outputted due to timeout
+    foreach ($logType in $PodeContext.Server.Logging.Types.Values) {
+        foreach ($logMethod in $logType.Method) {
+            $batch = $logMethod.Batch
 
+            # do nothing if not batching, or no items
+            if (($batch.Size -le 1) -or ($batch.Timeout -le 0) -or ($batch.Items.Length -eq 0)) {
+                continue
+            }
+
+            # do nothing if the batch timeout hasn't been reached
+            if (($null -eq $batch.LastUpdate) -or ($batch.LastUpdate.AddSeconds($batch.Timeout) -gt $now)) {
+                continue
+            }
+
+            # send batch to log method and reset batch
+            Invoke-PodeLogMethod -Method $logMethod -Item $batch.Items -RawItem $batch.RawItems
             $batch.Items = @()
             $batch.RawItems = @()
-
-            $_args = @(, $result) + @($logger.Method.Arguments) + @(, $rawItems)
-            $null = Invoke-PodeScriptBlock -ScriptBlock $logger.Method.ScriptBlock -Arguments $_args -UsingVariables $logger.Method.UsingVariables -Splat
         }
     }
+}
+
+function Invoke-PodeLogMethod {
+    param(
+        [Parameter(Mandatory = $true)]
+        [hashtable]
+        $Method,
+
+        [Parameter(Mandatory = $true)]
+        [object[]]
+        $Item,
+
+        [Parameter()]
+        [object[]]
+        $RawItem
+    )
+
+    $_args = @(, $Item) + @($Method.Arguments) + @(, $RawItem)
+    $null = Invoke-PodeScriptBlock -ScriptBlock $Method.ScriptBlock -Arguments $_args -UsingVariables $Method.UsingVariables -Splat
 }
 
 function New-PodeLogBatchConfig {

--- a/src/Private/Logging.ps1
+++ b/src/Private/Logging.ps1
@@ -441,7 +441,7 @@ function Write-PodeRequestLog {
 
     # set username - dot spaces
     if (Test-PodeAuthUser -IgnoreSession) {
-        $userProps = (Get-PodeLogType -Name [PodeLogger]::REQUEST_LOG_TYPE_NAME).Properties.Username.Split('.')
+        $userProps = (Get-PodeLogType -Name ([PodeLogger]::REQUEST_LOG_TYPE_NAME)).Properties.Username.Split('.')
 
         $user = $WebEvent.Auth.User
         foreach ($atom in $userProps) {
@@ -512,6 +512,10 @@ function Start-PodeLoggingRunspace {
 
                     # run the log item through the appropriate method
                     $logType = Get-PodeLogType -Name $log.Name
+                    if ($null -eq $logType) {
+                        continue
+                    }
+
                     $now = [datetime]::Now
 
                     # transform the log item into a writeable format
@@ -586,6 +590,7 @@ function Start-PodeLoggingRunspace {
     # start the log dispatcher runspace
     Write-Verbose 'Starting the Log Dispatcher runspace...'
     Add-PodeRunspace -Type Logs -Name 'Dispatcher' -ScriptBlock $script
+    $PodeContext.Server.Logging.Running = $true
 }
 
 function Add-PodeLogMethod {
@@ -625,6 +630,12 @@ function Add-PodeLogMethod {
 
     # add method to server
     $PodeContext.Server.Logging.Methods[$Id] = $Metadata
+
+    # extend runspace pool, and create runspace for the method - if logging is already running
+    if ($PodeContext.Server.Logging.Running) {
+        $null = $PodeContext.RunspacePools.Logs.Pool.SetMaxRunspaces($PodeContext.Server.Logging.Methods.Count + 1)
+        $Metadata.Runspace = Add-PodeRunspace -Type Logs -Name "Method_$($Metadata.Type)" -ScriptBlock $Metadata.ScriptBlock -Parameters @{ MethodId = $Id } -PassThru
+    }
 
     # return the method ID
     return $Id

--- a/src/Private/PodeServer.ps1
+++ b/src/Private/PodeServer.ps1
@@ -73,7 +73,7 @@ function Start-PodeWebServer {
 
     # Create the listener
     $listener = [PodeHttpListener]::new($PodeContext.Tokens.Cancellation.Token)
-    $listener.ErrorLoggingEnabled = (Test-PodeErrorLoggingEnabled)
+    $listener.ErrorLoggingEnabled = Test-PodeErrorLogTypeEnabled
     $listener.ErrorLoggingLevels = @(Get-PodeErrorLoggingLevel)
     $listener.RequestTimeout = $PodeContext.Server.Request.Timeout
     $listener.RequestBodySize = $PodeContext.Server.Request.BodySize

--- a/src/Private/PodeServer.ps1
+++ b/src/Private/PodeServer.ps1
@@ -74,7 +74,7 @@ function Start-PodeWebServer {
     # Create the listener
     $listener = [PodeHttpListener]::new($PodeContext.Tokens.Cancellation.Token)
     $listener.ErrorLoggingEnabled = Test-PodeErrorLogTypeEnabled
-    $listener.ErrorLoggingLevels = @(Get-PodeErrorLoggingLevel)
+    $listener.ErrorLoggingLevels = @(Get-PodeLogTypeLogLevel -Name (Get-PodeErrorLogTypeName))
     $listener.RequestTimeout = $PodeContext.Server.Request.Timeout
     $listener.RequestBodySize = $PodeContext.Server.Request.BodySize
     $listener.ShowServerDetails = [bool]$PodeContext.Server.Security.ServerDetails

--- a/src/Private/PodeServer.ps1
+++ b/src/Private/PodeServer.ps1
@@ -73,9 +73,7 @@ function Start-PodeWebServer {
     }
 
     # Create the listener
-    $listener = [PodeHttpListener]::new($PodeContext.Tokens.Cancellation.Token)
-    $listener.ErrorLoggingEnabled = Test-PodeErrorLogTypeEnabled
-    $listener.ErrorLoggingLevels = @(Get-PodeLogTypeLogLevel -Name [PodeLogger]::ERROR_LOG_TYPE_NAME)
+    $listener = [PodeHttpListener]::new($PodeContext.Server.Logging.Logger, $PodeContext.Tokens.Cancellation.Token)
     $listener.RequestTimeout = $PodeContext.Server.Request.Timeout
     $listener.RequestBodySize = $PodeContext.Server.Request.BodySize
     $listener.ShowServerDetails = [bool]$PodeContext.Server.Security.ServerDetails
@@ -102,9 +100,8 @@ function Start-PodeWebServer {
     }
     catch {
         $_ | Write-PodeErrorLog
-        $_.Exception | Write-PodeErrorLog -CheckInnerException
         Close-PodeDisposable -Disposable $listener
-        throw $_.Exception
+        throw
     }
 
     # only if HTTP endpoint
@@ -165,6 +162,7 @@ function Start-PodeWebServer {
                                     Ranges           = $null
                                     Sse              = $null
                                     Signal           = $null
+                                    ContextId        = $context.ID
                                     Metadata         = @{}
                                 }
 
@@ -280,13 +278,12 @@ function Start-PodeWebServer {
                 catch {
                     try {
                         $_ | Write-PodeErrorLog
-                        $_.Exception | Write-PodeErrorLog -CheckInnerException
                     }
                     catch {
                         $_ | Out-Default
                     }
                     finally {
-                        throw $_.Exception
+                        throw
                     }
                 }
 
@@ -348,6 +345,7 @@ function Start-PodeWebServer {
                                 ClientId  = $context.Signal.ClientId
                                 Timestamp = $context.Timestamp
                                 Streamed  = $true
+                                ContextId = $context.ID
                                 Metadata  = @{}
                             }
 
@@ -366,7 +364,6 @@ function Start-PodeWebServer {
                         }
                         catch {
                             $_ | Write-PodeErrorLog
-                            $_.Exception | Write-PodeErrorLog -CheckInnerException
                         }
                         finally {
                             Update-PodeServerSignalMetric -SignalEvent $SignalEvent
@@ -379,8 +376,7 @@ function Start-PodeWebServer {
                 }
                 catch {
                     $_ | Write-PodeErrorLog
-                    $_.Exception | Write-PodeErrorLog -CheckInnerException
-                    throw $_.Exception
+                    throw
                 }
 
                 # end do-while
@@ -418,8 +414,7 @@ function Start-PodeWebServer {
         }
         catch {
             $_ | Write-PodeErrorLog
-            $_.Exception | Write-PodeErrorLog -CheckInnerException
-            throw $_.Exception
+            throw
         }
         finally {
             Close-PodeDisposable -Disposable $Listener
@@ -483,7 +478,6 @@ function Start-PodeWebConnectionEventsRunspace {
                     }
                     catch {
                         $_ | Write-PodeErrorLog
-                        $_.Exception | Write-PodeErrorLog -CheckInnerException
                     }
                     finally {
                         Close-PodeDisposable -Disposable $evt
@@ -496,8 +490,7 @@ function Start-PodeWebConnectionEventsRunspace {
             }
             catch {
                 $_ | Write-PodeErrorLog
-                $_.Exception | Write-PodeErrorLog -CheckInnerException
-                throw $_.Exception
+                throw
             }
         } while (Test-PodeSuspensionToken) # Check for suspension token and wait for the debugger to reset if active
     }

--- a/src/Private/PodeServer.ps1
+++ b/src/Private/PodeServer.ps1
@@ -1,6 +1,7 @@
 using namespace Pode.Protocols.Http
 using namespace Pode.Transport.Sockets
 using namespace Pode.Utilities
+using namespace Pode.Utilities.Logging
 
 function Start-PodeWebServer {
     param(
@@ -74,7 +75,7 @@ function Start-PodeWebServer {
     # Create the listener
     $listener = [PodeHttpListener]::new($PodeContext.Tokens.Cancellation.Token)
     $listener.ErrorLoggingEnabled = Test-PodeErrorLogTypeEnabled
-    $listener.ErrorLoggingLevels = @(Get-PodeLogTypeLogLevel -Name (Get-PodeErrorLogTypeName))
+    $listener.ErrorLoggingLevels = @(Get-PodeLogTypeLogLevel -Name [PodeLogger]::ERROR_LOG_TYPE_NAME)
     $listener.RequestTimeout = $PodeContext.Server.Request.Timeout
     $listener.RequestBodySize = $PodeContext.Server.Request.BodySize
     $listener.ShowServerDetails = [bool]$PodeContext.Server.Security.ServerDetails
@@ -257,7 +258,6 @@ function Start-PodeWebServer {
                             }
                             catch {
                                 $_ | Write-PodeErrorLog
-                                $_.Exception | Write-PodeErrorLog -CheckInnerException
                                 Set-PodeResponseStatus -Code 500 -Exception $_
                             }
                             finally {
@@ -278,9 +278,16 @@ function Start-PodeWebServer {
                     $_ | Write-PodeErrorLog -Level Debug
                 }
                 catch {
-                    $_ | Write-PodeErrorLog
-                    $_.Exception | Write-PodeErrorLog -CheckInnerException
-                    throw $_.Exception
+                    try {
+                        $_ | Write-PodeErrorLog
+                        $_.Exception | Write-PodeErrorLog -CheckInnerException
+                    }
+                    catch {
+                        $_ | Out-Default
+                    }
+                    finally {
+                        throw $_.Exception
+                    }
                 }
 
                 # end do-while

--- a/src/Private/Runspaces.ps1
+++ b/src/Private/Runspaces.ps1
@@ -164,7 +164,7 @@ function Add-PodeRunspace {
     catch {
         # Log and throw any exceptions encountered during execution.
         $_ | Write-PodeErrorLog
-        throw $_.Exception
+        throw
     }
 }
 
@@ -320,7 +320,7 @@ function Close-PodeRunspace {
     }
     catch {
         $_ | Write-PodeErrorLog
-        throw $_.Exception
+        throw
     }
 }
 

--- a/src/Private/Runspaces.ps1
+++ b/src/Private/Runspaces.ps1
@@ -42,7 +42,7 @@
 function Add-PodeRunspace {
     param(
         [Parameter(Mandatory = $true)]
-        [ValidateSet('Main', 'Signals', 'Schedules', 'Gui', 'Web', 'Smtp', 'Tcp', 'Tasks', 'WebSockets', 'Files', 'Timers')]
+        [ValidateSet('Main', 'Signals', 'Schedules', 'Gui', 'Web', 'Smtp', 'Tcp', 'Tasks', 'WebSockets', 'Files', 'Timers', 'Logs')]
         [string]
         $Type,
 

--- a/src/Private/Schedules.ps1
+++ b/src/Private/Schedules.ps1
@@ -112,7 +112,7 @@ function Start-PodeScheduleRunspace {
         }
         catch {
             $_ | Write-PodeErrorLog
-            throw $_.Exception
+            throw
         }
     }
 

--- a/src/Private/Server.ps1
+++ b/src/Private/Server.ps1
@@ -372,7 +372,7 @@ function Restart-PodeInternalServer {
     }
     catch {
         $_ | Write-PodeErrorLog
-        throw $_.Exception
+        throw
     }
 }
 

--- a/src/Private/Server.ps1
+++ b/src/Private/Server.ps1
@@ -254,6 +254,7 @@ function Restart-PodeInternalServer {
 
         $PodeContext.Server.Views.Clear()
         $PodeContext.Timers.Items.Clear()
+        $PodeContext.Server.Logging.Methods.Clear()
         $PodeContext.Server.Logging.Types.Clear()
 
         # clear client connections

--- a/src/Private/Server.ps1
+++ b/src/Private/Server.ps1
@@ -3,7 +3,10 @@
     Starts the internal Pode server, initializing configurations, middleware, routes, and runspaces.
 
 .DESCRIPTION
-    This function sets up and starts the internal Pode server. It initializes the server's configurations, routes, middleware, runspace pools, logging, and schedules. It also handles different server modes, such as normal, service, or serverless (Azure Functions, AWS Lambda). The function ensures all necessary components are ready and operational before triggering the server's start.
+    This function sets up and starts the internal Pode server.
+    It initializes the server's configurations, routes, middleware, runspace pools, logging, and schedules.
+    It also handles different server modes, such as normal, service, or serverless (Azure Functions, AWS Lambda).
+    The function ensures all necessary components are ready and operational before triggering the server's start.
 
 .PARAMETER Request
     Provides request data for serverless execution scenarios.
@@ -256,6 +259,7 @@ function Restart-PodeInternalServer {
         $PodeContext.Timers.Items.Clear()
         $PodeContext.Server.Logging.Methods.Clear()
         $PodeContext.Server.Logging.Types.Clear()
+        $PodeContext.Server.Logging.Logger.Reset()
 
         # clear client connections
         $PodeContext.Server.Signals.BroadcastLevel.Clear()

--- a/src/Private/Server.ps1
+++ b/src/Private/Server.ps1
@@ -257,6 +257,9 @@ function Restart-PodeInternalServer {
 
         $PodeContext.Server.Views.Clear()
         $PodeContext.Timers.Items.Clear()
+
+        # clear up logging
+        $PodeContext.Server.Logging.Running = $false
         $PodeContext.Server.Logging.Methods.Clear()
         $PodeContext.Server.Logging.Types.Clear()
         $PodeContext.Server.Logging.Logger.Reset()

--- a/src/Private/Serverless.ps1
+++ b/src/Private/Serverless.ps1
@@ -122,7 +122,7 @@ function Start-PodeAzFuncServer {
     }
     catch {
         $_ | Write-PodeErrorLog
-        throw $_.Exception
+        throw
     }
     finally {
         $global:WebEvent = $null
@@ -253,7 +253,7 @@ function Start-PodeAwsLambdaServer {
     }
     catch {
         $_ | Write-PodeErrorLog
-        throw $_.Exception
+        throw
     }
     finally {
         $global:WebEvent = $null

--- a/src/Private/ServiceServer.ps1
+++ b/src/Private/ServiceServer.ps1
@@ -36,7 +36,7 @@ function Start-PodeServiceServer {
         }
         catch {
             $_ | Write-PodeErrorLog
-            throw $_.Exception
+            throw
         }
     }
 

--- a/src/Private/SmtpServer.ps1
+++ b/src/Private/SmtpServer.ps1
@@ -51,7 +51,7 @@ function Start-PodeSmtpServer {
 
     # create the listener
     $listener = [PodeSmtpListener]::new($PodeContext.Tokens.Cancellation.Token)
-    $listener.ErrorLoggingEnabled = (Test-PodeErrorLoggingEnabled)
+    $listener.ErrorLoggingEnabled = Test-PodeErrorLogTypeEnabled
     $listener.ErrorLoggingLevels = @(Get-PodeErrorLoggingLevel)
     $listener.RequestTimeout = $PodeContext.Server.Request.Timeout
     $listener.RequestBodySize = $PodeContext.Server.Request.BodySize

--- a/src/Private/SmtpServer.ps1
+++ b/src/Private/SmtpServer.ps1
@@ -51,9 +51,7 @@ function Start-PodeSmtpServer {
     }
 
     # create the listener
-    $listener = [PodeSmtpListener]::new($PodeContext.Tokens.Cancellation.Token)
-    $listener.ErrorLoggingEnabled = Test-PodeErrorLogTypeEnabled
-    $listener.ErrorLoggingLevels = @(Get-PodeLogTypeLogLevel -Name [PodeLogger]::ERROR_LOG_TYPE_NAME)
+    $listener = [PodeSmtpListener]::new($PodeContext.Server.Logging.Logger, $PodeContext.Tokens.Cancellation.Token)
     $listener.RequestTimeout = $PodeContext.Server.Request.Timeout
     $listener.RequestBodySize = $PodeContext.Server.Request.BodySize
 
@@ -76,9 +74,8 @@ function Start-PodeSmtpServer {
     }
     catch {
         $_ | Write-PodeErrorLog
-        $_.Exception | Write-PodeErrorLog -CheckInnerException
         Close-PodeDisposable -Disposable $listener
-        throw $_.Exception
+        throw
     }
 
     # script for listening out of for incoming requests
@@ -129,6 +126,7 @@ function Start-PodeSmtpServer {
                                     Name     = $context.EndpointName
                                 }
                                 Timestamp = [datetime]::UtcNow
+                                ContextId = $context.ID
                                 Metadata  = @{}
                             }
 
@@ -163,7 +161,6 @@ function Start-PodeSmtpServer {
                         }
                         catch {
                             $_ | Write-PodeErrorLog
-                            $_.Exception | Write-PodeErrorLog -CheckInnerException
                         }
                     }
                     finally {
@@ -177,8 +174,7 @@ function Start-PodeSmtpServer {
             }
             catch {
                 $_ | Write-PodeErrorLog
-                $_.Exception | Write-PodeErrorLog -CheckInnerException
-                throw $_.Exception
+                throw
             }
 
             # end do-while
@@ -210,8 +206,7 @@ function Start-PodeSmtpServer {
         }
         catch {
             $_ | Write-PodeErrorLog
-            $_.Exception | Write-PodeErrorLog -CheckInnerException
-            throw $_.Exception
+            throw
         }
         finally {
             Close-PodeDisposable -Disposable $Listener

--- a/src/Private/SmtpServer.ps1
+++ b/src/Private/SmtpServer.ps1
@@ -1,6 +1,7 @@
 using namespace Pode.Protocols.Smtp
 using namespace Pode.Transport.Sockets
 using namespace Pode.Utilities
+using namespace Pode.Utilities.Logging
 
 function Start-PodeSmtpServer {
     # ensure we have smtp handlers
@@ -52,7 +53,7 @@ function Start-PodeSmtpServer {
     # create the listener
     $listener = [PodeSmtpListener]::new($PodeContext.Tokens.Cancellation.Token)
     $listener.ErrorLoggingEnabled = Test-PodeErrorLogTypeEnabled
-    $listener.ErrorLoggingLevels = @(Get-PodeLogTypeLogLevel -Name (Get-PodeErrorLogTypeName))
+    $listener.ErrorLoggingLevels = @(Get-PodeLogTypeLogLevel -Name [PodeLogger]::ERROR_LOG_TYPE_NAME)
     $listener.RequestTimeout = $PodeContext.Server.Request.Timeout
     $listener.RequestBodySize = $PodeContext.Server.Request.BodySize
 

--- a/src/Private/SmtpServer.ps1
+++ b/src/Private/SmtpServer.ps1
@@ -52,7 +52,7 @@ function Start-PodeSmtpServer {
     # create the listener
     $listener = [PodeSmtpListener]::new($PodeContext.Tokens.Cancellation.Token)
     $listener.ErrorLoggingEnabled = Test-PodeErrorLogTypeEnabled
-    $listener.ErrorLoggingLevels = @(Get-PodeErrorLoggingLevel)
+    $listener.ErrorLoggingLevels = @(Get-PodeLogTypeLogLevel -Name (Get-PodeErrorLogTypeName))
     $listener.RequestTimeout = $PodeContext.Server.Request.Timeout
     $listener.RequestBodySize = $PodeContext.Server.Request.BodySize
 

--- a/src/Private/TcpServer.ps1
+++ b/src/Private/TcpServer.ps1
@@ -46,7 +46,7 @@ function Start-PodeTcpServer {
 
     # create the listener
     $listener = [PodeTcpListener]::new($PodeContext.Tokens.Cancellation.Token)
-    $listener.ErrorLoggingEnabled = (Test-PodeErrorLoggingEnabled)
+    $listener.ErrorLoggingEnabled = Test-PodeErrorLogTypeEnabled
     $listener.ErrorLoggingLevels = @(Get-PodeErrorLoggingLevel)
     $listener.RequestTimeout = $PodeContext.Server.Request.Timeout
     $listener.RequestBodySize = $PodeContext.Server.Request.BodySize

--- a/src/Private/TcpServer.ps1
+++ b/src/Private/TcpServer.ps1
@@ -46,9 +46,7 @@ function Start-PodeTcpServer {
     }
 
     # create the listener
-    $listener = [PodeTcpListener]::new($PodeContext.Tokens.Cancellation.Token)
-    $listener.ErrorLoggingEnabled = Test-PodeErrorLogTypeEnabled
-    $listener.ErrorLoggingLevels = @(Get-PodeLogTypeLogLevel -Name [PodeLogger]::ERROR_LOG_TYPE_NAME)
+    $listener = [PodeTcpListener]::new($PodeContext.Server.Logging.Logger, $PodeContext.Tokens.Cancellation.Token)
     $listener.RequestTimeout = $PodeContext.Server.Request.Timeout
     $listener.RequestBodySize = $PodeContext.Server.Request.BodySize
 
@@ -72,9 +70,8 @@ function Start-PodeTcpServer {
     }
     catch {
         $_ | Write-PodeErrorLog
-        $_.Exception | Write-PodeErrorLog -CheckInnerException
         Close-PodeDisposable -Disposable $listener
-        throw $_.Exception
+        throw
     }
 
     # script for listening out of for incoming requests
@@ -113,6 +110,7 @@ function Start-PodeTcpServer {
                                 }
                                 Parameters = $null
                                 Timestamp  = [datetime]::UtcNow
+                                ContextId  = $context.ID
                                 Metadata   = @{}
                             }
 
@@ -178,7 +176,6 @@ function Start-PodeTcpServer {
                         }
                         catch {
                             $_ | Write-PodeErrorLog
-                            $_.Exception | Write-PodeErrorLog -CheckInnerException
                         }
                     }
                     finally {
@@ -192,8 +189,7 @@ function Start-PodeTcpServer {
             }
             catch {
                 $_ | Write-PodeErrorLog
-                $_.Exception | Write-PodeErrorLog -CheckInnerException
-                throw $_.Exception
+                throw
             }
 
             # end do-while
@@ -225,8 +221,7 @@ function Start-PodeTcpServer {
         }
         catch {
             $_ | Write-PodeErrorLog
-            $_.Exception | Write-PodeErrorLog -CheckInnerException
-            throw $_.Exception
+            throw
         }
         finally {
             Close-PodeDisposable -Disposable $Listener

--- a/src/Private/TcpServer.ps1
+++ b/src/Private/TcpServer.ps1
@@ -47,7 +47,7 @@ function Start-PodeTcpServer {
     # create the listener
     $listener = [PodeTcpListener]::new($PodeContext.Tokens.Cancellation.Token)
     $listener.ErrorLoggingEnabled = Test-PodeErrorLogTypeEnabled
-    $listener.ErrorLoggingLevels = @(Get-PodeErrorLoggingLevel)
+    $listener.ErrorLoggingLevels = @(Get-PodeLogTypeLogLevel -Name (Get-PodeErrorLogTypeName))
     $listener.RequestTimeout = $PodeContext.Server.Request.Timeout
     $listener.RequestBodySize = $PodeContext.Server.Request.BodySize
 

--- a/src/Private/TcpServer.ps1
+++ b/src/Private/TcpServer.ps1
@@ -1,6 +1,7 @@
 using namespace Pode.Protocols.Tcp
 using namespace Pode.Transport.Sockets
 using namespace Pode.Utilities
+using namespace Pode.Utilities.Logging
 
 function Start-PodeTcpServer {
     # work out which endpoints to listen on
@@ -47,7 +48,7 @@ function Start-PodeTcpServer {
     # create the listener
     $listener = [PodeTcpListener]::new($PodeContext.Tokens.Cancellation.Token)
     $listener.ErrorLoggingEnabled = Test-PodeErrorLogTypeEnabled
-    $listener.ErrorLoggingLevels = @(Get-PodeLogTypeLogLevel -Name (Get-PodeErrorLogTypeName))
+    $listener.ErrorLoggingLevels = @(Get-PodeLogTypeLogLevel -Name [PodeLogger]::ERROR_LOG_TYPE_NAME)
     $listener.RequestTimeout = $PodeContext.Server.Request.Timeout
     $listener.RequestBodySize = $PodeContext.Server.Request.BodySize
 

--- a/src/Private/Timers.ps1
+++ b/src/Private/Timers.ps1
@@ -85,7 +85,7 @@ function Start-PodeTimerRunspace {
         }
         catch {
             $_ | Write-PodeErrorLog
-            throw $_.Exception
+            throw
         }
     }
 

--- a/src/Private/WebSockets.ps1
+++ b/src/Private/WebSockets.ps1
@@ -22,7 +22,7 @@ function New-PodeWebSocketConsumer {
 
     try {
         $consumer = [PodeConsumer]::new([PodeAdapterType]::WebSocket, $PodeContext.Tokens.Cancellation.Token)
-        $consumer.ErrorLoggingEnabled = (Test-PodeErrorLoggingEnabled)
+        $consumer.ErrorLoggingEnabled = Test-PodeErrorLogTypeEnabled
         $consumer.ErrorLoggingLevels = @(Get-PodeErrorLoggingLevel)
         $PodeContext.Server.WebSockets.Consumer = $consumer
         $PodeContext.Consumers += $consumer

--- a/src/Private/WebSockets.ps1
+++ b/src/Private/WebSockets.ps1
@@ -1,5 +1,6 @@
 using namespace Pode.Adapters
 using namespace Pode.Adapters.Consumers
+using namespace Pode.Utilities.Logging
 
 function Test-PodeWebSocketsExist {
     return (($null -ne $PodeContext.Server.WebSockets) -and (($PodeContext.Server.WebSockets.Enabled) -or ($PodeContext.Server.WebSockets.Connections.Count -gt 0)))
@@ -23,7 +24,7 @@ function New-PodeWebSocketConsumer {
     try {
         $consumer = [PodeConsumer]::new([PodeAdapterType]::WebSocket, $PodeContext.Tokens.Cancellation.Token)
         $consumer.ErrorLoggingEnabled = Test-PodeErrorLogTypeEnabled
-        $consumer.ErrorLoggingLevels = @(Get-PodeLogTypeLogLevel -Name (Get-PodeErrorLogTypeName))
+        $consumer.ErrorLoggingLevels = @(Get-PodeLogTypeLogLevel -Name [PodeLogger]::ERROR_LOG_TYPE_NAME)
         $PodeContext.Server.WebSockets.Consumer = $consumer
         $PodeContext.Consumers += $consumer
     }

--- a/src/Private/WebSockets.ps1
+++ b/src/Private/WebSockets.ps1
@@ -22,17 +22,14 @@ function New-PodeWebSocketConsumer {
     }
 
     try {
-        $consumer = [PodeConsumer]::new([PodeAdapterType]::WebSocket, $PodeContext.Tokens.Cancellation.Token)
-        $consumer.ErrorLoggingEnabled = Test-PodeErrorLogTypeEnabled
-        $consumer.ErrorLoggingLevels = @(Get-PodeLogTypeLogLevel -Name [PodeLogger]::ERROR_LOG_TYPE_NAME)
+        $consumer = [PodeConsumer]::new([PodeAdapterType]::WebSocket, $PodeContext.Server.Logging.Logger, $PodeContext.Tokens.Cancellation.Token)
         $PodeContext.Server.WebSockets.Consumer = $consumer
         $PodeContext.Consumers += $consumer
     }
     catch {
         $_ | Write-PodeErrorLog
-        $_.Exception | Write-PodeErrorLog -CheckInnerException
         Close-PodeDisposable -Disposable $consumer
-        throw $_.Exception
+        throw
     }
 }
 
@@ -91,7 +88,6 @@ function Start-PodeWebSocketRunspace {
                         }
                         catch {
                             $_ | Write-PodeErrorLog
-                            $_.Exception | Write-PodeErrorLog -CheckInnerException
                         }
                     }
                     finally {
@@ -105,8 +101,7 @@ function Start-PodeWebSocketRunspace {
             }
             catch {
                 $_ | Write-PodeErrorLog
-                $_.Exception | Write-PodeErrorLog -CheckInnerException
-                throw $_.Exception
+                throw
             }
 
             # end do-while
@@ -138,8 +133,7 @@ function Start-PodeWebSocketRunspace {
         }
         catch {
             $_ | Write-PodeErrorLog
-            $_.Exception | Write-PodeErrorLog -CheckInnerException
-            throw $_.Exception
+            throw
         }
         finally {
             Close-PodeDisposable -Disposable $Consumer

--- a/src/Private/WebSockets.ps1
+++ b/src/Private/WebSockets.ps1
@@ -23,7 +23,7 @@ function New-PodeWebSocketConsumer {
     try {
         $consumer = [PodeConsumer]::new([PodeAdapterType]::WebSocket, $PodeContext.Tokens.Cancellation.Token)
         $consumer.ErrorLoggingEnabled = Test-PodeErrorLogTypeEnabled
-        $consumer.ErrorLoggingLevels = @(Get-PodeErrorLoggingLevel)
+        $consumer.ErrorLoggingLevels = @(Get-PodeLogTypeLogLevel -Name (Get-PodeErrorLogTypeName))
         $PodeContext.Server.WebSockets.Consumer = $consumer
         $PodeContext.Consumers += $consumer
     }

--- a/src/Public/Logging.ps1
+++ b/src/Public/Logging.ps1
@@ -191,9 +191,9 @@ An optional property path within the $WebEvent.Auth.User object for the user's U
 If supplied, the log item returned will be the raw Request item as a hashtable and not a string (for Custom methods).
 
 .EXAMPLE
-New-PodeLogTerminalMethod | Enable-PodeRequestLogging
+New-PodeLogTerminalMethod | Enable-PodeRequestLogType
 #>
-function Enable-PodeRequestLogging {
+function Enable-PodeRequestLogType {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
@@ -208,9 +208,7 @@ function Enable-PodeRequestLogging {
         $Raw
     )
 
-    Test-PodeIsServerless -FunctionName 'Enable-PodeRequestLogging' -ThrowError
-
-    $name = Get-PodeRequestLoggingName
+    $name = Get-PodeRequestLogTypeName
 
     # error if it's already enabled
     if ($PodeContext.Server.Logging.Types.Contains($name)) {
@@ -242,32 +240,40 @@ function Enable-PodeRequestLogging {
     }
 }
 
-<#
-.SYNOPSIS
-Disables Request Logging.
-
-.DESCRIPTION
-Disables Request Logging.
-
-.EXAMPLE
-Disable-PodeRequestLogging
-#>
-function Disable-PodeRequestLogging {
-    [CmdletBinding()]
-    param()
-
-    Remove-PodeLogger -Name (Get-PodeRequestLoggingName)
+if (!(Test-Path Alias:Enable-PodeRequestLogging)) {
+    New-Alias Enable-PodeRequestLogging -Value Enable-PodeRequestLogType
 }
 
 <#
 .SYNOPSIS
-Enables Error Logging using a supplied output method.
+Disables Request log Type.
 
 .DESCRIPTION
-Enables Error Logging using a supplied output method.
+Disables Request log Type.
+
+.EXAMPLE
+Disable-PodeRequestLogType
+#>
+function Disable-PodeRequestLogType {
+    [CmdletBinding()]
+    param()
+
+    Remove-PodeLogType -Name (Get-PodeRequestLogTypeName)
+}
+
+IF (!(Test-Path Alias:Disable-PodeRequestLogging)) {
+    New-Alias Disable-PodeRequestLogging -Value Disable-PodeRequestLogType
+}
+
+<#
+.SYNOPSIS
+Enables Error log Type using a supplied log Method.
+
+.DESCRIPTION
+Enables Error log Type using a supplied log Method.
 
 .PARAMETER Method
-The logging Method to use for output the log entry.
+The log Method to use for output the log entry.
 
 .PARAMETER Levels
 The Levels of errors that should be logged (default is Error).
@@ -276,9 +282,9 @@ The Levels of errors that should be logged (default is Error).
 If supplied, the log item returned will be the raw Error item as a hashtable and not a string (for Custom methods).
 
 .EXAMPLE
-New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+New-PodeLogTerminalMethod | Enable-PodeErrorLogType
 #>
-function Enable-PodeErrorLogging {
+function Enable-PodeErrorLogType {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
@@ -295,7 +301,7 @@ function Enable-PodeErrorLogging {
         $Raw
     )
 
-    $name = Get-PodeErrorLoggingName
+    $name = Get-PodeErrorLogTypeName
 
     # error if it's already enabled
     if ($PodeContext.Server.Logging.Types.Contains($name)) {
@@ -325,21 +331,29 @@ function Enable-PodeErrorLogging {
     }
 }
 
+if (!(Test-Path Alias:Enable-PodeErrorLogging)) {
+    New-Alias Enable-PodeErrorLogging -Value Enable-PodeErrorLogType
+}
+
 <#
 .SYNOPSIS
-Disables Error Logging.
+Disables Error log Type.
 
 .DESCRIPTION
-Disables Error Logging.
+Disables Error log Type.
 
 .EXAMPLE
-Disable-PodeErrorLogging
+Disable-PodeErrorLogType
 #>
-function Disable-PodeErrorLogging {
+function Disable-PodeErrorLogType {
     [CmdletBinding()]
     param()
 
-    Remove-PodeLogger -Name (Get-PodeErrorLoggingName)
+    Remove-PodeLogType -Name (Get-PodeErrorLogTypeName)
+}
+
+if (!(Test-Path Alias:Disable-PodeErrorLogging)) {
+    New-Alias Disable-PodeErrorLogging -Value Disable-PodeErrorLogType
 }
 
 <#
@@ -422,18 +436,18 @@ if (!(Test-Path Alias:Add-PodeLogger)) {
 
 <#
 .SYNOPSIS
-Removes a configured Logging method.
+Removes a configured Log Type.
 
 .DESCRIPTION
-Removes a configured Logging method.
+Removes a configured Log Type.
 
 .PARAMETER Name
-The Name of the Logging type to remove.
+The Name of the Log Type to remove.
 
 .EXAMPLE
-Remove-PodeLogger -Name 'LogTypeName'
+Remove-PodeLogType -Name 'LogTypeName'
 #>
-function Remove-PodeLogger {
+function Remove-PodeLogType {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
@@ -444,22 +458,30 @@ function Remove-PodeLogger {
     $null = $PodeContext.Server.Logging.Types.Remove($Name)
 }
 
+if (!(Test-Path Alias:Remove-PodeLogger)) {
+    New-Alias Remove-PodeLogger -Value Remove-PodeLogType
+}
+
 <#
 .SYNOPSIS
-Clears all Logging methods that have been configured.
+Clears all Log Types that have been configured.
 
 .DESCRIPTION
-Clears all Logging methods that have been configured.
+Clears all Log Types that have been configured.
 
 .EXAMPLE
-Clear-PodeLoggers
+Clear-PodeLogTypes
 #>
-function Clear-PodeLoggers {
+function Clear-PodeLogTypes {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '')]
     [CmdletBinding()]
     param()
 
     $PodeContext.Server.Logging.Types.Clear()
+}
+
+if (!(Test-Path Alias:Clear-PodeLoggers)) {
+    New-Alias Clear-PodeLoggers -Value Clear-PodeLogTypes
 }
 
 <#
@@ -510,8 +532,8 @@ function Write-PodeErrorLog {
     )
 
     # do nothing if logging is disabled, or error logging isn't setup
-    $name = Get-PodeErrorLoggingName
-    if (!(Test-PodeLoggerEnabled -Name $name)) {
+    $name = Get-PodeErrorLogTypeName
+    if (!(Test-PodeLogTypeEnabled -Name $name)) {
         return
     }
 
@@ -587,7 +609,7 @@ function Write-PodeLog {
     )
 
     # do nothing if logging is disabled, or logger isn't setup
-    if (!(Test-PodeLoggerEnabled -Name $Name)) {
+    if (!(Test-PodeLogTypeEnabled -Name $Name)) {
         return
     }
 
@@ -722,7 +744,7 @@ Create a new Terminal logging Method.
 
 .DESCRIPTION
 Creates a new Terminal logging Method for outputting log items to the terminal.
-Can be used with Enable-PodeRequestLogging, Enable-PodeErrorLogging, or Add-PodeLogType.
+Can be used with Enable-PodeRequestLogType, Enable-PodeErrorLogType, or Add-PodeLogType.
 
 .PARAMETER BatchInfo
 An optional hashtable containing batch configuration for writing log items in bulk.
@@ -757,7 +779,7 @@ Create a new File logging Method.
 
 .DESCRIPTION
 Creates a new File logging Method for outputting log items to files.
-Can be used with Enable-PodeRequestLogging, Enable-PodeErrorLogging, or Add-PodeLogType.
+Can be used with Enable-PodeRequestLogType, Enable-PodeErrorLogType, or Add-PodeLogType.
 
 .PARAMETER Name
 The File Name to prepend new log files using.
@@ -835,7 +857,7 @@ Create a new Event Viewer logging Method.
 
 .DESCRIPTION
 Creates a new Event Viewer logging Method for outputting log items to the Windows Event Viewer.
-Can be used with Enable-PodeRequestLogging, Enable-PodeErrorLogging, or Add-PodeLogType.
+Can be used with Enable-PodeRequestLogType, Enable-PodeErrorLogType, or Add-PodeLogType.
 
 .PARAMETER EventLogName
 An Optional Log Name for the Event Viewer (Default: Application)
@@ -906,7 +928,7 @@ Create a new Custom logging Method.
 
 .DESCRIPTION
 Creates a new Custom logging Method for outputting log items using custom logic defined in a ScriptBlock.
-Can be used with Enable-PodeRequestLogging, Enable-PodeErrorLogging, or Add-PodeLogType.
+Can be used with Enable-PodeRequestLogType, Enable-PodeErrorLogType, or Add-PodeLogType.
 
 .PARAMETER ScriptBlock
 The ScriptBlock that defines how to output a log item.

--- a/src/Public/Logging.ps1
+++ b/src/Public/Logging.ps1
@@ -681,6 +681,22 @@ function Use-PodeLogging {
     Use-PodeFolder -Path $Path -DefaultPath 'logging'
 }
 
+<#
+.SYNOPSIS
+Create a new batch info object for logging.
+
+.DESCRIPTION
+Creates a new batch info object for logging, which can be used to configure batch processing of log items.
+
+.PARAMETER Size
+The number of log items to process in a single batch. (Default: 1)
+
+.PARAMETER Timeout
+The maximum amount of time, in seconds, to wait before processing a batch of log items. (Default: 0, which means no timeout)
+
+.EXAMPLE
+$batchInfo = New-PodeLogBatchInfo -Size 10 -Timeout 10
+#>
 function New-PodeLogBatchInfo {
     [CmdletBinding()]
     [OutputType([hashtable])]
@@ -700,6 +716,25 @@ function New-PodeLogBatchInfo {
     }
 }
 
+<#
+.SYNOPSIS
+Create a new Terminal logging Method.
+
+.DESCRIPTION
+Creates a new Terminal logging Method for outputting log items to the terminal.
+Can be used with Enable-PodeRequestLogging, Enable-PodeErrorLogging, or Add-PodeLogType.
+
+.PARAMETER BatchInfo
+An optional hashtable containing batch configuration for writing log items in bulk.
+Should be created using New-PodeLogBatchInfo.
+
+.EXAMPLE
+$method = New-PodeLogTerminalMethod
+
+.EXAMPLE
+$batchInfo = New-PodeLogBatchInfo -Size 10 -Timeout 10
+$method = New-PodeLogTerminalMethod -BatchInfo $batchInfo
+#>
 function New-PodeLogTerminalMethod {
     [CmdletBinding()]
     [OutputType([hashtable])]
@@ -716,6 +751,37 @@ function New-PodeLogTerminalMethod {
     }
 }
 
+<#
+.SYNOPSIS
+Create a new File logging Method.
+
+.DESCRIPTION
+Creates a new File logging Method for outputting log items to files.
+Can be used with Enable-PodeRequestLogging, Enable-PodeErrorLogging, or Add-PodeLogType.
+
+.PARAMETER Name
+The File Name to prepend new log files using.
+
+.PARAMETER Path
+The File Path of where to store the logs.
+
+.PARAMETER BatchInfo
+An optional hashtable containing batch configuration for writing log items in bulk.
+Should be created using New-PodeLogBatchInfo.
+
+.PARAMETER MaxDays
+The maximum number of days to keep logs, before Pode automatically removes them.
+
+.PARAMETER MaxSize
+The maximum size of a log file, before Pode starts writing to a new log file.
+
+.EXAMPLE
+$method = New-PodeLogFileMethod -Name 'requests'
+
+.EXAMPLE
+$batchInfo = New-PodeLogBatchInfo -Size 10 -Timeout 10
+$method = New-PodeLogFileMethod -Name 'requests' -BatchInfo $batchInfo -MaxDays 7 -MaxSize 10MB
+#>
 function New-PodeLogFileMethod {
     [CmdletBinding()]
     [OutputType([hashtable])]
@@ -763,6 +829,34 @@ function New-PodeLogFileMethod {
     }
 }
 
+<#
+.SYNOPSIS
+Create a new Event Viewer logging Method.
+
+.DESCRIPTION
+Creates a new Event Viewer logging Method for outputting log items to the Windows Event Viewer.
+Can be used with Enable-PodeRequestLogging, Enable-PodeErrorLogging, or Add-PodeLogType.
+
+.PARAMETER EventLogName
+An Optional Log Name for the Event Viewer (Default: Application)
+
+.PARAMETER Source
+An Optional Source for the Event Viewer (Default: Pode)
+
+.PARAMETER EventID
+An Optional EventID for the Event Viewer (Default: 0)
+
+.PARAMETER BatchInfo
+An optional hashtable containing batch configuration for writing log items in bulk.
+Should be created using New-PodeLogBatchInfo.
+
+.EXAMPLE
+$method = New-PodeLogEventViewerMethod
+
+.EXAMPLE
+$batchInfo = New-PodeLogBatchInfo -Size 10 -Timeout 10
+$method = New-PodeLogEventViewerMethod -EventLogName 'MyLog' -Source 'MyApp' -EventID 1001 -BatchInfo $batchInfo
+#>
 function New-PodeLogEventViewerMethod {
     [CmdletBinding()]
     [OutputType([hashtable])]
@@ -806,6 +900,31 @@ function New-PodeLogEventViewerMethod {
     }
 }
 
+<#
+.SYNOPSIS
+Create a new Custom logging Method.
+
+.DESCRIPTION
+Creates a new Custom logging Method for outputting log items using custom logic defined in a ScriptBlock.
+Can be used with Enable-PodeRequestLogging, Enable-PodeErrorLogging, or Add-PodeLogType.
+
+.PARAMETER ScriptBlock
+The ScriptBlock that defines how to output a log item.
+
+.PARAMETER ArgumentList
+An array of arguments to supply to the Custom Logging output method's ScriptBlock.
+
+.EXAMPLE
+$method = New-PodeLogCustomMethod -ScriptBlock { /* logic */ }
+
+.EXAMPLE
+$arguments = @('arg1', 'arg2')
+$method = New-PodeLogCustomMethod -ScriptBlock { param($args) /* logic using $args */ } -ArgumentList $arguments
+
+.EXAMPLE
+$batchInfo = New-PodeLogBatchInfo -Size 10 -Timeout 10
+$method = New-PodeLogCustomMethod -ScriptBlock { /* logic */ } -BatchInfo $batchInfo
+#>
 function New-PodeLogCustomMethod {
     [CmdletBinding()]
     [OutputType([hashtable])]

--- a/src/Public/Logging.ps1
+++ b/src/Public/Logging.ps1
@@ -3,7 +3,12 @@
 Create a new method of outputting logs.
 
 .DESCRIPTION
-Create a new method of outputting logs.
+This function has been deprecated and will be removed in future versions. It creates various logging methods for outputting logs.
+Please use the appropriate new functions for each logging method:
+- New-PodeLogTerminalMethod
+- New-PodeLogFileMethod
+- New-PodeLogEventViewerMethod
+- New-PodeLogCustomMethod
 
 .PARAMETER Terminal
 If supplied, will use the inbuilt Terminal logging output method.
@@ -104,26 +109,12 @@ function New-PodeLoggingMethod {
         $BatchTimeout = 0,
 
         [Parameter(ParameterSetName = 'File')]
-        [ValidateScript({
-                if ($_ -lt 0) {
-                    # MaxDays must be 0 or greater, but got
-                    throw ($PodeLocale.maxDaysInvalidExceptionMessage -f $MaxDays)
-                }
-
-                return $true
-            })]
+        [ValidateRange(0, [int]::MaxValue)]
         [int]
         $MaxDays = 0,
 
         [Parameter(ParameterSetName = 'File')]
-        [ValidateScript({
-                if ($_ -lt 0) {
-                    # MaxSize must be 0 or greater, but got
-                    throw ($PodeLocale.maxSizeInvalidExceptionMessage -f $MaxSize)
-                }
-
-                return $true
-            })]
+        [ValidateRange(0, [int]::MaxValue)]
         [int]
         $MaxSize = 0,
 
@@ -149,80 +140,39 @@ function New-PodeLoggingMethod {
     )
 
     # batch details
-    $batchInfo = @{
-        Size       = $Batch
-        Timeout    = $BatchTimeout
-        LastUpdate = $null
-        Items      = @()
-        RawItems   = @()
-    }
+    $batchInfo = New-PodeLogBatchInfo -Size $Batch -Timeout $BatchTimeout
 
     # return info on appropriate logging type
     switch ($PSCmdlet.ParameterSetName.ToLowerInvariant()) {
         'terminal' {
-            return @{
-                ScriptBlock = (Get-PodeLoggingTerminalMethod)
-                Batch       = $batchInfo
-                Arguments   = @{}
-            }
+            # WARNING: Function `New-PodeLoggingMethod` is deprecated.
+            Write-PodeHost ($PodeLocale.deprecatedFunctionWarningMessage -f 'New-PodeLoggingMethod', 'New-PodeLogTerminalMethod')  -ForegroundColor Yellow
+
+            return New-PodeLogTerminalMethod -BatchInfo $batchInfo
         }
 
         'file' {
-            $Path = (Protect-PodeValue -Value $Path -Default './logs')
-            $Path = (Get-PodeRelativePath -Path $Path -JoinRoot)
-            $null = New-Item -Path $Path -ItemType Directory -Force
+            # WARNING: Function `New-PodeLoggingMethod` is deprecated.
+            Write-PodeHost ($PodeLocale.deprecatedFunctionWarningMessage -f 'New-PodeLoggingMethod', 'New-PodeLogFileMethod')  -ForegroundColor Yellow
 
-            return @{
-                ScriptBlock = (Get-PodeLoggingFileMethod)
-                Batch       = $batchInfo
-                Arguments   = @{
-                    Name          = $Name
-                    Path          = $Path
-                    MaxDays       = $MaxDays
-                    MaxSize       = $MaxSize
-                    FileId        = 0
-                    Date          = $null
-                    NextClearDown = [datetime]::Now.Date
-                }
-            }
+            return New-PodeLogFileMethod -Name $Name -Path $Path -MaxDays $MaxDays -MaxSize $MaxSize -BatchInfo $batchInfo
         }
 
         'eventviewer' {
-            # only windows
-            if (!(Test-PodeIsWindows)) {
-                # Event Viewer logging only supported on Windows
-                throw ($PodeLocale.eventViewerLoggingSupportedOnWindowsOnlyExceptionMessage)
-            }
+            # WARNING: Function `New-PodeLoggingMethod` is deprecated.
+            Write-PodeHost ($PodeLocale.deprecatedFunctionWarningMessage -f 'New-PodeLoggingMethod', 'New-PodeLogEventViewerMethod')  -ForegroundColor Yellow
 
-            # create source
-            if (![System.Diagnostics.EventLog]::SourceExists($Source)) {
-                $null = [System.Diagnostics.EventLog]::CreateEventSource($Source, $EventLogName)
-            }
-
-            return @{
-                ScriptBlock = (Get-PodeLoggingEventViewerMethod)
-                Batch       = $batchInfo
-                Arguments   = @{
-                    LogName = $EventLogName
-                    Source  = $Source
-                    ID      = $EventID
-                }
-            }
+            return New-PodeLogEventViewerMethod -EventLogName $EventLogName -Source $Source -EventID $EventID -BatchInfo $batchInfo
         }
 
         'custom' {
-            $ScriptBlock, $usingVars = Convert-PodeScopedVariables -ScriptBlock $ScriptBlock -PSSession $PSCmdlet.SessionState
+            # WARNING: Function `New-PodeLoggingMethod` is deprecated.
+            Write-PodeHost ($PodeLocale.deprecatedFunctionWarningMessage -f 'New-PodeLoggingMethod', 'New-PodeLogCustomMethod')  -ForegroundColor Yellow
 
-            return @{
-                ScriptBlock    = $ScriptBlock
-                UsingVariables = $usingVars
-                Batch          = $batchInfo
-                Arguments      = $ArgumentList
-            }
+            return New-PodeLogCustomMethod -ScriptBlock $ScriptBlock -ArgumentList $ArgumentList -BatchInfo $batchInfo
         }
     }
 }
-
 
 <#
 .SYNOPSIS
@@ -232,7 +182,7 @@ Enables Request Logging using a supplied output method.
 Enables Request Logging using a supplied output method.
 
 .PARAMETER Method
-The Method to use for output the log entry (From New-PodeLoggingMethod).
+The logging Method to use for output the log entry.
 
 .PARAMETER UsernameProperty
 An optional property path within the $WebEvent.Auth.User object for the user's Username. (Default: Username).
@@ -241,7 +191,7 @@ An optional property path within the $WebEvent.Auth.User object for the user's U
 If supplied, the log item returned will be the raw Request item as a hashtable and not a string (for Custom methods).
 
 .EXAMPLE
-New-PodeLoggingMethod -Terminal | Enable-PodeRequestLogging
+New-PodeLogTerminalMethod | Enable-PodeRequestLogging
 #>
 function Enable-PodeRequestLogging {
     [CmdletBinding()]
@@ -317,7 +267,7 @@ Enables Error Logging using a supplied output method.
 Enables Error Logging using a supplied output method.
 
 .PARAMETER Method
-The Method to use for output the log entry (From New-PodeLoggingMethod).
+The logging Method to use for output the log entry.
 
 .PARAMETER Levels
 The Levels of errors that should be logged (default is Error).
@@ -326,7 +276,7 @@ The Levels of errors that should be logged (default is Error).
 If supplied, the log item returned will be the raw Error item as a hashtable and not a string (for Custom methods).
 
 .EXAMPLE
-New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+New-PodeLogTerminalMethod | Enable-PodeErrorLogging
 #>
 function Enable-PodeErrorLogging {
     [CmdletBinding()]
@@ -394,27 +344,27 @@ function Disable-PodeErrorLogging {
 
 <#
 .SYNOPSIS
-Adds a custom Logging method for parsing custom log items.
+Adds a custom Logging type for parsing custom log items.
 
 .DESCRIPTION
-Adds a custom Logging method for parsing custom log items.
+Adds a custom Logging type for parsing custom log items.
 
 .PARAMETER Name
-A unique Name for the Logging method.
+A unique Name for the Log type.
 
 .PARAMETER Method
-The Method to use for output the log entry (From New-PodeLoggingMethod).
+The logging Method to use for outputting the log entry.
 
 .PARAMETER ScriptBlock
 The ScriptBlock defining logic that transforms an item, and returns it for outputting.
 
 .PARAMETER ArgumentList
-An array of arguments to supply to the Custom Logger's ScriptBlock.
+An array of arguments to supply to the Custom Log type's ScriptBlock.
 
 .EXAMPLE
-New-PodeLoggingMethod -Terminal | Add-PodeLogger -Name 'Main' -ScriptBlock { /* logic */ }
+New-PodeLogTerminalMethod | Add-PodeLogType -Name 'LogTypeName' -ScriptBlock { /* logic */ }
 #>
-function Add-PodeLogger {
+function Add-PodeLogType {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
@@ -466,6 +416,8 @@ function Add-PodeLogger {
     }
 }
 
+New-Alias Add-PodeLogger -Value Add-PodeLogType
+
 <#
 .SYNOPSIS
 Removes a configured Logging method.
@@ -474,10 +426,10 @@ Removes a configured Logging method.
 Removes a configured Logging method.
 
 .PARAMETER Name
-The Name of the Logging method.
+The Name of the Logging type to remove.
 
 .EXAMPLE
-Remove-PodeLogger -Name 'LogName'
+Remove-PodeLogger -Name 'LogTypeName'
 #>
 function Remove-PodeLogger {
     [CmdletBinding()]
@@ -612,13 +564,13 @@ Write an object to a configured custom Logging method.
 Write an object to a configured custom Logging method.
 
 .PARAMETER Name
-The Name of the Logging method.
+The Name of the Logging type to use.
 
 .PARAMETER InputObject
 The Object to write.
 
 .EXAMPLE
-$object | Write-PodeLog -Name 'LogName'
+$object | Write-PodeLog -Name 'LogTypeName'
 #>
 function Write-PodeLog {
     [CmdletBinding()]
@@ -725,4 +677,164 @@ function Use-PodeLogging {
     )
 
     Use-PodeFolder -Path $Path -DefaultPath 'logging'
+}
+
+function New-PodeLogBatchInfo {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter()]
+        [int]
+        $Size = 1,
+
+        [Parameter()]
+        [int]
+        $Timeout = 0
+    )
+
+    return @{
+        Size    = $Size
+        Timeout = $Timeout
+    }
+}
+
+function New-PodeLogTerminalMethod {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter()]
+        [hashtable]
+        $BatchInfo = $null
+    )
+
+    return @{
+        ScriptBlock = Get-PodeLoggingTerminalMethod
+        Batch       = $BatchInfo | New-PodeLogBatchConfig
+        Arguments   = @{}
+    }
+}
+
+function New-PodeLogFileMethod {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Name,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $Path = './logs',
+
+        [Parameter()]
+        [ValidateRange(0, [int]::MaxValue)]
+        [int]
+        $MaxDays = 0,
+
+        [Parameter()]
+        [ValidateRange(0, [int]::MaxValue)]
+        [int]
+        $MaxSize = 0,
+
+        [Parameter()]
+        [hashtable]
+        $BatchInfo = $null
+    )
+
+    # resolve path and ensure it exists
+    $Path = Get-PodeRelativePath -Path $Path -JoinRoot
+    $null = New-Item -Path $Path -ItemType Directory -Force
+
+    return @{
+        ScriptBlock = Get-PodeLoggingFileMethod
+        Batch       = $BatchInfo | New-PodeLogBatchConfig
+        Arguments   = @{
+            Name          = $Name
+            Path          = $Path
+            MaxDays       = $MaxDays
+            MaxSize       = $MaxSize
+            FileId        = 0
+            Date          = $null
+            NextClearDown = [datetime]::Now.Date
+        }
+    }
+}
+
+function New-PodeLogEventViewerMethod {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter()]
+        [string]
+        $EventLogName = 'Application',
+
+        [Parameter()]
+        [string]
+        $Source = 'Pode',
+
+        [Parameter()]
+        [int]
+        $EventID = 0,
+
+        [Parameter()]
+        [hashtable]
+        $BatchInfo = $null
+    )
+
+    # only windows
+    if (!(Test-PodeIsWindows)) {
+        # Event Viewer logging only supported on Windows
+        throw ($PodeLocale.eventViewerLoggingSupportedOnWindowsOnlyExceptionMessage)
+    }
+
+    # create source
+    if (![System.Diagnostics.EventLog]::SourceExists($Source)) {
+        $null = [System.Diagnostics.EventLog]::CreateEventSource($Source, $EventLogName)
+    }
+
+    return @{
+        ScriptBlock = Get-PodeLoggingEventViewerMethod
+        Batch       = $BatchInfo | New-PodeLogBatchConfig
+        Arguments   = @{
+            LogName = $EventLogName
+            Source  = $Source
+            ID      = $EventID
+        }
+    }
+}
+
+function New-PodeLogCustomMethod {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateScript({
+                if (Test-PodeIsEmpty $_) {
+                    # A non-empty ScriptBlock is required for the Custom logging output method
+                    throw ($PodeLocale.nonEmptyScriptBlockRequiredForCustomLoggingExceptionMessage)
+                }
+
+                return $true
+            })]
+        [scriptblock]
+        $ScriptBlock,
+
+        [Parameter()]
+        [object[]]
+        $ArgumentList,
+
+        [Parameter()]
+        [hashtable]
+        $BatchInfo = $null
+    )
+
+    $ScriptBlock, $usingVars = Convert-PodeScopedVariables -ScriptBlock $ScriptBlock -PSSession $PSCmdlet.SessionState
+
+    return @{
+        ScriptBlock    = $ScriptBlock
+        UsingVariables = $usingVars
+        Batch          = $BatchInfo | New-PodeLogBatchConfig
+        Arguments      = $ArgumentList
+    }
 }

--- a/src/Public/Logging.ps1
+++ b/src/Public/Logging.ps1
@@ -416,7 +416,9 @@ function Add-PodeLogType {
     }
 }
 
-New-Alias Add-PodeLogger -Value Add-PodeLogType
+if (!(Test-Path Alias:Add-PodeLogger)) {
+    New-Alias Add-PodeLogger -Value Add-PodeLogType
+}
 
 <#
 .SYNOPSIS

--- a/src/Public/Logging.ps1
+++ b/src/Public/Logging.ps1
@@ -765,15 +765,15 @@ The File Name to prepend new log files using.
 .PARAMETER Path
 The File Path of where to store the logs.
 
-.PARAMETER BatchInfo
-An optional hashtable containing batch configuration for writing log items in bulk.
-Should be created using New-PodeLogBatchInfo.
-
 .PARAMETER MaxDays
 The maximum number of days to keep logs, before Pode automatically removes them.
 
 .PARAMETER MaxSize
 The maximum size of a log file, before Pode starts writing to a new log file.
+
+.PARAMETER BatchInfo
+An optional hashtable containing batch configuration for writing log items in bulk.
+Should be created using New-PodeLogBatchInfo.
 
 .EXAMPLE
 $method = New-PodeLogFileMethod -Name 'requests'
@@ -913,6 +913,10 @@ The ScriptBlock that defines how to output a log item.
 
 .PARAMETER ArgumentList
 An array of arguments to supply to the Custom Logging output method's ScriptBlock.
+
+.PARAMETER BatchInfo
+An optional hashtable containing batch configuration for writing log items in bulk.
+Should be created using New-PodeLogBatchInfo.
 
 .EXAMPLE
 $method = New-PodeLogCustomMethod -ScriptBlock { /* logic */ }

--- a/src/Public/Logging.ps1
+++ b/src/Public/Logging.ps1
@@ -722,14 +722,17 @@ function Write-PodeErrorLog {
         return
     }
 
+    # attempt to get current contextId
+    $contextId = Get-PodeLoggingContextId
+
     # log error object appropriately based on parameter set
     switch ($PSCmdlet.ParameterSetName) {
         'Exception' {
-            $PodeContext.Server.Logging.Logger.AddException($Exception, $Level, [int]$ThreadId)
+            $PodeContext.Server.Logging.Logger.AddException($Exception, $contextId, $Level, [int]$ThreadId)
         }
 
         'Error' {
-            $PodeContext.Server.Logging.Logger.AddException($ErrorRecord.CategoryInfo.ToString(), $ErrorRecord.Exception.Message, $ErrorRecord.ScriptStackTrace, $Level, [int]$ThreadId)
+            $PodeContext.Server.Logging.Logger.AddException($ErrorRecord.CategoryInfo.ToString(), $ErrorRecord.Exception.Message, $ErrorRecord.ScriptStackTrace, $contextId, $Level, [int]$ThreadId)
         }
     }
 

--- a/src/Public/Logging.ps1
+++ b/src/Public/Logging.ps1
@@ -10,6 +10,9 @@ Please use the appropriate new functions for each logging method:
 - New-PodeLogEventViewerMethod
 - New-PodeLogCustomMethod
 
+.PARAMETER Id
+An optional ID to assign to the logging method. If not supplied, a random ID will be generated.
+
 .PARAMETER Terminal
 If supplied, will use the inbuilt Terminal logging output method.
 
@@ -227,7 +230,7 @@ function Enable-PodeRequestLogType {
     process {
         # ensure the Method exists
         if (!(Test-PodeLogMethod -Id $_)) {
-            #TODO: The supplied logging Method for Request Logging doesn't exist
+            # The supplied logging Method for Request Logging doesn't exist
             throw ($PodeLocale.loggingMethodDoesNotExistExceptionMessage -f $_)
         }
 
@@ -246,7 +249,7 @@ function Enable-PodeRequestLogType {
             $UsernameProperty = 'Username'
         }
 
-        # add the request logger
+        # add the request log type, associated with the supplied log method(s)
         $PodeContext.Server.Logging.Types[$name] = @{
             Method      = $Method
             ScriptBlock = Get-PodeLoggingInbuiltType -Type Requests
@@ -256,6 +259,11 @@ function Enable-PodeRequestLogType {
             Arguments   = @{
                 Raw = $Raw
             }
+        }
+
+        # then associate the supplied log method(s) with the request log type
+        foreach ($methodId in $Method) {
+            Register-PodeLogTypeToMethod -TypeName $name -MethodId $methodId
         }
     }
 }
@@ -335,7 +343,7 @@ function Enable-PodeErrorLogType {
     process {
         # ensure the Method exists
         if (!(Test-PodeLogMethod -Id $_)) {
-            #TODO: The supplied logging Method for Request Logging doesn't exist
+            # The supplied logging Method for Request Logging doesn't exist
             throw ($PodeLocale.loggingMethodDoesNotExistExceptionMessage -f $_)
         }
 
@@ -354,7 +362,7 @@ function Enable-PodeErrorLogType {
             $Levels = @('Error', 'Warning', 'Informational', 'Verbose', 'Debug')
         }
 
-        # add the error logger
+        # add the error log type, associated with the supplied log method(s)
         $PodeContext.Server.Logging.Types[$name] = @{
             Method      = $Method
             ScriptBlock = Get-PodeLoggingInbuiltType -Type Errors
@@ -362,6 +370,11 @@ function Enable-PodeErrorLogType {
             Arguments   = @{
                 Raw = $Raw
             }
+        }
+
+        # then associate the supplied log method(s) with the request log type
+        foreach ($methodId in $Method) {
+            Register-PodeLogTypeToMethod -TypeName $name -MethodId $methodId
         }
     }
 }
@@ -463,7 +476,7 @@ function Add-PodeLogType {
     process {
         # ensure the Method exists
         if (!(Test-PodeLogMethod -Id $_)) {
-            #TODO: The supplied logging Method for Request Logging doesn't exist
+            # The supplied logging Method for Request Logging doesn't exist
             throw ($PodeLocale.loggingMethodDoesNotExistExceptionMessage -f $_)
         }
 
@@ -485,13 +498,18 @@ function Add-PodeLogType {
         # check for scoped vars
         $ScriptBlock, $usingVars = Convert-PodeScopedVariables -ScriptBlock $ScriptBlock -PSSession $PSCmdlet.SessionState
 
-        # add logging method to server
+        # add custom log method to server, associated with the supplied log method(s)
         $PodeContext.Server.Logging.Types[$Name] = @{
             Method         = $Method
             ScriptBlock    = $ScriptBlock
             UsingVariables = $usingVars
             Levels         = $Levels
             Arguments      = $ArgumentList
+        }
+
+        # then associate the supplied log method(s) with the request log type
+        foreach ($methodId in $Method) {
+            Register-PodeLogTypeToMethod -TypeName $Name -MethodId $methodId
         }
     }
 }
@@ -521,7 +539,21 @@ function Remove-PodeLogType {
         $Name
     )
 
-    $null = $PodeContext.Server.Logging.Types.Remove($Name)
+    process {
+        # get the log type
+        $type = Get-PodeLogType -Name $Name
+        if ($null -eq $type) {
+            return
+        }
+
+        # unregister log type from method
+        foreach ($methodId in $type.Method) {
+            Unregister-PodeLogTypeFromMethod -TypeName $Name -MethodId $methodId
+        }
+
+        # remove the log type
+        $null = $PodeContext.Server.Logging.Types.Remove($Name)
+    }
 }
 
 if (!(Test-Path Alias:Remove-PodeLogger)) {
@@ -536,17 +568,35 @@ function Remove-PodeLogMethod {
         $Id
     )
 
-    # dispose of any log method queue
-    $method = Get-PodeLogMethod -Id $Id
-    if ($null -ne $method.Queue) {
-        $method.Queue.Dispose()
+    process {
+        # get the log method
+        $method = Get-PodeLogMethod -Id $Id
+        if ($null -eq $method) {
+            return
+        }
+
+        # close the runspace and reduce max count (not below 1)
+        $method.Runspace.Pipeline.Stop()
+        $method.Runspace.Pipeline.Dispose()
+
+        $maxRunspaces = $PodeContext.RunspacePools.Logs.Pool.GetMaxRunspaces()
+        if ($maxRunspaces -gt 1) {
+            $PodeContext.RunspacePools.Logs.Pool.SetMaxRunspaces($maxRunspaces - 1)
+        }
+
+        # dispose the log method queue
+        if ($null -ne $method.Queue) {
+            $method.Queue.Dispose()
+        }
+
+        # unregister log method from types that reference it
+        foreach ($typeName in $method.Types) {
+            Unregister-PodeLogMethodFromType -TypeName $typeName -MethodId $Id
+        }
+
+        # remove the log method
+        $null = $PodeContext.Server.Logging.Methods.Remove($Id)
     }
-
-    #TODO: remove method from Types that reference it?
-    #TODO: close runspace, and reduce max count (not below 1)
-
-    # remove the log method
-    $null = $PodeContext.Server.Logging.Methods.Remove($Id)
 }
 
 <#
@@ -564,7 +614,10 @@ function Clear-PodeLogTypes {
     [CmdletBinding()]
     param()
 
-    $PodeContext.Server.Logging.Types.Clear()
+    $typeNames = $PodeContext.Server.Logging.Types.Keys
+    foreach ($typeName in $typeNames) {
+        Remove-PodeLogType -Name $typeName
+    }
 }
 
 if (!(Test-Path Alias:Clear-PodeLoggers)) {
@@ -576,18 +629,17 @@ function Clear-PodeLogMethods {
     [CmdletBinding()]
     param()
 
+    $methodIds = $PodeContext.Server.Logging.Methods.Keys
+    foreach ($methodId in $methodIds) {
+        Remove-PodeLogMethod -Id $methodId
+    }
+
     # dispose of any log method queues
     foreach ($method in $PodeContext.Server.Logging.Methods.Values) {
         if ($null -ne $method.Queue) {
             $method.Queue.Dispose()
         }
     }
-
-    #TODO: remove method from Types that reference it?
-    #TODO: close runspace, and reduce max count (not below 1)
-
-    # clear the log methods
-    $PodeContext.Server.Logging.Methods.Clear()
 }
 
 <#
@@ -865,6 +917,9 @@ Create a new Terminal logging Method.
 Creates a new Terminal logging Method for outputting log items to the terminal.
 Can be used with Enable-PodeRequestLogType, Enable-PodeErrorLogType, or Add-PodeLogType.
 
+.PARAMETER Id
+An optional ID to assign to the logging method. If not supplied, a random ID will be generated.
+
 .PARAMETER BatchInfo
 An optional hashtable containing batch configuration for writing log items in bulk.
 Should be created using New-PodeLogBatchInfo.
@@ -904,6 +959,9 @@ Create a new File logging Method.
 .DESCRIPTION
 Creates a new File logging Method for outputting log items to files.
 Can be used with Enable-PodeRequestLogType, Enable-PodeErrorLogType, or Add-PodeLogType.
+
+.PARAMETER Id
+An optional ID to assign to the logging method. If not supplied, a random ID will be generated.
 
 .PARAMETER Name
 The File Name to prepend new log files using.
@@ -988,6 +1046,9 @@ Create a new Event Viewer logging Method.
 Creates a new Event Viewer logging Method for outputting log items to the Windows Event Viewer.
 Can be used with Enable-PodeRequestLogType, Enable-PodeErrorLogType, or Add-PodeLogType.
 
+.PARAMETER Id
+An optional ID to assign to the logging method. If not supplied, a random ID will be generated.
+
 .PARAMETER EventLogName
 An Optional Log Name for the Event Viewer (Default: Application)
 
@@ -1063,6 +1124,9 @@ Create a new Custom logging Method.
 .DESCRIPTION
 Creates a new Custom logging Method for outputting log items using custom logic defined in a ScriptBlock.
 Can be used with Enable-PodeRequestLogType, Enable-PodeErrorLogType, or Add-PodeLogType.
+
+.PARAMETER Id
+An optional ID to assign to the logging method. If not supplied, a random ID will be generated.
 
 .PARAMETER ScriptBlock
 The ScriptBlock that defines how to output a log item.

--- a/src/Public/Logging.ps1
+++ b/src/Public/Logging.ps1
@@ -255,12 +255,11 @@ function Enable-PodeRequestLogType {
         $PodeContext.Server.Logging.Types[$name] = @{
             Method      = $Method
             ScriptBlock = Get-PodeLoggingInbuiltType -Type Requests
+            Raw         = $Raw.IsPresent
             Properties  = @{
                 Username = $UsernameProperty
             }
-            Arguments   = @{
-                Raw = $Raw
-            }
+            Arguments   = @{}
         }
         $PodeContext.Server.Logging.Logger.RegisterType([PodeLogType]::new($name, @([PodeLogLevel]::Informational)))
 
@@ -370,9 +369,8 @@ function Enable-PodeErrorLogType {
             Method      = $Method
             ScriptBlock = Get-PodeLoggingInbuiltType -Type Errors
             Levels      = $Levels
-            Arguments   = @{
-                Raw = $Raw
-            }
+            Raw         = $Raw.IsPresent
+            Arguments   = @{}
         }
         $PodeContext.Server.Logging.Logger.RegisterType([PodeLogType]::new($name, $Levels))
 
@@ -430,11 +428,17 @@ The Levels of log items that should be logged. (Default: Informational)
 .PARAMETER ArgumentList
 An array of arguments to supply to the Custom Log type's ScriptBlock.
 
+.PARAMETER Raw
+If supplied, the log item returned will be the raw Request item as a hashtable and not a string.
+
 .EXAMPLE
 New-PodeLogTerminalMethod | Add-PodeLogType -Name 'LogTypeName' -ScriptBlock { /* logic */ }
+
+.EXAMPLE
+New-PodeLogTerminalMethod | Add-PodeLogType -Name 'LogTypeName' -Raw
 #>
 function Add-PodeLogType {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'ScriptBlock')]
     param(
         [Parameter(Mandatory = $true)]
         [string]
@@ -444,7 +448,7 @@ function Add-PodeLogType {
         [string[]]
         $Method,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ScriptBlock')]
         [ValidateScript({
                 if (Test-PodeIsEmpty $_) {
                     # A non-empty ScriptBlock is required for the logging method
@@ -461,9 +465,13 @@ function Add-PodeLogType {
         [string[]]
         $Levels = @('Informational'),
 
-        [Parameter()]
+        [Parameter(ParameterSetName = 'ScriptBlock')]
         [object[]]
-        $ArgumentList
+        $ArgumentList,
+
+        [Parameter(ParameterSetName = 'Raw')]
+        [switch]
+        $Raw
     )
 
     begin {
@@ -500,7 +508,9 @@ function Add-PodeLogType {
         }
 
         # check for scoped vars
-        $ScriptBlock, $usingVars = Convert-PodeScopedVariables -ScriptBlock $ScriptBlock -PSSession $PSCmdlet.SessionState
+        if ($PSCmdlet.ParameterSetName -eq 'ScriptBlock') {
+            $ScriptBlock, $usingVars = Convert-PodeScopedVariables -ScriptBlock $ScriptBlock -PSSession $PSCmdlet.SessionState
+        }
 
         # add custom log method to server, associated with the supplied log method(s)
         $PodeContext.Server.Logging.Types[$Name] = @{
@@ -508,6 +518,7 @@ function Add-PodeLogType {
             ScriptBlock    = $ScriptBlock
             UsingVariables = $usingVars
             Levels         = $Levels
+            Raw            = $Raw.IsPresent
             Arguments      = $ArgumentList
         }
         $PodeContext.Server.Logging.Logger.RegisterType([PodeLogType]::new($Name, $Levels))

--- a/src/Public/Logging.ps1
+++ b/src/Public/Logging.ps1
@@ -1,3 +1,5 @@
+using namespace Pode.Utilities.Logging
+
 <#
 .SYNOPSIS
 Create a new method of outputting logs.
@@ -217,7 +219,7 @@ function Enable-PodeRequestLogType {
 
     begin {
         # error if it's already enabled
-        $name = Get-PodeRequestLogTypeName
+        $name = [PodeLogger]::REQUEST_LOG_TYPE_NAME
         if ($PodeContext.Server.Logging.Types.Contains($name)) {
             # Request Logging has already been enabled
             throw ($PodeLocale.requestLoggingAlreadyEnabledExceptionMessage)
@@ -260,6 +262,7 @@ function Enable-PodeRequestLogType {
                 Raw = $Raw
             }
         }
+        $PodeContext.Server.Logging.Logger.RegisterType([PodeLogType]::new($name, @([PodeLogLevel]::Informational)))
 
         # then associate the supplied log method(s) with the request log type
         foreach ($methodId in $Method) {
@@ -286,7 +289,7 @@ function Disable-PodeRequestLogType {
     [CmdletBinding()]
     param()
 
-    Remove-PodeLogType -Name (Get-PodeRequestLogTypeName)
+    Remove-PodeLogType -Name [PodeLogger]::REQUEST_LOG_TYPE_NAME
 }
 
 if (!(Test-Path Alias:Disable-PodeRequestLogging)) {
@@ -330,7 +333,7 @@ function Enable-PodeErrorLogType {
 
     begin {
         # error if it's already enabled
-        $name = Get-PodeErrorLogTypeName
+        $name = [PodeLogger]::ERROR_LOG_TYPE_NAME
         if ($PodeContext.Server.Logging.Types.Contains($name)) {
             # Error Logging has already been enabled
             throw ($PodeLocale.errorLoggingAlreadyEnabledExceptionMessage)
@@ -371,6 +374,7 @@ function Enable-PodeErrorLogType {
                 Raw = $Raw
             }
         }
+        $PodeContext.Server.Logging.Logger.RegisterType([PodeLogType]::new($name, $Levels))
 
         # then associate the supplied log method(s) with the request log type
         foreach ($methodId in $Method) {
@@ -397,7 +401,7 @@ function Disable-PodeErrorLogType {
     [CmdletBinding()]
     param()
 
-    Remove-PodeLogType -Name (Get-PodeErrorLogTypeName)
+    Remove-PodeLogType -Name [PodeLogger]::ERROR_LOG_TYPE_NAME
 }
 
 if (!(Test-Path Alias:Disable-PodeErrorLogging)) {
@@ -506,6 +510,7 @@ function Add-PodeLogType {
             Levels         = $Levels
             Arguments      = $ArgumentList
         }
+        $PodeContext.Server.Logging.Logger.RegisterType([PodeLogType]::new($Name, $Levels))
 
         # then associate the supplied log method(s) with the request log type
         foreach ($methodId in $Method) {
@@ -553,6 +558,7 @@ function Remove-PodeLogType {
 
         # remove the log type
         $null = $PodeContext.Server.Logging.Types.Remove($Name)
+        $PodeContext.Server.Logging.Logger.UnregisterType($Name)
     }
 }
 
@@ -711,48 +717,21 @@ function Write-PodeErrorLog {
         $CheckInnerException
     )
 
-    # do nothing if logging is disabled, or error logging isn't setup
-    $name = Get-PodeErrorLogTypeName
-    if (!(Test-PodeLogTypeEnabled -Name $name)) {
+    # do nothing if error logging isn't setup
+    if (!$PodeContext.Server.Logging.Logger.IsErrorLoggingEnabled) {
         return
     }
 
-    # do nothing if the error level isn't present
-    $levels = @(Get-PodeLogTypeLogLevel -Name $name)
-    if ($levels -inotcontains $Level) {
-        return
-    }
-
-    # build error object for what we need
-    switch ($PSCmdlet.ParameterSetName.ToLowerInvariant()) {
-        'exception' {
-            $item = @{
-                Category   = $Exception.Source
-                Message    = $Exception.Message
-                StackTrace = $Exception.StackTrace
-            }
+    # log error object appropriately based on parameter set
+    switch ($PSCmdlet.ParameterSetName) {
+        'Exception' {
+            $PodeContext.Server.Logging.Logger.AddException($Exception, $Level, [int]$ThreadId)
         }
 
-        'error' {
-            $item = @{
-                Category   = $ErrorRecord.CategoryInfo.ToString()
-                Message    = $ErrorRecord.Exception.Message
-                StackTrace = $ErrorRecord.ScriptStackTrace
-            }
+        'Error' {
+            $PodeContext.Server.Logging.Logger.AddException($ErrorRecord.CategoryInfo.ToString(), $ErrorRecord.Exception.Message, $ErrorRecord.ScriptStackTrace, $Level, [int]$ThreadId)
         }
     }
-
-    # add general info
-    $item['Server'] = $PodeContext.Server.ComputerName
-    $item['Level'] = $Level
-    $item['Date'] = [datetime]::Now
-    $item['ThreadId'] = [int]$ThreadId
-
-    # add the item to be processed
-    $null = $PodeContext.LogsToProcess.Add(@{
-            Name = $name
-            Item = $item
-        })
 
     # for exceptions, check the inner exception
     if ($CheckInnerException -and ($null -ne $Exception.InnerException) -and ![string]::IsNullOrWhiteSpace($Exception.InnerException.Message)) {
@@ -796,22 +775,8 @@ function Write-PodeLog {
         $InputObject
     )
 
-    # do nothing if logging is disabled, or logger isn't setup
-    if (!(Test-PodeLogTypeEnabled -Name $Name)) {
-        return
-    }
-
-    # do nothing if the error level isn't present
-    $levels = @(Get-PodeLogTypeLogLevel -Name $Name)
-    if ($levels -inotcontains $Level) {
-        return
-    }
-
     # add the item to be processed
-    $null = $PodeContext.LogsToProcess.Add(@{
-            Name = $Name
-            Item = $InputObject
-        })
+    $PodeContext.Server.Logging.Logger.Add($Name, $Level, $InputObject)
 }
 
 <#

--- a/src/Public/Logging.ps1
+++ b/src/Public/Logging.ps1
@@ -56,18 +56,22 @@ The ScriptBlock that defines how to output a log item.
 An array of arguments to supply to the Custom Logging output method's ScriptBlock.
 
 .EXAMPLE
-$term_logging = New-PodeLoggingMethod -Terminal
+$term_logging_id = New-PodeLoggingMethod -Terminal
 
 .EXAMPLE
-$file_logging = New-PodeLoggingMethod -File -Path ./logs -Name 'requests'
+$file_logging_id = New-PodeLoggingMethod -File -Path ./logs -Name 'requests'
 
 .EXAMPLE
-$custom_logging = New-PodeLoggingMethod -Custom -ScriptBlock { /* logic */ }
+$custom_logging_id = New-PodeLoggingMethod -Custom -ScriptBlock { /* logic */ }
 #>
 function New-PodeLoggingMethod {
     [CmdletBinding(DefaultParameterSetName = 'Terminal')]
-    [OutputType([hashtable])]
+    [OutputType([string])]
     param(
+        [Parameter()]
+        [string]
+        $Id,
+
         [Parameter(ParameterSetName = 'Terminal')]
         [switch]
         $Terminal,
@@ -148,28 +152,28 @@ function New-PodeLoggingMethod {
             # WARNING: Function `New-PodeLoggingMethod` is deprecated.
             Write-PodeHost ($PodeLocale.deprecatedFunctionWarningMessage -f 'New-PodeLoggingMethod', 'New-PodeLogTerminalMethod')  -ForegroundColor Yellow
 
-            return New-PodeLogTerminalMethod -BatchInfo $batchInfo
+            return New-PodeLogTerminalMethod -Id $Id -BatchInfo $batchInfo
         }
 
         'file' {
             # WARNING: Function `New-PodeLoggingMethod` is deprecated.
             Write-PodeHost ($PodeLocale.deprecatedFunctionWarningMessage -f 'New-PodeLoggingMethod', 'New-PodeLogFileMethod')  -ForegroundColor Yellow
 
-            return New-PodeLogFileMethod -Name $Name -Path $Path -MaxDays $MaxDays -MaxSize $MaxSize -BatchInfo $batchInfo
+            return New-PodeLogFileMethod -Id $Id -Name $Name -Path $Path -MaxDays $MaxDays -MaxSize $MaxSize -BatchInfo $batchInfo
         }
 
         'eventviewer' {
             # WARNING: Function `New-PodeLoggingMethod` is deprecated.
             Write-PodeHost ($PodeLocale.deprecatedFunctionWarningMessage -f 'New-PodeLoggingMethod', 'New-PodeLogEventViewerMethod')  -ForegroundColor Yellow
 
-            return New-PodeLogEventViewerMethod -EventLogName $EventLogName -Source $Source -EventID $EventID -BatchInfo $batchInfo
+            return New-PodeLogEventViewerMethod -Id $Id -EventLogName $EventLogName -Source $Source -EventID $EventID -BatchInfo $batchInfo
         }
 
         'custom' {
             # WARNING: Function `New-PodeLoggingMethod` is deprecated.
             Write-PodeHost ($PodeLocale.deprecatedFunctionWarningMessage -f 'New-PodeLoggingMethod', 'New-PodeLogCustomMethod')  -ForegroundColor Yellow
 
-            return New-PodeLogCustomMethod -ScriptBlock $ScriptBlock -ArgumentList $ArgumentList -BatchInfo $batchInfo
+            return New-PodeLogCustomMethod -Id $Id -ScriptBlock $ScriptBlock -ArgumentList $ArgumentList -BatchInfo $batchInfo
         }
     }
 }
@@ -182,7 +186,7 @@ Enables Request Logging using a supplied output method.
 Enables Request Logging using a supplied output method.
 
 .PARAMETER Method
-The logging Method to use for output the log entry.
+The logging Method ID to use for output the log entry.
 
 .PARAMETER UsernameProperty
 An optional property path within the $WebEvent.Auth.User object for the user's Username. (Default: Username).
@@ -197,7 +201,7 @@ function Enable-PodeRequestLogType {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
-        [hashtable[]]
+        [string[]]
         $Method,
 
         [Parameter()]
@@ -221,10 +225,10 @@ function Enable-PodeRequestLogType {
     }
 
     process {
-        # ensure the Method contains a scriptblock
-        if (Test-PodeIsEmpty $_.ScriptBlock) {
-            # The supplied output Method for Request Logging requires a valid ScriptBlock
-            throw ($PodeLocale.loggingMethodRequiresValidScriptBlockExceptionMessage -f 'Request')
+        # ensure the Method exists
+        if (!(Test-PodeLogMethod -Id $_)) {
+            #TODO: The supplied logging Method for Request Logging doesn't exist
+            throw ($PodeLocale.loggingMethodDoesNotExistExceptionMessage -f $_)
         }
 
         # add to pipeline methods array
@@ -277,7 +281,7 @@ function Disable-PodeRequestLogType {
     Remove-PodeLogType -Name (Get-PodeRequestLogTypeName)
 }
 
-IF (!(Test-Path Alias:Disable-PodeRequestLogging)) {
+if (!(Test-Path Alias:Disable-PodeRequestLogging)) {
     New-Alias Disable-PodeRequestLogging -Value Disable-PodeRequestLogType
 }
 
@@ -289,7 +293,7 @@ Enables Error log Type using a supplied log Method.
 Enables Error log Type using a supplied log Method.
 
 .PARAMETER Method
-The log Method to use for output the log entry.
+The log Method ID to use for output the log entry.
 
 .PARAMETER Levels
 The Levels of errors that should be logged (Default: Error)
@@ -304,7 +308,7 @@ function Enable-PodeErrorLogType {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
-        [hashtable[]]
+        [string[]]
         $Method,
 
         [Parameter()]
@@ -329,10 +333,10 @@ function Enable-PodeErrorLogType {
     }
 
     process {
-        # ensure the Method contains a scriptblock
-        if (Test-PodeIsEmpty $_.ScriptBlock) {
-            # The supplied output Method for Error Logging requires a valid ScriptBlock
-            throw ($PodeLocale.loggingMethodRequiresValidScriptBlockExceptionMessage -f 'Error')
+        # ensure the Method exists
+        if (!(Test-PodeLogMethod -Id $_)) {
+            #TODO: The supplied logging Method for Request Logging doesn't exist
+            throw ($PodeLocale.loggingMethodDoesNotExistExceptionMessage -f $_)
         }
 
         # add to pipeline methods array
@@ -398,7 +402,7 @@ Adds a custom Logging type for parsing custom log items.
 A unique Name for the Log type.
 
 .PARAMETER Method
-The logging Method to use for outputting the log entry.
+The logging Method ID to use for outputting the log entry.
 
 .PARAMETER ScriptBlock
 The ScriptBlock defining logic that transforms an item, and returns it for outputting.
@@ -420,7 +424,7 @@ function Add-PodeLogType {
         $Name,
 
         [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
-        [hashtable[]]
+        [string[]]
         $Method,
 
         [Parameter(Mandatory = $true)]
@@ -457,10 +461,10 @@ function Add-PodeLogType {
     }
 
     process {
-        # ensure the Method contains a scriptblock
-        if (Test-PodeIsEmpty $_.ScriptBlock) {
-            # The supplied output Method for the Logging method requires a valid ScriptBlock
-            throw ($PodeLocale.loggingMethodRequiresValidScriptBlockExceptionMessage -f $Name)
+        # ensure the Method exists
+        if (!(Test-PodeLogMethod -Id $_)) {
+            #TODO: The supplied logging Method for Request Logging doesn't exist
+            throw ($PodeLocale.loggingMethodDoesNotExistExceptionMessage -f $_)
         }
 
         # add to pipeline methods array
@@ -524,6 +528,27 @@ if (!(Test-Path Alias:Remove-PodeLogger)) {
     New-Alias Remove-PodeLogger -Value Remove-PodeLogType
 }
 
+function Remove-PodeLogMethod {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [string]
+        $Id
+    )
+
+    # dispose of any log method queue
+    $method = Get-PodeLogMethod -Id $Id
+    if ($null -ne $method.Queue) {
+        $method.Queue.Dispose()
+    }
+
+    #TODO: remove method from Types that reference it?
+    #TODO: close runspace, and reduce max count (not below 1)
+
+    # remove the log method
+    $null = $PodeContext.Server.Logging.Methods.Remove($Id)
+}
+
 <#
 .SYNOPSIS
 Clears all Log Types that have been configured.
@@ -544,6 +569,25 @@ function Clear-PodeLogTypes {
 
 if (!(Test-Path Alias:Clear-PodeLoggers)) {
     New-Alias Clear-PodeLoggers -Value Clear-PodeLogTypes
+}
+
+function Clear-PodeLogMethods {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '')]
+    [CmdletBinding()]
+    param()
+
+    # dispose of any log method queues
+    foreach ($method in $PodeContext.Server.Logging.Methods.Values) {
+        if ($null -ne $method.Queue) {
+            $method.Queue.Dispose()
+        }
+    }
+
+    #TODO: remove method from Types that reference it?
+    #TODO: close runspace, and reduce max count (not below 1)
+
+    # clear the log methods
+    $PodeContext.Server.Logging.Methods.Clear()
 }
 
 <#
@@ -826,24 +870,29 @@ An optional hashtable containing batch configuration for writing log items in bu
 Should be created using New-PodeLogBatchInfo.
 
 .EXAMPLE
-$method = New-PodeLogTerminalMethod
+$methodId = New-PodeLogTerminalMethod
 
 .EXAMPLE
 $batchInfo = New-PodeLogBatchInfo -Size 10 -Timeout 10
-$method = New-PodeLogTerminalMethod -BatchInfo $batchInfo
+$methodId = New-PodeLogTerminalMethod -BatchInfo $batchInfo
 #>
 function New-PodeLogTerminalMethod {
     [CmdletBinding()]
-    [OutputType([hashtable])]
+    [OutputType([string])]
     param(
+        [Parameter()]
+        [string]
+        $Id,
+
         [Parameter()]
         [hashtable]
         $BatchInfo = $null
     )
 
-    return @{
+    # add method to server
+    return Add-PodeLogMethod -Id $Id -Batch $BatchInfo -Metadata @{
+        Type        = 'Terminal'
         ScriptBlock = Get-PodeLoggingTerminalMethod
-        Batch       = $BatchInfo | New-PodeLogBatchConfig
         Arguments   = @{}
     }
 }
@@ -873,16 +922,20 @@ An optional hashtable containing batch configuration for writing log items in bu
 Should be created using New-PodeLogBatchInfo.
 
 .EXAMPLE
-$method = New-PodeLogFileMethod -Name 'requests'
+$methodId = New-PodeLogFileMethod -Name 'requests'
 
 .EXAMPLE
 $batchInfo = New-PodeLogBatchInfo -Size 10 -Timeout 10
-$method = New-PodeLogFileMethod -Name 'requests' -BatchInfo $batchInfo -MaxDays 7 -MaxSize 10MB
+$methodId = New-PodeLogFileMethod -Name 'requests' -BatchInfo $batchInfo -MaxDays 7 -MaxSize 10MB
 #>
 function New-PodeLogFileMethod {
     [CmdletBinding()]
-    [OutputType([hashtable])]
+    [OutputType([string])]
     param(
+        [Parameter()]
+        [string]
+        $Id,
+
         [Parameter(Mandatory = $true)]
         [string]
         $Name,
@@ -911,10 +964,11 @@ function New-PodeLogFileMethod {
     $Path = Get-PodeRelativePath -Path $Path -JoinRoot
     $null = New-Item -Path $Path -ItemType Directory -Force
 
-    return @{
-        ScriptBlock = Get-PodeLoggingFileMethod
-        Batch       = $BatchInfo | New-PodeLogBatchConfig
-        Arguments   = @{
+    # add method to server
+    return Add-PodeLogMethod -Id $Id -Batch $BatchInfo -Metadata @{
+        Arguments = @{
+            Type          = 'File'
+            ScriptBlock   = Get-PodeLoggingFileMethod
             Name          = $Name
             Path          = $Path
             MaxDays       = $MaxDays
@@ -948,16 +1002,20 @@ An optional hashtable containing batch configuration for writing log items in bu
 Should be created using New-PodeLogBatchInfo.
 
 .EXAMPLE
-$method = New-PodeLogEventViewerMethod
+$methodId = New-PodeLogEventViewerMethod
 
 .EXAMPLE
 $batchInfo = New-PodeLogBatchInfo -Size 10 -Timeout 10
-$method = New-PodeLogEventViewerMethod -EventLogName 'MyLog' -Source 'MyApp' -EventID 1001 -BatchInfo $batchInfo
+$methodId = New-PodeLogEventViewerMethod -EventLogName 'MyLog' -Source 'MyApp' -EventID 1001 -BatchInfo $batchInfo
 #>
 function New-PodeLogEventViewerMethod {
     [CmdletBinding()]
-    [OutputType([hashtable])]
+    [OutputType([string])]
     param(
+        [Parameter()]
+        [string]
+        $Id,
+
         [Parameter()]
         [string]
         $EventLogName = 'Application',
@@ -986,13 +1044,14 @@ function New-PodeLogEventViewerMethod {
         $null = [System.Diagnostics.EventLog]::CreateEventSource($Source, $EventLogName)
     }
 
-    return @{
-        ScriptBlock = Get-PodeLoggingEventViewerMethod
-        Batch       = $BatchInfo | New-PodeLogBatchConfig
-        Arguments   = @{
-            LogName = $EventLogName
-            Source  = $Source
-            ID      = $EventID
+    # add method to server
+    return Add-PodeLogMethod -Id $Id -Batch $BatchInfo -Metadata @{
+        Arguments = @{
+            Type        = 'EventViewer'
+            ScriptBlock = Get-PodeLoggingEventViewerMethod
+            LogName     = $EventLogName
+            Source      = $Source
+            ID          = $EventID
         }
     }
 }
@@ -1020,16 +1079,20 @@ $method = New-PodeLogCustomMethod -ScriptBlock { /* logic */ }
 
 .EXAMPLE
 $arguments = @('arg1', 'arg2')
-$method = New-PodeLogCustomMethod -ScriptBlock { param($args) /* logic using $args */ } -ArgumentList $arguments
+$methodId = New-PodeLogCustomMethod -ScriptBlock { param($args) /* logic using $args */ } -ArgumentList $arguments
 
 .EXAMPLE
 $batchInfo = New-PodeLogBatchInfo -Size 10 -Timeout 10
-$method = New-PodeLogCustomMethod -ScriptBlock { /* logic */ } -BatchInfo $batchInfo
+$methodId = New-PodeLogCustomMethod -ScriptBlock { /* logic */ } -BatchInfo $batchInfo
 #>
 function New-PodeLogCustomMethod {
     [CmdletBinding()]
-    [OutputType([hashtable])]
+    [OutputType([string])]
     param(
+        [Parameter()]
+        [string]
+        $Id,
+
         [Parameter(Mandatory = $true)]
         [ValidateScript({
                 if (Test-PodeIsEmpty $_) {
@@ -1051,12 +1114,17 @@ function New-PodeLogCustomMethod {
         $BatchInfo = $null
     )
 
+    # check for scoped vars
     $ScriptBlock, $usingVars = Convert-PodeScopedVariables -ScriptBlock $ScriptBlock -PSSession $PSCmdlet.SessionState
 
-    return @{
-        ScriptBlock    = $ScriptBlock
-        UsingVariables = $usingVars
-        Batch          = $BatchInfo | New-PodeLogBatchConfig
-        Arguments      = $ArgumentList
+    # add method to server
+    return Add-PodeLogMethod -Id $Id -Batch $BatchInfo -Metadata @{
+        Type        = 'Custom'
+        ScriptBlock = Get-PodeLoggingCustomMethod
+        Custom      = @{
+            ScriptBlock    = $ScriptBlock
+            UsingVariables = $usingVars
+        }
+        Arguments   = $ArgumentList
     }
 }

--- a/src/Public/Logging.ps1
+++ b/src/Public/Logging.ps1
@@ -197,7 +197,7 @@ function Enable-PodeRequestLogType {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
-        [hashtable]
+        [hashtable[]]
         $Method,
 
         [Parameter()]
@@ -208,34 +208,50 @@ function Enable-PodeRequestLogType {
         $Raw
     )
 
-    $name = Get-PodeRequestLogTypeName
-
-    # error if it's already enabled
-    if ($PodeContext.Server.Logging.Types.Contains($name)) {
-        # Request Logging has already been enabled
-        throw ($PodeLocale.requestLoggingAlreadyEnabledExceptionMessage)
-    }
-
-    # ensure the Method contains a scriptblock
-    if (Test-PodeIsEmpty $Method.ScriptBlock) {
-        # The supplied output Method for Request Logging requires a valid ScriptBlock
-        throw ($PodeLocale.loggingMethodRequiresValidScriptBlockExceptionMessage -f 'Request')
-    }
-
-    # username property
-    if ([string]::IsNullOrWhiteSpace($UsernameProperty)) {
-        $UsernameProperty = 'Username'
-    }
-
-    # add the request logger
-    $PodeContext.Server.Logging.Types[$name] = @{
-        Method      = $Method
-        ScriptBlock = (Get-PodeLoggingInbuiltType -Type Requests)
-        Properties  = @{
-            Username = $UsernameProperty
+    begin {
+        # error if it's already enabled
+        $name = Get-PodeRequestLogTypeName
+        if ($PodeContext.Server.Logging.Types.Contains($name)) {
+            # Request Logging has already been enabled
+            throw ($PodeLocale.requestLoggingAlreadyEnabledExceptionMessage)
         }
-        Arguments   = @{
-            Raw = $Raw
+
+        # setup array for log methods being piped in
+        $pipelineMethods = @()
+    }
+
+    process {
+        # ensure the Method contains a scriptblock
+        if (Test-PodeIsEmpty $_.ScriptBlock) {
+            # The supplied output Method for Request Logging requires a valid ScriptBlock
+            throw ($PodeLocale.loggingMethodRequiresValidScriptBlockExceptionMessage -f 'Request')
+        }
+
+        # add to pipeline methods array
+        $pipelineMethods += $_
+    }
+
+    end {
+        # multiple methods from pipeline?
+        if ($pipelineMethods.Length -gt 1) {
+            $Method = $pipelineMethods
+        }
+
+        # username property
+        if ([string]::IsNullOrWhiteSpace($UsernameProperty)) {
+            $UsernameProperty = 'Username'
+        }
+
+        # add the request logger
+        $PodeContext.Server.Logging.Types[$name] = @{
+            Method      = $Method
+            ScriptBlock = Get-PodeLoggingInbuiltType -Type Requests
+            Properties  = @{
+                Username = $UsernameProperty
+            }
+            Arguments   = @{
+                Raw = $Raw
+            }
         }
     }
 }
@@ -288,7 +304,7 @@ function Enable-PodeErrorLogType {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
-        [hashtable]
+        [hashtable[]]
         $Method,
 
         [Parameter()]
@@ -301,32 +317,48 @@ function Enable-PodeErrorLogType {
         $Raw
     )
 
-    $name = Get-PodeErrorLogTypeName
+    begin {
+        # error if it's already enabled
+        $name = Get-PodeErrorLogTypeName
+        if ($PodeContext.Server.Logging.Types.Contains($name)) {
+            # Error Logging has already been enabled
+            throw ($PodeLocale.errorLoggingAlreadyEnabledExceptionMessage)
+        }
 
-    # error if it's already enabled
-    if ($PodeContext.Server.Logging.Types.Contains($name)) {
-        # Error Logging has already been enabled
-        throw ($PodeLocale.errorLoggingAlreadyEnabledExceptionMessage)
+        # setup array for log methods being piped in
+        $pipelineMethods = @()
     }
 
-    # ensure the Method contains a scriptblock
-    if (Test-PodeIsEmpty $Method.ScriptBlock) {
-        # The supplied output Method for Error Logging requires a valid ScriptBlock
-        throw ($PodeLocale.loggingMethodRequiresValidScriptBlockExceptionMessage -f 'Error')
+    process {
+        # ensure the Method contains a scriptblock
+        if (Test-PodeIsEmpty $_.ScriptBlock) {
+            # The supplied output Method for Error Logging requires a valid ScriptBlock
+            throw ($PodeLocale.loggingMethodRequiresValidScriptBlockExceptionMessage -f 'Error')
+        }
+
+        # add to pipeline methods array
+        $pipelineMethods += $_
     }
 
-    # all errors?
-    if ($Levels -contains '*') {
-        $Levels = @('Error', 'Warning', 'Informational', 'Verbose', 'Debug')
-    }
+    end {
+        # multiple methods from pipeline?
+        if ($pipelineMethods.Length -gt 1) {
+            $Method = $pipelineMethods
+        }
 
-    # add the error logger
-    $PodeContext.Server.Logging.Types[$name] = @{
-        Method      = $Method
-        ScriptBlock = (Get-PodeLoggingInbuiltType -Type Errors)
-        Arguments   = @{
-            Raw    = $Raw
-            Levels = $Levels
+        # all errors?
+        if ($Levels -contains '*') {
+            $Levels = @('Error', 'Warning', 'Informational', 'Verbose', 'Debug')
+        }
+
+        # add the error logger
+        $PodeContext.Server.Logging.Types[$name] = @{
+            Method      = $Method
+            ScriptBlock = Get-PodeLoggingInbuiltType -Type Errors
+            Arguments   = @{
+                Raw    = $Raw
+                Levels = $Levels
+            }
         }
     }
 }
@@ -386,7 +418,7 @@ function Add-PodeLogType {
         $Name,
 
         [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
-        [hashtable]
+        [hashtable[]]
         $Method,
 
         [Parameter(Mandatory = $true)]
@@ -406,27 +438,44 @@ function Add-PodeLogType {
         $ArgumentList
     )
 
-    # ensure the name doesn't already exist
-    if ($PodeContext.Server.Logging.Types.ContainsKey($Name)) {
-        # Logging method already defined
-        throw ($PodeLocale.loggingMethodAlreadyDefinedExceptionMessage -f $Name)
+    begin {
+        # ensure the name doesn't already exist
+        if ($PodeContext.Server.Logging.Types.ContainsKey($Name)) {
+            # Logging method already defined
+            throw ($PodeLocale.loggingMethodAlreadyDefinedExceptionMessage -f $Name)
+        }
+
+        # setup array for log methods being piped in
+        $pipelineMethods = @()
     }
 
-    # ensure the Method contains a scriptblock
-    if (Test-PodeIsEmpty $Method.ScriptBlock) {
-        # The supplied output Method for the Logging method requires a valid ScriptBlock
-        throw ($PodeLocale.loggingMethodRequiresValidScriptBlockExceptionMessage -f $Name)
+    process {
+        # ensure the Method contains a scriptblock
+        if (Test-PodeIsEmpty $_.ScriptBlock) {
+            # The supplied output Method for the Logging method requires a valid ScriptBlock
+            throw ($PodeLocale.loggingMethodRequiresValidScriptBlockExceptionMessage -f $Name)
+        }
+
+        # add to pipeline methods array
+        $pipelineMethods += $_
     }
 
-    # check for scoped vars
-    $ScriptBlock, $usingVars = Convert-PodeScopedVariables -ScriptBlock $ScriptBlock -PSSession $PSCmdlet.SessionState
+    end {
+        # multiple methods from pipeline?
+        if ($pipelineMethods.Length -gt 1) {
+            $Method = $pipelineMethods
+        }
 
-    # add logging method to server
-    $PodeContext.Server.Logging.Types[$Name] = @{
-        Method         = $Method
-        ScriptBlock    = $ScriptBlock
-        UsingVariables = $usingVars
-        Arguments      = $ArgumentList
+        # check for scoped vars
+        $ScriptBlock, $usingVars = Convert-PodeScopedVariables -ScriptBlock $ScriptBlock -PSSession $PSCmdlet.SessionState
+
+        # add logging method to server
+        $PodeContext.Server.Logging.Types[$Name] = @{
+            Method         = $Method
+            ScriptBlock    = $ScriptBlock
+            UsingVariables = $usingVars
+            Arguments      = $ArgumentList
+        }
     }
 }
 

--- a/src/Public/Logging.ps1
+++ b/src/Public/Logging.ps1
@@ -560,6 +560,19 @@ if (!(Test-Path Alias:Remove-PodeLogger)) {
     New-Alias Remove-PodeLogger -Value Remove-PodeLogType
 }
 
+<#
+.SYNOPSIS
+Removes a configured Log Method.
+
+.DESCRIPTION
+Removes a configured Log Method.
+
+.PARAMETER Id
+The ID of the Log Method to remove.
+
+.EXAMPLE
+Remove-PodeLogMethod -Id '<log-method-id>'
+#>
 function Remove-PodeLogMethod {
     [CmdletBinding()]
     param(
@@ -624,6 +637,16 @@ if (!(Test-Path Alias:Clear-PodeLoggers)) {
     New-Alias Clear-PodeLoggers -Value Clear-PodeLogTypes
 }
 
+<#
+.SYNOPSIS
+Clears all Log Methods that have been configured.
+
+.DESCRIPTION
+Clears all Log Methods that have been configured.
+
+.EXAMPLE
+Clear-PodeLogMethods
+#>
 function Clear-PodeLogMethods {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '')]
     [CmdletBinding()]

--- a/src/Public/Logging.ps1
+++ b/src/Public/Logging.ps1
@@ -292,7 +292,7 @@ Enables Error log Type using a supplied log Method.
 The log Method to use for output the log entry.
 
 .PARAMETER Levels
-The Levels of errors that should be logged (default is Error).
+The Levels of errors that should be logged (Default: Error)
 
 .PARAMETER Raw
 If supplied, the log item returned will be the raw Error item as a hashtable and not a string (for Custom methods).
@@ -308,7 +308,6 @@ function Enable-PodeErrorLogType {
         $Method,
 
         [Parameter()]
-        [ValidateNotNullOrEmpty()]
         [ValidateSet('Error', 'Warning', 'Informational', 'Verbose', 'Debug', '*')]
         [string[]]
         $Levels = @('Error'),
@@ -355,9 +354,9 @@ function Enable-PodeErrorLogType {
         $PodeContext.Server.Logging.Types[$name] = @{
             Method      = $Method
             ScriptBlock = Get-PodeLoggingInbuiltType -Type Errors
+            Levels      = $Levels
             Arguments   = @{
-                Raw    = $Raw
-                Levels = $Levels
+                Raw = $Raw
             }
         }
     }
@@ -404,6 +403,9 @@ The logging Method to use for outputting the log entry.
 .PARAMETER ScriptBlock
 The ScriptBlock defining logic that transforms an item, and returns it for outputting.
 
+.PARAMETER Levels
+The Levels of log items that should be logged. (Default: Informational)
+
 .PARAMETER ArgumentList
 An array of arguments to supply to the Custom Log type's ScriptBlock.
 
@@ -432,6 +434,11 @@ function Add-PodeLogType {
             })]
         [scriptblock]
         $ScriptBlock,
+
+        [Parameter()]
+        [ValidateSet('Error', 'Warning', 'Informational', 'Verbose', 'Debug', '*')]
+        [string[]]
+        $Levels = @('Informational'),
 
         [Parameter()]
         [object[]]
@@ -466,6 +473,11 @@ function Add-PodeLogType {
             $Method = $pipelineMethods
         }
 
+        # all errors?
+        if ($Levels -contains '*') {
+            $Levels = @('Error', 'Warning', 'Informational', 'Verbose', 'Debug')
+        }
+
         # check for scoped vars
         $ScriptBlock, $usingVars = Convert-PodeScopedVariables -ScriptBlock $ScriptBlock -PSSession $PSCmdlet.SessionState
 
@@ -474,6 +486,7 @@ function Add-PodeLogType {
             Method         = $Method
             ScriptBlock    = $ScriptBlock
             UsingVariables = $usingVars
+            Levels         = $Levels
             Arguments      = $ArgumentList
         }
     }
@@ -547,7 +560,7 @@ An Exception to write.
 An ErrorRecord to write.
 
 .PARAMETER Level
-The Level of the error being logged.
+The Level of the error being logged. (Default: Error)
 
 .PARAMETER CheckInnerException
 If supplied, any exceptions are check for inner exceptions. If one is present, this is also logged.
@@ -570,7 +583,6 @@ function Write-PodeErrorLog {
         $ErrorRecord,
 
         [Parameter()]
-        [ValidateNotNullOrEmpty()]
         [ValidateSet('Error', 'Warning', 'Informational', 'Verbose', 'Debug')]
         [string]
         $Level = 'Error',
@@ -587,7 +599,7 @@ function Write-PodeErrorLog {
     }
 
     # do nothing if the error level isn't present
-    $levels = @(Get-PodeErrorLoggingLevel)
+    $levels = @(Get-PodeLogTypeLogLevel -Name $name)
     if ($levels -inotcontains $Level) {
         return
     }
@@ -639,6 +651,9 @@ Write an object to a configured custom Logging method.
 .PARAMETER Name
 The Name of the Logging type to use.
 
+.PARAMETER Level
+The Level of the log item being logged. (Default: Informational)
+
 .PARAMETER InputObject
 The Object to write.
 
@@ -652,6 +667,11 @@ function Write-PodeLog {
         [string]
         $Name,
 
+        [Parameter()]
+        [ValidateSet('Error', 'Warning', 'Informational', 'Verbose', 'Debug')]
+        [string]
+        $Level = 'Informational',
+
         [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
         [object]
         $InputObject
@@ -659,6 +679,12 @@ function Write-PodeLog {
 
     # do nothing if logging is disabled, or logger isn't setup
     if (!(Test-PodeLogTypeEnabled -Name $Name)) {
+        return
+    }
+
+    # do nothing if the error level isn't present
+    $levels = @(Get-PodeLogTypeLogLevel -Name $Name)
+    if ($levels -inotcontains $Level) {
         return
     }
 

--- a/src/Public/Logging.ps1
+++ b/src/Public/Logging.ps1
@@ -695,6 +695,9 @@ An Exception to write.
 .PARAMETER ErrorRecord
 An ErrorRecord to write.
 
+.PARAMETER Message
+A Message to write.
+
 .PARAMETER Level
 The Level of the error being logged. (Default: Error)
 
@@ -706,6 +709,9 @@ try { /* logic */ } catch { $_ | Write-PodeErrorLog }
 
 .EXAMPLE
 [System.Exception]::new('error message') | Write-PodeErrorLog
+
+.EXAMPLE
+Write-PodeErrorLog -Message 'error message' -Level 'Warning'
 #>
 function Write-PodeErrorLog {
     [CmdletBinding()]
@@ -717,6 +723,10 @@ function Write-PodeErrorLog {
         [Parameter(Mandatory = $true, ValueFromPipeline = $true, ParameterSetName = 'Error')]
         [System.Management.Automation.ErrorRecord]
         $ErrorRecord,
+
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true, ParameterSetName = 'Message')]
+        [string]
+        $Message,
 
         [Parameter()]
         [ValidateSet('Error', 'Warning', 'Informational', 'Verbose', 'Debug')]
@@ -744,6 +754,11 @@ function Write-PodeErrorLog {
 
         'Error' {
             $PodeContext.Server.Logging.Logger.AddException($ErrorRecord.CategoryInfo.ToString(), $ErrorRecord.Exception.Message, $ErrorRecord.ScriptStackTrace, $contextId, $Level, [int]$ThreadId)
+        }
+
+        'Message' {
+            $category = (Get-PSCallStack)[1].Location
+            $PodeContext.Server.Logging.Logger.AddException($category, $Message, [string]::Empty, $contextId, $Level, [int]$ThreadId)
         }
     }
 

--- a/src/Public/Logging.ps1
+++ b/src/Public/Logging.ps1
@@ -1026,9 +1026,9 @@ function New-PodeLogFileMethod {
 
     # add method to server
     return Add-PodeLogMethod -Id $Id -Batch $BatchInfo -Metadata @{
-        Arguments = @{
-            Type          = 'File'
-            ScriptBlock   = Get-PodeLoggingFileMethod
+        Type        = 'File'
+        ScriptBlock = Get-PodeLoggingFileMethod
+        Arguments   = @{
             Name          = $Name
             Path          = $Path
             MaxDays       = $MaxDays
@@ -1109,12 +1109,12 @@ function New-PodeLogEventViewerMethod {
 
     # add method to server
     return Add-PodeLogMethod -Id $Id -Batch $BatchInfo -Metadata @{
-        Arguments = @{
-            Type        = 'EventViewer'
-            ScriptBlock = Get-PodeLoggingEventViewerMethod
-            LogName     = $EventLogName
-            Source      = $Source
-            ID          = $EventID
+        Type        = 'EventViewer'
+        ScriptBlock = Get-PodeLoggingEventViewerMethod
+        Arguments   = @{
+            LogName = $EventLogName
+            Source  = $Source
+            ID      = $EventID
         }
     }
 }

--- a/src/Public/Logging.ps1
+++ b/src/Public/Logging.ps1
@@ -288,7 +288,7 @@ function Disable-PodeRequestLogType {
     [CmdletBinding()]
     param()
 
-    Remove-PodeLogType -Name [PodeLogger]::REQUEST_LOG_TYPE_NAME
+    Remove-PodeLogType -Name ([PodeLogger]::REQUEST_LOG_TYPE_NAME)
 }
 
 if (!(Test-Path Alias:Disable-PodeRequestLogging)) {
@@ -399,7 +399,7 @@ function Disable-PodeErrorLogType {
     [CmdletBinding()]
     param()
 
-    Remove-PodeLogType -Name [PodeLogger]::ERROR_LOG_TYPE_NAME
+    Remove-PodeLogType -Name ([PodeLogger]::ERROR_LOG_TYPE_NAME)
 }
 
 if (!(Test-Path Alias:Disable-PodeErrorLogging)) {

--- a/src/Public/Schedules.ps1
+++ b/src/Public/Schedules.ps1
@@ -203,7 +203,7 @@ function Set-PodeScheduleConcurrency {
     # set the max schedules
     $PodeContext.Threads.Schedules = $Maximum
     if ($null -ne $PodeContext.RunspacePools.Schedules) {
-        $PodeContext.RunspacePools.Schedules.Pool.SetMaxRunspaces($Maximum)
+        $null = $PodeContext.RunspacePools.Schedules.Pool.SetMaxRunspaces($Maximum)
     }
 }
 
@@ -427,7 +427,7 @@ function Get-PodeSchedule {
                 }
 
                 if (($null -ne $schedule.EndTime) -and
-                (($StartTime -gt $schedule.EndTime) -or
+                    (($StartTime -gt $schedule.EndTime) -or
                     ((Get-PodeScheduleNextTrigger -Name $schedule.Name -DateTime $StartTime) -gt $_end))) {
                     continue
                 }
@@ -449,7 +449,7 @@ function Get-PodeSchedule {
                 }
 
                 if (($null -ne $schedule.StartTime) -and
-                (($EndTime -lt $schedule.StartTime) -or
+                    (($EndTime -lt $schedule.StartTime) -or
                     ((Get-PodeScheduleNextTrigger -Name $schedule.Name -DateTime $_start) -gt $EndTime))) {
                     continue
                 }

--- a/src/Public/Tasks.ps1
+++ b/src/Public/Tasks.ps1
@@ -161,7 +161,7 @@ function Set-PodeTaskConcurrency {
     # set the max tasks
     $PodeContext.Threads.Tasks = $Maximum
     if ($null -ne $PodeContext.RunspacePools.Tasks) {
-        $PodeContext.RunspacePools.Tasks.Pool.SetMaxRunspaces($Maximum)
+        $null = $PodeContext.RunspacePools.Tasks.Pool.SetMaxRunspaces($Maximum)
     }
 }
 
@@ -469,8 +469,8 @@ function Test-PodeTaskCompleted {
 
     process {
         return ([bool]$Process.Runspace.Handler.IsCompleted) -or
-            ($Process.State -ieq 'Completed') -or
-            ($Process.State -ieq 'Failed')
+        ($Process.State -ieq 'Completed') -or
+        ($Process.State -ieq 'Failed')
     }
 }
 

--- a/src/Public/Threading.ps1
+++ b/src/Public/Threading.ps1
@@ -87,7 +87,7 @@ function Lock-PodeObject {
         }
         catch {
             $_ | Write-PodeErrorLog
-            throw $_.Exception
+            throw
         }
         finally {
             if ([string]::IsNullOrEmpty($Name)) {
@@ -578,7 +578,7 @@ function Use-PodeMutex {
     }
     catch {
         $_ | Write-PodeErrorLog
-        throw $_.Exception
+        throw
     }
     finally {
         if ($acquired) {
@@ -881,7 +881,7 @@ function Use-PodeSemaphore {
     }
     catch {
         $_ | Write-PodeErrorLog
-        throw $_.Exception
+        throw
     }
     finally {
         if ($acquired) {

--- a/src/Public/Utilities.ps1
+++ b/src/Public/Utilities.ps1
@@ -41,13 +41,13 @@ function Close-PodeDisposable {
                 $Disposable.Close()
             }
         }
-        catch [exception] {
+        catch {
             if ($CheckNetwork -and (Test-PodeValidNetworkFailure $_.Exception)) {
                 return
             }
 
             $_ | Write-PodeErrorLog
-            throw $_.Exception
+            throw
         }
         finally {
             $Disposable.Dispose()
@@ -119,7 +119,7 @@ function Start-PodeStopwatch {
         }
         catch {
             $_ | Write-PodeErrorLog
-            throw $_.Exception
+            throw
         }
         finally {
             $watch.Stop()
@@ -162,7 +162,7 @@ function Use-PodeStream {
     }
     catch {
         $_ | Write-PodeErrorLog
-        throw $_.Exception
+        throw
     }
     finally {
         $Stream.Dispose()

--- a/src/Public/WebSockets.ps1
+++ b/src/Public/WebSockets.ps1
@@ -43,7 +43,7 @@ function Set-PodeWebSocketConcurrency {
     # set the max tasks
     $PodeContext.Threads.WebSockets = $Maximum
     if ($null -ne $PodeContext.RunspacePools.WebSockets) {
-        $PodeContext.RunspacePools.WebSockets.Pool.SetMaxRunspaces($Maximum)
+        $null = $PodeContext.RunspacePools.WebSockets.Pool.SetMaxRunspaces($Maximum)
     }
 }
 

--- a/tests/integration/Authentication.Tests.ps1
+++ b/tests/integration/Authentication.Tests.ps1
@@ -14,7 +14,7 @@ Describe 'Authentication Requests' {
             Start-PodeServer -Quiet -ScriptBlock {
                 Add-PodeEndpoint -Address localhost -Port $using:Port -Protocol Http
 
-                New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+                New-PodeLogTerminalMethod | Enable-PodeErrorLogging
                 Add-PodeRoute -Method Get -Path '/close' -ScriptBlock {
                     Close-PodeServer
                 }

--- a/tests/integration/Authentication.Tests.ps1
+++ b/tests/integration/Authentication.Tests.ps1
@@ -14,7 +14,7 @@ Describe 'Authentication Requests' {
             Start-PodeServer -Quiet -ScriptBlock {
                 Add-PodeEndpoint -Address localhost -Port $using:Port -Protocol Http
 
-                New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+                New-PodeLogTerminalMethod | Enable-PodeErrorLogType
                 Add-PodeRoute -Method Get -Path '/close' -ScriptBlock {
                     Close-PodeServer
                 }

--- a/tests/integration/Endpoints.Tests.ps1
+++ b/tests/integration/Endpoints.Tests.ps1
@@ -17,7 +17,7 @@ Describe 'Endpoint Requests' {
                 Add-PodeEndpoint -Address localhost -Port $using:Port1 -Protocol Http -Name 'Endpoint1'
                 Add-PodeEndpoint -Address localhost -Port $using:Port2 -Protocol Http -Name 'Endpoint2'
 
-                New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+                New-PodeLogTerminalMethod | Enable-PodeErrorLogType
                 Add-PodeRoute -Method Get -Path '/close'  -ScriptBlock {
                     Close-PodeServer
                 }

--- a/tests/integration/Endpoints.Tests.ps1
+++ b/tests/integration/Endpoints.Tests.ps1
@@ -17,7 +17,7 @@ Describe 'Endpoint Requests' {
                 Add-PodeEndpoint -Address localhost -Port $using:Port1 -Protocol Http -Name 'Endpoint1'
                 Add-PodeEndpoint -Address localhost -Port $using:Port2 -Protocol Http -Name 'Endpoint2'
 
-                New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+                New-PodeLogTerminalMethod | Enable-PodeErrorLogging
                 Add-PodeRoute -Method Get -Path '/close'  -ScriptBlock {
                     Close-PodeServer
                 }

--- a/tests/integration/RestApi.Https.Tests.ps1
+++ b/tests/integration/RestApi.Https.Tests.ps1
@@ -44,7 +44,7 @@ Describe 'REST API HTTPS Requests' {
             Start-PodeServer -RootPath $using:PSScriptRoot -Quiet -ScriptBlock {
                 Add-PodeEndpoint -Address localhost -Port $using:Port -Protocol Https -SelfSigned
 
-                New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+                New-PodeLogTerminalMethod | Enable-PodeErrorLogType
                 Add-PodeRoute -Method Get -Path '/close' -ScriptBlock {
                     Close-PodeServer
                 }

--- a/tests/integration/RestApi.Https.Tests.ps1
+++ b/tests/integration/RestApi.Https.Tests.ps1
@@ -44,7 +44,7 @@ Describe 'REST API HTTPS Requests' {
             Start-PodeServer -RootPath $using:PSScriptRoot -Quiet -ScriptBlock {
                 Add-PodeEndpoint -Address localhost -Port $using:Port -Protocol Https -SelfSigned
 
-                New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+                New-PodeLogTerminalMethod | Enable-PodeErrorLogging
                 Add-PodeRoute -Method Get -Path '/close' -ScriptBlock {
                     Close-PodeServer
                 }

--- a/tests/integration/RestApi.Tests.ps1
+++ b/tests/integration/RestApi.Tests.ps1
@@ -18,7 +18,7 @@ Describe 'REST API Requests' {
             Start-PodeServer -RootPath $using:PSScriptRoot -Quiet -ScriptBlock {
                 Add-PodeEndpoint -Address localhost -Port $using:Port -Protocol Http
 
-                New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+                New-PodeLogTerminalMethod | Enable-PodeErrorLogging
                 Add-PodeRoute -Method Get -Path '/close' -ScriptBlock {
                     Close-PodeServer
                 }

--- a/tests/integration/RestApi.Tests.ps1
+++ b/tests/integration/RestApi.Tests.ps1
@@ -18,7 +18,7 @@ Describe 'REST API Requests' {
             Start-PodeServer -RootPath $using:PSScriptRoot -Quiet -ScriptBlock {
                 Add-PodeEndpoint -Address localhost -Port $using:Port -Protocol Http
 
-                New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+                New-PodeLogTerminalMethod | Enable-PodeErrorLogType
                 Add-PodeRoute -Method Get -Path '/close' -ScriptBlock {
                     Close-PodeServer
                 }

--- a/tests/integration/Schedules.Tests.ps1
+++ b/tests/integration/Schedules.Tests.ps1
@@ -14,7 +14,7 @@ Describe 'Schedules' {
             Start-PodeServer -RootPath $using:PSScriptRoot -Quiet -ScriptBlock {
                 Add-PodeEndpoint -Address localhost -Port $using:Port -Protocol Http
 
-                New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+                New-PodeLogTerminalMethod | Enable-PodeErrorLogging
                 Add-PodeRoute -Method Get -Path '/close' -ScriptBlock {
                     Close-PodeServer
                 }

--- a/tests/integration/Schedules.Tests.ps1
+++ b/tests/integration/Schedules.Tests.ps1
@@ -14,7 +14,7 @@ Describe 'Schedules' {
             Start-PodeServer -RootPath $using:PSScriptRoot -Quiet -ScriptBlock {
                 Add-PodeEndpoint -Address localhost -Port $using:Port -Protocol Http
 
-                New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+                New-PodeLogTerminalMethod | Enable-PodeErrorLogType
                 Add-PodeRoute -Method Get -Path '/close' -ScriptBlock {
                     Close-PodeServer
                 }

--- a/tests/integration/Timers.Tests.ps1
+++ b/tests/integration/Timers.Tests.ps1
@@ -13,7 +13,7 @@ Describe 'Timers' {
             Start-PodeServer -RootPath $using:PSScriptRoot -Quiet -ScriptBlock {
                 Add-PodeEndpoint -Address localhost -Port $using:Port -Protocol Http
 
-                New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+                New-PodeLogTerminalMethod | Enable-PodeErrorLogType
                 Add-PodeRoute -Method Get -Path '/close' -ScriptBlock {
                     Close-PodeServer
                 }

--- a/tests/integration/Timers.Tests.ps1
+++ b/tests/integration/Timers.Tests.ps1
@@ -13,7 +13,7 @@ Describe 'Timers' {
             Start-PodeServer -RootPath $using:PSScriptRoot -Quiet -ScriptBlock {
                 Add-PodeEndpoint -Address localhost -Port $using:Port -Protocol Http
 
-                New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+                New-PodeLogTerminalMethod | Enable-PodeErrorLogging
                 Add-PodeRoute -Method Get -Path '/close' -ScriptBlock {
                     Close-PodeServer
                 }

--- a/tests/integration/WebSocket.Tests.ps1
+++ b/tests/integration/WebSocket.Tests.ps1
@@ -15,7 +15,7 @@ Describe 'WebSocket' {
                 Add-PodeEndpoint -Address localhost -Port $using:Port -Protocol Http
                 Add-PodeEndpoint -Address localhost -Port $using:Port -Protocol Ws
 
-                New-PodeLoggingMethod -Terminal | Enable-PodeErrorLogging
+                New-PodeLogTerminalMethod | Enable-PodeErrorLogging
                 Add-PodeRoute -Method Get -Path '/close' -ScriptBlock {
                     Close-PodeServer
                 }

--- a/tests/integration/WebSocket.Tests.ps1
+++ b/tests/integration/WebSocket.Tests.ps1
@@ -15,7 +15,7 @@ Describe 'WebSocket' {
                 Add-PodeEndpoint -Address localhost -Port $using:Port -Protocol Http
                 Add-PodeEndpoint -Address localhost -Port $using:Port -Protocol Ws
 
-                New-PodeLogTerminalMethod | Enable-PodeErrorLogging
+                New-PodeLogTerminalMethod | Enable-PodeErrorLogType
                 Add-PodeRoute -Method Get -Path '/close' -ScriptBlock {
                     Close-PodeServer
                 }

--- a/tests/unit/Logging.Tests.ps1
+++ b/tests/unit/Logging.Tests.ps1
@@ -2,22 +2,22 @@
 param()
 
 InModuleScope -ModuleName 'Pode' {
-    Describe 'Get-PodeLogger' {
+    Describe 'Get-PodeLogType' {
         It 'Returns null as the logger does not exist' {
             $PodeContext = @{ 'Server' = @{ 'Logging' = @{ 'Types' = @{}; } }; }
-            Get-PodeLogger -Name 'test' | Should -Be $null
+            Get-PodeLogType -Name 'test' | Should -Be $null
         }
 
         It 'Returns terminal logger for name' {
             $PodeContext = @{ 'Server' = @{ 'Logging' = @{ 'Types' = @{ 'test' = $null }; } }; }
-            $result = (Get-PodeLogger -Name 'test')
+            $result = (Get-PodeLogType -Name 'test')
 
             $result | Should -Be $null
         }
 
         It 'Returns custom logger for name' {
             $PodeContext = @{ 'Server' = @{ 'Logging' = @{ 'Types' = @{ 'test' = { Write-Host 'hello' } }; } }; }
-            $result = (Get-PodeLogger -Name 'test')
+            $result = (Get-PodeLogType -Name 'test')
 
             $result | Should -Not -Be $null
             $result.ToString() | Should -Be ({ Write-Host 'hello' }).ToString()
@@ -26,7 +26,7 @@ InModuleScope -ModuleName 'Pode' {
 
     Describe 'Write-PodeLog' {
         It 'Does nothing when logging disabled' {
-            Mock Test-PodeLoggerEnabled { return $false }
+            Mock Test-PodeLogTypeEnabled { return $false }
             $PodeContext = @{ LogsToProcess = [System.Collections.ArrayList]::new() }
 
             Write-PodeLog -Name 'test' -InputObject 'test'
@@ -35,7 +35,7 @@ InModuleScope -ModuleName 'Pode' {
         }
 
         It 'Adds a log item' {
-            Mock Test-PodeLoggerEnabled { return $true }
+            Mock Test-PodeLogTypeEnabled { return $true }
             $PodeContext = @{ LogsToProcess = [System.Collections.ArrayList]::new() }
 
             Write-PodeLog -Name 'test' -InputObject 'test'
@@ -48,7 +48,7 @@ InModuleScope -ModuleName 'Pode' {
 
     Describe 'Write-PodeErrorLog' {
         It 'Does nothing when logging disabled' {
-            Mock Test-PodeLoggerEnabled { return $false }
+            Mock Test-PodeLogTypeEnabled { return $false }
             $PodeContext = @{ LogsToProcess = [System.Collections.ArrayList]::new() }
 
             Write-PodeLog -Name 'test' -InputObject 'test'
@@ -57,8 +57,8 @@ InModuleScope -ModuleName 'Pode' {
         }
 
         It 'Adds an error log item' {
-            Mock Test-PodeLoggerEnabled { return $true }
-            Mock Get-PodeLogger { return @{ Arguments = @{
+            Mock Test-PodeLogTypeEnabled { return $true }
+            Mock Get-PodeLogType { return @{ Arguments = @{
                         Levels = @('Error')
                     }
                 } }
@@ -75,8 +75,8 @@ InModuleScope -ModuleName 'Pode' {
         }
 
         It 'Adds an exception log item' {
-            Mock Test-PodeLoggerEnabled { return $true }
-            Mock Get-PodeLogger { return @{ Arguments = @{
+            Mock Test-PodeLogTypeEnabled { return $true }
+            Mock Get-PodeLogType { return @{ Arguments = @{
                         Levels = @('Error')
                     }
                 } }
@@ -91,8 +91,8 @@ InModuleScope -ModuleName 'Pode' {
         }
 
         It 'Does not log as Verbose not allowed' {
-            Mock Test-PodeLoggerEnabled { return $true }
-            Mock Get-PodeLogger { return @{ Arguments = @{
+            Mock Test-PodeLogTypeEnabled { return $true }
+            Mock Get-PodeLogType { return @{ Arguments = @{
                         Levels = @('Error')
                     }
                 } }
@@ -106,15 +106,15 @@ InModuleScope -ModuleName 'Pode' {
         }
     }
 
-    Describe 'Get-PodeRequestLoggingName' {
+    Describe 'Get-PodeRequestLogTypeName' {
         It 'Returns logger name' {
-            Get-PodeRequestLoggingName | Should -Be '__pode_log_requests__'
+            Get-PodeRequestLogTypeName | Should -Be '__pode_log_requests__'
         }
     }
 
-    Describe 'Get-PodeErrorLoggingName' {
+    Describe 'Get-PodeErrorLogTypeName' {
         It 'Returns logger name' {
-            Get-PodeErrorLoggingName | Should -Be '__pode_log_errors__'
+            Get-PodeErrorLogTypeName | Should -Be '__pode_log_errors__'
         }
     }
 

--- a/tests/unit/Logging.Tests.ps1
+++ b/tests/unit/Logging.Tests.ps1
@@ -36,7 +36,7 @@ InModuleScope -ModuleName 'Pode' {
 
         It 'Adds a log item' {
             Mock Test-PodeLogTypeEnabled { return $true }
-            Mock Get-PodeLogType { return @{ Levels = @('Error') } }
+            Mock Get-PodeLogType { return @{ Levels = @('Informational') } }
             $PodeContext = @{ LogsToProcess = [System.Collections.ArrayList]::new() }
 
             Write-PodeLog -Name 'test' -InputObject 'test'

--- a/tests/unit/Logging.Tests.ps1
+++ b/tests/unit/Logging.Tests.ps1
@@ -25,88 +25,104 @@ InModuleScope -ModuleName 'Pode' {
     }
 
     Describe 'Write-PodeLog' {
-        It 'Does nothing when logging disabled' {
-            Mock Test-PodeLogTypeEnabled { return $false }
-            $PodeContext = @{ LogsToProcess = [System.Collections.ArrayList]::new() }
+        BeforeEach {
+            $PodeContext = @{
+                Server = @{
+                    Logging = @{
+                        Logger = [Pode.Utilities.Logging.PodeLogger]::new()
+                    }
+                }
+            }
+        }
 
+        AfterEach {
+            $PodeContext.Server.Logging.Logger.Dispose()
+        }
+
+        It 'Does nothing when logging disabled' {
+            $PodeContext.Server.Logging.Logger.IsEnabled = $false
             Write-PodeLog -Name 'test' -InputObject 'test'
 
-            $PodeContext.LogsToProcess.Count | Should -Be 0
+            $PodeContext.Server.Logging.Logger.Count | Should -Be 0
         }
 
         It 'Adds a log item' {
-            Mock Test-PodeLogTypeEnabled { return $true }
-            Mock Get-PodeLogType { return @{ Levels = @('Informational') } }
-            $PodeContext = @{ LogsToProcess = [System.Collections.ArrayList]::new() }
+            $logType = [Pode.Utilities.Logging.PodeLogType]::new('test', @('Informational'))
+            $PodeContext.Server.Logging.Logger.RegisterType($logType)
 
             Write-PodeLog -Name 'test' -InputObject 'test'
 
-            $PodeContext.LogsToProcess.Count | Should -Be 1
-            $PodeContext.LogsToProcess[0].Name | Should -Be 'test'
-            $PodeContext.LogsToProcess[0].Item | Should -Be 'test'
+            $PodeContext.Server.Logging.Logger.Count | Should -Be 1
+
+            $logItem = $null
+            $PodeContext.Server.Logging.Logger.TryTake([ref]$logItem, [System.Threading.CancellationToken]::None) | Should -Be $true
+            $logItem.Name | Should -Be 'test'
+            $logItem.Item | Should -Be 'test'
         }
     }
 
     Describe 'Write-PodeErrorLog' {
-        It 'Does nothing when logging disabled' {
-            Mock Test-PodeLogTypeEnabled { return $false }
-            $PodeContext = @{ LogsToProcess = [System.Collections.ArrayList]::new() }
-
-            Write-PodeLog -Name 'test' -InputObject 'test'
-
-            $PodeContext.LogsToProcess.Count | Should -Be 0
+        BeforeEach {
+            $PodeContext = @{
+                Server = @{
+                    Logging = @{
+                        Logger = [Pode.Utilities.Logging.PodeLogger]::new()
+                    }
+                }
+            }
         }
 
-        It 'Adds an error log item' {
-            Mock Test-PodeLogTypeEnabled { return $true }
-            Mock Get-PodeLogType { return @{ Levels = @('Error') } }
+        AfterEach {
+            $PodeContext.Server.Logging.Logger.Dispose()
+        }
 
-            $PodeContext = @{ LogsToProcess = [System.Collections.ArrayList]::new() }
+        It 'Does nothing when logging disabled' {
+            $PodeContext.Server.Logging.Logger.IsEnabled = $false
 
             try { throw 'some error' }
             catch {
                 Write-PodeErrorLog -ErrorRecord $_
             }
 
-            $PodeContext.LogsToProcess.Count | Should -Be 1
-            $PodeContext.LogsToProcess[0].Item.Message | Should -Be 'some error'
+            $PodeContext.Server.Logging.Logger.Count | Should -Be 0
+        }
+
+        It 'Adds an error log item' {
+            $logType = [Pode.Utilities.Logging.PodeLogType]::new([Pode.Utilities.Logging.PodeLogger]::ERROR_LOG_TYPE_NAME, @('Error'))
+            $PodeContext.Server.Logging.Logger.RegisterType($logType)
+
+            try { throw 'some error' }
+            catch {
+                Write-PodeErrorLog -ErrorRecord $_
+            }
+
+            $PodeContext.Server.Logging.Logger.Count | Should -Be 1
+
+            $logItem = $null
+            $PodeContext.Server.Logging.Logger.TryTake([ref]$logItem, [System.Threading.CancellationToken]::None) | Should -Be $true
+            $logItem.Item.Message | Should -Be 'some error'
         }
 
         It 'Adds an exception log item' {
-            Mock Test-PodeLogTypeEnabled { return $true }
-            Mock Get-PodeLogType { return @{ Levels = @('Error') } }
-
-            $PodeContext = @{ LogsToProcess = [System.Collections.ArrayList]::new() }
+            $logType = [Pode.Utilities.Logging.PodeLogType]::new([Pode.Utilities.Logging.PodeLogger]::ERROR_LOG_TYPE_NAME, @('Error'))
+            $PodeContext.Server.Logging.Logger.RegisterType($logType)
 
             $exp = [exception]::new('some error')
             Write-PodeErrorLog -Exception $exp
 
-            $PodeContext.LogsToProcess.Count | Should -Be 1
-            $PodeContext.LogsToProcess[0].Item.Message | Should -Be 'some error'
+            $logItem = $null
+            $PodeContext.Server.Logging.Logger.TryTake([ref]$logItem, [System.Threading.CancellationToken]::None) | Should -Be $true
+            $logItem.Item.Message | Should -Be 'some error'
         }
 
         It 'Does not log as Verbose not allowed' {
-            Mock Test-PodeLogTypeEnabled { return $true }
-            Mock Get-PodeLogType { return @{ Levels = @('Error') } }
-
-            $PodeContext = @{ LogsToProcess = [System.Collections.ArrayList]::new() }
+            $logType = [Pode.Utilities.Logging.PodeLogType]::new([Pode.Utilities.Logging.PodeLogger]::ERROR_LOG_TYPE_NAME, @('Error'))
+            $PodeContext.Server.Logging.Logger.RegisterType($logType)
 
             $exp = [exception]::new('some error')
             Write-PodeErrorLog -Exception $exp -Level Verbose
 
-            $PodeContext.LogsToProcess.Count | Should -Be 0
-        }
-    }
-
-    Describe 'Get-PodeRequestLogTypeName' {
-        It 'Returns logger name' {
-            Get-PodeRequestLogTypeName | Should -Be '__pode_log_requests__'
-        }
-    }
-
-    Describe 'Get-PodeErrorLogTypeName' {
-        It 'Returns logger name' {
-            Get-PodeErrorLogTypeName | Should -Be '__pode_log_errors__'
+            $PodeContext.Server.Logging.Logger.Count | Should -Be 0
         }
     }
 

--- a/tests/unit/Logging.Tests.ps1
+++ b/tests/unit/Logging.Tests.ps1
@@ -36,6 +36,7 @@ InModuleScope -ModuleName 'Pode' {
 
         It 'Adds a log item' {
             Mock Test-PodeLogTypeEnabled { return $true }
+            Mock Get-PodeLogType { return @{ Levels = @('Error') } }
             $PodeContext = @{ LogsToProcess = [System.Collections.ArrayList]::new() }
 
             Write-PodeLog -Name 'test' -InputObject 'test'
@@ -58,10 +59,7 @@ InModuleScope -ModuleName 'Pode' {
 
         It 'Adds an error log item' {
             Mock Test-PodeLogTypeEnabled { return $true }
-            Mock Get-PodeLogType { return @{ Arguments = @{
-                        Levels = @('Error')
-                    }
-                } }
+            Mock Get-PodeLogType { return @{ Levels = @('Error') } }
 
             $PodeContext = @{ LogsToProcess = [System.Collections.ArrayList]::new() }
 
@@ -76,10 +74,7 @@ InModuleScope -ModuleName 'Pode' {
 
         It 'Adds an exception log item' {
             Mock Test-PodeLogTypeEnabled { return $true }
-            Mock Get-PodeLogType { return @{ Arguments = @{
-                        Levels = @('Error')
-                    }
-                } }
+            Mock Get-PodeLogType { return @{ Levels = @('Error') } }
 
             $PodeContext = @{ LogsToProcess = [System.Collections.ArrayList]::new() }
 
@@ -92,10 +87,7 @@ InModuleScope -ModuleName 'Pode' {
 
         It 'Does not log as Verbose not allowed' {
             Mock Test-PodeLogTypeEnabled { return $true }
-            Mock Get-PodeLogType { return @{ Arguments = @{
-                        Levels = @('Error')
-                    }
-                } }
+            Mock Get-PodeLogType { return @{ Levels = @('Error') } }
 
             $PodeContext = @{ LogsToProcess = [System.Collections.ArrayList]::new() }
 

--- a/tests/unit/Server.Tests.ps1
+++ b/tests/unit/Server.Tests.ps1
@@ -126,7 +126,8 @@ InModuleScope -ModuleName 'Pode' {
                         key = @{}
                     }
                     Logging         = @{
-                        Types = @{ 'key' = 'value' }
+                        Methods = @{ 'key' = 'value' }
+                        Types   = @{ 'key' = 'value' }
                     }
                     Mcp             = @{
                         Tools  = @{}
@@ -283,6 +284,7 @@ InModuleScope -ModuleName 'Pode' {
             Restart-PodeInternalServer | Out-Null
 
             $PodeContext.Server.Routes['GET'].Count | Should -Be 0
+            $PodeContext.Server.Logging.Methods.Count | Should -Be 0
             $PodeContext.Server.Logging.Types.Count | Should -Be 0
             $PodeContext.Server.Middleware.Count | Should -Be 0
             $PodeContext.Server.Endware.Count | Should -Be 0

--- a/tests/unit/Server.Tests.ps1
+++ b/tests/unit/Server.Tests.ps1
@@ -111,7 +111,7 @@ InModuleScope -ModuleName 'Pode' {
             Mock Invoke-PodeEvent {}
         }
 
-        It 'Resetting the server values' {
+        BeforeEach {
             $PodeContext = @{
                 Tokens    = Initialize-PodeCancellationToken
                 Server    = @{
@@ -126,6 +126,7 @@ InModuleScope -ModuleName 'Pode' {
                         key = @{}
                     }
                     Logging         = @{
+                        Logger  = [Pode.Utilities.Logging.PodeLogger]::new()
                         Methods = @{ 'key' = 'value' }
                         Types   = @{ 'key' = 'value' }
                     }
@@ -280,6 +281,13 @@ InModuleScope -ModuleName 'Pode' {
                     Semaphores = @{}
                 }
             }
+        }
+
+        AfterEach {
+            $PodeContext.Server.Logging.Logger.Dispose()
+        }
+
+        It 'Resetting the server values' {
             Restart-PodeServer
             Restart-PodeInternalServer | Out-Null
 


### PR DESCRIPTION
### Description of the Change
Overhauls how Pode's logging works so the internal .NET errors, which were CLI-based only, now support Pode's main logging functionality - allowing you to write the internal logs to CLI, File, or where ever your heart may choose.

Additionally, the Log Methods now each run within their own Runspaces; this improves the performance of logging so Terminal logs aren't slowed down by File or API logs.

Furthermore, there are some deprecation notices in place for:
* `New-PodeLoggingMethod`
* `Add-PodeLogger`
* `Enable-PodeErrorLogging`
* `Enable-PodeRequestLogging`

These functions still exist, but have been replaced by the following new functions - and the above ones will be removed in v3.0:

* `New-PodeLogCustomMethod`
* `New-PodeLogEventViewerMethod`
* `New-PodeLogFileMethod`
* `New-PodeLogTerminalMethod`
* `Add-PodeLogType`
* `Enable-PodeErrorLogType`
* `Enable-PodeRequestLogType`

Further changes:
* Log Events are now thread-safe - they now use a BlockingCollection, not an Array
* Log Types now support multiple Log Methods - want to give multiple Log Methods for error logging? Now you can!
* Custom Log Types now support -Raw item pass-thru - removing needless scriptblock that just return the item

### Related Issue
- Resolves #1706
- Resolves #1108
- Resolves #1453
- Resolves #1268
- Resolves #1035

