### PR TITLE
Also fail on Pester block/container failures (not just failed tests)

### DIFF
--- a/pode.build.ps1
+++ b/pode.build.ps1
@@ -899,7 +899,7 @@ function Invoke-PodeBuildPester {
     )
 
     $results = Invoke-Pester -Configuration $Configuration
-    if ($results.FailedCount -gt 0) {
+    if (($results.FailedCount + $results.FailedBlocksCount + $results.FailedContainersCount) -gt 0) {
         throw "$($results.FailedCount) tests failed."
     }
 }


### PR DESCRIPTION
> ⚠️ This PR was generated by an AI agent (GitHub Copilot CLI). Please review accordingly.

I've been seeing this commonly across Pester 5 build scripts and I'm fixing it where it looks like it could hide real failures.

In Pester 5 a run reports three independent failure counts:

- `FailedCount` — failed tests (`It`)
- `FailedBlocksCount` — failed `BeforeAll` / `AfterAll`
- `FailedContainersCount` — files that error during discovery / fail to load

Gating on only `FailedCount` means a `BeforeAll` that throws, or a test file that fails to load, leaves `FailedCount = 0` and the build passes green despite real failures. Pester itself derives the overall pass/fail from the sum of all three.

This change includes all three counts in the gate. Display/log messages are left unchanged.
