### PR TITLE
Update Pester to 6.0.0

### DIFF
--- a/pode.build.ps1
+++ b/pode.build.ps1
@@ -126,7 +126,7 @@ param(
 
 # Dependency Versions
 $Versions = @{
-    Pester      = '6.0.0-rc1'
+    Pester      = '6.0.0-rc2'
     MkDocs      = '1.6.1'
     DotNet      = $SdkVersion
     MkDocsTheme = '9.7.6'

--- a/pode.build.ps1
+++ b/pode.build.ps1
@@ -126,7 +126,7 @@ param(
 
 # Dependency Versions
 $Versions = @{
-    Pester      = '5.7.1'
+    Pester      = '6.0.0-rc1'
     MkDocs      = '1.6.1'
     DotNet      = $SdkVersion
     MkDocsTheme = '9.7.6'
@@ -356,7 +356,7 @@ function Install-PodeBuildModule($name) {
 
     Write-Host "Installing $($name) v$($Versions[$name])"
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-    Install-Module -Name "$($name)" -Scope CurrentUser -RequiredVersion "$($Versions[$name])" -Force -SkipPublisherCheck -AllowClobber
+    Install-Module -Name "$($name)" -Scope CurrentUser -RequiredVersion "$($Versions[$name])" -Force -SkipPublisherCheck -AllowClobber -AllowPrerelease
 }
 
 <#
@@ -1348,10 +1348,11 @@ Add-BuildTask TestNoBuild TestDeps, {
     }
 
     # ensure correct pester version is loaded
+    $pesterModuleVersion = [version]($Versions.Pester -replace '-.*$')
     $p = Get-Command Invoke-Pester
-    if (($null -eq $p) -or ($p.Version -ine $Versions.Pester)) {
+    if (($null -eq $p) -or ($p.Version -ne $pesterModuleVersion)) {
         Remove-Module Pester -Force -ErrorAction Ignore
-        Import-Module Pester -Force -RequiredVersion $Versions.Pester
+        Import-Module Pester -Force -RequiredVersion $pesterModuleVersion
     }
 
     # set UICulture if specified

--- a/pode.build.ps1
+++ b/pode.build.ps1
@@ -126,7 +126,7 @@ param(
 
 # Dependency Versions
 $Versions = @{
-    Pester      = '6.0.0-rc4'
+    Pester      = '6.0.0'
     MkDocs      = '1.6.1'
     DotNet      = $SdkVersion
     MkDocsTheme = '9.7.6'

--- a/pode.build.ps1
+++ b/pode.build.ps1
@@ -126,7 +126,7 @@ param(
 
 # Dependency Versions
 $Versions = @{
-    Pester      = '6.0.0-rc2'
+    Pester      = '6.0.0-rc4'
     MkDocs      = '1.6.1'
     DotNet      = $SdkVersion
     MkDocsTheme = '9.7.6'

--- a/tests/compliance/Localization.Tests.ps1
+++ b/tests/compliance/Localization.Tests.ps1
@@ -39,18 +39,18 @@ Describe 'Localization Check' {
         return $keys
     }
 
-    Describe 'Verify Invalid Hashtable Keys in [<_>]' -ForEach  ($sourceFiles) {
+    Describe 'Verify Invalid Hashtable Keys in [<_>]' -ForEach  ($sourceFiles) -AllowNullOrEmptyForEach {
         $keysInFile = Export-KeysFromFile -filePath $_
-        It "should find the key '[<_>]' in the hashtable"  -ForEach  ($keysInFile) {
+        It "should find the key '[<_>]' in the hashtable"  -ForEach  ($keysInFile) -AllowNullOrEmptyForEach {
             $PodeLocale.Keys -contains $_ | Should -BeTrue
         }
     }
 
-    It "Check 'throw' is not using a static string in [<_>]" -ForEach  ($sourceFiles) {
+    It "Check 'throw' is not using a static string in [<_>]" -ForEach  ($sourceFiles) -AllowNullOrEmptyForEach {
         (Get-Content -Path $_ -Raw -Force) -match 'throw\s*["\'']' | Should -BeFalse
     }
 
-    Describe  'Verifying Language [<_>]' -ForEach  ($languageDirs) {
+    Describe  'Verifying Language [<_>]' -ForEach  ($languageDirs) -AllowNullOrEmptyForEach {
         BeforeAll {
             $content = Import-LocalizedData -FileName 'Pode.psd1' -BaseDirectory $localizationDir -UICulture (Split-Path $_ -Leaf)
         }
@@ -63,7 +63,7 @@ Describe 'Localization Check' {
             $content.Keys.Count | Should -be $PodeLocale.Count
         }
 
-        It  -Name 'Resource File contains <_>' -ForEach ( $LanguageOfReference.Keys) {
+        It  -Name 'Resource File contains <_>' -ForEach ( $LanguageOfReference.Keys) -AllowNullOrEmptyForEach {
             $content.Keys -contains $_ | Should -BeTrue
         }
     }

--- a/tests/unit/Authentication.Tests.ps1
+++ b/tests/unit/Authentication.Tests.ps1
@@ -24,26 +24,26 @@ InModuleScope -ModuleName 'Pode' {
 
         It 'Redirects to a failure URL' {
             Set-PodeAuthStatus -StatusCode 500 -Name ExampleAuth | Should -Be $false
-            Assert-MockCalled Move-PodeResponseUrl -Times 1 -Scope It
-            Assert-MockCalled Set-PodeResponseStatus -Times 0 -Scope It
+            Should -Invoke Move-PodeResponseUrl -Times 1 -Scope It
+            Should -Invoke Set-PodeResponseStatus -Times 0 -Scope It
         }
 
         It 'Sets status to failure' {
             Set-PodeAuthStatus -StatusCode 500 -Name ExampleAuth | Should -Be $false
-            Assert-MockCalled Move-PodeResponseUrl -Times 1 -Scope It
-            Assert-MockCalled Set-PodeResponseStatus -Times 0 -Scope It
+            Should -Invoke Move-PodeResponseUrl -Times 1 -Scope It
+            Should -Invoke Set-PodeResponseStatus -Times 0 -Scope It
         }
 
         It 'Redirects to a success URL' {
             Set-PodeAuthStatus -Name ExampleAuth -LoginRoute | Should -Be $false
-            Assert-MockCalled Move-PodeResponseUrl -Times 1 -Scope It
-            Assert-MockCalled Set-PodeResponseStatus -Times 0 -Scope It
+            Should -Invoke Move-PodeResponseUrl -Times 1 -Scope It
+            Should -Invoke Set-PodeResponseStatus -Times 0 -Scope It
         }
 
         It 'Returns true for next middleware' {
             Set-PodeAuthStatus -Name ExampleAuth -NoSuccessRedirect | Should -Be $true
-            Assert-MockCalled Move-PodeResponseUrl -Times 0 -Scope It
-            Assert-MockCalled Set-PodeResponseStatus -Times 0 -Scope It
+            Should -Invoke Move-PodeResponseUrl -Times 0 -Scope It
+            Should -Invoke Set-PodeResponseStatus -Times 0 -Scope It
         }
     }
 
@@ -98,7 +98,7 @@ InModuleScope -ModuleName 'Pode' {
             $WebEvent.Auth.User | Should -Be $null
             $WebEvent.Session.Data.Auth | Should -Be $null
 
-            Assert-MockCalled Revoke-PodeSession -Times 1 -Scope It
+            Should -Invoke Revoke-PodeSession -Times 1 -Scope It
         }
 
         It 'Removes the user, and kills the session, redirecting to root' {
@@ -122,7 +122,7 @@ InModuleScope -ModuleName 'Pode' {
             $WebEvent.Auth.User | Should -Be $null
             $WebEvent.Session.Data.Auth | Should -Be $null
 
-            Assert-MockCalled Revoke-PodeSession -Times 1 -Scope It
+            Should -Invoke Revoke-PodeSession -Times 1 -Scope It
         }
     }
 

--- a/tests/unit/Context.Tests.ps1
+++ b/tests/unit/Context.Tests.ps1
@@ -528,7 +528,7 @@ InModuleScope -ModuleName 'Pode' {
 
             It 'Returns null for no shared state in context' {
                 Import-PodeModule -Path 'file.txt'
-                Assert-MockCalled Import-Module -Times 1 -Scope It
+                Should -Invoke Import-Module -Times 1 -Scope It
             }
         }
     }

--- a/tests/unit/Cookies.Tests.ps1
+++ b/tests/unit/Cookies.Tests.ps1
@@ -47,7 +47,7 @@ InModuleScope -ModuleName 'Pode' {
             }
 
             { Test-PodeCookieSigned -Name 'test' } | Should -Throw -ErrorId 'ParameterArgumentValidationError,Test-PodeCookieSigned'
-            Assert-MockCalled Invoke-PodeValueUnsign -Times 0 -Scope It
+            Should -Invoke Invoke-PodeValueUnsign -Times 0 -Scope It
         }
 
         It 'Returns false for invalid signed cookie' {
@@ -59,7 +59,7 @@ InModuleScope -ModuleName 'Pode' {
             }
 
             Test-PodeCookieSigned -Name 'test' -Secret 'key' | Should -Be $false
-            Assert-MockCalled Invoke-PodeValueUnsign -Times 1 -Scope It
+            Should -Invoke Invoke-PodeValueUnsign -Times 1 -Scope It
         }
 
         It 'Returns true for valid signed cookie' {
@@ -71,7 +71,7 @@ InModuleScope -ModuleName 'Pode' {
             }
 
             Test-PodeCookieSigned -Name 'test' -Secret 'key' | Should -Be $true
-            Assert-MockCalled Invoke-PodeValueUnsign -Times 1 -Scope It
+            Should -Invoke Invoke-PodeValueUnsign -Times 1 -Scope It
         }
 
         It 'Returns true for valid signed cookie, using global secret' {
@@ -91,7 +91,7 @@ InModuleScope -ModuleName 'Pode' {
             }
 
             Test-PodeCookieSigned -Name 'test' -Secret (Get-PodeCookieSecret -Global) | Should -Be $true
-            Assert-MockCalled Invoke-PodeValueUnsign -Times 1 -Scope It
+            Should -Invoke Invoke-PodeValueUnsign -Times 1 -Scope It
         }
     }
 
@@ -137,7 +137,7 @@ InModuleScope -ModuleName 'Pode' {
             $c | Should -Not -Be $null
             $c.Value | Should -Be 'example'
 
-            Assert-MockCalled Invoke-PodeValueUnsign -Times 1 -Scope It
+            Should -Invoke Invoke-PodeValueUnsign -Times 1 -Scope It
         }
 
         It 'Returns a cookie, with secret but valid signed' {
@@ -152,7 +152,7 @@ InModuleScope -ModuleName 'Pode' {
             $c | Should -Not -Be $null
             $c.Value | Should -Be 'some-id'
 
-            Assert-MockCalled Invoke-PodeValueUnsign -Times 1 -Scope It
+            Should -Invoke Invoke-PodeValueUnsign -Times 1 -Scope It
         }
 
         It 'Returns a cookie, with secret but valid signed, using global secret' {
@@ -175,7 +175,7 @@ InModuleScope -ModuleName 'Pode' {
             $c | Should -Not -Be $null
             $c.Value | Should -Be 'some-id'
 
-            Assert-MockCalled Invoke-PodeValueUnsign -Times 1 -Scope It
+            Should -Invoke Invoke-PodeValueUnsign -Times 1 -Scope It
         }
     }
 
@@ -235,7 +235,7 @@ InModuleScope -ModuleName 'Pode' {
             $h = $WebEvent.Response.Headers['Set-Cookie']
             $h | Should -Not -Be $null
 
-            Assert-MockCalled Invoke-PodeValueSign -Times 1 -Scope It
+            Should -Invoke Invoke-PodeValueSign -Times 1 -Scope It
         }
 
         It 'Adds signed cookie to response' {
@@ -272,7 +272,7 @@ InModuleScope -ModuleName 'Pode' {
             $h = $WebEvent.Response.Headers['Set-Cookie']
             $h | Should -Not -Be $null
 
-            Assert-MockCalled Invoke-PodeValueSign -Times 1 -Scope It
+            Should -Invoke Invoke-PodeValueSign -Times 1 -Scope It
         }
 
         It 'Adds cookie to response with options' {

--- a/tests/unit/Endware.Tests.ps1
+++ b/tests/unit/Endware.Tests.ps1
@@ -10,7 +10,7 @@ InModuleScope -ModuleName 'Pode' {
         It 'Runs the logic for a single endware' {
             Mock Invoke-PodeScriptBlock { }
             Invoke-PodeEndware -Endware @(@{ Logic = { 'test' | Out-Null } })
-            Assert-MockCalled Invoke-PodeScriptBlock -Times 1 -Scope It
+            Should -Invoke Invoke-PodeScriptBlock -Times 1 -Scope It
         }
 
         It 'Runs the logic for 2 endwares' {
@@ -19,7 +19,7 @@ InModuleScope -ModuleName 'Pode' {
                 @{ Logic = { 'test' | Out-Null } },
                 @{ Logic = { 'test2' | Out-Null } }
             )
-            Assert-MockCalled Invoke-PodeScriptBlock -Times 2 -Scope It
+            Should -Invoke Invoke-PodeScriptBlock -Times 2 -Scope It
         }
 
         It 'Runs the logic for a single endware and errors' {
@@ -28,8 +28,8 @@ InModuleScope -ModuleName 'Pode' {
 
             Invoke-PodeEndware -Endware @(@{ Logic = { 'test' | Out-Null } })
 
-            Assert-MockCalled Invoke-PodeScriptBlock -Times 1 -Scope It
-            Assert-MockCalled Write-PodeErrorLog -Times 1 -Scope It
+            Should -Invoke Invoke-PodeScriptBlock -Times 1 -Scope It
+            Should -Invoke Write-PodeErrorLog -Times 1 -Scope It
         }
     }
 

--- a/tests/unit/Helpers.Tests.ps1
+++ b/tests/unit/Helpers.Tests.ps1
@@ -134,13 +134,13 @@ InModuleScope -ModuleName 'Pode' {
         It 'Returns false for non-unix' {
             Mock Get-PodePSVersionTable { return @{ 'Platform' = 'Windows' } }
             Test-PodeIsUnix | Should -Be $false
-            Assert-MockCalled Get-PodePSVersionTable -Times 1
+            Should -Invoke Get-PodePSVersionTable -Times 1
         }
 
         It 'Returns true for unix' {
             Mock Get-PodePSVersionTable { return @{ 'Platform' = 'Unix' } }
             Test-PodeIsUnix | Should -Be $true
-            Assert-MockCalled Get-PodePSVersionTable -Times 1
+            Should -Invoke Get-PodePSVersionTable -Times 1
         }
     }
 
@@ -148,19 +148,19 @@ InModuleScope -ModuleName 'Pode' {
         It 'Returns false for non-windows' {
             Mock Get-PodePSVersionTable { return @{ 'Platform' = 'Unix' } }
             Test-PodeIsWindows | Should -Be $false
-            Assert-MockCalled Get-PodePSVersionTable -Times 1
+            Should -Invoke Get-PodePSVersionTable -Times 1
         }
 
         It 'Returns true for windows and desktop' {
             Mock Get-PodePSVersionTable { return @{ 'PSEdition' = 'Desktop' } }
             Test-PodeIsWindows | Should -Be $true
-            Assert-MockCalled Get-PodePSVersionTable -Times 1
+            Should -Invoke Get-PodePSVersionTable -Times 1
         }
 
         It 'Returns true for windows and core' {
             Mock Get-PodePSVersionTable { return @{ 'Platform' = 'Win32NT'; 'PSEdition' = 'Core' } }
             Test-PodeIsWindows | Should -Be $true
-            Assert-MockCalled Get-PodePSVersionTable -Times 1
+            Should -Invoke Get-PodePSVersionTable -Times 1
         }
     }
 
@@ -168,13 +168,13 @@ InModuleScope -ModuleName 'Pode' {
         It 'Returns false for non-core' {
             Mock Get-PodePSVersionTable { return @{ 'PSEdition' = 'Desktop' } }
             Test-PodeIsPSCore | Should -Be $false
-            Assert-MockCalled Get-PodePSVersionTable -Times 1
+            Should -Invoke Get-PodePSVersionTable -Times 1
         }
 
         It 'Returns true for unix' {
             Mock Get-PodePSVersionTable { return @{ 'PSEdition' = 'Core' } }
             Test-PodeIsPSCore | Should -Be $true
-            Assert-MockCalled Get-PodePSVersionTable -Times 1
+            Should -Invoke Get-PodePSVersionTable -Times 1
         }
     }
 
@@ -1141,8 +1141,8 @@ InModuleScope -ModuleName 'Pode' {
             }
 
             Close-PodeServerInternal
-            Assert-MockCalled Write-PodeHost -Times 0 -Scope It
-            Assert-MockCalled Close-PodeDisposable -Times 2 -Scope It
+            Should -Invoke Write-PodeHost -Times 0 -Scope It
+            Should -Invoke Close-PodeDisposable -Times 2 -Scope It
         }
 
     }
@@ -1280,22 +1280,22 @@ InModuleScope -ModuleName 'Pode' {
         }
         It 'Writes a message to the Host by parameters' {
             Out-PodeHost -InputObject 'Hello'
-            Assert-MockCalled Out-Default -Scope It -Times 1
+            Should -Invoke Out-Default -Scope It -Times 1
         }
 
         It 'Writes a message to the Host by pipeline' {
             'Hello' | Out-PodeHost
-            Assert-MockCalled Out-Default -Scope It -Times 1
+            Should -Invoke Out-Default -Scope It -Times 1
         }
 
         It 'Writes a hashtable to the Host by pipeline' {
             @{ Name = 'Rick' } | Out-PodeHost
-            Assert-MockCalled Out-Default -Scope It -Times 1
+            Should -Invoke Out-Default -Scope It -Times 1
         }
 
         It 'Writes an Array to the Host by pipeline' {
             @('France', 'Rick', 21 , 'male') | Out-PodeHost
-            Assert-MockCalled Out-Default -Scope It -Times 1
+            Should -Invoke Out-Default -Scope It -Times 1
         }
     }
 
@@ -1487,13 +1487,13 @@ InModuleScope -ModuleName 'Pode' {
         It 'Errors when no encoding matches, and identity disabled' {
             $PodeContext.Server.Web.Compression.Enabled = $true
             { Get-PodeAcceptEncoding -AcceptEncoding 'br,identity;q=0' -ThrowError } | Should -Throw -ExceptionType 'System.Net.Http.HttpRequestException'
-            Assert-MockCalled New-PodeRequestException -Scope It -Times 1
+            Should -Invoke New-PodeRequestException -Scope It -Times 1
         }
 
         It 'Errors when no encoding matches, and wildcard disabled' {
             $PodeContext.Server.Web.Compression.Enabled = $true
             { Get-PodeAcceptEncoding -AcceptEncoding 'br,*;q=0' -ThrowError } | Should -Throw -ExceptionType 'System.Net.Http.HttpRequestException'
-            Assert-MockCalled New-PodeRequestException -Scope It -Times 1
+            Should -Invoke New-PodeRequestException -Scope It -Times 1
         }
 
         It 'Returns empty if identity is allowed, but wildcard disabled' {
@@ -1536,7 +1536,7 @@ InModuleScope -ModuleName 'Pode' {
 
         It 'Errors when no encoding matches' {
             { Get-PodeTransferEncoding -TransferEncoding 'compress,chunked' -ThrowError } | Should -Throw -ExceptionType 'System.Net.Http.HttpRequestException'
-            Assert-MockCalled New-PodeRequestException -Scope It -Times 1
+            Should -Invoke New-PodeRequestException -Scope It -Times 1
         }
     }
 

--- a/tests/unit/Middleware.Tests.ps1
+++ b/tests/unit/Middleware.Tests.ps1
@@ -177,7 +177,7 @@ InModuleScope -ModuleName 'Pode' {
 
             Invoke-PodeMiddleware -Middleware @($midware) | Should -Be $true
 
-            Assert-MockCalled Invoke-PodeScriptBlock -Times 1 -Scope It
+            Should -Invoke Invoke-PodeScriptBlock -Times 1 -Scope It
         }
 
         It 'Runs the logic for a single middleware mapped to a route' {
@@ -191,7 +191,7 @@ InModuleScope -ModuleName 'Pode' {
 
             Invoke-PodeMiddleware -Middleware @($midware) -Route '/' | Should -Be $true
 
-            Assert-MockCalled Invoke-PodeScriptBlock -Times 1 -Scope It
+            Should -Invoke Invoke-PodeScriptBlock -Times 1 -Scope It
         }
 
         It 'Runs the logic for two middlewares and returns true' {
@@ -210,7 +210,7 @@ InModuleScope -ModuleName 'Pode' {
 
             Invoke-PodeMiddleware -Middleware @($midware1, $midware2) | Should -Be $true
 
-            Assert-MockCalled Invoke-PodeScriptBlock -Times 2 -Scope It
+            Should -Invoke Invoke-PodeScriptBlock -Times 2 -Scope It
         }
 
         It 'Runs the logic for a single middleware and returns false' {
@@ -223,7 +223,7 @@ InModuleScope -ModuleName 'Pode' {
 
             Invoke-PodeMiddleware -Middleware @($midware) | Should -Be $false
 
-            Assert-MockCalled Invoke-PodeScriptBlock -Times 1 -Scope It
+            Should -Invoke Invoke-PodeScriptBlock -Times 1 -Scope It
         }
 
         It 'Runs the logic for a single middleware and returns false after erroring' {
@@ -239,8 +239,8 @@ InModuleScope -ModuleName 'Pode' {
 
             Invoke-PodeMiddleware -Middleware @($midware) | Should -Be $false
 
-            Assert-MockCalled Invoke-PodeScriptBlock -Times 1 -Scope It
-            Assert-MockCalled Set-PodeResponseStatus -Times 1 -Scope It
+            Should -Invoke Invoke-PodeScriptBlock -Times 1 -Scope It
+            Should -Invoke Set-PodeResponseStatus -Times 1 -Scope It
         }
     }
 
@@ -678,7 +678,7 @@ InModuleScope -ModuleName 'Pode' {
 
             (. $r.Logic) | Should -Be $false
 
-            Assert-MockCalled Write-PodeFileResponse -Times 1 -Scope It
+            Should -Invoke Write-PodeFileResponse -Times 1 -Scope It
         }
 
         It 'Returns a ScriptBlock, invokes false for static path, with no caching' {
@@ -705,7 +705,7 @@ InModuleScope -ModuleName 'Pode' {
 
             (. $r.Logic) | Should -Be $false
 
-            Assert-MockCalled Write-PodeFileResponse -Times 1 -Scope It
+            Should -Invoke Write-PodeFileResponse -Times 1 -Scope It
         }
 
         It 'Returns a ScriptBlock, invokes false for static path, with no caching from exclude' {
@@ -733,7 +733,7 @@ InModuleScope -ModuleName 'Pode' {
 
             (. $r.Logic) | Should -Be $false
 
-            Assert-MockCalled Write-PodeFileResponse -Times 1 -Scope It
+            Should -Invoke Write-PodeFileResponse -Times 1 -Scope It
         }
 
         It 'Returns a ScriptBlock, invokes false for static path, with no caching from include' {
@@ -761,7 +761,7 @@ InModuleScope -ModuleName 'Pode' {
 
             (. $r.Logic) | Should -Be $false
 
-            Assert-MockCalled Write-PodeFileResponse -Times 1 -Scope It
+            Should -Invoke Write-PodeFileResponse -Times 1 -Scope It
         }
 
         It 'Returns a ScriptBlock, invokes false for static path, with caching' {
@@ -788,7 +788,7 @@ InModuleScope -ModuleName 'Pode' {
 
             (. $r.Logic) | Should -Be $false
 
-            Assert-MockCalled Write-PodeFileResponse -Times 1 -Scope It
+            Should -Invoke Write-PodeFileResponse -Times 1 -Scope It
         }
     }
 

--- a/tests/unit/Responses.Tests.ps1
+++ b/tests/unit/Responses.Tests.ps1
@@ -18,7 +18,7 @@ InModuleScope -ModuleName 'Pode' {
                 $WebEvent.Response.StatusCode | Should -Be 418
                 $WebEvent.Response.StatusDescription | Should -Be "I'm a Teapot"
                 Should -Invoke Show-PodeErrorPage -Times 1 -Scope It
-                #   Assert-MockCalled 'Show-PodeErrorPage' -Scope It -Times 1
+                #   Should -Invoke 'Show-PodeErrorPage' -Scope It -Times 1
             }
 
             It 'Sets StatusCode and StatusDescription' {
@@ -28,7 +28,7 @@ InModuleScope -ModuleName 'Pode' {
                 $WebEvent.Response.StatusCode | Should -Be 418
                 $WebEvent.Response.StatusDescription | Should -Be 'I am a Teapot'
                 Should -Invoke Show-PodeErrorPage -Times 1 -Scope It
-                #Assert-MockCalled 'Show-PodeErrorPage' -Scope It -Times 1
+                #Should -Invoke 'Show-PodeErrorPage' -Scope It -Times 1
             }
 
             It 'Sets 200 StatusCode' {
@@ -38,7 +38,7 @@ InModuleScope -ModuleName 'Pode' {
                 $WebEvent.Response.StatusCode | Should -Be 200
                 $WebEvent.Response.StatusDescription | Should -Be 'OK'
                 Should -Invoke Show-PodeErrorPage -Times 0 -Scope It
-                # Assert-MockCalled 'Show-PodeErrorPage' -Scope It -Times 0
+                # Should -Invoke 'Show-PodeErrorPage' -Scope It -Times 0
             }
         }
     }
@@ -201,7 +201,7 @@ InModuleScope -ModuleName 'Pode' {
             Mock Test-PodePath { return $false }
             Write-PodeJsonResponse -Path 'fake-file' | Out-Null
             Should -Invoke Test-PodePath -Times 1 -Scope It
-            #  Assert-MockCalled -CommandName 'Test-PodePath' -Times 1 -Scope It
+            #  Should -Invoke -CommandName 'Test-PodePath' -Times 1 -Scope It
         }
 
         It 'Load the file contents and returns it' {
@@ -276,7 +276,7 @@ InModuleScope -ModuleName 'Pode' {
             Mock Test-PodePath { return $false }
             Write-PodeCsvResponse -Path 'fake-file' | Out-Null
             Should -Invoke Test-PodePath -Times 1 -Scope It
-            # Assert-MockCalled -CommandName 'Test-PodePath' -Times 1 -Scope It
+            # Should -Invoke -CommandName 'Test-PodePath' -Times 1 -Scope It
         }
 
         It 'Load the file contents and returns it' {
@@ -352,7 +352,7 @@ InModuleScope -ModuleName 'Pode' {
             Mock Test-PodePath { return $false }
             Write-PodeXmlResponse -Path 'fake-file' | Out-Null
             Should -Invoke Test-PodePath -Times 1 -Scope It
-            #  Assert-MockCalled -CommandName 'Test-PodePath' -Times 1 -Scope It
+            #  Should -Invoke -CommandName 'Test-PodePath' -Times 1 -Scope It
         }
 
         It 'Load the file contents and returns it' {
@@ -392,7 +392,7 @@ InModuleScope -ModuleName 'Pode' {
             Mock Test-PodePath { return $false }
             Write-PodeHtmlResponse -Path 'fake-file' | Out-Null
             Should -Invoke Test-PodePath -Times 1 -Scope It
-            #  Assert-MockCalled -CommandName 'Test-PodePath' -Times 1 -Scope It
+            #  Should -Invoke -CommandName 'Test-PodePath' -Times 1 -Scope It
         }
 
         It 'Load the file contents and returns it' {
@@ -423,7 +423,7 @@ InModuleScope -ModuleName 'Pode' {
             Mock Get-Item { return $null }
             Write-PodeFileResponse -Path './path' | Out-Null
             Should -Invoke Set-PodeResponseStatus -Times 1 -Scope It
-            # Assert-MockCalled Test-PodePath -Times 1 -Scope It
+            # Should -Invoke Test-PodePath -Times 1 -Scope It
         }
 
 
@@ -436,7 +436,7 @@ InModuleScope -ModuleName 'Pode' {
 
             Write-PodeFileResponse -Path './path/file.pode' | Should -Be 'file contents'
             Should -Invoke Get-PodeFileContentUsingViewEngine -Times 1 -Scope It
-            #Assert-MockCalled Get-PodeFileContentUsingViewEngine -Times 1 -Scope It
+            #Should -Invoke Get-PodeFileContentUsingViewEngine -Times 1 -Scope It
         }
 
         It 'Loads the contents of a static file' {
@@ -448,7 +448,7 @@ InModuleScope -ModuleName 'Pode' {
             Mock Get-Item { return @{ PSIsContainer = $false } }
             Write-PodeFileResponse -Path './path/file.pode' | Should -Be 'file contents'
             Should -Invoke Get-PodeFileContentUsingViewEngine -Times 1 -Scope It
-            #   Assert-MockCalled Get-PodeFileContentUsingViewEngine -Times 1 -Scope It
+            #   Should -Invoke Get-PodeFileContentUsingViewEngine -Times 1 -Scope It
         }
     }
 
@@ -495,7 +495,7 @@ InModuleScope -ModuleName 'Pode' {
             Mock Find-PodeErrorPage { return $null }
             Show-PodeErrorPage -Code 404 | Out-Null
             Should -Invoke Write-PodeFileResponse -Times 0 -Scope It
-            #  Assert-MockCalled Write-PodeFileResponse -Times 0 -Scope It
+            #  Should -Invoke Write-PodeFileResponse -Times 0 -Scope It
         }
 
 
@@ -504,7 +504,7 @@ InModuleScope -ModuleName 'Pode' {
             Mock Get-PodeUrl { return 'url' }
             $d = Show-PodeErrorPage -Code 404
             Should -Invoke Write-PodeFileResponse -Times 1 -Scope It
-            #Assert-MockCalled Write-PodeFileResponse -Times 1 -Scope It
+            #Should -Invoke Write-PodeFileResponse -Times 1 -Scope It
             $d.Url | Should -Be 'url'
             $d.Exception | Should -Be $null
             $d.ContentType | Should -Be 'json'
@@ -529,7 +529,7 @@ InModuleScope -ModuleName 'Pode' {
 
             $d = Show-PodeErrorPage -Code 404 -Exception $e
             Should -Invoke Write-PodeFileResponse -Times 1 -Scope It
-            #Assert-MockCalled Write-PodeFileResponse -Times 1 -Scope It
+            #Should -Invoke Write-PodeFileResponse -Times 1 -Scope It
             $d.Url | Should -Be 'url'
             $d.Exception | Should -Not -Be $null
             $d.Exception.Message | Should -Match 'cannot call a method'

--- a/tests/unit/Routes.Tests.ps1
+++ b/tests/unit/Routes.Tests.ps1
@@ -629,22 +629,22 @@ InModuleScope -ModuleName 'Pode' {
 
         It 'Calls Add-PodeRoute twice for commands' {
             ConvertTo-PodeRoute -Commands @('Get-ChildItem', 'Invoke-Expression') -NoOpenApi
-            Assert-MockCalled Add-PodeRoute -Times 2 -Scope It
+            Should -Invoke Add-PodeRoute -Times 2 -Scope It
         }
 
         It 'Calls Add-PodeRoute twice for commands by pipe' {
             @('Get-ChildItem', 'Invoke-Expression') | ConvertTo-PodeRoute   -NoOpenApi
-            Assert-MockCalled Add-PodeRoute -Times 2 -Scope It
+            Should -Invoke Add-PodeRoute -Times 2 -Scope It
         }
 
         It 'Calls Add-PodeRoute twice for module commands' {
             ConvertTo-PodeRoute -Module Example -NoOpenApi
-            Assert-MockCalled Add-PodeRoute -Times 2 -Scope It
+            Should -Invoke Add-PodeRoute -Times 2 -Scope It
         }
 
         It 'Calls Add-PodeRoute once for module filtered commands' {
             ConvertTo-PodeRoute -Module Example -Commands 'Some-ModuleCommand1' -NoOpenApi
-            Assert-MockCalled Add-PodeRoute -Times 1 -Scope It
+            Should -Invoke Add-PodeRoute -Times 1 -Scope It
         }
     }
 
@@ -668,18 +668,18 @@ InModuleScope -ModuleName 'Pode' {
 
         It 'Call Add-PodeRoute once for ScriptBlock page' {
             Add-PodePage -Name 'Name' -ScriptBlock { Get-Service }
-            Assert-MockCalled Add-PodeRoute -Times 1 -Scope It
+            Should -Invoke Add-PodeRoute -Times 1 -Scope It
         }
 
         It 'Call Add-PodeRoute once for FilePath page' {
             Mock Get-PodeRelativePath { return $Path }
             Add-PodePage -Name 'Name' -FilePath './fake/path'
-            Assert-MockCalled Add-PodeRoute -Times 1 -Scope It
+            Should -Invoke Add-PodeRoute -Times 1 -Scope It
         }
 
         It 'Call Add-PodeRoute once for FilePath page' {
             Add-PodePage -Name 'Name' -View 'index'
-            Assert-MockCalled Add-PodeRoute -Times 1 -Scope It
+            Should -Invoke Add-PodeRoute -Times 1 -Scope It
         }
     }
 

--- a/tests/unit/Security.Tests.ps1
+++ b/tests/unit/Security.Tests.ps1
@@ -16,26 +16,26 @@ InModuleScope -ModuleName 'Pode' {
         Context 'Valid parameters' {
             It 'Adds single IP address' {
                 Add-PodeLimitRule -Type 'IP' -Values '127.0.0.1' -Limit 1 -Seconds 1
-                Assert-MockCalled New-PodeLimitIPComponent -Times 1 -Scope It
-                Assert-MockCalled Add-PodeLimitRateRule -Times 1 -Scope It
+                Should -Invoke New-PodeLimitIPComponent -Times 1 -Scope It
+                Should -Invoke Add-PodeLimitRateRule -Times 1 -Scope It
             }
 
             It 'Adds single subnet' {
                 Add-PodeLimitRule -Type 'IP' -Values '10.10.0.0/24' -Limit 1 -Seconds 1
-                Assert-MockCalled New-PodeLimitIPComponent -Times 1 -Scope It
-                Assert-MockCalled Add-PodeLimitRateRule -Times 1 -Scope It
+                Should -Invoke New-PodeLimitIPComponent -Times 1 -Scope It
+                Should -Invoke Add-PodeLimitRateRule -Times 1 -Scope It
             }
 
             It 'Adds 3 IP addresses' {
                 Add-PodeLimitRule -Type 'IP' -Values @('127.0.0.1', '127.0.0.2', '127.0.0.3') -Limit 1 -Seconds 1
-                Assert-MockCalled New-PodeLimitIPComponent -Times 1 -Scope It
-                Assert-MockCalled Add-PodeLimitRateRule -Times 1 -Scope It
+                Should -Invoke New-PodeLimitIPComponent -Times 1 -Scope It
+                Should -Invoke Add-PodeLimitRateRule -Times 1 -Scope It
             }
 
             It 'Adds 3 subnets' {
                 Add-PodeLimitRule -Type 'IP' -Value @('10.10.0.0/24', '10.10.1.0/24', '10.10.2.0/24') -Limit 1 -Seconds 1
-                Assert-MockCalled New-PodeLimitIPComponent -Times 1 -Scope It
-                Assert-MockCalled Add-PodeLimitRateRule -Times 1 -Scope It
+                Should -Invoke New-PodeLimitIPComponent -Times 1 -Scope It
+                Should -Invoke Add-PodeLimitRateRule -Times 1 -Scope It
             }
         }
     }
@@ -48,26 +48,26 @@ InModuleScope -ModuleName 'Pode' {
         Context 'Valid parameters' {
             It 'Adds single IP address' {
                 Add-PodeAccessRule -Access 'Allow' -Type 'IP' -Values '127.0.0.1'
-                Assert-MockCalled New-PodeLimitIPComponent -Times 1 -Scope It
-                Assert-MockCalled Add-PodeLimitAccessRule -Times 1 -Scope It
+                Should -Invoke New-PodeLimitIPComponent -Times 1 -Scope It
+                Should -Invoke Add-PodeLimitAccessRule -Times 1 -Scope It
             }
 
             It 'Adds single subnet' {
                 Add-PodeAccessRule -Access 'Allow' -Type 'IP' -Values '10.10.0.0/24'
-                Assert-MockCalled New-PodeLimitIPComponent -Times 1 -Scope It
-                Assert-MockCalled Add-PodeLimitAccessRule -Times 1 -Scope It
+                Should -Invoke New-PodeLimitIPComponent -Times 1 -Scope It
+                Should -Invoke Add-PodeLimitAccessRule -Times 1 -Scope It
             }
 
             It 'Adds 3 IP addresses' {
                 Add-PodeAccessRule -Access 'Allow' -Type 'IP' -Values @('127.0.0.1', '127.0.0.2', '127.0.0.3')
-                Assert-MockCalled New-PodeLimitIPComponent -Times 1 -Scope It
-                Assert-MockCalled Add-PodeLimitAccessRule -Times 1 -Scope It
+                Should -Invoke New-PodeLimitIPComponent -Times 1 -Scope It
+                Should -Invoke Add-PodeLimitAccessRule -Times 1 -Scope It
             }
 
             It 'Adds 3 subnets' {
                 Add-PodeAccessRule -Access 'Allow' -Type 'IP' -Values @('10.10.0.0/24', '10.10.1.0/24', '10.10.2.0/24')
-                Assert-MockCalled New-PodeLimitIPComponent -Times 1 -Scope It
-                Assert-MockCalled Add-PodeLimitAccessRule -Times 1 -Scope It
+                Should -Invoke New-PodeLimitIPComponent -Times 1 -Scope It
+                Should -Invoke Add-PodeLimitAccessRule -Times 1 -Scope It
             }
         }
     }
@@ -80,8 +80,8 @@ InModuleScope -ModuleName 'Pode' {
 
             Enable-PodeCsrfMiddleware
 
-            Assert-MockCalled New-PodeMiddleware -Times 1 -Scope It
-            Assert-MockCalled Add-PodeMiddleware -Times 1 -Scope It
+            Should -Invoke New-PodeMiddleware -Times 1 -Scope It
+            Should -Invoke Add-PodeMiddleware -Times 1 -Scope It
         }
     }
 
@@ -315,7 +315,7 @@ InModuleScope -ModuleName 'Pode' {
 
             Set-PodeCsrfSecret -Secret 'some-secret'
 
-            Assert-MockCalled Set-PodeCookie -Times 1 -Scope It
+            Should -Invoke Set-PodeCookie -Times 1 -Scope It
         }
     }
 
@@ -342,7 +342,7 @@ InModuleScope -ModuleName 'Pode' {
 
             Get-PodeCsrfSecret | Should -Be 'some-secret'
 
-            Assert-MockCalled Get-PodeCookie -Times 1 -Scope It
+            Should -Invoke Get-PodeCookie -Times 1 -Scope It
         }
     }
 }

--- a/tests/unit/Server.Tests.ps1
+++ b/tests/unit/Server.Tests.ps1
@@ -43,14 +43,14 @@ InModuleScope -ModuleName 'Pode' {
             $PodeContext.Tokens = Initialize-PodeCancellationToken
             Start-PodeInternalServer | Out-Null
 
-            Assert-MockCalled Invoke-PodeScriptBlock -Times 1 -Scope It
-            Assert-MockCalled New-PodeRunspacePool -Times 1 -Scope It
-            Assert-MockCalled New-PodeRunspaceState -Times 1 -Scope It
-            Assert-MockCalled Start-PodeTimerRunspace -Times 1 -Scope It
-            Assert-MockCalled Start-PodeScheduleRunspace -Times 1 -Scope It
-            Assert-MockCalled Start-PodeSmtpServer -Times 0 -Scope It
-            Assert-MockCalled Start-PodeTcpServer -Times 0 -Scope It
-            Assert-MockCalled Start-PodeWebServer -Times 0 -Scope It
+            Should -Invoke Invoke-PodeScriptBlock -Times 1 -Scope It
+            Should -Invoke New-PodeRunspacePool -Times 1 -Scope It
+            Should -Invoke New-PodeRunspaceState -Times 1 -Scope It
+            Should -Invoke Start-PodeTimerRunspace -Times 1 -Scope It
+            Should -Invoke Start-PodeScheduleRunspace -Times 1 -Scope It
+            Should -Invoke Start-PodeSmtpServer -Times 0 -Scope It
+            Should -Invoke Start-PodeTcpServer -Times 0 -Scope It
+            Should -Invoke Start-PodeWebServer -Times 0 -Scope It
         }
 
         It 'Calls smtp server logic' {
@@ -58,14 +58,14 @@ InModuleScope -ModuleName 'Pode' {
             $PodeContext.Tokens = Initialize-PodeCancellationToken
             Start-PodeInternalServer | Out-Null
 
-            Assert-MockCalled Invoke-PodeScriptBlock -Times 1 -Scope It
-            Assert-MockCalled New-PodeRunspacePool -Times 1 -Scope It
-            Assert-MockCalled New-PodeRunspaceState -Times 1 -Scope It
-            Assert-MockCalled Start-PodeTimerRunspace -Times 1 -Scope It
-            Assert-MockCalled Start-PodeScheduleRunspace -Times 1 -Scope It
-            Assert-MockCalled Start-PodeSmtpServer -Times 1 -Scope It
-            Assert-MockCalled Start-PodeTcpServer -Times 0 -Scope It
-            Assert-MockCalled Start-PodeWebServer -Times 0 -Scope It
+            Should -Invoke Invoke-PodeScriptBlock -Times 1 -Scope It
+            Should -Invoke New-PodeRunspacePool -Times 1 -Scope It
+            Should -Invoke New-PodeRunspaceState -Times 1 -Scope It
+            Should -Invoke Start-PodeTimerRunspace -Times 1 -Scope It
+            Should -Invoke Start-PodeScheduleRunspace -Times 1 -Scope It
+            Should -Invoke Start-PodeSmtpServer -Times 1 -Scope It
+            Should -Invoke Start-PodeTcpServer -Times 0 -Scope It
+            Should -Invoke Start-PodeWebServer -Times 0 -Scope It
         }
 
         It 'Calls tcp server logic' {
@@ -73,14 +73,14 @@ InModuleScope -ModuleName 'Pode' {
             $PodeContext.Tokens = Initialize-PodeCancellationToken
             Start-PodeInternalServer | Out-Null
 
-            Assert-MockCalled Invoke-PodeScriptBlock -Times 1 -Scope It
-            Assert-MockCalled New-PodeRunspacePool -Times 1 -Scope It
-            Assert-MockCalled New-PodeRunspaceState -Times 1 -Scope It
-            Assert-MockCalled Start-PodeTimerRunspace -Times 1 -Scope It
-            Assert-MockCalled Start-PodeScheduleRunspace -Times 1 -Scope It
-            Assert-MockCalled Start-PodeSmtpServer -Times 0 -Scope It
-            Assert-MockCalled Start-PodeTcpServer -Times 1 -Scope It
-            Assert-MockCalled Start-PodeWebServer -Times 0 -Scope It
+            Should -Invoke Invoke-PodeScriptBlock -Times 1 -Scope It
+            Should -Invoke New-PodeRunspacePool -Times 1 -Scope It
+            Should -Invoke New-PodeRunspaceState -Times 1 -Scope It
+            Should -Invoke Start-PodeTimerRunspace -Times 1 -Scope It
+            Should -Invoke Start-PodeScheduleRunspace -Times 1 -Scope It
+            Should -Invoke Start-PodeSmtpServer -Times 0 -Scope It
+            Should -Invoke Start-PodeTcpServer -Times 1 -Scope It
+            Should -Invoke Start-PodeWebServer -Times 0 -Scope It
         }
 
         It 'Calls http web server logic' {
@@ -88,14 +88,14 @@ InModuleScope -ModuleName 'Pode' {
             $PodeContext.Tokens = Initialize-PodeCancellationToken
             Start-PodeInternalServer | Out-Null
 
-            Assert-MockCalled Invoke-PodeScriptBlock -Times 1 -Scope It
-            Assert-MockCalled New-PodeRunspacePool -Times 1 -Scope It
-            Assert-MockCalled New-PodeRunspaceState -Times 1 -Scope It
-            Assert-MockCalled Start-PodeTimerRunspace -Times 1 -Scope It
-            Assert-MockCalled Start-PodeScheduleRunspace -Times 1 -Scope It
-            Assert-MockCalled Start-PodeSmtpServer -Times 0 -Scope It
-            Assert-MockCalled Start-PodeTcpServer -Times 0 -Scope It
-            Assert-MockCalled Start-PodeWebServer -Times 1 -Scope It
+            Should -Invoke Invoke-PodeScriptBlock -Times 1 -Scope It
+            Should -Invoke New-PodeRunspacePool -Times 1 -Scope It
+            Should -Invoke New-PodeRunspaceState -Times 1 -Scope It
+            Should -Invoke Start-PodeTimerRunspace -Times 1 -Scope It
+            Should -Invoke Start-PodeScheduleRunspace -Times 1 -Scope It
+            Should -Invoke Start-PodeSmtpServer -Times 0 -Scope It
+            Should -Invoke Start-PodeTcpServer -Times 0 -Scope It
+            Should -Invoke Start-PodeWebServer -Times 1 -Scope It
         }
     }
 

--- a/tests/unit/Serverless.Tests.ps1
+++ b/tests/unit/Serverless.Tests.ps1
@@ -45,8 +45,8 @@ InModuleScope -ModuleName 'Pode' {
             $result.Name | Should -Be 'Response'
             $result.Value | Should -Not -Be $null
 
-            Assert-MockCalled Set-PodeResponseStatus -Times 0 -Scope It
-            Assert-MockCalled Invoke-PodeMiddleware -Times 1 -Scope It
+            Should -Invoke Set-PodeResponseStatus -Times 0 -Scope It
+            Should -Invoke Invoke-PodeMiddleware -Times 1 -Scope It
         }
 
         It 'Runs the server, using static content path from query' {
@@ -67,8 +67,8 @@ InModuleScope -ModuleName 'Pode' {
             $result.Name | Should -Be 'Response'
             $result.Value | Should -Not -Be $null
 
-            Assert-MockCalled Set-PodeResponseStatus -Times 0 -Scope It
-            Assert-MockCalled Invoke-PodeMiddleware -Times 1 -Scope It
+            Should -Invoke Set-PodeResponseStatus -Times 0 -Scope It
+            Should -Invoke Invoke-PodeMiddleware -Times 1 -Scope It
         }
 
         It 'Runs the server, succeeds middleware with route' {
@@ -89,9 +89,9 @@ InModuleScope -ModuleName 'Pode' {
             $result.Name | Should -Be 'Response'
             $result.Value | Should -Not -Be $null
 
-            Assert-MockCalled Set-PodeResponseStatus -Times 0 -Scope It
-            Assert-MockCalled Invoke-PodeMiddleware -Times 2 -Scope It
-            Assert-MockCalled Invoke-PodeScriptBlock -Times 1 -Scope It
+            Should -Invoke Set-PodeResponseStatus -Times 0 -Scope It
+            Should -Invoke Invoke-PodeMiddleware -Times 2 -Scope It
+            Should -Invoke Invoke-PodeScriptBlock -Times 1 -Scope It
         }
 
         It 'Runs the server, errors in middleware' {
@@ -112,8 +112,8 @@ InModuleScope -ModuleName 'Pode' {
             $result.Name | Should -Be 'Response'
             $result.Value | Should -Not -Be $null
 
-            Assert-MockCalled Set-PodeResponseStatus -Times 1 -Scope It
-            Assert-MockCalled Invoke-PodeMiddleware -Times 1 -Scope It
+            Should -Invoke Set-PodeResponseStatus -Times 1 -Scope It
+            Should -Invoke Invoke-PodeMiddleware -Times 1 -Scope It
         }
 
         It 'Runs the server, errors in endware' {
@@ -134,8 +134,8 @@ InModuleScope -ModuleName 'Pode' {
 
             { Start-PodeAzFuncServer -Data $d } | Should -Throw -ExpectedMessage 'some error'
 
-            Assert-MockCalled Set-PodeResponseStatus -Times 0 -Scope It
-            Assert-MockCalled Invoke-PodeMiddleware -Times 1 -Scope It
+            Should -Invoke Set-PodeResponseStatus -Times 0 -Scope It
+            Should -Invoke Invoke-PodeMiddleware -Times 1 -Scope It
         }
     }
 
@@ -170,8 +170,8 @@ InModuleScope -ModuleName 'Pode' {
 
             $result | Should -Not -Be $null
 
-            Assert-MockCalled Set-PodeResponseStatus -Times 0 -Scope It
-            Assert-MockCalled Invoke-PodeMiddleware -Times 1 -Scope It
+            Should -Invoke Set-PodeResponseStatus -Times 0 -Scope It
+            Should -Invoke Invoke-PodeMiddleware -Times 1 -Scope It
         }
 
         It 'Runs the server, succeeds middleware with route' {
@@ -186,9 +186,9 @@ InModuleScope -ModuleName 'Pode' {
 
             $result | Should -Not -Be $null
 
-            Assert-MockCalled Set-PodeResponseStatus -Times 0 -Scope It
-            Assert-MockCalled Invoke-PodeMiddleware -Times 2 -Scope It
-            Assert-MockCalled Invoke-PodeScriptBlock -Times 1 -Scope It
+            Should -Invoke Set-PodeResponseStatus -Times 0 -Scope It
+            Should -Invoke Invoke-PodeMiddleware -Times 2 -Scope It
+            Should -Invoke Invoke-PodeScriptBlock -Times 1 -Scope It
         }
 
         It 'Runs the server, errors in middleware' {
@@ -203,8 +203,8 @@ InModuleScope -ModuleName 'Pode' {
 
             $result | Should -Not -Be $null
 
-            Assert-MockCalled Set-PodeResponseStatus -Times 1 -Scope It
-            Assert-MockCalled Invoke-PodeMiddleware -Times 1 -Scope It
+            Should -Invoke Set-PodeResponseStatus -Times 1 -Scope It
+            Should -Invoke Invoke-PodeMiddleware -Times 1 -Scope It
         }
 
         It 'Runs the server, errors in endware' {
@@ -220,8 +220,8 @@ InModuleScope -ModuleName 'Pode' {
 
             { Start-PodeAwsLambdaServer -Data $d } | Should -Throw -ExpectedMessage 'some error'
 
-            Assert-MockCalled Set-PodeResponseStatus -Times 0 -Scope It
-            Assert-MockCalled Invoke-PodeMiddleware -Times 1 -Scope It
+            Should -Invoke Set-PodeResponseStatus -Times 0 -Scope It
+            Should -Invoke Invoke-PodeMiddleware -Times 1 -Scope It
         }
     }
 }

--- a/tests/unit/Sessions.Tests.ps1
+++ b/tests/unit/Sessions.Tests.ps1
@@ -243,8 +243,8 @@ InModuleScope -ModuleName 'Pode' {
 
             Set-PodeSession
 
-            Assert-MockCalled Set-PodeCookie -Times 1 -Scope It
-            Assert-MockCalled Get-PodeSessionExpiry -Times 1 -Scope It
+            Should -Invoke Set-PodeCookie -Times 1 -Scope It
+            Should -Invoke Get-PodeSessionExpiry -Times 1 -Scope It
         }
     }
 
@@ -261,7 +261,7 @@ InModuleScope -ModuleName 'Pode' {
             $WebEvent = @{}
             Remove-PodeSession
 
-            Assert-MockCalled Remove-PodeAuthSession -Times 0 -Scope It
+            Should -Invoke Remove-PodeAuthSession -Times 0 -Scope It
         }
 
         It 'Call removes the session' {
@@ -271,7 +271,7 @@ InModuleScope -ModuleName 'Pode' {
             $WebEvent = @{ Session = @{} }
             Remove-PodeSession
 
-            Assert-MockCalled Remove-PodeAuthSession -Times 1 -Scope It
+            Should -Invoke Remove-PodeAuthSession -Times 1 -Scope It
         }
     }
 
@@ -297,7 +297,7 @@ InModuleScope -ModuleName 'Pode' {
             }
 
             Save-PodeSession
-            Assert-MockCalled Save-PodeSessionInternal -Times 1 -Scope It
+            Should -Invoke Save-PodeSessionInternal -Times 1 -Scope It
         }
     }
 }

--- a/tests/unit/State.Tests.ps1
+++ b/tests/unit/State.Tests.ps1
@@ -72,7 +72,7 @@ InModuleScope -ModuleName 'Pode' {
             Set-PodeState -Name 'test' -Value 8
             Save-PodeState -Path './state.json'
 
-            Assert-MockCalled Out-File -Times 1 -Scope It
+            Should -Invoke Out-File -Times 1 -Scope It
         }
 
         It 'Saves the state to file with Include' {
@@ -83,7 +83,7 @@ InModuleScope -ModuleName 'Pode' {
             Set-PodeState -Name 'test' -Value 8
             Save-PodeState -Path './state.json' -Include 'test'
 
-            Assert-MockCalled Out-File -Times 1 -Scope It
+            Should -Invoke Out-File -Times 1 -Scope It
         }
 
         It 'Saves the state to file with Exclude' {
@@ -94,7 +94,7 @@ InModuleScope -ModuleName 'Pode' {
             Set-PodeState -Name 'test' -Value 8
             Save-PodeState -Path './state.json' -Exclude 'test'
 
-            Assert-MockCalled Out-File -Times 1 -Scope It
+            Should -Invoke Out-File -Times 1 -Scope It
         }
     }
 


### PR DESCRIPTION
Pester **6.0.0 is now released** 🎉 — thanks for letting me pilot the release candidates against your suite.

This updates the earlier release-candidate pin to the final **6.0.0** and keeps the test changes needed to run on Pester 6 (already in this PR). It's the same migration you'd make yourself, so you're welcome to merge it, cherry-pick just the compatibility changes, or use it purely as a reference.

Your full test suite passes on 6.0.0 across macOS, Ubuntu and Windows in this PR. 🟢

The real-world CI signal from this pilot was genuinely valuable in getting 6.0.0 right. Thanks for the CI time this used, and for maintaining a suite I could test against.

This PR was co-authored by GitHub Copilot.

— Jakub & Copilot
