### PR TITLE
Adds support for creating multiple Error/Request Log Types

### DIFF
--- a/docs/Tutorials/Logging/Types/Errors.md
+++ b/docs/Tutorials/Logging/Types/Errors.md
@@ -8,7 +8,7 @@ It also has support for error levels (such as Error, Warning, Verbose), with sup
 
 To enable the Error Log Type use [`Enable-PodeLogErrorType`](../../../../Functions/Logging/Enable-PodeLogErrorType), and supply one or more Log Methods - such as the [Terminal](../../Methods/Terminal) Method.
 
-You can call [`Enable-PodeLogErrorType`](../../../../Functions/Logging/Enable-PodeLogErrorType) multiple times, supplying a different `-Name` for each, to enable multiple Error Log Types.
+You can call [`Enable-PodeLogErrorType`](../../../../Functions/Logging/Enable-PodeLogErrorType) multiple times, supplying a different `-Name` for each, to enable multiple Error Log Types. When multiple are enabled, an Error will be sent to all enabled Error Log Types.
 
 !!! note
     For backwards compatibility support: if you call `Enable-PodeLogErrorType` with no `-Name`, then a default name will be used. Subsequent `Enable-PodeLogErrorType` calls **must** supply a `-Name`.

--- a/docs/Tutorials/Logging/Types/Errors.md
+++ b/docs/Tutorials/Logging/Types/Errors.md
@@ -8,6 +8,11 @@ It also has support for error levels (such as Error, Warning, Verbose), with sup
 
 To enable the Error Log Type use [`Enable-PodeLogErrorType`](../../../../Functions/Logging/Enable-PodeLogErrorType), and supply one or more Log Methods - such as the [Terminal](../../Methods/Terminal) Method.
 
+You can call [`Enable-PodeLogErrorType`](../../../../Functions/Logging/Enable-PodeLogErrorType) multiple times, supplying a different `-Name` for each, to enable multiple Error Log Types.
+
+!!! note
+    For backwards compatibility support: if you call `Enable-PodeLogErrorType` with no `-Name`, then a default name will be used. Subsequent `Enable-PodeLogErrorType` calls **must** supply a `-Name`.
+
 !!! important
     The `Enable-PodeErrorLogging` function is now deprecated, please use [`Enable-PodeLogErrorType`](../../../../Functions/Logging/Enable-PodeLogErrorType) instead. The former is aliased to the latter for now.
 
@@ -117,6 +122,15 @@ The following example enables the Error Log Type, and will output all items to t
 
 ```powershell
 New-PodeLogTerminalMethod | Enable-PodeLogErrorType
+```
+
+### Log Multiple
+
+The following example enables 2 Error Log Types, one with the inbuilt default name and one with a custom name:
+
+```powershell
+New-PodeLogTerminalMethod | Enable-PodeLogErrorType
+New-PodeLogTerminalMethod | Enable-PodeLogErrorType -Name 'custom-err'
 ```
 
 ### Log as JSON

--- a/docs/Tutorials/Logging/Types/Requests.md
+++ b/docs/Tutorials/Logging/Types/Requests.md
@@ -9,6 +9,11 @@ Pode has an inbuilt Request Log Type, which will parse and transform web request
 
 To enable the Request Log Type use [`Enable-PodeLogRequestType`](../../../../Functions/Logging/Enable-PodeLogRequestType), and supply one or more Log Methods - such as the [Terminal](../../Methods/Terminal) Method.
 
+You can call [`Enable-PodeLogRequestType`](../../../../Functions/Logging/Enable-PodeLogRequestType) multiple times, supplying a different `-Name` for each, to enable multiple Request Log Types.
+
+!!! note
+    For backwards compatibility support: if you call `Enable-PodeLogRequestType` with no `-Name`, then a default name will be used. Subsequent `Enable-PodeLogRequestType` calls **must** supply a `-Name`.
+
 !!! important
     The `Enable-PodeRequestLogging` function is now deprecated, please use [`Enable-PodeLogRequestType`](../../../../Functions/Logging/Enable-PodeLogRequestType) instead. The former is aliased to the latter for now.
 
@@ -142,6 +147,15 @@ The following example enables the Request Log Type, and will output all items to
 
 ```powershell
 New-PodeLogTerminalMethod | Enable-PodeLogRequestType
+```
+
+### Log Multiple
+
+The following example enables 2 Request Log Types, one with the inbuilt default name and one with a custom name:
+
+```powershell
+New-PodeLogTerminalMethod | Enable-PodeLogRequestType
+New-PodeLogTerminalMethod | Enable-PodeLogRequestType -Name 'custom-req'
 ```
 
 ### Log Proxy IP

--- a/docs/Tutorials/Logging/Types/Requests.md
+++ b/docs/Tutorials/Logging/Types/Requests.md
@@ -9,7 +9,7 @@ Pode has an inbuilt Request Log Type, which will parse and transform web request
 
 To enable the Request Log Type use [`Enable-PodeLogRequestType`](../../../../Functions/Logging/Enable-PodeLogRequestType), and supply one or more Log Methods - such as the [Terminal](../../Methods/Terminal) Method.
 
-You can call [`Enable-PodeLogRequestType`](../../../../Functions/Logging/Enable-PodeLogRequestType) multiple times, supplying a different `-Name` for each, to enable multiple Request Log Types.
+You can call [`Enable-PodeLogRequestType`](../../../../Functions/Logging/Enable-PodeLogRequestType) multiple times, supplying a different `-Name` for each, to enable multiple Request Log Types. When multiple are enabled, a Request will be sent to all enabled Request Log Types.
 
 !!! note
     For backwards compatibility support: if you call `Enable-PodeLogRequestType` with no `-Name`, then a default name will be used. Subsequent `Enable-PodeLogRequestType` calls **must** supply a `-Name`.

--- a/src/Listener/Utilities/Logging/IPodeLogType.cs
+++ b/src/Listener/Utilities/Logging/IPodeLogType.cs
@@ -10,6 +10,6 @@ namespace Pode.Utilities.Logging
         bool AsUtc { get; }
 
         bool IsLevelEnabled(PodeLogLevel level);
-        DateTime GetTimestamp();
+        DateTime GetTimestamp(DateTime? timestamp = null);
     }
 }

--- a/src/Listener/Utilities/Logging/IPodeLogger.cs
+++ b/src/Listener/Utilities/Logging/IPodeLogger.cs
@@ -10,6 +10,9 @@ namespace Pode.Utilities.Logging
         bool IsDisposed { get; }
         int Count { get; }
 
+        PodeConcurrentSet<string> ErrorLogTypeNames { get; }
+        PodeConcurrentSet<string> RequestLogTypeNames { get; }
+
         bool IsEnabled { get; set; }
         bool IsRequestLoggingEnabled { get; }
         bool IsErrorLoggingEnabled { get; }

--- a/src/Listener/Utilities/Logging/PodeLogType.cs
+++ b/src/Listener/Utilities/Logging/PodeLogType.cs
@@ -26,9 +26,10 @@ namespace Pode.Utilities.Logging
             return Levels.Contains(level);
         }
 
-        public DateTime GetTimestamp()
+        public DateTime GetTimestamp(DateTime? timestamp = null)
         {
-            return AsUtc ? DateTime.UtcNow : DateTime.Now;
+            var ts = timestamp ?? DateTime.Now;
+            return AsUtc ? ts.ToUniversalTime() : ts;
         }
     }
 }

--- a/src/Listener/Utilities/Logging/PodeLogger.cs
+++ b/src/Listener/Utilities/Logging/PodeLogger.cs
@@ -13,7 +13,10 @@ namespace Pode.Utilities.Logging
         public const string ERROR_LOG_TYPE_NAME = "__pode_log_errors__";
 
         private readonly PodeLogQueue<IPodeLogEvent> Queue;
+
         private readonly ConcurrentDictionary<string, IPodeLogType> LogTypes;
+        public PodeConcurrentSet<string> ErrorLogTypeNames { get; private set; }
+        public PodeConcurrentSet<string> RequestLogTypeNames { get; private set; }
 
         public bool IsDisposed { get; private set; } = false;
         public int Count => Queue.Count;
@@ -25,12 +28,14 @@ namespace Pode.Utilities.Logging
             set => _isEnabled = value;
         }
 
-        public bool IsRequestLoggingEnabled => IsEnabled && (LogTypes?.ContainsKey(REQUEST_LOG_TYPE_NAME) ?? false);
-        public bool IsErrorLoggingEnabled => IsEnabled && (LogTypes?.ContainsKey(ERROR_LOG_TYPE_NAME) ?? false);
+        public bool IsRequestLoggingEnabled => IsEnabled && RequestLogTypeNames?.Count > 0;
+        public bool IsErrorLoggingEnabled => IsEnabled && ErrorLogTypeNames?.Count > 0;
 
         public PodeLogger()
         {
             LogTypes = new ConcurrentDictionary<string, IPodeLogType>();
+            ErrorLogTypeNames = new PodeConcurrentSet<string>();
+            RequestLogTypeNames = new PodeConcurrentSet<string>();
             Queue = new PodeLogQueue<IPodeLogEvent>();
         }
 
@@ -42,6 +47,18 @@ namespace Pode.Utilities.Logging
             }
 
             LogTypes.TryAdd(logType.Name, logType);
+
+            // register as error log type
+            if (logType is PodeLogErrorType)
+            {
+                ErrorLogTypeNames.TryAdd(logType.Name);
+            }
+
+            // else register as request log type
+            else if (logType is PodeLogRequestType)
+            {
+                RequestLogTypeNames.TryAdd(logType.Name);
+            }
         }
 
         public void UnregisterType(string name)
@@ -52,6 +69,8 @@ namespace Pode.Utilities.Logging
             }
 
             LogTypes.TryRemove(name, out _);
+            ErrorLogTypeNames.TryRemove(name, out _);
+            RequestLogTypeNames.TryRemove(name, out _);
         }
 
         public void Add(string logTypeName, PodeLogLevel level, object data, Hashtable metadata = null)
@@ -98,41 +117,9 @@ namespace Pode.Utilities.Logging
 
         public void AddException(string category, string message, string stackTrace, string contextId, PodeLogLevel level, PodeRequestExceptionKind kind = PodeRequestExceptionKind.Server, Hashtable metadata = null, int threadId = 0)
         {
-            if (IsDisposed || !IsEnabled)
+            if (IsDisposed || !IsEnabled || !IsErrorLoggingEnabled)
             {
                 return;
-            }
-
-            // does the Log Type exist?
-            if (!LogTypes.TryGetValue(ERROR_LOG_TYPE_NAME, out var logType))
-            {
-                return;
-            }
-
-            // is the log level enabled for the Log Type?
-            if (!logType.IsLevelEnabled(level))
-            {
-                return;
-            }
-
-            // is error kind enabled?
-            if (logType is PodeLogErrorType errorLogType && !errorLogType.IsKindEnabled(kind))
-            {
-                return;
-            }
-
-            // set a category to calling class and method if not set
-            if (string.IsNullOrWhiteSpace(category))
-            {
-                var diag = new System.Diagnostics.StackTrace();
-                if (diag.FrameCount > 3)
-                {
-                    var frame = diag.GetFrame(3);
-                    var method = frame.GetMethod();
-                    var className = method.DeclaringType?.Name;
-                    var methodName = method.Name;
-                    category = $"{className}.{methodName}";
-                }
             }
 
             // default "<none>" values where not set
@@ -140,22 +127,64 @@ namespace Pode.Utilities.Logging
             message = string.IsNullOrWhiteSpace(message) ? "<none>" : message;
             contextId = string.IsNullOrWhiteSpace(contextId) ? "<none>" : contextId;
 
-            // convert the exception to a log item
-            var item = new Hashtable(StringComparer.InvariantCultureIgnoreCase)
-            {
-                { "Category", category },
-                { "Message", message },
-                { "StackTrace", stackTrace },
-                { "Server", Dns.GetHostName() },
-                { "Level", level.ToString() },
-                { "Kind", kind.ToString() },
-                { "Date", logType.GetTimestamp() },
-                { "ThreadId", threadId == 0 ? Environment.CurrentManagedThreadId : threadId },
-                { "ContextId", contextId }
-            };
+            // set the threadId to the current thread if not set
+            threadId = threadId == 0 ? Environment.CurrentManagedThreadId : threadId;
 
-            // add the log event to the queue
-            Queue.Add(new PodeLogEvent(logType, level, item, metadata));
+            // timestamp (will be converted to UTC by the log type if required)
+            var timestamp = DateTime.Now;
+
+            // loop through all registered error log types, and queue exception for each
+            foreach (var logTypeName in ErrorLogTypeNames)
+            {
+                // does the Log Type exist?
+                if (!LogTypes.TryGetValue(logTypeName, out var logType))
+                {
+                    continue;
+                }
+
+                // is the log level enabled for the Log Type?
+                if (!logType.IsLevelEnabled(level))
+                {
+                    continue;
+                }
+
+                // is error kind enabled?
+                if (logType is PodeLogErrorType errorLogType && !errorLogType.IsKindEnabled(kind))
+                {
+                    continue;
+                }
+
+                // set a category to calling class and method if not set (will only be set on first log type)
+                if (string.IsNullOrWhiteSpace(category))
+                {
+                    var diag = new System.Diagnostics.StackTrace();
+                    if (diag.FrameCount > 3)
+                    {
+                        var frame = diag.GetFrame(3);
+                        var method = frame.GetMethod();
+                        var className = method.DeclaringType?.Name;
+                        var methodName = method.Name;
+                        category = $"{className}.{methodName}";
+                    }
+                }
+
+                // convert the exception to a log item
+                var item = new Hashtable(StringComparer.InvariantCultureIgnoreCase)
+                {
+                    { "Category", category },
+                    { "Message", message },
+                    { "StackTrace", stackTrace },
+                    { "Server", Dns.GetHostName() },
+                    { "Level", level },
+                    { "Kind", kind },
+                    { "Date", logType.GetTimestamp(timestamp) },
+                    { "ThreadId", threadId },
+                    { "ContextId", contextId }
+                };
+
+                // add the log event to the queue
+                Queue.Add(new PodeLogEvent(logType, level, item, metadata));
+            }
         }
 
         public bool TryTake(out IPodeLogEvent logEvent, CancellationToken cancellationToken)
@@ -187,6 +216,8 @@ namespace Pode.Utilities.Logging
 
             // clear Log Types
             LogTypes.Clear();
+            ErrorLogTypeNames.Clear();
+            RequestLogTypeNames.Clear();
         }
 
         public void Dispose()
@@ -203,6 +234,8 @@ namespace Pode.Utilities.Logging
 
             // clear the Log Types
             LogTypes.Clear();
+            ErrorLogTypeNames.Clear();
+            RequestLogTypeNames.Clear();
 
             // suppress finalization
             GC.SuppressFinalize(this);

--- a/src/Listener/Utilities/PodeConcurrentSet.cs
+++ b/src/Listener/Utilities/PodeConcurrentSet.cs
@@ -1,0 +1,79 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Pode.Utilities
+{
+    public class PodeConcurrentSet<T> : IEnumerable<T>
+    {
+        private readonly HashSet<T> Items = new HashSet<T>();
+        private readonly object Lock = new object();
+
+        public PodeConcurrentSet() { }
+
+        public int Count
+        {
+            get
+            {
+                lock (Lock)
+                {
+                    return Items.Count;
+                }
+            }
+        }
+
+        public bool TryAdd(T item)
+        {
+            lock (Lock)
+            {
+                return Items.Add(item);
+            }
+        }
+
+        public bool TryRemove(T item, out T removedItem)
+        {
+            lock (Lock)
+            {
+                var removed = Items.Remove(item);
+                removedItem = removed ? item : default;
+                return removed;
+            }
+        }
+
+        public bool Contains(T item)
+        {
+            lock (Lock)
+            {
+                return Items.Contains(item);
+            }
+        }
+
+        public void Clear()
+        {
+            lock (Lock)
+            {
+                Items.Clear();
+            }
+        }
+
+        public T[] ToArray()
+        {
+            lock (Lock)
+            {
+                return Items.ToArray();
+            }
+        }
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            lock (Lock)
+            {
+                return ((IReadOnlyList<T>)Items.ToArray()).GetEnumerator();
+            }
+        }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}

--- a/src/Private/Logging.ps1
+++ b/src/Private/Logging.ps1
@@ -1053,10 +1053,6 @@ function Write-PodeRequestLog {
         return
     }
 
-    # get the request log type
-    $logTypeName = [PodeLogger]::REQUEST_LOG_TYPE_NAME
-    $logType = Get-PodeLogType -Name $logTypeName
-
     # http method
     $method = $null
     if (![string]::IsNullOrEmpty($WebEvent.Request.HttpMethod)) {
@@ -1075,104 +1071,119 @@ function Write-PodeRequestLog {
         $scheme = $WebEvent.Request.Handler.Scheme.ToLowerInvariant()
     }
 
-    # date/timestamp
-    $timestamp = $WebEvent.Timestamp
-    if (!$logType.Options.Formatting.AsUtc) {
-        $timestamp = $timestamp.ToLocalTime()
-    }
+    # duration
+    $duration = [datetime]::UtcNow.Subtract($WebEvent.Timestamp)
 
-    # build a request object
-    $item = @{
-        Host            = $WebEvent.Request.Handler.RemoteEndPoint.Address.IPAddressToString
-        RfcUserIdentity = $null
-        User            = $null
-        Date            = $timestamp
-        UtcDate         = $WebEvent.Timestamp
-        Duration        = [datetime]::UtcNow.Subtract($WebEvent.Timestamp)
-        Server          = @{
-            IP   = $WebEvent.Request.Handler.LocalEndPoint.Address.IPAddressToString
-            Port = $WebEvent.Request.Handler.LocalEndPoint.Port
-        }
-        Environment     = @{
-            Variables = @{}
-        }
-        Request         = @{
-            Method   = $method
-            Hostname = $hostname
-            Scheme   = $scheme
-            Resource = $WebEvent.Path
-            Query    = (Protect-PodeValue -Value $WebEvent.Request.Url.Query -Default ([string]::Empty)).TrimStart('?')
-            Protocol = "HTTP/$($WebEvent.Request.ProtocolVersion)"
-            Referrer = $WebEvent.Request.UrlReferrer
-            Agent    = $WebEvent.Request.UserAgent
-            Size     = $WebEvent.Request.ContentLength
-            Headers  = @{}
-        }
-        Response        = @{
-            StatusCode        = $WebEvent.Response.StatusCode
-            StatusDescription = $WebEvent.Response.StatusDescription
-            Size              = $null
-            Headers           = @{}
-        }
-    }
+    # query
+    $query = (Protect-PodeValue -Value $WebEvent.Request.Url.Query -Default ([string]::Empty)).TrimStart('?')
 
-    # set size of data sent back to the client if >0
+    # protocol
+    $protocol = "HTTP/$($WebEvent.Request.ProtocolVersion)"
+
+    # response size
+    $respSize = $null
     if ($WebEvent.Response.ContentLength64 -gt 0) {
-        $item.Response.Size = $WebEvent.Response.ContentLength64
+        $respSize = $WebEvent.Response.ContentLength64
     }
 
-    # do we need to get the host address from req headers (if behind a reverse proxy)?
-    $remoteIpHeaders = $logType.Metadata.RemoteIPHeader
-    if (($null -ne $remoteIpHeaders) -and ($remoteIpHeaders.Count -gt 0)) {
-        foreach ($header in $remoteIpHeaders) {
-            if (Test-PodeHeader -Name $header) {
-                $item.Host = ((Get-PodeHeader -Name $header) -split ',')[0].Trim()
-                break
+    # loop through each request log type and add to the queue
+    foreach ($logTypeName in $PodeContext.Server.Logging.Logger.RequestLogTypeNames) {
+        $logType = Get-PodeLogType -Name $logTypeName
+
+        # date/timestamp
+        $timestamp = $WebEvent.Timestamp
+        if (!$logType.Options.Formatting.AsUtc) {
+            $timestamp = $timestamp.ToLocalTime()
+        }
+
+        # build a request object
+        $item = @{
+            Host            = $WebEvent.Request.Handler.RemoteEndPoint.Address.IPAddressToString
+            RfcUserIdentity = $null
+            User            = $null
+            Date            = $timestamp
+            UtcDate         = $WebEvent.Timestamp
+            Duration        = $duration
+            Server          = @{
+                IP   = $WebEvent.Request.Handler.LocalEndPoint.Address.IPAddressToString
+                Port = $WebEvent.Request.Handler.LocalEndPoint.Port
+            }
+            Environment     = @{
+                Variables = @{}
+            }
+            Request         = @{
+                Method   = $method
+                Hostname = $hostname
+                Scheme   = $scheme
+                Resource = $WebEvent.Path
+                Query    = $query
+                Protocol = $protocol
+                Referrer = $WebEvent.Request.UrlReferrer
+                Agent    = $WebEvent.Request.UserAgent
+                Size     = $WebEvent.Request.ContentLength
+                Headers  = @{}
+            }
+            Response        = @{
+                StatusCode        = $WebEvent.Response.StatusCode
+                StatusDescription = $WebEvent.Response.StatusDescription
+                Size              = $respSize
+                Headers           = @{}
             }
         }
-    }
 
-    # set username - dot spaces
-    if (Test-PodeAuthUser -IgnoreSession) {
-        $userProps = $logType.Metadata.Username.Split('.')
-
-        $user = $WebEvent.Auth.User
-        foreach ($atom in $userProps) {
-            $user = $user.($atom)
+        # do we need to get the host address from req headers (if behind a reverse proxy)?
+        $remoteIpHeaders = $logType.Metadata.RemoteIPHeader
+        if (($null -ne $remoteIpHeaders) -and ($remoteIpHeaders.Count -gt 0)) {
+            foreach ($header in $remoteIpHeaders) {
+                if (Test-PodeHeader -Name $header) {
+                    $item.Host = ((Get-PodeHeader -Name $header) -split ',')[0].Trim()
+                    break
+                }
+            }
         }
 
-        if (![string]::IsNullOrWhiteSpace($user)) {
-            $item.User = $user -ireplace '\s+', '.'
+        # set username - dot spaces
+        if (Test-PodeAuthUser -IgnoreSession) {
+            $userProps = $logType.Metadata.Username.Split('.')
+
+            $user = $WebEvent.Auth.User
+            foreach ($atom in $userProps) {
+                $user = $user.($atom)
+            }
+
+            if (![string]::IsNullOrWhiteSpace($user)) {
+                $item.User = $user -ireplace '\s+', '.'
+            }
         }
-    }
 
-    # for w3c format, we need to fetch req/resp headers, and server env vars
-    if ($logType.Metadata.Format -ieq 'W3C') {
-        foreach ($field in $logType.Metadata.W3CFields) {
-            switch ($field.Type) {
-                'Request' {
-                    if (Test-PodeHeader -Name $field.Name) {
-                        $item.Request.Headers[$field.Name] = Get-PodeHeader -Name $field.Name
+        # for w3c format, we need to fetch req/resp headers, and server env vars
+        if ($logType.Metadata.Format -ieq 'W3C') {
+            foreach ($field in $logType.Metadata.W3CFields) {
+                switch ($field.Type) {
+                    'Request' {
+                        if (Test-PodeHeader -Name $field.Name) {
+                            $item.Request.Headers[$field.Name] = Get-PodeHeader -Name $field.Name
+                        }
                     }
-                }
 
-                'Response' {
-                    if (Test-PodeHeader -Name $field.Name -Response) {
-                        $item.Response.Headers[$field.Name] = Get-PodeHeader -Name $field.Name -Response
+                    'Response' {
+                        if (Test-PodeHeader -Name $field.Name -Response) {
+                            $item.Response.Headers[$field.Name] = Get-PodeHeader -Name $field.Name -Response
+                        }
                     }
-                }
 
-                'Environment' {
-                    if (Test-PodeEnvironmentVariable -Name $field.Name) {
-                        $item.Environment.Variables[$field.Name] = Get-PodeEnvironmentVariable -Name $field.Name
+                    'Environment' {
+                        if (Test-PodeEnvironmentVariable -Name $field.Name) {
+                            $item.Environment.Variables[$field.Name] = Get-PodeEnvironmentVariable -Name $field.Name
+                        }
                     }
                 }
             }
         }
-    }
 
-    # add the item to be processed
-    $PodeContext.Server.Logging.Logger.Add($logTypeName, [PodeLogLevel]::Informational, $item)
+        # add the item to be processed
+        $PodeContext.Server.Logging.Logger.Add($logTypeName, [PodeLogLevel]::Informational, $item)
+    }
 }
 
 function Add-PodeRequestLogEndware {

--- a/src/Public/Logging.ps1
+++ b/src/Public/Logging.ps1
@@ -190,6 +190,9 @@ Enables Request Logging using a supplied output method.
 .DESCRIPTION
 Enables Request Logging using a supplied output method.
 
+.PARAMETER Name
+An optional Name to assign to the Request Log Type. If not supplied, a default name will be used.
+
 .PARAMETER Method
 One or more Log Method IDs to use for outputting the log entry.
 
@@ -243,7 +246,7 @@ New-PodeLogTerminalMethod | Enable-PodeLogRequestType -AsUtc
 New-PodeLogTerminalMethod | Enable-PodeLogRequestType -RemoteIPHeader 'X-Forwarded-For'
 
 .EXAMPLE
-New-PodeLogTerminalMethod | Enable-PodeLogRequestType -SerialiseFormat 'Json'
+New-PodeLogTerminalMethod | Enable-PodeLogRequestType -Name 'custom-req' -SerialiseFormat 'Json'
 
 .EXAMPLE
 New-PodeLogTerminalMethod | Enable-PodeLogRequestType -SerialiseFormat 'Custom' -SerialiseScriptBlock {
@@ -266,6 +269,10 @@ New-PodeLogTerminalMethod | Enable-PodeLogRequestType -LogFormat Syslog -SyslogI
 function Enable-PodeLogRequestType {
     [CmdletBinding(DefaultParameterSetName = 'ScriptBlock')]
     param(
+        [Parameter()]
+        [string]
+        $Name,
+
         [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
         [string[]]
         $Method,
@@ -325,7 +332,7 @@ function Enable-PodeLogRequestType {
 
     begin {
         # error if it's already enabled
-        $name = [PodeLogger]::REQUEST_LOG_TYPE_NAME
+        $name = Protect-PodeValue -Value $Name -Default ([PodeLogger]::REQUEST_LOG_TYPE_NAME)
 
         # setup array for Log Methods being piped in
         $pipelineMethods = @()
@@ -447,14 +454,25 @@ Disables Request Log Type.
 .DESCRIPTION
 Disables Request Log Type.
 
+.PARAMETER Name
+An optional Name to assign to the Request Log Type. If not supplied, a default name will be used.
+
 .EXAMPLE
 Disable-PodeLogRequestType
+
+.EXAMPLE
+Disable-PodeLogRequestType -Name 'custom-req'
 #>
 function Disable-PodeLogRequestType {
     [CmdletBinding()]
-    param()
+    param(
+        [Parameter()]
+        [string]
+        $Name
+    )
 
-    Remove-PodeLogType -Name ([PodeLogger]::REQUEST_LOG_TYPE_NAME)
+    $Name = Protect-PodeValue -Value $Name -Default ([PodeLogger]::REQUEST_LOG_TYPE_NAME)
+    Remove-PodeLogType -Name $Name
 }
 
 if (!(Test-Path Alias:Disable-PodeRequestLogging)) {
@@ -467,6 +485,9 @@ Enables Error Log Type using a supplied Log Method.
 
 .DESCRIPTION
 Enables Error Log Type using a supplied Log Method.
+
+.PARAMETER Name
+An optional Name to assign to the Error Log Type. If not supplied, a default name will be used.
 
 .PARAMETER Method
 One or more Log Method IDs to use for outputting the log entry.
@@ -514,7 +535,7 @@ New-PodeLogTerminalMethod | Enable-PodeLogErrorType -Kind Server, Client
 New-PodeLogTerminalMethod | Enable-PodeLogErrorType -AsUtc
 
 .EXAMPLE
-New-PodeLogTerminalMethod | Enable-PodeLogErrorType -SerialiseFormat 'Json'
+New-PodeLogTerminalMethod | Enable-PodeLogErrorType -Name 'custom-error' -SerialiseFormat 'Json'
 
 .EXAMPLE
 New-PodeLogTerminalMethod | Enable-PodeLogErrorType -SerialiseFormat 'Custom' -SerialiseScriptBlock {
@@ -537,6 +558,10 @@ New-PodeLogTerminalMethod | Enable-PodeLogErrorType -LogFormat Syslog -SyslogInf
 function Enable-PodeLogErrorType {
     [CmdletBinding(DefaultParameterSetName = 'ScriptBlock')]
     param(
+        [Parameter()]
+        [string]
+        $Name,
+
         [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
         [string[]]
         $Method,
@@ -590,7 +615,7 @@ function Enable-PodeLogErrorType {
 
     begin {
         # get error log type name
-        $name = [PodeLogger]::ERROR_LOG_TYPE_NAME
+        $name = Protect-PodeValue -Value $Name -Default ([PodeLogger]::ERROR_LOG_TYPE_NAME)
 
         # setup array for Log Methods being piped in
         $pipelineMethods = @()
@@ -684,14 +709,25 @@ Disables Error Log Type.
 .DESCRIPTION
 Disables Error Log Type.
 
+.PARAMETER Name
+An optional Name to assign to the Error Log Type. If not supplied, a default name will
+
 .EXAMPLE
 Disable-PodeLogErrorType
+
+.EXAMPLE
+Disable-PodeLogErrorType -Name 'custom-error'
 #>
 function Disable-PodeLogErrorType {
     [CmdletBinding()]
-    param()
+    param(
+        [Parameter()]
+        [string]
+        $Name
+    )
 
-    Remove-PodeLogType -Name ([PodeLogger]::ERROR_LOG_TYPE_NAME)
+    $Name = Protect-PodeValue -Value $Name -Default ([PodeLogger]::ERROR_LOG_TYPE_NAME)
+    Remove-PodeLogType -Name $Name
 }
 
 if (!(Test-Path Alias:Disable-PodeErrorLogging)) {

--- a/tests/unit/Logging.Tests.ps1
+++ b/tests/unit/Logging.Tests.ps1
@@ -88,7 +88,7 @@ InModuleScope -ModuleName 'Pode' {
         }
 
         It 'Adds an error log item' {
-            $logType = [Pode.Utilities.Logging.PodeLogType]::new([Pode.Utilities.Logging.PodeLogger]::ERROR_LOG_TYPE_NAME, @('Error'), $false)
+            $logType = [Pode.Utilities.Logging.PodeLogErrorType]::new([Pode.Utilities.Logging.PodeLogger]::ERROR_LOG_TYPE_NAME, @('Error'), @('Server'), $false)
             $PodeContext.Server.Logging.Logger.RegisterType($logType)
 
             try { throw 'some error' }
@@ -104,7 +104,7 @@ InModuleScope -ModuleName 'Pode' {
         }
 
         It 'Adds an exception log item' {
-            $logType = [Pode.Utilities.Logging.PodeLogType]::new([Pode.Utilities.Logging.PodeLogger]::ERROR_LOG_TYPE_NAME, @('Error'), $false)
+            $logType = [Pode.Utilities.Logging.PodeLogErrorType]::new([Pode.Utilities.Logging.PodeLogger]::ERROR_LOG_TYPE_NAME, @('Error'), @('Server'), $false)
             $PodeContext.Server.Logging.Logger.RegisterType($logType)
 
             $exp = [exception]::new('some error')
@@ -116,7 +116,7 @@ InModuleScope -ModuleName 'Pode' {
         }
 
         It 'Does not log as Verbose not allowed' {
-            $logType = [Pode.Utilities.Logging.PodeLogType]::new([Pode.Utilities.Logging.PodeLogger]::ERROR_LOG_TYPE_NAME, @('Error'), $false)
+            $logType = [Pode.Utilities.Logging.PodeLogErrorType]::new([Pode.Utilities.Logging.PodeLogger]::ERROR_LOG_TYPE_NAME, @('Error'), @('Server'), $false)
             $PodeContext.Server.Logging.Logger.RegisterType($logType)
 
             $exp = [exception]::new('some error')


### PR DESCRIPTION
### Description of the Change
Currently you can only call `Enable-PodeLogErrorType` and `Enable-PodeLogRequestType` once. This change adds support for allowing both functions to be called multiple times, so long as they have a unique `-Name`.

If no `-Name` is supplied a default one will be supplied, but this can only be done once. After that subsequent calls require a `-Name`.

When an Error or Request log item is created, it's sent to all enabled Request/Error log types.

### Examples
The following example enables 2 Error Log Types, one with the inbuilt default name and one with a custom name:

```powershell
New-PodeLogTerminalMethod | Enable-PodeLogErrorType
New-PodeLogTerminalMethod | Enable-PodeLogErrorType -Name 'custom-err' -SerialiseFormat Json
```