### PR TITLE
Fixes the Date timestamp on the Request Logging object; Adds Common and W3C Request Logging formats; Adds support for retrieving headers from the Response

### DIFF
--- a/docs/Tutorials/Logging/Formatting.md
+++ b/docs/Tutorials/Logging/Formatting.md
@@ -56,8 +56,11 @@ For example, the inbuilt Request Log Type's serialise scriptblock looks as follo
 ```powershell
 $scriptblock = {
     param($data)
-    $reqLine = "$($data.Method) $($data.Resource) $($data.Protocol)"
-    return "$($data.Host) $($data.Identifier) $($data.User) [$($data.Date)] `"$($reqLine)`" $($data.StatusCode) $($data.Size) `"$($data.Referrer)`" `"$($data.UserAgent)`""
+
+    $reqLine = "$($data.Request.Method) $($data.Request.Resource) $($data.Request.Protocol)"
+    $date = $data.Date.ToString('dd/MMM/yyyy:HH:mm:ss zzz')
+
+    return "$($data.Request.Host) $($data.Request.Identifier) $($data.Request.User) [$($date)] `"$($reqLine)`" $($data.Response.Status.Code) $($data.Response.Size) `"$($data.Request.Referrer)`" `"$($data.Request.UserAgent)`""
 }
 ```
 
@@ -98,7 +101,7 @@ When serialising custom Log Types into XML the default root element is `<root>`,
 
 ### Global
 
-You can configure a global serialisation format to use via [`Set-PodeLogDefaultSerialiseFormat`]. If you **don't** supply `-SerialiseFormat` then the global default will be used instead.
+You can configure a global serialisation format to use via [`Set-PodeLogDefaultSerialiseFormat`](../../../Functions/Logging/Set-PodeLogDefaultSerialiseFormat). If you **don't** supply `-SerialiseFormat` then the global default will be used instead.
 
 By default there is no global default; not supplying `-SerialiseFormat` will default to the Log Type's local default value - format inbuilt type this is Custom, and for custom types this is None.
 
@@ -166,8 +169,8 @@ New-PodeLogTerminalMethod | Enable-PodeLogRequestType -LogFormat Syslog -SyslogI
 
 ### Global
 
-You can configure a global log format to use via [`Set-PodeLogDefaultFormat`]. If you **don't** supply `-LogFormat` then the global default will be used instead.
+You can configure a global log format to use via [`Set-PodeLogDefaultFormat`](../../../Functions/Logging/Set-PodeLogDefaultFormat). If you **don't** supply `-LogFormat` then the global default will be used instead.
 
 By default there is no global default; not supplying `-LogFormat` will default to the Log Type's local default value - usually None.
 
-The same can also be done for syslog formatting using [`Set-PodeLogDefaultSyslogFormat`]. Similar to above this will apply when either no `-SyslogInfo` is supplied, or no `-Format` is supplied to [`New-PodeLogSyslogInfo`].
+The same can also be done for syslog formatting using [`Set-PodeLogDefaultSyslogFormat`](../../../Functions/Logging/Set-PodeLogDefaultSyslogFormat). Similar to above this will apply when either no `-SyslogInfo` is supplied, or no `-Format` is supplied to [`New-PodeLogSyslogInfo`](../../../Functions/Logging/New-PodeLogSyslogInfo).

--- a/docs/Tutorials/Logging/Formatting.md
+++ b/docs/Tutorials/Logging/Formatting.md
@@ -125,9 +125,10 @@ When Custom is specified then a `-LogScriptBlock` is required to be supplied as 
 
 When log formatting occurs, after serialisation, this scriptblock will be invoked. Supplied to this scriptblock are the following parameters:
 
-1. The resultant data returned from the Log Type's main `-ScriptBlock`, and after any serialisation
+1. The resultant data returned from the Log Type's main `-ScriptBlock`, and after any serialisation - could also be a log header value
 2. The [Log Event](../Objects#log-event) object
-3. Items supplied to `-ArgumentList`, splatted as individual parameters
+3. A boolean value, if `$true` the data in the first parameter is a log header, if `$false` it's the log item data
+4. Items supplied to `-ArgumentList`, splatted as individual parameters
 
 For example, a simple pipe-delimited format of `<LEVEL>|<DATETIME>|<MESSAGE>:
 

--- a/docs/Tutorials/Logging/Types/Requests.md
+++ b/docs/Tutorials/Logging/Types/Requests.md
@@ -91,7 +91,7 @@ If nothing is supplied to `-W3CInfo` then default fields will be used instead, i
 * cs(USer-Agent)
 * cs(Referer)
 
-For example:
+For example, the following will log requests in W3C format to the terminal:
 
 ```powershell
 $fields = New-PodeLogW3CInfo -Fields @(
@@ -107,7 +107,20 @@ $fields = New-PodeLogW3CInfo -Fields @(
     Add-PodeLogW3CCustomField -Name 'User-Agent' -Type Request
     Add-PodeLogW3CCustomField -Name 'Referer' -Type Request
 )
+
+New-PodeLogTerminalMethod | Enable-PodeLogRequestType -Format W3C -W3CInfo $fields
 ```
+
+Additionally, with this being W3C format, the first log item being written after server Start or Restart will also produce the following directive log headers:
+
+```plain
+#Software: Pode 2.14.0
+#Version: 1.0
+#Date: 2026-07-14 18:55:00
+#Fields: date time c-ip cs-method cs-uri-stem cs-uri-query cs-username sc-status time-taken cs(USer-Agent) cs(Referer)
+```
+
+If you do not want these to appear, supply `-NoLogHeader` to `New-PodeLogW3CInfo`.
 
 ## Remote IP
 

--- a/docs/Tutorials/Logging/Types/Requests.md
+++ b/docs/Tutorials/Logging/Types/Requests.md
@@ -34,7 +34,80 @@ Enable-PodeLogRequestType -ScriptBlock {
 
 More information on formatting can be [found here](../../Formatting).
 
-The Request Log Type will transform a supplied raw web request into a [Combined Log Format](https://httpd.apache.org/docs/1.3/logs.html#combined) string. This string is then supplied to the Log Method's scriptblock. If you're using a Custom Log Method and want the raw log item instead, you can supply `-Raw` to [`Enable-PodeLogRequestType`](../../../../Functions/Logging/Enable-PodeLogRequestType).
+The Request Log Type also has its own additional formatting options supplied via `-Format`, and will transform a supplied raw web request into one of the following formats:
+
+* Combined (default)
+* Common
+* W3C
+
+This formatted string is then supplied to the Log Methods. If you're using a Custom Log Method and want the raw unformatted log item instead, you can supply `-Raw` to [`Enable-PodeLogRequestType`](../../../../Functions/Logging/Enable-PodeLogRequestType).
+
+### W3C
+
+Unlike the Common and Combined log formats, with W3C you can customise the fields that are logged.
+
+To do this you will need to build and supply a W3C Info object to the `-W3CInfo` parameter. This info object will let you define which inbuilt fields to log, as well as which request/response headers, and any process environment variables. To build the info object, you'll need to use [`New-PodeLogW3CInfo`](../../../../Functions/Logging/New-PodeLogW3CInfo), and supply `-Fields` using [`Add-PodeLogW3CField`](../../../../Functions/Logging/Add-PodeLogW3CField) or [`Add-PodeLogW3CCustomField`](../../../../Functions/Logging/Add-PodeLogW3CCustomField).
+
+The inbuilt fields are:
+
+| Field          | Description                                                 |
+| -------------- | ----------------------------------------------------------- |
+| date           | The date that the request occurred, as `yyyy-MM-dd`         |
+| time           | The time that the request occurred, as `HH:mm:ss`           |
+| c-ip           | The IP address of the client making the request             |
+| cs-username    | The username of any authenticated user                      |
+| s-ip           | The IP address of the endpoint the request was received on  |
+| s-port         | The port of the endpoint the request was received on        |
+| s-computername | The computer name of the server the request was received on |
+| cs-method      | The HTTP method of the request                              |
+| cs-uri-stem    | The URI stem of the request                                 |
+| cs-uri-query   | The query string of the request                             |
+| sc-status      | The HTTP status code of the response                        |
+| time-taken     | The time taken to process the request, in milliseconds      |
+| sc-bytes       | The number of bytes sent by the server                      |
+| cs-bytes       | The number of bytes received from the client                |
+| cs-version     | The HTTP version of the request                             |
+| cs-host        | The host header of the request                              |
+
+Any custom fields will be named as follows:
+
+| Type        | Field Decorator |
+| ----------- | --------------- |
+| Request     | `cs(...)`       |
+| Response    | `sc(...)`       |
+| Environment | `x-...`         |
+
+If nothing is supplied to `-W3CInfo` then default fields will be used instead, in the ordered displayed here:
+
+* date
+* time
+* c-ip
+* cs-method
+* cs-uri-stem
+* cs-uri-query
+* cs-username
+* sc-status
+* time-taken
+* cs(USer-Agent)
+* cs(Referer)
+
+For example:
+
+```powershell
+$fields = New-PodeLogW3CInfo -Fields @(
+    Add-PodeLogW3CField -Name 'date'
+    Add-PodeLogW3CField -Name 'time'
+    Add-PodeLogW3CField -Name 'c-ip'
+    Add-PodeLogW3CField -Name 'cs-method'
+    Add-PodeLogW3CField -Name 'cs-uri-stem'
+    Add-PodeLogW3CField -Name 'cs-uri-query'
+    Add-PodeLogW3CField -Name 'cs-username'
+    Add-PodeLogW3CField -Name 'sc-status'
+    Add-PodeLogW3CField -Name 'time-taken'
+    Add-PodeLogW3CCustomField -Name 'User-Agent' -Type Request
+    Add-PodeLogW3CCustomField -Name 'Referer' -Type Request
+)
+```
 
 ## Remote IP
 

--- a/pode.build.ps1
+++ b/pode.build.ps1
@@ -1402,7 +1402,7 @@ Add-BuildTask DocsNoBuild DocsDeps, {
 }
 
 # Synopsis: Build the function help documentation
-Add-BuildTask DocsHelpBuild IndexSamples, DocsDeps, Build, {
+Add-BuildTask DocsHelpBuild { #IndexSamples, DocsDeps, Build, {
     # import the local module
     Remove-Module Pode -Force -ErrorAction Ignore | Out-Null
     Import-Module ./src/Pode.psm1 -Force | Out-Null
@@ -1429,7 +1429,7 @@ Add-BuildTask DocsHelpBuild IndexSamples, DocsDeps, Build, {
         $content = (Get-Content -Path $_.FullName | ForEach-Object {
                 $line = $_
 
-                while ($line -imatch '(?<func>\[`(?<name>[a-z]+\-pode[a-z]+)`\])([^(])') {
+                while ($line -imatch '(?<func>\[`(?<name>[a-z]+\-pode[a-z0-9]+)`\])([^(])') {
                     $updated = $true
                     $func = $Matches['func']
                     $name = $Matches['name']

--- a/pode.build.ps1
+++ b/pode.build.ps1
@@ -1402,7 +1402,7 @@ Add-BuildTask DocsNoBuild DocsDeps, {
 }
 
 # Synopsis: Build the function help documentation
-Add-BuildTask DocsHelpBuild { #IndexSamples, DocsDeps, Build, {
+Add-BuildTask DocsHelpBuild IndexSamples, DocsDeps, Build, {
     # import the local module
     Remove-Module Pode -Force -ErrorAction Ignore | Out-Null
     Import-Module ./src/Pode.psm1 -Force | Out-Null

--- a/src/Listener/Protocols/Common/Responses/PodeResponseHeaders.cs
+++ b/src/Listener/Protocols/Common/Responses/PodeResponseHeaders.cs
@@ -28,7 +28,7 @@ namespace Pode.Protocols.Common.Responses
 
         public IList<object> Get(string name)
         {
-            return Headers.TryGetValue(name, out IList<object> value) ? value : default(IList<object>);
+            return Headers.TryGetValue(name, out IList<object> value) ? value : default;
         }
 
         public void Set(string name, object value)
@@ -63,6 +63,5 @@ namespace Pode.Protocols.Common.Responses
         {
             Headers.Clear();
         }
-
     }
 }

--- a/src/Pode.psd1
+++ b/src/Pode.psd1
@@ -180,6 +180,9 @@
         'ConvertTo-PodeString',
         'Get-PodeServerName',
         'Get-PodeAppName',
+        'Get-PodeEnvironmentVariable',
+        'Set-PodeEnvironmentVariable',
+        'Test-PodeEnvironmentVariable',
 
         # routes
         'Add-PodeRoute',
@@ -358,6 +361,9 @@
         'Set-PodeLogDefaultFormat',
         'Set-PodeLogDefaultSerialiseFormat',
         'Set-PodeLogDefaultSyslogFormat',
+        'New-PodeLogW3CInfo',
+        'Add-PodeLogW3CField',
+        'Add-PodeLogW3CCustomField',
 
         # core
         'Start-PodeServer',

--- a/src/Private/Logging.ps1
+++ b/src/Private/Logging.ps1
@@ -806,6 +806,97 @@ function ConvertTo-PodeDatadogLevel {
     return 'INFO'
 }
 
+function Get-PodeLoggingInbuiltSerialiseType {
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('Errors', 'Requests')]
+        [string]
+        $Type
+    )
+
+    switch ($Type.ToLowerInvariant()) {
+        'requests' {
+            return {
+                param($data)
+                $logType = Get-PodeLogType -Name ([PodeLogger]::REQUEST_LOG_TYPE_NAME)
+
+                # are we dealing with common/combined?
+                if ($logType.Metadata.Format -iin @('common', 'combined')) {
+                    $method = Protect-PodeLogRequestItem -Value $data.Request.Method
+                    $resource = Protect-PodeLogRequestItem -Value $data.Request.Resource
+                    $protocol = Protect-PodeLogRequestItem -Value $data.Request.Protocol
+                    $reqLine = "$($method) $($resource) $($protocol)"
+
+                    $ip = Protect-PodeLogRequestItem -Value $data.Request.Host
+                    $identifier = Protect-PodeLogRequestItem -Value $data.Request.Identifier
+                    $user = Protect-PodeLogRequestItem -Value $data.Request.User
+                    $date = $data.Date.ToString('dd/MMM/yyyy:HH:mm:ss zzz')
+                    $statusCode = Protect-PodeLogRequestItem -Value $data.Response.Status.Code
+                    $size = Protect-PodeLogRequestItem -Value $data.Response.Size
+
+                    $baseMsg = "$($ip) $($identifier) $($user) [$($date)] `"$($reqLine)`" $($statusCode) $($size)"
+
+                    if ($logType.Metadata.Format -ieq 'combined') {
+                        $referrer = Protect-PodeLogRequestItem -Value $data.Request.Referrer
+                        $userAgent = Protect-PodeLogRequestItem -Value $data.Request.UserAgent
+                        $baseMsg = "$($baseMsg) `"$($referrer)`" `"$($userAgent)`""
+                    }
+
+                    return $baseMsg
+                }
+
+                # otherwise, we're dealing with W3C
+                $builder = [System.Text.StringBuilder]::new()
+
+                foreach ($field in $logType.Metadata.W3CFields) {
+                    $value = switch ($field.Type) {
+                        'Request' { $data.Request.Headers[$field.Name] }
+                        'Response' { $data.Response.Headers[$field.Name] }
+                        'Environment' { $data.Environment.Variables[$field.Name] }
+
+                        'Standard' {
+                            switch ($field.FieldName) {
+                                'date' { $data.Date.ToString('yyyy-MM-dd') }
+                                'time' { $data.Date.ToString('HH:mm:ss') }
+                                'c-ip' { $data.Request.Host }
+                                'cs-username' { $data.Request.User }
+                                's-ip' { $data.Server.IP }
+                                's-port' { $data.Server.Port }
+                                's-computername' { $PodeContext.Server.ComputerName }
+                                'cs-method' { $data.Request.Method }
+                                'cs-uri-stem' { $data.Request.Resource }
+                                'cs-uri-query' { $data.Request.Query }
+                                'sc-status' { $data.Response.Status.Code }
+                                'time-taken' { [long]$data.Duration.TotalMilliseconds }
+                                'sc-bytes' { $data.Response.Size }
+                                'cs-bytes' { $data.Request.Size }
+                                'cs-version' { $data.Request.Protocol }
+                                'cs-host' { $data.Request.Hostname }
+                            }
+                        }
+                    }
+
+                    $value = Protect-PodeLogRequestItem -Value $value -Encode
+                    $null = $builder.Append($value).Append(' ')
+                }
+
+                return $builder.ToString()
+            }
+        }
+
+        'errors' {
+            return {
+                param($data)
+                $msg = @(foreach ($key in $data.Keys) {
+                        "$($key): $($data[$key])"
+                    }) -join "`n"
+
+                return "$($msg)`n"
+            }
+        }
+    }
+}
+
 function Get-PodeLoggingInbuiltType {
     param(
         [Parameter(Mandatory = $true)]
@@ -816,30 +907,51 @@ function Get-PodeLoggingInbuiltType {
 
     switch ($Type.ToLowerInvariant()) {
         'requests' {
-            $script = {
+            return {
                 param(
                     [Pode.Utilities.Logging.IPodeLogEvent]
                     $logEvent
                 )
 
                 return [ordered]@{
-                    Host       = Protect-PodeLogRequestItem -Value $logEvent.Data.Host
-                    Identifier = Protect-PodeLogRequestItem -Value $logEvent.Data.RfcUserIdentity
-                    User       = Protect-PodeLogRequestItem -Value $logEvent.Data.User
-                    Date       = Protect-PodeLogRequestItem -Value $logEvent.Data.Date
-                    Method     = Protect-PodeLogRequestItem -Value $logEvent.Data.Request.Method
-                    Resource   = Protect-PodeLogRequestItem -Value $logEvent.Data.Request.Resource
-                    Protocol   = Protect-PodeLogRequestItem -Value $logEvent.Data.Request.Protocol
-                    StatusCode = Protect-PodeLogRequestItem -Value $logEvent.Data.Response.StatusCode
-                    Size       = Protect-PodeLogRequestItem -Value $logEvent.Data.Response.Size
-                    Referrer   = Protect-PodeLogRequestItem -Value $logEvent.Data.Request.Referrer
-                    UserAgent  = Protect-PodeLogRequestItem -Value $logEvent.Data.Request.Agent
+                    Date        = $logEvent.Data.Date
+                    Duration    = $logEvent.Data.Duration
+                    Server      = [ordered]@{
+                        IP   = $logEvent.Data.Server.IP
+                        Port = $logEvent.Data.Server.Port
+                    }
+                    Environment = [ordered]@{
+                        Variables = $logEvent.Data.Environment.Variables
+                    }
+                    Request     = [ordered]@{
+                        Host       = $logEvent.Data.Host
+                        Identifier = $logEvent.Data.RfcUserIdentity
+                        User       = $logEvent.Data.User
+                        Method     = $logEvent.Data.Request.Method
+                        Hostname   = $logEvent.Data.Request.Hostname
+                        Scheme     = $logEvent.Data.Request.Scheme
+                        Resource   = $logEvent.Data.Request.Resource
+                        Query      = $logEvent.Data.Request.Query
+                        Protocol   = $logEvent.Data.Request.Protocol
+                        Referrer   = $logEvent.Data.Request.Referrer
+                        UserAgent  = $logEvent.Data.Request.Agent
+                        Size       = $logEvent.Data.Request.Size
+                        Headers    = $logEvent.Data.Request.Headers
+                    }
+                    Response    = [ordered]@{
+                        Status  = [ordered]@{
+                            Code        = $logEvent.Data.Response.StatusCode
+                            Description = $logEvent.Data.Response.StatusDescription
+                        }
+                        Size    = $logEvent.Data.Response.Size
+                        Headers = $logEvent.Data.Response.Headers
+                    }
                 }
             }
         }
 
         'errors' {
-            $script = {
+            return {
                 param(
                     [Pode.Utilities.Logging.IPodeLogEvent]
                     $logEvent
@@ -858,19 +970,24 @@ function Get-PodeLoggingInbuiltType {
             }
         }
     }
-
-    return $script
 }
 
 function Protect-PodeLogRequestItem {
     param(
         [Parameter()]
         [object]
-        $Value
+        $Value,
+
+        [switch]
+        $Encode
     )
 
     if ([string]::IsNullOrWhiteSpace($Value)) {
-        return '-'
+        $Value = '-'
+    }
+
+    if ($Encode) {
+        $Value = [uri]::EscapeUriString($Value)
     }
 
     return $Value
@@ -909,19 +1026,27 @@ function Test-PodeLogMethod {
     return $PodeContext.Server.Logging.Methods.ContainsKey($Id)
 }
 
-function Write-PodeRequestLog {
-    param(
-        [Parameter(Mandatory = $true)]
-        $Request,
+function Get-PodeRequestLogW3CDefaultInfo {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param()
 
-        [Parameter(Mandatory = $true)]
-        $Response,
-
-        [Parameter()]
-        [string]
-        $Path
+    return New-PodeLogW3CInfo -Fields @(
+        Add-PodeLogW3CField -Name 'date'
+        Add-PodeLogW3CField -Name 'time'
+        Add-PodeLogW3CField -Name 'c-ip'
+        Add-PodeLogW3CField -Name 'cs-method'
+        Add-PodeLogW3CField -Name 'cs-uri-stem'
+        Add-PodeLogW3CField -Name 'cs-uri-query'
+        Add-PodeLogW3CField -Name 'cs-username'
+        Add-PodeLogW3CField -Name 'sc-status'
+        Add-PodeLogW3CField -Name 'time-taken'
+        Add-PodeLogW3CCustomField -Name 'User-Agent' -Type Request
+        Add-PodeLogW3CCustomField -Name 'Referer' -Type Request
     )
+}
 
+function Write-PodeRequestLog {
     # do nothing if request logging isn't setup
     if (!$PodeContext.Server.Logging.Logger.IsRequestLoggingEnabled) {
         return
@@ -930,33 +1055,62 @@ function Write-PodeRequestLog {
     # get the request log type
     $logType = Get-PodeLogType -Name ([PodeLogger]::REQUEST_LOG_TYPE_NAME)
 
+    # http method
+    $method = $null
+    if (![string]::IsNullOrEmpty($WebEvent.Request.HttpMethod)) {
+        $method = $WebEvent.Request.HttpMethod.ToUpperInvariant()
+    }
+
+    # hostname
+    $hostname = $null
+    if (![string]::IsNullOrEmpty($WebEvent.Request.Host)) {
+        $hostname = $WebEvent.Request.Host.ToLowerInvariant()
+    }
+
+    # scheme
+    $scheme = $null
+    if (![string]::IsNullOrEmpty($WebEvent.Request.Handler.Scheme)) {
+        $scheme = $WebEvent.Request.Handler.Scheme.ToLowerInvariant()
+    }
+
     # build a request object
     $item = @{
-        Host            = $Request.Handler.RemoteEndPoint.Address.IPAddressToString
+        Host            = $WebEvent.Request.Handler.RemoteEndPoint.Address.IPAddressToString
         RfcUserIdentity = $null
         User            = $null
-        Date            = [DateTime]::Now.ToString('dd/MMM/yyyy:HH:mm:ss zzz')
-        UtcDate         = [DateTime]::UtcNow
+        Date            = $WebEvent.Timestamp.ToLocalTime()
+        UtcDate         = $WebEvent.Timestamp
+        Duration        = [datetime]::UtcNow.Subtract($WebEvent.Timestamp)
+        Server          = @{
+            IP   = $WebEvent.Request.Handler.LocalEndPoint.Address.IPAddressToString
+            Port = $WebEvent.Request.Handler.LocalEndPoint.Port
+        }
+        Environment     = @{
+            Variables = @{}
+        }
         Request         = @{
-            Method   = $Request.HttpMethod.ToUpperInvariant()
-            Hostname = $Request.Host.ToLowerInvariant()
-            Scheme   = $Request.Handler.Scheme.ToLowerInvariant()
-            Resource = $Path
-            Query    = (Protect-PodeValue -Value $Request.Url.Query -Default ([string]::Empty)).TrimStart('?')
-            Protocol = "HTTP/$($Request.ProtocolVersion)"
-            Referrer = $Request.UrlReferrer
-            Agent    = $Request.UserAgent
+            Method   = $method
+            Hostname = $hostname
+            Scheme   = $scheme
+            Resource = $WebEvent.Path
+            Query    = (Protect-PodeValue -Value $WebEvent.Request.Url.Query -Default ([string]::Empty)).TrimStart('?')
+            Protocol = "HTTP/$($WebEvent.Request.ProtocolVersion)"
+            Referrer = $WebEvent.Request.UrlReferrer
+            Agent    = $WebEvent.Request.UserAgent
+            Size     = $WebEvent.Request.ContentLength
+            Headers  = @{}
         }
         Response        = @{
-            StatusCode        = $Response.StatusCode
-            StatusDescription = $Response.StatusDescription
+            StatusCode        = $WebEvent.Response.StatusCode
+            StatusDescription = $WebEvent.Response.StatusDescription
             Size              = $null
+            Headers           = @{}
         }
     }
 
-    # set size if >0
-    if ($Response.ContentLength64 -gt 0) {
-        $item.Response.Size = $Response.ContentLength64
+    # set size of data sent back to the client if >0
+    if ($WebEvent.Response.ContentLength64 -gt 0) {
+        $item.Response.Size = $WebEvent.Response.ContentLength64
     }
 
     # do we need to get the host address from req headers (if behind a reverse proxy)?
@@ -984,6 +1138,31 @@ function Write-PodeRequestLog {
         }
     }
 
+    # for w3c format, we need to fetch req/resp headers, and server env vars
+    if ($logType.Metadata.Format -ieq 'W3C') {
+        foreach ($field in $logType.Metadata.W3CFields) {
+            switch ($field.Type) {
+                'Request' {
+                    if (Test-PodeHeader -Name $field.Name) {
+                        $item.Request.Headers[$field.Name] = Get-PodeHeader -Name $field.Name
+                    }
+                }
+
+                'Response' {
+                    if (Test-PodeHeader -Name $field.Name -Response) {
+                        $item.Response.Headers[$field.Name] = Get-PodeHeader -Name $field.Name -Response
+                    }
+                }
+
+                'Environment' {
+                    if (Test-PodeEnvironmentVariable -Name $field.Name) {
+                        $item.Environment.Variables[$field.Name] = Get-PodeEnvironmentVariable -Name $field.Name
+                    }
+                }
+            }
+        }
+    }
+
     # add the item to be processed
     $logEvent = [PodeLogEvent]::new([PodeLogger]::REQUEST_LOG_TYPE_NAME, [PodeLogLevel]::Informational, $item)
     $PodeContext.Server.Logging.Logger.Add($logEvent)
@@ -1004,7 +1183,7 @@ function Add-PodeRequestLogEndware {
     # add the request logging endware
     $WebEvent.OnEnd += @{
         Logic = {
-            Write-PodeRequestLog -Request $WebEvent.Request -Response $WebEvent.Response -Path $WebEvent.Path
+            Write-PodeRequestLog
         }
     }
 }
@@ -1094,41 +1273,26 @@ function Start-PodeLoggingRunspace {
                         }
                     }
 
-                    # transform the result to syslog or other log formats (None just leaves "result" as it - no formatting
-                    switch ($logType.Options.Formatting.Log.Format) {
-                        'Syslog' {
-                            $params = @{
-                                Message   = $result
-                                Level     = $logEvent.Level
-                                Timestamp = $logEvent.Timestamp
-                                AppName   = $logType.Options.Formatting.SyslogInfo.AppName
-                                Tags      = $logType.Options.Formatting.SyslogInfo.Tags
-                                Format    = $logType.Options.Formatting.SyslogInfo.Format
-                                Facility  = $logType.Options.Formatting.SyslogInfo.Facility
+                    # is this the first log for the log type, if so do we have any log headers to send?
+                    if (!$logType.SentFirstLog) {
+                        foreach ($logHeader in $logType.Options.Formatting.Headers) {
+                            if ([string]::IsNullOrEmpty($logHeader)) {
+                                continue
                             }
-                            $result = ConvertTo-PodeSyslog @params
+
+                            # transform log header, and push to log methods
+                            $logHeader = ConvertTo-PodeLogFormat -LogEvent $logEvent -LogType $logType -Message $logHeader -IsLogHeader
+                            Push-PodeLogItem -LogEvent $logEvent -LogType $logType -Message $logHeader
                         }
 
-                        'Custom' {
-                            $_args = @($result) + @($logEvent) + @($logType.Arguments)
-                            $result = Invoke-PodeScriptBlock -ScriptBlock $logType.Options.Formatting.Log.ScriptBlock -Arguments $_args -UsingVariables $logType.Options.Formatting.Log.UsingVariables -Return -Splat
-                        }
+                        $logType.SentFirstLog = $true
                     }
 
-                    # loop through each Log Method available to the Log Type
-                    foreach ($logMethodId in $logType.Method) {
-                        $logMethod = Get-PodeLogMethod -Id $logMethodId
-                        $batch = $logMethod.Batch
+                    # transform the result to syslog or other log formats
+                    $result = ConvertTo-PodeLogFormat -LogEvent $logEvent -LogType $logType -Message $result
 
-                        # add current item to batch
-                        $batch.Items.Add([Pode.Utilities.Logging.PodeLogItem]::new($result, $logEvent))
-
-                        # if the batch is full, send to Log Method and reset
-                        if ($batch.Items.IsFull) {
-                            $logMethod.Queue.Add($batch.Items)
-                            $batch.Items = [Pode.Utilities.Logging.PodeLogItemCollection]::new($batch.Items.MaxCount, $batch.Items.Timeout)
-                        }
-                    }
+                    # push Log Item to each Log Method for the Log Type
+                    Push-PodeLogItem -LogEvent $logEvent -LogType $logType -Message $result
 
                     # small sleep to lower cpu usage when there are lots of logs to process
                     Start-Sleep -Milliseconds 100
@@ -1163,6 +1327,85 @@ function Start-PodeLoggingRunspace {
     Write-Verbose 'Starting the Log Dispatcher runspace...'
     Add-PodeRunspace -Type Logs -Name 'Dispatcher' -ScriptBlock $script
     $PodeContext.Server.Logging.Running = $true
+}
+
+function ConvertTo-PodeLogFormat {
+    param(
+        [Parameter(Mandatory = $true)]
+        [Pode.Utilities.Logging.IPodeLogEvent]
+        $LogEvent,
+
+        [Parameter(Mandatory = $true)]
+        [hashtable]
+        $LogType,
+
+        [Parameter(Mandatory = $true)]
+        $Message,
+
+        [switch]
+        $IsLogHeader
+    )
+
+    switch ($LogType.Options.Formatting.Log.Format) {
+        'Syslog' {
+            $params = @{
+                Message   = $Message
+                Level     = $LogEvent.Level
+                Timestamp = $LogEvent.Timestamp
+                AppName   = $LogType.Options.Formatting.SyslogInfo.AppName
+                Tags      = $LogType.Options.Formatting.SyslogInfo.Tags
+                Format    = $LogType.Options.Formatting.SyslogInfo.Format
+                Facility  = $LogType.Options.Formatting.SyslogInfo.Facility
+            }
+
+            return ConvertTo-PodeSyslog @params
+        }
+
+        'Custom' {
+            $params = @{
+                ScriptBlock    = $LogType.Options.Formatting.Log.ScriptBlock
+                Arguments      = @($Message, $LogEvent, $IsLogHeader.IsPresent) + @($LogType.Arguments)
+                UsingVariables = $LogType.Options.Formatting.Log.UsingVariables
+                Return         = $true
+                Splat          = $true
+            }
+
+            return Invoke-PodeScriptBlock @params
+        }
+
+        default {
+            return $Message
+        }
+    }
+}
+
+function Push-PodeLogItem {
+    param(
+        [Parameter(Mandatory = $true)]
+        [Pode.Utilities.Logging.IPodeLogEvent]
+        $LogEvent,
+
+        [Parameter(Mandatory = $true)]
+        [hashtable]
+        $LogType,
+
+        [Parameter(Mandatory = $true)]
+        $Message
+    )
+
+    foreach ($logMethodId in $LogType.Method) {
+        $logMethod = Get-PodeLogMethod -Id $logMethodId
+        $batch = $logMethod.Batch
+
+        # add current item to batch
+        $batch.Items.Add([Pode.Utilities.Logging.PodeLogItem]::new($Message, $LogEvent))
+
+        # if the batch is full, send to Log Method and reset
+        if ($batch.Items.IsFull) {
+            $logMethod.Queue.Add($batch.Items)
+            $batch.Items = [Pode.Utilities.Logging.PodeLogItemCollection]::new($batch.Items.MaxCount, $batch.Items.Timeout)
+        }
+    }
 }
 
 function Add-PodeLogMethod {

--- a/src/Public/Headers.ps1
+++ b/src/Public/Headers.ps1
@@ -107,16 +107,22 @@ function Add-PodeHeaderBulk {
 
 <#
 .SYNOPSIS
-Tests if a header is present on the Request.
+Tests if a header is present on the Request or Response.
 
 .DESCRIPTION
-Tests if a header is present on the Request.
+Tests if a header is present on the Request or Response.
 
 .PARAMETER Name
 The name of the header to test.
 
+.PARAMETER Response
+If supplied, the header will be tested against the Response instead of the Request.
+
 .EXAMPLE
 Test-PodeHeader -Name 'X-AuthToken'
+
+.EXAMPLE
+Test-PodeHeader -Name 'X-AuthToken' -Response
 #>
 function Test-PodeHeader {
     [CmdletBinding()]
@@ -124,18 +130,25 @@ function Test-PodeHeader {
     param(
         [Parameter(Mandatory = $true)]
         [string]
-        $Name
+        $Name,
+
+        [switch]
+        $Response
     )
 
-    return $WebEvent.Request.Headers.ContainsKey($Name)
+    if ($Response) {
+        return $WebEvent.Response.Headers -and $WebEvent.Response.Headers.ContainsKey($Name)
+    }
+
+    return $WebEvent.Request.Headers -and $WebEvent.Request.Headers.ContainsKey($Name)
 }
 
 <#
 .SYNOPSIS
-Retrieves the value of a header from the Request.
+Retrieves the value of a header from the Request or Response.
 
 .DESCRIPTION
-Retrieves the value of a header from the Request.
+Retrieves the value of a header from the Request or Response.
 
 .PARAMETER Name
 The name of the header to retrieve.
@@ -146,8 +159,17 @@ The secret used to unsign the header's value.
 .PARAMETER Strict
 If supplied, the Secret will be extended using the client request's UserAgent and RemoteIPAddress.
 
+.PARAMETER Response
+If supplied, the header will be retrieved from the Response instead of the Request.
+
 .EXAMPLE
 Get-PodeHeader -Name 'X-AuthToken'
+
+.EXAMPLE
+Get-PodeHeader -Name 'X-AuthToken' -Secret 'hunter2' -Strict
+
+.EXAMPLE
+Get-PodeHeader -Name 'X-AuthToken' -Response
 #>
 function Get-PodeHeader {
     [CmdletBinding()]
@@ -162,14 +184,28 @@ function Get-PodeHeader {
         $Secret,
 
         [switch]
-        $Strict
+        $Strict,
+
+        [switch]
+        $Response
     )
 
-    # get the value for the header from the request
-    $header = $WebEvent.Request.Headers.$Name
+    # if the Response switch is supplied, get the value from the Response headers
+    if ($Response) {
+        if ($WebEvent.Response.Headers) {
+            $header = $WebEvent.Response.Headers[$Name]
+        }
+    }
+
+    # else, get the value for the header from the request
+    else {
+        if ($WebEvent.Request.Headers) {
+            $header = $WebEvent.Request.Headers.$Name
+        }
+    }
 
     # if a secret was supplied, attempt to unsign the header's value
-    if (![string]::IsNullOrWhiteSpace($Secret)) {
+    if (![string]::IsNullOrEmpty($Secret) -and ![string]::IsNullOrEmpty($header)) {
         $header = Invoke-PodeValueUnsign -Value $header -Secret $Secret -Strict:$Strict
     }
 
@@ -285,10 +321,10 @@ function Set-PodeHeaderBulk {
 
 <#
 .SYNOPSIS
-Tests if a header on the Request is validly signed.
+Tests if a header on the Request or Response is validly signed.
 
 .DESCRIPTION
-Tests if a header on the Request is validly signed, by attempting to unsign it using some secret.
+Tests if a header on the Request or Response is validly signed, by attempting to unsign it using some secret.
 
 .PARAMETER Name
 The name of the header to test.
@@ -299,8 +335,17 @@ A secret to use for attempting to unsign the header's value.
 .PARAMETER Strict
 If supplied, the Secret will be extended using the client request's UserAgent and RemoteIPAddress.
 
+.PARAMETER Response
+If supplied, the header will be tested against the Response instead of the Request.
+
 .EXAMPLE
 Test-PodeHeaderSigned -Name 'X-Header-Name' -Secret 'hunter2'
+
+.EXAMPLE
+Test-PodeHeaderSigned -Name 'X-Header-Name' -Secret 'hunter2' -Strict
+
+.EXAMPLE
+Test-PodeHeaderSigned -Name 'X-Header-Name' -Secret 'hunter2' -Response
 #>
 function Test-PodeHeaderSigned {
     [CmdletBinding()]
@@ -315,9 +360,18 @@ function Test-PodeHeaderSigned {
         $Secret,
 
         [switch]
-        $Strict
+        $Strict,
+
+        [switch]
+        $Response
     )
 
-    $header = Get-PodeHeader -Name $Name
+    if ($Response) {
+        $header = $WebEvent.Response.Headers[$Name]
+    }
+    else {
+        $header = $WebEvent.Request.Headers.$Name
+    }
+
     return Test-PodeValueSigned -Value $header -Secret $Secret -Strict:$Strict
 }

--- a/src/Public/Logging.ps1
+++ b/src/Public/Logging.ps1
@@ -196,6 +196,13 @@ One or more Log Method IDs to use for outputting the log entry.
 .PARAMETER UsernameProperty
 An optional property path within the $WebEvent.Auth.User object for the user's Username. (Default: Username).
 
+.PARAMETER Format
+The format to use for the log output. (Default: Combined)
+
+.PARAMETER W3CInfo
+An optional hashtable of W3C log configuration information, built using New-PodeLogW3CInfo.
+If not supplied, but -Format=W3C, then default W3C fields will be used.
+
 .PARAMETER LogFormat
 The format to use for the log output. (Default: Server default, or 'None' if no default set).
 
@@ -260,6 +267,15 @@ function Enable-PodeLogRequestType {
         [Parameter()]
         [string]
         $UsernameProperty,
+
+        [Parameter()]
+        [ValidateSet('Common', 'Combined', 'W3C')]
+        [string]
+        $Format = 'Combined',
+
+        [Parameter()]
+        [hashtable]
+        $W3CInfo,
 
         [Parameter()]
         [Pode.Utilities.Logging.PodeLogFormat]
@@ -331,10 +347,32 @@ function Enable-PodeLogRequestType {
             $UsernameProperty = 'Username'
         }
 
-        # add metadata
+        # add base metadata
         $params['Metadata'] = @{
             Username       = $UsernameProperty
             RemoteIPHeader = $RemoteIPHeader
+            Format         = $Format.ToLowerInvariant()
+        }
+
+        # handle w3c fields
+        if ($Format -ieq 'W3C') {
+            # use default fields, if none supplied
+            if (Test-PodeIsEmpty $W3CInfo) {
+                $W3CInfo = Get-PodeRequestLogW3CDefaultInfo
+            }
+
+            # build log header directives
+            if (!$W3CInfo.NoLogHeader) {
+                $params['LogHeader'] = @(
+                    "#Software: Pode $($PodeContext.Server.Version)"
+                    "#Version: $($W3CInfo.Version)"
+                    "#Date: $([datetime]::Now.ToString('yyyy-MM-dd HH:mm:ss'))"
+                    "#Fields: $($W3CInfo.Fields.FieldName -join ' ')"
+                )
+            }
+
+            # add the fields to the metadata
+            $params['Metadata']['W3CFields'] = $W3CInfo.Fields
         }
 
         # add LogFormat if supplied
@@ -360,11 +398,7 @@ function Enable-PodeLogRequestType {
 
         # add SerialiseScriptBlock if supplied, otherwise use local default
         if ($null -eq $SerialiseScriptBlock) {
-            $SerialiseScriptBlock = {
-                param($data)
-                $reqLine = "$($data.Method) $($data.Resource) $($data.Protocol)"
-                return "$($data.Host) $($data.Identifier) $($data.User) [$($data.Date)] `"$($reqLine)`" $($data.StatusCode) $($data.Size) `"$($data.Referrer)`" `"$($data.UserAgent)`""
-            }
+            $SerialiseScriptBlock = Get-PodeLoggingInbuiltSerialiseType -Type Requests
         }
         $params['SerialiseScriptBlock'] = $SerialiseScriptBlock
 
@@ -569,14 +603,7 @@ function Enable-PodeLogErrorType {
 
         # add SerialiseScriptBlock if supplied, otherwise use local default
         if ($null -eq $SerialiseScriptBlock) {
-            $SerialiseScriptBlock = {
-                param($data)
-                $msg = @(foreach ($key in $data.Keys) {
-                        "$($key): $($data[$key])"
-                    }) -join "`n"
-
-                return "$($msg)`n"
-            }
+            $SerialiseScriptBlock = Get-PodeLoggingInbuiltSerialiseType -Type Errors
         }
         $params['SerialiseScriptBlock'] = $SerialiseScriptBlock
 
@@ -676,6 +703,9 @@ An optional name to use for the root element of the log item when serialising to
 .PARAMETER Metadata
 A hashtable of metadata to associate with the Log Type. This data can be retrieved via Get-PodeLogType.
 
+.PARAMETER LogHeader
+An optional array of strings to use as the header(s) for the log, such as W3C log directives.
+
 .PARAMETER Raw
 If supplied, the log item returned will be the raw Request item as a hashtable and not a string.
 
@@ -758,6 +788,10 @@ function Add-PodeLogType {
         [Parameter()]
         [hashtable]
         $Metadata,
+
+        [Parameter()]
+        [string[]]
+        $LogHeader,
 
         [Parameter(ParameterSetName = 'Raw')]
         [switch]
@@ -852,6 +886,7 @@ function Add-PodeLogType {
             Levels         = $Levels
             Raw            = $Raw.IsPresent
             Version        = $Version
+            SentFirstLog   = $false
             Metadata       = $Metadata
             Options        = @{
                 Formatting = @{
@@ -867,6 +902,7 @@ function Add-PodeLogType {
                         UsingVariables = $serialiseUsingVars
                         XmlRootName    = Protect-PodeValue -Value $XmlRootName -Default 'Log'
                     }
+                    Headers    = $LogHeader
                 }
             }
             Arguments      = $ArgumentList
@@ -2795,5 +2831,139 @@ function Convert-PodeLogItemToString {
                 return $Item.Data | ConvertTo-PodeString
             }
         }
+    }
+}
+
+<#
+.SYNOPSIS
+Creates a new Pode Log W3C Info object.
+
+.DESCRIPTION
+Creates a new Pode Log W3C Info object with the specified fields, version, and log header settings.
+
+.PARAMETER Fields
+The fields to include in the W3C log, created using Add-PodeLogW3CField or Add-PodeLogW3CCustomField.
+
+.PARAMETER Version
+The version of the W3C log format. (Default: 1.0)
+
+.PARAMETER NoLogHeader
+If supplied, the W3C log will not include the log header.
+
+.EXAMPLE
+$fields = @(
+    Add-PodeLogW3CField -Name 'date'
+    Add-PodeLogW3CField -Name 'time'
+    Add-PodeLogW3CField -Name 'c-ip'
+    Add-PodeLogW3CField -Name 'cs-method'
+    Add-PodeLogW3CField -Name 'cs-uri-stem'
+    Add-PodeLogW3CCustomField -Name 'custom-field' -Type 'Request'
+)
+$info = New-PodeLogW3CInfo -Fields $fields
+#>
+function New-PodeLogW3CInfo {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [hashtable[]]
+        $Fields,
+
+        [Parameter()]
+        [version]
+        $Version = [version]'1.0',
+
+        [switch]
+        $NoLogHeader
+    )
+
+    return @{
+        Fields      = $Fields
+        Version     = $Version
+        NoLogHeader = $NoLogHeader.IsPresent
+    }
+}
+
+<#
+.SYNOPSIS
+Creates a new Pode Log W3C Field object.
+
+.DESCRIPTION
+Creates a new Pode Log W3C Field object with the specified name.
+
+.PARAMETER Name
+The name of the W3C field to create.
+
+.EXAMPLE
+$field = Add-PodeLogW3CField -Name 'date'
+#>
+function Add-PodeLogW3CField {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('date', 'time', 'c-ip', 'cs-username', 's-ip', 's-port', 's-computername', 'cs-method', 'cs-uri-stem', 'cs-uri-query', 'sc-status', 'time-taken', 'sc-bytes', 'cs-bytes', 'cs-version', 'cs-host')]
+        [string]
+        $Name
+    )
+
+    return @{
+        Type      = 'Standard'
+        FieldName = $Name.ToLowerInvariant()
+    }
+}
+
+<#
+.SYNOPSIS
+Creates a new Pode Log W3C Custom Field object.
+
+.DESCRIPTION
+Creates a new Pode Log W3C Custom Field object with the specified name and type.
+
+.PARAMETER Name
+The name of the custom field to create. Custom field names can only contain alphanumeric characters, hyphens, and underscores.
+
+.PARAMETER Type
+The type of the custom field, which can be 'Request', 'Response', or 'Environment'.
+
+Request: retrieved from the request headers, and wrapped with "cs(...)" in the W3C log.
+Response: retrieved from the response headers, and wrapped with "sc(...)" in the W3C log.
+Environment: retrieved from the process environment variables, and prefixed with "x-" in the W3C log.
+
+.EXAMPLE
+$field = Add-PodeLogW3CCustomField -Name 'custom-field' -Type 'Request'
+
+.EXAMPLE
+$field = Add-PodeLogW3CCustomField -Name 'custom-field' -Type 'Response'
+
+.EXAMPLE
+$field = Add-PodeLogW3CCustomField -Name 'custom-field' -Type 'Environment'
+#>
+function Add-PodeLogW3CCustomField {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidatePattern('^[a-z0-9\-_]+$')]
+        [string]
+        $Name,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('Request', 'Response', 'Environment')]
+        [string]
+        $Type
+    )
+
+    $fieldName = switch ($Type) {
+        'Request' { "cs($($Name))" }
+        'Response' { "sc($($Name))" }
+        'Environment' { "x-$($Name)" }
+    }
+
+    return @{
+        Type      = $Type
+        Name      = $Name
+        FieldName = $fieldName
     }
 }

--- a/src/Public/Utilities.ps1
+++ b/src/Public/Utilities.ps1
@@ -1783,3 +1783,114 @@ function ConvertTo-PodeString {
         return ($InputObject | Out-String).TrimEnd("`r", "`n")
     }
 }
+
+<#
+.SYNOPSIS
+Gets an environment variable value.
+
+.DESCRIPTION
+Gets an environment variable value from the specified target (Process, User, or Machine).
+
+.PARAMETER Name
+The name of the environment variable to retrieve.
+
+.PARAMETER Target
+The target scope from which to retrieve the environment variable. Default is Process.
+
+.EXAMPLE
+$envValue = Get-PodeEnvironmentVariable -Name 'PATH'
+
+.EXAMPLE
+$envValue = Get-PodeEnvironmentVariable -Name 'MY_VAR' -Target 'User'
+#>
+function Get-PodeEnvironmentVariable {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Name,
+
+        [Parameter()]
+        [System.EnvironmentVariableTarget]
+        $Target = [System.EnvironmentVariableTarget]::Process
+    )
+
+    return [System.Environment]::GetEnvironmentVariable($Name, $Target)
+}
+
+<#
+.SYNOPSIS
+Sets an environment variable value.
+
+.DESCRIPTION
+Sets an environment variable value in the specified target (Process, User, or Machine).
+
+.PARAMETER Name
+The name of the environment variable to set.
+
+.PARAMETER Value
+The value to assign to the environment variable. Setting this to empty/null will remove the environment variable.
+
+.PARAMETER Target
+The target scope in which to set the environment variable. Default is Process.
+
+.EXAMPLE
+Set-PodeEnvironmentVariable -Name 'MY_VAR' -Value 'SomeValue'
+
+.EXAMPLE
+Set-PodeEnvironmentVariable -Name 'MY_VAR' -Value 'SomeValue' -Target 'User'
+#>
+function Set-PodeEnvironmentVariable {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Name,
+
+        [Parameter()]
+        [string]
+        $Value,
+
+        [Parameter()]
+        [System.EnvironmentVariableTarget]
+        $Target = [System.EnvironmentVariableTarget]::Process
+    )
+
+    [System.Environment]::SetEnvironmentVariable($Name, $Value, $Target)
+}
+
+<#
+.SYNOPSIS
+Tests if an environment variable exists.
+
+.DESCRIPTION
+Tests if an environment variable exists in the specified target (Process, User, or Machine).
+
+.PARAMETER Name
+The name of the environment variable to check for existence.
+
+.PARAMETER Target
+The target scope in which to check for the environment variable. Default is Process.
+
+.EXAMPLE
+if (Test-PodeEnvironmentVariable -Name 'MY_VAR') { /* logic */ }
+
+.EXAMPLE
+if (Test-PodeEnvironmentVariable -Name 'MY_VAR' -Target 'User') { /* logic */ }
+#>
+function Test-PodeEnvironmentVariable {
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Name,
+
+        [Parameter()]
+        [System.EnvironmentVariableTarget]
+        $Target = [System.EnvironmentVariableTarget]::Process
+    )
+
+    return ![string]::IsNullOrEmpty([System.Environment]::GetEnvironmentVariable($Name, $Target))
+}


### PR DESCRIPTION
### Description of the Change
Adds support for the W3C log format, as well the Common log format, when enabling Request logging.

Also adds/fixes:
* The `Date` in the request log item was the timestamp after the request had been processed, and has now been set to `$WebEvent.Timestamp`
* The `Test-PodeHeader` and `Get-PodeHeader` functions now support headers on the Response as well

### Related Issue
Resolves #1726 

### Examples
```powershell
$fields = New-PodeLogW3CInfo -Fields @(
    Add-PodeLogW3CField -Name 'date'
    Add-PodeLogW3CField -Name 'time'
    Add-PodeLogW3CField -Name 'c-ip'
    Add-PodeLogW3CField -Name 'cs-method'
    Add-PodeLogW3CField -Name 'cs-uri-stem'
    Add-PodeLogW3CField -Name 'cs-uri-query'
    Add-PodeLogW3CField -Name 'cs-username'
    Add-PodeLogW3CField -Name 'sc-status'
    Add-PodeLogW3CField -Name 'time-taken'
    Add-PodeLogW3CCustomField -Name 'User-Agent' -Type Request
    Add-PodeLogW3CCustomField -Name 'Referer' -Type Request
)

New-PodeLogTerminalMethod | Enable-PodeLogRequestType -Format W3C -W3CInfo $fields
```
