### PR TITLE
Adds support for controlling which Error Kinds are logged

### DIFF
--- a/docs/Tutorials/Logging/Types/Errors.md
+++ b/docs/Tutorials/Logging/Types/Errors.md
@@ -37,14 +37,15 @@ When Pode logs an error, the information logged is as follows:
 
 | Property     | Description                                           |
 | ------------ | ----------------------------------------------------- |
-| `Date`       | The date/time the error occurred                      |
-| `Level`      | The level of the error, such as Error or verbose      |
-| `ThreadId`   | The thread ID of the current runspace/process         |
-| `ContextId`  | The Pode Context ID of the current request            |
-| `Server`     | The name of the machine from where the error occurred |
 | `Category`   | The category/type of error that was thrown            |
+| `ContextId`  | The Pode Context ID of the current request            |
+| `Date`       | The date/time the error occurred                      |
+| `Kind`       | The kind of the error, such as Server or Client       |
+| `Level`      | The level of the error, such as Error or Verbose      |
 | `Message`    | The error message                                     |
+| `Server`     | The name of the machine from where the error occurred |
 | `StackTrace` | The error StackTrace                                  |
+| `ThreadId`   | The thread ID of the current runspace/process         |
 
 ## Log Levels
 
@@ -64,6 +65,18 @@ You can alter the log level by supplying `-Levels` to [`Enable-PodeLogErrorType`
 
 !!! tip
     To enable all log levels more easily, simply supply `-Levels '*'`
+
+## Error Categories
+
+The Error Log Type uses the following error categories, the default is Server:
+
+| Type    | Description                                                                                                      |
+| ------- | ---------------------------------------------------------------------------------------------------------------- |
+| Server  | Errors thrown by the server itself; unhandled exceptions; or those requests which result in an HTTP 5XX response |
+| Client  | Request Errors which result in an HTTP 4XX response                                                              |
+| Timeout | Request Errors which result in an HTTP 408 response                                                              |
+
+You can alter the error categories which are logged by supplying `-Category` to [`Enable-PodeLogErrorType`](../../../../Functions/Logging/Enable-PodeLogErrorType) - you can supply one or more.
 
 ## Writing Errors
 

--- a/src/Listener/Protocols/Common/Contexts/PodeContext.cs
+++ b/src/Listener/Protocols/Common/Contexts/PodeContext.cs
@@ -140,7 +140,7 @@ namespace Pode.Protocols.Common.Contexts
             try
             {
                 PodeHelpers.WriteErrorMessage("TimeoutCallback triggered", PodeLogLevel.Debug, this);
-                PodeHelpers.WriteErrorMessage($"Request timeout reached: {Listener.RequestTimeout} seconds", PodeLogLevel.Warning, this);
+                PodeHelpers.WriteErrorMessage($"Request timeout reached: {Listener.RequestTimeout} seconds", PodeLogLevel.Warning, this, PodeRequestExceptionKind.Timeout);
 
                 State = PodeContextState.Timeout;
                 ContextTimeoutToken.Cancel();
@@ -149,7 +149,7 @@ namespace Pode.Protocols.Common.Contexts
                 Response.StatusCode = Request.Error.StatusCode;
 
                 Dispose();
-                PodeHelpers.WriteErrorMessage($"Request timeout reached: Dispose", PodeLogLevel.Debug, this);
+                PodeHelpers.WriteErrorMessage($"Request timeout reached: Dispose", PodeLogLevel.Debug, this, PodeRequestExceptionKind.Timeout);
             }
             catch (Exception ex)
             {

--- a/src/Listener/Protocols/Common/Requests/PodeEmptyRequestException.cs
+++ b/src/Listener/Protocols/Common/Requests/PodeEmptyRequestException.cs
@@ -21,5 +21,10 @@ namespace Pode.Protocols.Common.Requests
         {
             return 0;
         }
+
+        protected override PodeRequestExceptionKind GetKind(int statusCode)
+        {
+            return PodeRequestExceptionKind.Server;
+        }
     }
 }

--- a/src/Listener/Protocols/Common/Requests/PodeRequestException.cs
+++ b/src/Listener/Protocols/Common/Requests/PodeRequestException.cs
@@ -8,17 +8,20 @@ namespace Pode.Protocols.Common.Requests
         // the status code of the exception
         public int StatusCode { get; private set; } = 0;
 
+        // the type of the exception
+        public PodeRequestExceptionKind Kind { get; private set; } = PodeRequestExceptionKind.Server;
+
         // is the exception a timeout status code
-        public virtual bool IsTimeout => false;
+        public bool IsTimeout => Kind == PodeRequestExceptionKind.Timeout;
 
         // is the exception a client error status code
-        public virtual bool IsClientError => false;
+        public bool IsClientError => Kind == PodeRequestExceptionKind.Client;
 
         // is the exception a server error status code
-        public virtual bool IsServerError => false;
+        public bool IsServerError => Kind == PodeRequestExceptionKind.Server;
 
         // the logging level of the exception
-        public PodeLogLevel LoggingLevel => IsClientError ? PodeLogLevel.Debug : PodeLogLevel.Error;
+        public PodeLogLevel LoggingLevel => Kind == PodeRequestExceptionKind.Client ? PodeLogLevel.Debug : PodeLogLevel.Error;
 
 
         // constructors
@@ -35,6 +38,8 @@ namespace Pode.Protocols.Common.Requests
             {
                 StatusCode = statusCode;
             }
+
+            Kind = GetKind(StatusCode);
         }
 
         protected PodeRequestException(string message, PodeRequestStatusType statusType)
@@ -47,9 +52,11 @@ namespace Pode.Protocols.Common.Requests
             : base(message, innerException)
         {
             StatusCode = GetStatusCode(statusType);
+            Kind = GetKind(StatusCode);
         }
 
 
         protected abstract int GetStatusCode(PodeRequestStatusType statusType);
+        protected abstract PodeRequestExceptionKind GetKind(int statusCode);
     }
 }

--- a/src/Listener/Protocols/Common/Requests/PodeRequestExceptionKind.cs
+++ b/src/Listener/Protocols/Common/Requests/PodeRequestExceptionKind.cs
@@ -1,0 +1,9 @@
+namespace Pode.Protocols.Common.Requests
+{
+    public enum PodeRequestExceptionKind
+    {
+        Client,
+        Timeout,
+        Server
+    }
+}

--- a/src/Listener/Protocols/Common/Requests/PodeRequestHandler.cs
+++ b/src/Listener/Protocols/Common/Requests/PodeRequestHandler.cs
@@ -316,6 +316,7 @@ namespace Pode.Protocols.Common.Requests
             catch (PodeRequestException ex)
             {
                 Error = ex;
+                return false;
             }
             catch (Exception ex) when (ex is IOException || ex is ObjectDisposedException)
             {

--- a/src/Listener/Protocols/Http/PodeHttpRequestException.cs
+++ b/src/Listener/Protocols/Http/PodeHttpRequestException.cs
@@ -11,16 +11,6 @@ namespace Pode.Protocols.Http
         private const int ProxyErrorStatusCode = 502;
 
 
-        // is the exception a timeout status code
-        public override bool IsTimeout => StatusCode == TimeoutStatusCode;
-
-        // is the exception a client error status code
-        public override bool IsClientError => StatusCode >= 400 && StatusCode < 500;
-
-        // is the exception a server error status code
-        public override bool IsServerError => StatusCode >= 500 && StatusCode < 600;
-
-
         public PodeHttpRequestException(string message, int statusCode)
             : base(message, statusCode) { }
 
@@ -49,6 +39,21 @@ namespace Pode.Protocols.Http
                 default:
                     throw new ArgumentOutOfRangeException(nameof(statusType), statusType, null);
             }
+        }
+
+        protected override PodeRequestExceptionKind GetKind(int statusCode)
+        {
+            if (statusCode == TimeoutStatusCode)
+            {
+                return PodeRequestExceptionKind.Timeout;
+            }
+
+            if (statusCode >= 400 && statusCode < 500)
+            {
+                return PodeRequestExceptionKind.Client;
+            }
+
+            return PodeRequestExceptionKind.Server;
         }
     }
 }

--- a/src/Listener/Protocols/Http/PodeHttpResponse.cs
+++ b/src/Listener/Protocols/Http/PodeHttpResponse.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Pode.Utilities;
 using Pode.Protocols.Common.Responses;
 using Pode.Utilities.Logging;
+using Pode.Protocols.Common.Requests;
 
 namespace Pode.Protocols.Http
 {
@@ -110,14 +111,14 @@ namespace Pode.Protocols.Http
                 return;
             }
 
-            PodeHelpers.WriteErrorMessage($"Sending response timed-out", PodeLogLevel.Verbose, Context);
+            PodeHelpers.WriteErrorMessage($"Sending response timed-out", PodeLogLevel.Verbose, Context, PodeRequestExceptionKind.Timeout);
             StatusCode = 408;
 
             try
             {
                 await SendHeaders(true).ConfigureAwait(false);
                 IsSent = true;
-                PodeHelpers.WriteErrorMessage($"Response timed-out sent", PodeLogLevel.Verbose, Context);
+                PodeHelpers.WriteErrorMessage($"Response timed-out sent", PodeLogLevel.Verbose, Context, PodeRequestExceptionKind.Timeout);
             }
             catch (OperationCanceledException) { }
             catch (IOException) { }

--- a/src/Listener/Protocols/Smtp/PodeSmtpRequestException.cs
+++ b/src/Listener/Protocols/Smtp/PodeSmtpRequestException.cs
@@ -11,16 +11,6 @@ namespace Pode.Protocols.Smtp
         private const int ProxyErrorStatusCode = 554;
 
 
-        // is the exception a timeout status code
-        public override bool IsTimeout => StatusCode == TimeoutStatusCode;
-
-        // is the exception a client error status code
-        public override bool IsClientError => StatusCode >= 400 && StatusCode < 500;
-
-        // is the exception a server error status code
-        public override bool IsServerError => StatusCode >= 500 && StatusCode < 600;
-
-
         public PodeSmtpRequestException(string message, int statusCode)
             : base(message, statusCode) { }
 
@@ -49,6 +39,21 @@ namespace Pode.Protocols.Smtp
                 default:
                     throw new ArgumentOutOfRangeException(nameof(statusType), statusType, null);
             }
+        }
+
+        protected override PodeRequestExceptionKind GetKind(int statusCode)
+        {
+            if (statusCode == TimeoutStatusCode)
+            {
+                return PodeRequestExceptionKind.Timeout;
+            }
+
+            if (statusCode >= 400 && statusCode < 500)
+            {
+                return PodeRequestExceptionKind.Client;
+            }
+
+            return PodeRequestExceptionKind.Server;
         }
     }
 }

--- a/src/Listener/Utilities/Logging/IPodeLogger.cs
+++ b/src/Listener/Utilities/Logging/IPodeLogger.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Threading;
+using Pode.Protocols.Common.Requests;
 
 namespace Pode.Utilities.Logging
 {
@@ -18,8 +19,8 @@ namespace Pode.Utilities.Logging
 
         void Add(string logTypeName, PodeLogLevel level, object data, Hashtable metadata = null);
         void AddException(Exception exception, string contextId, PodeLogLevel level, Hashtable metadata = null, int threadId = 0);
-        void AddException(string message, string contextId, PodeLogLevel level, Hashtable metadata = null, int threadId = 0);
-        void AddException(string category, string message, string stackTrace, string contextId, PodeLogLevel level, Hashtable metadata = null, int threadId = 0);
+        void AddException(string message, string contextId, PodeLogLevel level, PodeRequestExceptionKind kind = PodeRequestExceptionKind.Server, Hashtable metadata = null, int threadId = 0);
+        void AddException(string category, string message, string stackTrace, string contextId, PodeLogLevel level, PodeRequestExceptionKind kind = PodeRequestExceptionKind.Server, Hashtable metadata = null, int threadId = 0);
         bool TryTake(out IPodeLogEvent logEvent, CancellationToken cancellationToken);
         void Reset();
     }

--- a/src/Listener/Utilities/Logging/PodeLogErrorType.cs
+++ b/src/Listener/Utilities/Logging/PodeLogErrorType.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using Pode.Protocols.Common.Requests;
+
+namespace Pode.Utilities.Logging
+{
+    public class PodeLogErrorType : PodeLogType
+    {
+        public HashSet<PodeRequestExceptionKind> Kinds { get; private set; }
+
+        public PodeLogErrorType(string name, HashSet<PodeLogLevel> levels, HashSet<PodeRequestExceptionKind> kinds, bool asUtc)
+            : base(name, levels, asUtc)
+        {
+            Kinds = kinds;
+        }
+
+        public bool IsKindEnabled(PodeRequestExceptionKind kind)
+        {
+            return Kinds.Contains(kind);
+        }
+    }
+}

--- a/src/Listener/Utilities/Logging/PodeLogRequestType.cs
+++ b/src/Listener/Utilities/Logging/PodeLogRequestType.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace Pode.Utilities.Logging
+{
+    public class PodeLogRequestType : PodeLogType
+    {
+        public PodeLogRequestType(string name, bool asUtc)
+            : base(name, new HashSet<PodeLogLevel>() { PodeLogLevel.Informational }, asUtc)
+        { }
+    }
+}

--- a/src/Listener/Utilities/Logging/PodeLogger.cs
+++ b/src/Listener/Utilities/Logging/PodeLogger.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Concurrent;
 using System.Net;
 using System.Threading;
+using Pode.Protocols.Common.Requests;
 
 namespace Pode.Utilities.Logging
 {
@@ -83,15 +84,19 @@ namespace Pode.Utilities.Logging
                 return;
             }
 
-            AddException(exception.Source, exception.Message, exception.StackTrace, contextId, level, metadata, threadId);
+            var kind = exception is PodeRequestException podeRequestException
+                ? podeRequestException.Kind
+                : PodeRequestExceptionKind.Server;
+
+            AddException(exception.Source, exception.Message, exception.StackTrace, contextId, level, kind, metadata, threadId);
         }
 
-        public void AddException(string message, string contextId, PodeLogLevel level, Hashtable metadata = null, int threadId = 0)
+        public void AddException(string message, string contextId, PodeLogLevel level, PodeRequestExceptionKind kind = PodeRequestExceptionKind.Server, Hashtable metadata = null, int threadId = 0)
         {
-            AddException(string.Empty, message, string.Empty, contextId, level, metadata, threadId);
+            AddException(string.Empty, message, string.Empty, contextId, level, kind, metadata, threadId);
         }
 
-        public void AddException(string category, string message, string stackTrace, string contextId, PodeLogLevel level, Hashtable metadata = null, int threadId = 0)
+        public void AddException(string category, string message, string stackTrace, string contextId, PodeLogLevel level, PodeRequestExceptionKind kind = PodeRequestExceptionKind.Server, Hashtable metadata = null, int threadId = 0)
         {
             if (IsDisposed || !IsEnabled)
             {
@@ -106,6 +111,12 @@ namespace Pode.Utilities.Logging
 
             // is the log level enabled for the Log Type?
             if (!logType.IsLevelEnabled(level))
+            {
+                return;
+            }
+
+            // is error kind enabled?
+            if (logType is PodeLogErrorType errorLogType && !errorLogType.IsKindEnabled(kind))
             {
                 return;
             }
@@ -137,6 +148,7 @@ namespace Pode.Utilities.Logging
                 { "StackTrace", stackTrace },
                 { "Server", Dns.GetHostName() },
                 { "Level", level.ToString() },
+                { "Kind", kind.ToString() },
                 { "Date", logType.GetTimestamp() },
                 { "ThreadId", threadId == 0 ? Environment.CurrentManagedThreadId : threadId },
                 { "ContextId", contextId }

--- a/src/Listener/Utilities/PodeHelpers.cs
+++ b/src/Listener/Utilities/PodeHelpers.cs
@@ -11,6 +11,7 @@ using System.Text;
 using System.IO.Compression;
 using Pode.Protocols.Common.Contexts;
 using Pode.Utilities.Logging;
+using Pode.Protocols.Common.Requests;
 
 namespace Pode.Utilities
 {
@@ -102,7 +103,7 @@ namespace Pode.Utilities
             }
         }
 
-        public static void WriteErrorMessage(string message, PodeLogLevel level = PodeLogLevel.Error, IPodeContext context = default)
+        public static void WriteErrorMessage(string message, PodeLogLevel level = PodeLogLevel.Error, IPodeContext context = default, PodeRequestExceptionKind kind = PodeRequestExceptionKind.Server)
         {
             // do nothing if no message, or no logger
             if (string.IsNullOrWhiteSpace(message) || Logger == default(IPodeLogger))
@@ -111,7 +112,7 @@ namespace Pode.Utilities
             }
 
             // add the error message to the logger
-            Logger.AddException(message, context?.ID, level);
+            Logger.AddException(message, context?.ID, level, kind);
         }
 
         public static string NewGuid(int length = 16)

--- a/src/Private/Logging.ps1
+++ b/src/Private/Logging.ps1
@@ -1414,7 +1414,7 @@ function Push-PodeLogItem {
     }
 }
 
-function Add-PodeLogMethod {
+function Add-PodeLogMethodInternal {
     param(
         [Parameter()]
         [string]
@@ -1460,6 +1460,192 @@ function Add-PodeLogMethod {
 
     # return the method ID
     return $Id
+}
+
+function Add-PodeLogTypeInternal {
+    [CmdletBinding(DefaultParameterSetName = 'ScriptBlock')]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Name,
+
+        [Parameter(Mandatory = $true)]
+        [string[]]
+        $Method,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'ScriptBlock')]
+        [scriptblock]
+        $ScriptBlock,
+
+        [Parameter()]
+        [ValidateSet('Emergency', 'Alert', 'Critical', 'Error', 'Warning', 'Notice', 'Informational', 'Verbose', 'Debug', '*')]
+        [string[]]
+        $Levels,
+
+        [Parameter(ParameterSetName = 'ScriptBlock')]
+        [object[]]
+        $ArgumentList,
+
+        [Parameter(ParameterSetName = 'ScriptBlock')]
+        [ValidateSet(1, 2)]
+        [int]
+        $Version,
+
+        [Parameter()]
+        [Pode.Utilities.Logging.PodeLogFormat]
+        $LogFormat = [Pode.Utilities.Logging.PodeLogFormat]::None,
+
+        [Parameter()]
+        [scriptblock]
+        $LogScriptBlock,
+
+        [Parameter()]
+        [Pode.Utilities.Logging.PodeSerialiseFormat]
+        $SerialiseFormat = [Pode.Utilities.Logging.PodeSerialiseFormat]::None,
+
+        [Parameter()]
+        [scriptblock]
+        $SerialiseScriptBlock,
+
+        [Parameter()]
+        [hashtable]
+        $SyslogInfo,
+
+        [Parameter()]
+        [string]
+        $XmlRootName,
+
+        [Parameter()]
+        [hashtable]
+        $Metadata,
+
+        [Parameter()]
+        [string[]]
+        $LogHeader,
+
+        [Parameter()]
+        [hashtable]
+        $Options,
+
+        [switch]
+        $AsUtc,
+
+        [Parameter(ParameterSetName = 'Raw')]
+        [switch]
+        $Raw
+    )
+
+    # ensure the name doesn't already exist
+    if ($PodeContext.Server.Logging.Types.ContainsKey($Name)) {
+        # Log Method already defined
+        throw ($PodeLocale.loggingMethodAlreadyDefinedExceptionMessage -f $Name)
+    }
+
+    # ensure the log methods exists
+    foreach ($methodId in $Method) {
+        if (!(Test-PodeLogMethod -Id $methodId)) {
+            # The supplied Log Method for Custom Logging doesn't exist
+            throw ($PodeLocale.loggingMethodDoesNotExistExceptionMessage -f $methodId)
+        }
+    }
+
+    # all errors?
+    if ($Levels -contains '*') {
+        $Levels = @('Emergency', 'Alert', 'Critical', 'Error', 'Warning', 'Notice', 'Informational', 'Verbose', 'Debug')
+    }
+
+    # default metadata
+    if ($null -eq $Metadata) {
+        $Metadata = @{}
+    }
+
+    # default log formatter
+    if (!$PSBoundParameters.ContainsKey('LogFormat')) {
+        $LogFormat = Protect-PodeValue -Value (Get-PodeLogDefaultFormat) -Default $LogFormat -EnumType ([PodeLogFormat])
+    }
+
+    # do we need default syslog info?
+    if (($LogFormat -eq [PodeLogFormat]::Syslog) -and ($null -eq $SyslogInfo)) {
+        $SyslogInfo = New-PodeLogSyslogInfo
+    }
+
+    # are we using a custom log scriptblock?
+    if ($LogFormat -eq [PodeLogFormat]::Custom) {
+        if ($null -eq $LogScriptBlock) {
+            # A non-empty ScriptBlock is required for the Custom log format
+            throw ($PodeLocale.nonEmptyScriptBlockRequiredForCustomLogExceptionMessage)
+        }
+
+        $LogScriptBlock, $logUsingVars = Convert-PodeScopedVariables -ScriptBlock $LogScriptBlock -PSSession $PSCmdlet.SessionState
+    }
+
+    # default serialise formatter
+    if (!$PSBoundParameters.ContainsKey('SerialiseFormat')) {
+        $SerialiseFormat = Protect-PodeValue -Value (Get-PodeLogDefaultSerialiseFormat) -Default $SerialiseFormat -EnumType ([PodeSerialiseFormat])
+    }
+
+    # if custom serialisation, ensure we have a scriptblock, and check for scoped vars in scriptblock
+    if ($SerialiseFormat -eq [PodeSerialiseFormat]::Custom) {
+        if ($null -eq $SerialiseScriptBlock) {
+            # A non-empty ScriptBlock is required for the Custom logging serialisation format
+            throw ($PodeLocale.nonEmptyScriptBlockRequiredForCustomSerialisationExceptionMessage)
+        }
+
+        $SerialiseScriptBlock, $serialiseUsingVars = Convert-PodeScopedVariables -ScriptBlock $SerialiseScriptBlock -PSSession $PSCmdlet.SessionState
+    }
+
+    # check for scoped vars in scriptblock
+    if ($PSCmdlet.ParameterSetName -eq 'ScriptBlock') {
+        $ScriptBlock, $usingVars = Convert-PodeScopedVariables -ScriptBlock $ScriptBlock -PSSession $PSCmdlet.SessionState
+    }
+
+    # build log type options
+    if ($null -eq $Options) {
+        $Options = @{}
+    }
+
+    $_opts = @{
+        Formatting = @{
+            Log        = @{
+                Format         = $LogFormat
+                ScriptBlock    = $LogScriptBlock
+                UsingVariables = $logUsingVars
+            }
+            SyslogInfo = $SyslogInfo
+            Serialise  = @{
+                Type           = $SerialiseFormat
+                ScriptBlock    = $SerialiseScriptBlock
+                UsingVariables = $serialiseUsingVars
+                XmlRootName    = Protect-PodeValue -Value $XmlRootName -Default 'Log'
+            }
+            Headers    = $LogHeader
+            AsUtc      = $AsUtc.IsPresent
+        }
+    }
+    $_opts += $Options
+
+    # add custom Log Method to server, associated with the supplied Log Method(s)
+    $PodeContext.Server.Logging.Types[$Name] = @{
+        Name           = $Name
+        Method         = $Method
+        ScriptBlock    = $ScriptBlock
+        UsingVariables = $usingVars
+        Levels         = $Levels
+        Raw            = $Raw.IsPresent
+        Version        = $Version
+        SentFirstLog   = $false
+        Metadata       = $Metadata
+        Options        = $_opts
+        Arguments      = $ArgumentList
+    }
+
+    # then associate the supplied Log Method(s) with the custom Log Type
+    foreach ($methodId in $Method) {
+        Register-PodeLogTypeToMethod -TypeName $Name -MethodId $methodId
+    }
+
+    # return the type with all info just created
+    return $PodeContext.Server.Logging.Types[$Name]
 }
 
 function Register-PodeLogTypeToMethod {

--- a/src/Private/Logging.ps1
+++ b/src/Private/Logging.ps1
@@ -963,6 +963,7 @@ function Get-PodeLoggingInbuiltType {
                     ThreadId   = $logEvent.Data.ThreadId
                     ContextId  = $logEvent.Data.ContextId
                     Server     = $logEvent.Data.Server
+                    Kind       = $logEvent.Data.Kind
                     Category   = $logEvent.Data.Category
                     Message    = $logEvent.Data.Message
                     StackTrace = $logEvent.Data.StackTrace

--- a/src/Public/Logging.ps1
+++ b/src/Public/Logging.ps1
@@ -427,7 +427,12 @@ function Enable-PodeLogRequestType {
             $params['Version'] = 2
         }
 
-        Add-PodeLogType @params
+        # add the type internally
+        $typeInfo = Add-PodeLogTypeInternal @params
+
+        # register the type with the logger
+        $logType = [PodeLogRequestType]::new($typeInfo.Name, $typeInfo.Options.Formatting.AsUtc)
+        $PodeContext.Server.Logging.Logger.RegisterType($logType)
     }
 }
 
@@ -469,6 +474,9 @@ One or more Log Method IDs to use for outputting the log entry.
 .PARAMETER Levels
 The Levels of errors that should be logged (Default: Emergency, Alert, Critical, Error)
 
+.PARAMETER Kind
+The Kinds of errors that should be logged (Default: Server)
+
 .PARAMETER LogFormat
 The format to use for the log output. (Default: Server default, or 'None' if no default set).
 
@@ -498,6 +506,9 @@ If supplied, the log item returned will be the raw Error item as a hashtable and
 
 .EXAMPLE
 New-PodeLogTerminalMethod | Enable-PodeLogErrorType
+
+.EXAMPLE
+New-PodeLogTerminalMethod | Enable-PodeLogErrorType -Kind Server, Client
 
 .EXAMPLE
 New-PodeLogTerminalMethod | Enable-PodeLogErrorType -AsUtc
@@ -531,9 +542,15 @@ function Enable-PodeLogErrorType {
         $Method,
 
         [Parameter()]
+        [Alias('Level')]
         [ValidateSet('Emergency', 'Alert', 'Critical', 'Error', 'Warning', 'Notice', 'Informational', 'Verbose', 'Debug', '*')]
         [string[]]
         $Levels = @('Emergency', 'Alert', 'Critical', 'Error'),
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [Pode.Protocols.Common.Requests.PodeRequestExceptionKind[]]
+        $Kind = @([Pode.Protocols.Common.Requests.PodeRequestExceptionKind]::Server),
 
         [Parameter()]
         [Pode.Utilities.Logging.PodeLogFormat]
@@ -642,7 +659,17 @@ function Enable-PodeLogErrorType {
             $params['Version'] = 2
         }
 
-        Add-PodeLogType @params
+        # add types as additional options
+        $params['Options'] = @{
+            Kinds = $Kind
+        }
+
+        # add the type internally
+        $typeInfo = Add-PodeLogTypeInternal @params
+
+        # register the type with the logger
+        $logType = [PodeLogErrorType]::new($typeInfo.Name, $typeInfo.Levels, $Kind, $typeInfo.Options.Formatting.AsUtc)
+        $PodeContext.Server.Logging.Logger.RegisterType($logType)
     }
 }
 
@@ -771,6 +798,7 @@ function Add-PodeLogType {
         $ScriptBlock,
 
         [Parameter()]
+        [Alias('Level')]
         [ValidateSet('Emergency', 'Alert', 'Critical', 'Error', 'Warning', 'Notice', 'Informational', 'Verbose', 'Debug', '*')]
         [string[]]
         $Levels = @('Informational'),
@@ -825,12 +853,6 @@ function Add-PodeLogType {
     )
 
     begin {
-        # ensure the name doesn't already exist
-        if ($PodeContext.Server.Logging.Types.ContainsKey($Name)) {
-            # Log Method already defined
-            throw ($PodeLocale.loggingMethodAlreadyDefinedExceptionMessage -f $Name)
-        }
-
         # setup array for Log Methods being piped in
         $pipelineMethods = @()
     }
@@ -845,101 +867,12 @@ function Add-PodeLogType {
             $Method = $pipelineMethods
         }
 
-        # ensure the methods exists
-        foreach ($methodId in $Method) {
-            if (!(Test-PodeLogMethod -Id $methodId)) {
-                # The supplied Log Method for Custom Logging doesn't exist
-                throw ($PodeLocale.loggingMethodDoesNotExistExceptionMessage -f $methodId)
-            }
-        }
+        # add the type internally
+        $typeInfo = Add-PodeLogTypeInternal @PSBoundParameters -Levels $Levels
 
-        # all errors?
-        if ($Levels -contains '*') {
-            $Levels = @('Emergency', 'Alert', 'Critical', 'Error', 'Warning', 'Notice', 'Informational', 'Verbose', 'Debug')
-        }
-
-        # default metadata
-        if ($null -eq $Metadata) {
-            $Metadata = @{}
-        }
-
-        # default log formatter
-        if (!$PSBoundParameters.ContainsKey('LogFormat')) {
-            $LogFormat = Protect-PodeValue -Value (Get-PodeLogDefaultFormat) -Default $LogFormat -EnumType ([PodeLogFormat])
-        }
-
-        # do we need default syslog info?
-        if (($LogFormat -eq [PodeLogFormat]::Syslog) -and ($null -eq $SyslogInfo)) {
-            $SyslogInfo = New-PodeLogSyslogInfo
-        }
-
-        # are we using a custom log scriptblock?
-        if ($LogFormat -eq [PodeLogFormat]::Custom) {
-            if ($null -eq $LogScriptBlock) {
-                # A non-empty ScriptBlock is required for the Custom log format
-                throw ($PodeLocale.nonEmptyScriptBlockRequiredForCustomLogExceptionMessage)
-            }
-
-            $LogScriptBlock, $logUsingVars = Convert-PodeScopedVariables -ScriptBlock $LogScriptBlock -PSSession $PSCmdlet.SessionState
-        }
-
-        # default serialise formatter
-        if (!$PSBoundParameters.ContainsKey('SerialiseFormat')) {
-            $SerialiseFormat = Protect-PodeValue -Value (Get-PodeLogDefaultSerialiseFormat) -Default $SerialiseFormat -EnumType ([PodeSerialiseFormat])
-        }
-
-        # if custom serialisation, ensure we have a scriptblock, and check for scoped vars in scriptblock
-        if ($SerialiseFormat -eq [PodeSerialiseFormat]::Custom) {
-            if ($null -eq $SerialiseScriptBlock) {
-                # A non-empty ScriptBlock is required for the Custom logging serialisation format
-                throw ($PodeLocale.nonEmptyScriptBlockRequiredForCustomSerialisationExceptionMessage)
-            }
-
-            $SerialiseScriptBlock, $serialiseUsingVars = Convert-PodeScopedVariables -ScriptBlock $SerialiseScriptBlock -PSSession $PSCmdlet.SessionState
-        }
-
-        # check for scoped vars in scriptblock
-        if ($PSCmdlet.ParameterSetName -eq 'ScriptBlock') {
-            $ScriptBlock, $usingVars = Convert-PodeScopedVariables -ScriptBlock $ScriptBlock -PSSession $PSCmdlet.SessionState
-        }
-
-        # add custom Log Method to server, associated with the supplied Log Method(s)
-        $PodeContext.Server.Logging.Types[$Name] = @{
-            Custom         = $true
-            Method         = $Method
-            ScriptBlock    = $ScriptBlock
-            UsingVariables = $usingVars
-            Levels         = $Levels
-            Raw            = $Raw.IsPresent
-            Version        = $Version
-            SentFirstLog   = $false
-            Metadata       = $Metadata
-            Options        = @{
-                Formatting = @{
-                    Log        = @{
-                        Format         = $LogFormat
-                        ScriptBlock    = $LogScriptBlock
-                        UsingVariables = $logUsingVars
-                    }
-                    SyslogInfo = $SyslogInfo
-                    Serialise  = @{
-                        Type           = $SerialiseFormat
-                        ScriptBlock    = $SerialiseScriptBlock
-                        UsingVariables = $serialiseUsingVars
-                        XmlRootName    = Protect-PodeValue -Value $XmlRootName -Default 'Log'
-                    }
-                    Headers    = $LogHeader
-                    AsUtc      = $AsUtc.IsPresent
-                }
-            }
-            Arguments      = $ArgumentList
-        }
-        $PodeContext.Server.Logging.Logger.RegisterType([PodeLogType]::new($Name, $Levels, $AsUtc.IsPresent))
-
-        # then associate the supplied Log Method(s) with the custom Log Type
-        foreach ($methodId in $Method) {
-            Register-PodeLogTypeToMethod -TypeName $Name -MethodId $methodId
-        }
+        # register the type with the logger
+        $logType = [PodeLogType]::new($typeInfo.Name, $typeInfo.Levels, $typeInfo.Options.Formatting.AsUtc)
+        $PodeContext.Server.Logging.Logger.RegisterType($logType)
     }
 }
 
@@ -1170,16 +1103,40 @@ function Write-PodeErrorLog {
         # log error object appropriately based on parameter set
         switch ($PSCmdlet.ParameterSetName) {
             'Exception' {
-                $PodeContext.Server.Logging.Logger.AddException($Exception, $contextId, $Level, $Metadata, [int]$ThreadId)
+                $PodeContext.Server.Logging.Logger.AddException(
+                    $Exception,
+                    $contextId,
+                    $Level,
+                    $Metadata,
+                    [int]$ThreadId
+                )
             }
 
             'Error' {
-                $PodeContext.Server.Logging.Logger.AddException($ErrorRecord.CategoryInfo.ToString(), $ErrorRecord.Exception.Message, $ErrorRecord.ScriptStackTrace, $contextId, $Level, $Metadata, [int]$ThreadId)
+                $PodeContext.Server.Logging.Logger.AddException(
+                    $ErrorRecord.CategoryInfo.ToString(),
+                    $ErrorRecord.Exception.Message,
+                    $ErrorRecord.ScriptStackTrace,
+                    $contextId,
+                    $Level,
+                    [Pode.Protocols.Common.Requests.PodeRequestExceptionKind]::Server,
+                    $Metadata,
+                    [int]$ThreadId
+                )
             }
 
             'Message' {
                 $category = (Get-PSCallStack)[1].Location
-                $PodeContext.Server.Logging.Logger.AddException($category, $Message, [string]::Empty, $contextId, $Level, $Metadata, [int]$ThreadId)
+                $PodeContext.Server.Logging.Logger.AddException(
+                    $category,
+                    $Message,
+                    [string]::Empty,
+                    $contextId,
+                    $Level,
+                    [Pode.Protocols.Common.Requests.PodeRequestExceptionKind]::Server,
+                    $Metadata,
+                    [int]$ThreadId
+                )
             }
         }
 
@@ -1409,7 +1366,7 @@ function New-PodeLogTerminalMethod {
     )
 
     # add method to server
-    return Add-PodeLogMethod -Id $Id -Batch $BatchInfo -Metadata @{
+    return Add-PodeLogMethodInternal -Id $Id -Batch $BatchInfo -Metadata @{
         Type        = 'Terminal'
         ScriptBlock = Get-PodeLoggingTerminalMethod
         Arguments   = @{}
@@ -1487,7 +1444,7 @@ function New-PodeLogFileMethod {
     $null = New-Item -Path $Path -ItemType Directory -Force
 
     # add method to server
-    return Add-PodeLogMethod -Id $Id -Batch $BatchInfo -Metadata @{
+    return Add-PodeLogMethodInternal -Id $Id -Batch $BatchInfo -Metadata @{
         Type        = 'File'
         ScriptBlock = Get-PodeLoggingFileMethod
         Arguments   = @{
@@ -1570,7 +1527,7 @@ function New-PodeLogEventViewerMethod {
     }
 
     # add method to server
-    return Add-PodeLogMethod -Id $Id -Batch $BatchInfo -Metadata @{
+    return Add-PodeLogMethodInternal -Id $Id -Batch $BatchInfo -Metadata @{
         Type        = 'EventViewer'
         ScriptBlock = Get-PodeLoggingEventViewerMethod
         Arguments   = @{
@@ -1660,7 +1617,7 @@ function New-PodeLogCustomMethod {
     $ScriptBlock, $usingVars = Convert-PodeScopedVariables -ScriptBlock $ScriptBlock -PSSession $PSCmdlet.SessionState
 
     # add method to server
-    return Add-PodeLogMethod -Id $Id -Batch $BatchInfo -Metadata @{
+    return Add-PodeLogMethodInternal -Id $Id -Batch $BatchInfo -Metadata @{
         Type        = 'Custom'
         ScriptBlock = Get-PodeLoggingCustomMethod
         Custom      = @{
@@ -1810,7 +1767,7 @@ function New-PodeLogApiMethod {
     }
 
     # add method to server
-    return Add-PodeLogMethod -Id $Id -Batch $BatchInfo -Metadata @{
+    return Add-PodeLogMethodInternal -Id $Id -Batch $BatchInfo -Metadata @{
         Type        = $Type
         ScriptBlock = Get-PodeLoggingApiMethod
         Arguments   = @{
@@ -2493,7 +2450,7 @@ function New-PodeLogNetworkMethod {
     )
 
     # add method to server
-    return Add-PodeLogMethod -Id $Id -Batch $BatchInfo -Metadata @{
+    return Add-PodeLogMethodInternal -Id $Id -Batch $BatchInfo -Metadata @{
         Type        = 'Network'
         ScriptBlock = Get-PodeLoggingNetworkMethod
         Arguments   = @{


### PR DESCRIPTION
### Description of the Change
Adds support for controlling which Error Kinds get logged. Until now every Error will be logged (depending on log level), regardless if there Error is produced by the Server; erroneous data from the Client; or a Timeout.

With this change, the default Error Kind logged will be `Server`, but Client and Timeout can be set by using the new `-Kind` parameter on `Enable-PodeLogErrorType`.

### Examples
```powershell
# Server by default
New-PodeLogTerminalMethod | Enable-PodeLogErrorType

# Server and Client
New-PodeLogTerminalMethod | Enable-PodeLogErrorType -Kind Server, Client

# Client and Timeout
New-PodeLogTerminalMethod | Enable-PodeLogErrorType -Kind Client, Timeout

# Just Client
New-PodeLogTerminalMethod | Enable-PodeLogErrorType -Kind Client
```
