### PR TITLE
Adds support for Error/Request log timestamps to be in UTC

### DIFF
--- a/docs/Tutorials/Logging/Types/Errors.md
+++ b/docs/Tutorials/Logging/Types/Errors.md
@@ -92,6 +92,10 @@ When error logging is enabled, you'll also see internal logging from Pode. Pode 
 
 The internal error logging will show you unhandled exceptions from routes, middleware, etc.
 
+## Timestamps
+
+By default all timestamps will use the hosting server's local time, if you require the timestamps to be explicitly UTC then supply `-AsUtc` to `Enable-PodeLogErrorType`.
+
 ## Examples
 
 ### Log to Terminal

--- a/docs/Tutorials/Logging/Types/Requests.md
+++ b/docs/Tutorials/Logging/Types/Requests.md
@@ -130,6 +130,10 @@ You can use the `-RemoteIPHeader` parameter to set one, or more, possible header
 
 If multiple request header names are supplied, they will be checked in the order they are supplied.
 
+## Timestamps
+
+By default all timestamps will use the hosting server's local time, if you require the timestamps to be explicitly UTC then supply `-AsUtc` to `Enable-PodeLogRequestType`.
+
 ## Examples
 
 ### Log to Terminal

--- a/src/Listener/Utilities/Logging/IPodeLogEvent.cs
+++ b/src/Listener/Utilities/Logging/IPodeLogEvent.cs
@@ -5,7 +5,7 @@ namespace Pode.Utilities.Logging
 {
     public interface IPodeLogEvent
     {
-        string Name { get; }
+        IPodeLogType Type { get; }
         PodeLogLevel Level { get; }
         DateTime Timestamp { get; }
         Hashtable Metadata { get; }

--- a/src/Listener/Utilities/Logging/IPodeLogType.cs
+++ b/src/Listener/Utilities/Logging/IPodeLogType.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace Pode.Utilities.Logging
@@ -6,7 +7,9 @@ namespace Pode.Utilities.Logging
     {
         string Name { get; }
         HashSet<PodeLogLevel> Levels { get; }
+        bool AsUtc { get; }
 
         bool IsLevelEnabled(PodeLogLevel level);
+        DateTime GetTimestamp();
     }
 }

--- a/src/Listener/Utilities/Logging/IPodeLogger.cs
+++ b/src/Listener/Utilities/Logging/IPodeLogger.cs
@@ -16,7 +16,7 @@ namespace Pode.Utilities.Logging
         void RegisterType(IPodeLogType logType);
         void UnregisterType(string name);
 
-        void Add(IPodeLogEvent logEvent);
+        void Add(string logTypeName, PodeLogLevel level, object data, Hashtable metadata = null);
         void AddException(Exception exception, string contextId, PodeLogLevel level, Hashtable metadata = null, int threadId = 0);
         void AddException(string message, string contextId, PodeLogLevel level, Hashtable metadata = null, int threadId = 0);
         void AddException(string category, string message, string stackTrace, string contextId, PodeLogLevel level, Hashtable metadata = null, int threadId = 0);

--- a/src/Listener/Utilities/Logging/PodeLogEvent.cs
+++ b/src/Listener/Utilities/Logging/PodeLogEvent.cs
@@ -5,23 +5,19 @@ namespace Pode.Utilities.Logging
 {
     public class PodeLogEvent : IPodeLogEvent
     {
-        public string Name { get; private set; }
+        public IPodeLogType Type { get; private set; }
         public PodeLogLevel Level { get; private set; }
-        public DateTime Timestamp { get; private set; } = DateTime.Now;
+        public DateTime Timestamp { get; private set; }
         public Hashtable Metadata { get; private set; }
         public object Data { get; private set; }
 
-        public PodeLogEvent(string name, PodeLogLevel level, object data, Hashtable metadata = null)
+        public PodeLogEvent(IPodeLogType type, PodeLogLevel level, object data, Hashtable metadata = null)
         {
-            if (string.IsNullOrEmpty(name))
-            {
-                throw new ArgumentException("Log item name cannot be null or empty.", nameof(name));
-            }
-
-            Name = name;
+            Type = type ?? throw new ArgumentNullException(nameof(type), "Log item type cannot be null.");
             Level = level;
             Data = data;
             Metadata = metadata ?? new Hashtable(StringComparer.InvariantCultureIgnoreCase);
+            Timestamp = type.GetTimestamp();
         }
     }
 }

--- a/src/Listener/Utilities/Logging/PodeLogType.cs
+++ b/src/Listener/Utilities/Logging/PodeLogType.cs
@@ -7,8 +7,9 @@ namespace Pode.Utilities.Logging
     {
         public string Name { get; private set; }
         public HashSet<PodeLogLevel> Levels { get; private set; }
+        public bool AsUtc { get; private set; }
 
-        public PodeLogType(string name, HashSet<PodeLogLevel> levels)
+        public PodeLogType(string name, HashSet<PodeLogLevel> levels, bool asUtc)
         {
             if (string.IsNullOrEmpty(name))
             {
@@ -17,11 +18,17 @@ namespace Pode.Utilities.Logging
 
             Name = name;
             Levels = levels;
+            AsUtc = asUtc;
         }
 
         public bool IsLevelEnabled(PodeLogLevel level)
         {
             return Levels.Contains(level);
+        }
+
+        public DateTime GetTimestamp()
+        {
+            return AsUtc ? DateTime.UtcNow : DateTime.Now;
         }
     }
 }

--- a/src/Listener/Utilities/Logging/PodeLogger.cs
+++ b/src/Listener/Utilities/Logging/PodeLogger.cs
@@ -53,7 +53,7 @@ namespace Pode.Utilities.Logging
             LogTypes.TryRemove(name, out _);
         }
 
-        public void Add(IPodeLogEvent logEvent)
+        public void Add(string logTypeName, PodeLogLevel level, object data, Hashtable metadata = null)
         {
             if (IsDisposed || !IsEnabled)
             {
@@ -61,19 +61,19 @@ namespace Pode.Utilities.Logging
             }
 
             // does the Log Type exist?
-            if (!LogTypes.TryGetValue(logEvent.Name, out var logType))
+            if (!LogTypes.TryGetValue(logTypeName, out var logType))
             {
                 return;
             }
 
             // is the log level enabled for the Log Type?
-            if (!logType.IsLevelEnabled(logEvent.Level))
+            if (!logType.IsLevelEnabled(level))
             {
                 return;
             }
 
             // add the log event to the queue
-            Queue.Add(logEvent);
+            Queue.Add(new PodeLogEvent(logType, level, data, metadata));
         }
 
         public void AddException(Exception exception, string contextId, PodeLogLevel level, Hashtable metadata = null, int threadId = 0)
@@ -137,13 +137,13 @@ namespace Pode.Utilities.Logging
                 { "StackTrace", stackTrace },
                 { "Server", Dns.GetHostName() },
                 { "Level", level.ToString() },
-                { "Date", DateTime.Now },
+                { "Date", logType.GetTimestamp() },
                 { "ThreadId", threadId == 0 ? Environment.CurrentManagedThreadId : threadId },
                 { "ContextId", contextId }
             };
 
             // add the log event to the queue
-            Queue.Add(new PodeLogEvent(ERROR_LOG_TYPE_NAME, level, item, metadata));
+            Queue.Add(new PodeLogEvent(logType, level, item, metadata));
         }
 
         public bool TryTake(out IPodeLogEvent logEvent, CancellationToken cancellationToken)
@@ -156,7 +156,7 @@ namespace Pode.Utilities.Logging
 
             var found = Queue.TryTake(out var _event, cancellationToken);
 
-            if (!found || string.IsNullOrEmpty(_event?.Name) || !LogTypes.ContainsKey(_event?.Name))
+            if (!found || string.IsNullOrEmpty(_event?.Type?.Name) || !LogTypes.ContainsKey(_event?.Type?.Name))
             {
                 logEvent = null;
                 return false;

--- a/src/Pode.psd1
+++ b/src/Pode.psd1
@@ -183,6 +183,7 @@
         'Get-PodeEnvironmentVariable',
         'Set-PodeEnvironmentVariable',
         'Test-PodeEnvironmentVariable',
+        'Get-PodeTimestamp',
 
         # routes
         'Add-PodeRoute',

--- a/src/Private/Logging.ps1
+++ b/src/Private/Logging.ps1
@@ -1053,7 +1053,8 @@ function Write-PodeRequestLog {
     }
 
     # get the request log type
-    $logType = Get-PodeLogType -Name ([PodeLogger]::REQUEST_LOG_TYPE_NAME)
+    $logTypeName = [PodeLogger]::REQUEST_LOG_TYPE_NAME
+    $logType = Get-PodeLogType -Name $logTypeName
 
     # http method
     $method = $null
@@ -1073,12 +1074,18 @@ function Write-PodeRequestLog {
         $scheme = $WebEvent.Request.Handler.Scheme.ToLowerInvariant()
     }
 
+    # date/timestamp
+    $timestamp = $WebEvent.Timestamp
+    if (!$logType.Options.Formatting.AsUtc) {
+        $timestamp = $timestamp.ToLocalTime()
+    }
+
     # build a request object
     $item = @{
         Host            = $WebEvent.Request.Handler.RemoteEndPoint.Address.IPAddressToString
         RfcUserIdentity = $null
         User            = $null
-        Date            = $WebEvent.Timestamp.ToLocalTime()
+        Date            = $timestamp
         UtcDate         = $WebEvent.Timestamp
         Duration        = [datetime]::UtcNow.Subtract($WebEvent.Timestamp)
         Server          = @{
@@ -1164,8 +1171,7 @@ function Write-PodeRequestLog {
     }
 
     # add the item to be processed
-    $logEvent = [PodeLogEvent]::new([PodeLogger]::REQUEST_LOG_TYPE_NAME, [PodeLogLevel]::Informational, $item)
-    $PodeContext.Server.Logging.Logger.Add($logEvent)
+    $PodeContext.Server.Logging.Logger.Add($logTypeName, [PodeLogLevel]::Informational, $item)
 }
 
 function Add-PodeRequestLogEndware {
@@ -1222,7 +1228,7 @@ function Start-PodeLoggingRunspace {
                     }
 
                     # run the log item through the appropriate method
-                    $logType = Get-PodeLogType -Name $logEvent.Name
+                    $logType = Get-PodeLogType -Name $logEvent.Type.Name
                     if ($null -eq $logType) {
                         continue
                     }

--- a/src/Public/Logging.ps1
+++ b/src/Public/Logging.ps1
@@ -227,11 +227,17 @@ A hashtable containing Syslog configuration information, built using New-PodeSys
 .PARAMETER RemoteIPHeader
 One or more optional headers to check for the client's remote IP address, if behind a reverse proxy.
 
+.PARAMETER AsUtc
+If supplied, the log entry's timestamp will be in UTC, otherwise it will be in local time.
+
 .PARAMETER Raw
 If supplied, the log item returned will be the raw Request item as a hashtable and not a string (for Custom methods).
 
 .EXAMPLE
 New-PodeLogTerminalMethod | Enable-PodeLogRequestType
+
+.EXAMPLE
+New-PodeLogTerminalMethod | Enable-PodeLogRequestType -AsUtc
 
 .EXAMPLE
 New-PodeLogTerminalMethod | Enable-PodeLogRequestType -RemoteIPHeader 'X-Forwarded-For'
@@ -309,6 +315,9 @@ function Enable-PodeLogRequestType {
         [string[]]
         $RemoteIPHeader,
 
+        [switch]
+        $AsUtc,
+
         [Parameter(ParameterSetName = 'Raw')]
         [switch]
         $Raw
@@ -340,6 +349,7 @@ function Enable-PodeLogRequestType {
             LogScriptBlock = $LogScriptBlock
             SyslogInfo     = $SyslogInfo
             XmlRootName    = 'Request'
+            AsUtc          = $AsUtc.IsPresent
         }
 
         # username property
@@ -480,11 +490,17 @@ An array of arguments to supply to the Custom Log Type's ScriptBlock and Seriali
 .PARAMETER SyslogInfo
 A hashtable containing Syslog configuration information, built using New-PodeSyslogInfo.
 
+.PARAMETER AsUtc
+If supplied, the log entry's timestamp will be in UTC, otherwise it will be in local time.
+
 .PARAMETER Raw
 If supplied, the log item returned will be the raw Error item as a hashtable and not a string (for Custom methods).
 
 .EXAMPLE
 New-PodeLogTerminalMethod | Enable-PodeLogErrorType
+
+.EXAMPLE
+New-PodeLogTerminalMethod | Enable-PodeLogErrorType -AsUtc
 
 .EXAMPLE
 New-PodeLogTerminalMethod | Enable-PodeLogErrorType -SerialiseFormat 'Json'
@@ -547,6 +563,9 @@ function Enable-PodeLogErrorType {
         [hashtable]
         $SyslogInfo,
 
+        [switch]
+        $AsUtc,
+
         [Parameter(ParameterSetName = 'Raw')]
         [switch]
         $Raw
@@ -578,6 +597,7 @@ function Enable-PodeLogErrorType {
             LogScriptBlock = $LogScriptBlock
             SyslogInfo     = $SyslogInfo
             XmlRootName    = 'Error'
+            AsUtc          = $AsUtc.IsPresent
         }
 
         # add LogFormat if supplied
@@ -706,6 +726,9 @@ A hashtable of metadata to associate with the Log Type. This data can be retriev
 .PARAMETER LogHeader
 An optional array of strings to use as the header(s) for the log, such as W3C log directives.
 
+.PARAMETER AsUtc
+If supplied, will be set in the Log Type's Formatting Options as to whether to use UTC timestamps or local timestamps.
+
 .PARAMETER Raw
 If supplied, the log item returned will be the raw Request item as a hashtable and not a string.
 
@@ -792,6 +815,9 @@ function Add-PodeLogType {
         [Parameter()]
         [string[]]
         $LogHeader,
+
+        [switch]
+        $AsUtc,
 
         [Parameter(ParameterSetName = 'Raw')]
         [switch]
@@ -903,11 +929,12 @@ function Add-PodeLogType {
                         XmlRootName    = Protect-PodeValue -Value $XmlRootName -Default 'Log'
                     }
                     Headers    = $LogHeader
+                    AsUtc      = $AsUtc.IsPresent
                 }
             }
             Arguments      = $ArgumentList
         }
-        $PodeContext.Server.Logging.Logger.RegisterType([PodeLogType]::new($Name, $Levels))
+        $PodeContext.Server.Logging.Logger.RegisterType([PodeLogType]::new($Name, $Levels, $AsUtc.IsPresent))
 
         # then associate the supplied Log Method(s) with the custom Log Type
         foreach ($methodId in $Method) {
@@ -1214,8 +1241,7 @@ function Write-PodeLog {
 
     process {
         foreach ($n in $Name) {
-            $logEvent = [PodeLogEvent]::new($n, $Level, $InputObject, $Metadata)
-            $PodeContext.Server.Logging.Logger.Add($logEvent)
+            $PodeContext.Server.Logging.Logger.Add($n, $Level, $InputObject, $Metadata)
         }
     }
 }

--- a/src/Public/Utilities.ps1
+++ b/src/Public/Utilities.ps1
@@ -1894,3 +1894,18 @@ function Test-PodeEnvironmentVariable {
 
     return ![string]::IsNullOrEmpty([System.Environment]::GetEnvironmentVariable($Name, $Target))
 }
+
+function Get-PodeTimestamp {
+    [CmdletBinding()]
+    [OutputType([datetime])]
+    param(
+        [switch]
+        $AsUtc
+    )
+
+    if ($AsUtc) {
+        return [DateTime]::UtcNow
+    }
+
+    return [DateTime]::Now
+}

--- a/src/Public/Utilities.ps1
+++ b/src/Public/Utilities.ps1
@@ -1895,6 +1895,22 @@ function Test-PodeEnvironmentVariable {
     return ![string]::IsNullOrEmpty([System.Environment]::GetEnvironmentVariable($Name, $Target))
 }
 
+<#
+.SYNOPSIS
+Gets the current timestamp.
+
+.DESCRIPTION
+Gets the current timestamp, as a DateTime object.
+
+.PARAMETER AsUtc
+If specified, returns the timestamp in UTC format.
+
+.EXAMPLE
+$timestamp = Get-PodeTimestamp
+
+.EXAMPLE
+$timestamp = Get-PodeTimestamp -AsUtc
+#>
 function Get-PodeTimestamp {
     [CmdletBinding()]
     [OutputType([datetime])]

--- a/tests/unit/Logging.Tests.ps1
+++ b/tests/unit/Logging.Tests.ps1
@@ -47,7 +47,7 @@ InModuleScope -ModuleName 'Pode' {
         }
 
         It 'Adds a log item' {
-            $logType = [Pode.Utilities.Logging.PodeLogType]::new('test', @('Informational'))
+            $logType = [Pode.Utilities.Logging.PodeLogType]::new('test', @('Informational'), $false)
             $PodeContext.Server.Logging.Logger.RegisterType($logType)
 
             Write-PodeLog -Name 'test' -InputObject 'test'
@@ -88,7 +88,7 @@ InModuleScope -ModuleName 'Pode' {
         }
 
         It 'Adds an error log item' {
-            $logType = [Pode.Utilities.Logging.PodeLogType]::new([Pode.Utilities.Logging.PodeLogger]::ERROR_LOG_TYPE_NAME, @('Error'))
+            $logType = [Pode.Utilities.Logging.PodeLogType]::new([Pode.Utilities.Logging.PodeLogger]::ERROR_LOG_TYPE_NAME, @('Error'), $false)
             $PodeContext.Server.Logging.Logger.RegisterType($logType)
 
             try { throw 'some error' }
@@ -104,7 +104,7 @@ InModuleScope -ModuleName 'Pode' {
         }
 
         It 'Adds an exception log item' {
-            $logType = [Pode.Utilities.Logging.PodeLogType]::new([Pode.Utilities.Logging.PodeLogger]::ERROR_LOG_TYPE_NAME, @('Error'))
+            $logType = [Pode.Utilities.Logging.PodeLogType]::new([Pode.Utilities.Logging.PodeLogger]::ERROR_LOG_TYPE_NAME, @('Error'), $false)
             $PodeContext.Server.Logging.Logger.RegisterType($logType)
 
             $exp = [exception]::new('some error')
@@ -116,7 +116,7 @@ InModuleScope -ModuleName 'Pode' {
         }
 
         It 'Does not log as Verbose not allowed' {
-            $logType = [Pode.Utilities.Logging.PodeLogType]::new([Pode.Utilities.Logging.PodeLogger]::ERROR_LOG_TYPE_NAME, @('Error'))
+            $logType = [Pode.Utilities.Logging.PodeLogType]::new([Pode.Utilities.Logging.PodeLogger]::ERROR_LOG_TYPE_NAME, @('Error'), $false)
             $PodeContext.Server.Logging.Logger.RegisterType($logType)
 
             $exp = [exception]::new('some error')

--- a/tests/unit/Logging.Tests.ps1
+++ b/tests/unit/Logging.Tests.ps1
@@ -56,7 +56,7 @@ InModuleScope -ModuleName 'Pode' {
 
             $logEvent = $null
             $PodeContext.Server.Logging.Logger.TryTake([ref]$logEvent, [System.Threading.CancellationToken]::None) | Should -Be $true
-            $logEvent.Name | Should -Be 'test'
+            $logEvent.Type.Name | Should -Be 'test'
             $logEvent.Data | Should -Be 'test'
         }
     }


### PR DESCRIPTION
### Description of the Change
Timestamps on Error/Requests logs are in local server time by default, this adds a new `-AsUtc` switch to `Enable-PodeLogRequestType` and `Enable-PodeLogErrorType` to have them be in UTC instead.
