### PR TITLE
Add support for fetching remote IP from Request headers when logging

### DIFF
--- a/docs/Tutorials/Logging/Types/Requests.md
+++ b/docs/Tutorials/Logging/Types/Requests.md
@@ -36,6 +36,14 @@ More information on formatting can be [found here](../../Formatting).
 
 The Request Log Type will transform a supplied raw web request into a [Combined Log Format](https://httpd.apache.org/docs/1.3/logs.html#combined) string. This string is then supplied to the Log Method's scriptblock. If you're using a Custom Log Method and want the raw log item instead, you can supply `-Raw` to [`Enable-PodeLogRequestType`](../../../../Functions/Logging/Enable-PodeLogRequestType).
 
+## Remote IP
+
+When logging requests, Pode will log the client's remote IP as the IP of network connection. Meaning if you're running Pode behind a proxy, you'll get the proxy's IP and not the originating client's IP.
+
+You can use the `-RemoteIPHeader` parameter to set one, or more, possible headers to check for the original client IP - typically `X-Forwarded-For` unless you're using a custom header. If the header is present on the request, that IP will be used; if no header is found then the default will be the raw network connection's IP.
+
+If multiple request header names are supplied, they will be checked in the order they are supplied.
+
 ## Examples
 
 ### Log to Terminal
@@ -44,6 +52,14 @@ The following example enables the Request Log Type, and will output all items to
 
 ```powershell
 New-PodeLogTerminalMethod | Enable-PodeLogRequestType
+```
+
+### Log Proxy IP
+
+The following example enables the Request Log Type, and will fetch the client IP from `X-Forwarded-For`:
+
+```powershell
+New-PodeLogTerminalMethod | Enable-PodeLogRequestType -RemoteIPHeader 'X-Forwarded-For'
 ```
 
 ### Log as JSON

--- a/src/Private/Logging.ps1
+++ b/src/Private/Logging.ps1
@@ -927,6 +927,9 @@ function Write-PodeRequestLog {
         return
     }
 
+    # get the request log type
+    $logType = Get-PodeLogType -Name ([PodeLogger]::REQUEST_LOG_TYPE_NAME)
+
     # build a request object
     $item = @{
         Host            = $Request.Handler.RemoteEndPoint.Address.IPAddressToString
@@ -956,9 +959,20 @@ function Write-PodeRequestLog {
         $item.Response.Size = $Response.ContentLength64
     }
 
+    # do we need to get the host address from req headers (if behind a reverse proxy)?
+    $remoteIpHeaders = $logType.Metadata.RemoteIPHeader
+    if (($null -ne $remoteIpHeaders) -and ($remoteIpHeaders.Count -gt 0)) {
+        foreach ($header in $remoteIpHeaders) {
+            if (Test-PodeHeader -Name $header) {
+                $item.Host = ((Get-PodeHeader -Name $header) -split ',')[0].Trim()
+                break
+            }
+        }
+    }
+
     # set username - dot spaces
     if (Test-PodeAuthUser -IgnoreSession) {
-        $userProps = (Get-PodeLogType -Name ([PodeLogger]::REQUEST_LOG_TYPE_NAME)).Metadata.Username.Split('.')
+        $userProps = $logType.Metadata.Username.Split('.')
 
         $user = $WebEvent.Auth.User
         foreach ($atom in $userProps) {

--- a/src/Public/Headers.ps1
+++ b/src/Public/Headers.ps1
@@ -127,8 +127,7 @@ function Test-PodeHeader {
         $Name
     )
 
-    $header = (Get-PodeHeader -Name $Name)
-    return (![string]::IsNullOrWhiteSpace($header))
+    return $WebEvent.Request.Headers.ContainsKey($Name)
 }
 
 <#
@@ -171,7 +170,7 @@ function Get-PodeHeader {
 
     # if a secret was supplied, attempt to unsign the header's value
     if (![string]::IsNullOrWhiteSpace($Secret)) {
-        $header = (Invoke-PodeValueUnsign -Value $header -Secret $Secret -Strict:$Strict)
+        $header = Invoke-PodeValueUnsign -Value $header -Secret $Secret -Strict:$Strict
     }
 
     return $header

--- a/src/Public/Logging.ps1
+++ b/src/Public/Logging.ps1
@@ -217,11 +217,17 @@ An array of arguments to supply to the Custom Log Type's ScriptBlock and Seriali
 .PARAMETER SyslogInfo
 A hashtable containing Syslog configuration information, built using New-PodeSyslogInfo.
 
+.PARAMETER RemoteIPHeader
+One or more optional headers to check for the client's remote IP address, if behind a reverse proxy.
+
 .PARAMETER Raw
 If supplied, the log item returned will be the raw Request item as a hashtable and not a string (for Custom methods).
 
 .EXAMPLE
 New-PodeLogTerminalMethod | Enable-PodeLogRequestType
+
+.EXAMPLE
+New-PodeLogTerminalMethod | Enable-PodeLogRequestType -RemoteIPHeader 'X-Forwarded-For'
 
 .EXAMPLE
 New-PodeLogTerminalMethod | Enable-PodeLogRequestType -SerialiseFormat 'Json'
@@ -283,6 +289,10 @@ function Enable-PodeLogRequestType {
         [hashtable]
         $SyslogInfo,
 
+        [Parameter()]
+        [string[]]
+        $RemoteIPHeader,
+
         [Parameter(ParameterSetName = 'Raw')]
         [switch]
         $Raw
@@ -320,8 +330,11 @@ function Enable-PodeLogRequestType {
         if ([string]::IsNullOrWhiteSpace($UsernameProperty)) {
             $UsernameProperty = 'Username'
         }
+
+        # add metadata
         $params['Metadata'] = @{
-            Username = $UsernameProperty
+            Username       = $UsernameProperty
+            RemoteIPHeader = $RemoteIPHeader
         }
 
         # add LogFormat if supplied
@@ -783,6 +796,11 @@ function Add-PodeLogType {
         # all errors?
         if ($Levels -contains '*') {
             $Levels = @('Emergency', 'Alert', 'Critical', 'Error', 'Warning', 'Notice', 'Informational', 'Verbose', 'Debug')
+        }
+
+        # default metadata
+        if ($null -eq $Metadata) {
+            $Metadata = @{}
         }
 
         # default log formatter


### PR DESCRIPTION
### Description of the Change
Adds a `-RemoteIPHeader` parameter on `Enable-PodeLogRequestType` to enable retrieving remote IPs of clients from Request headers. If not supplied, or if the header(s) are not found on the Request, then the network connection's remote IP will be used.

### Related Issue
Resolves #1587 

### Examples
```powershell
New-PodeLogTerminalMethod | Enable-PodeLogRequestType -RemoteIPHeader 'X-Forwarded-For'
```
