### PR TITLE
Adds support for overriding Log Method properties during a Write call

### DIFF
--- a/docs/Tutorials/Logging/Methods/API.md
+++ b/docs/Tutorials/Logging/Methods/API.md
@@ -22,8 +22,8 @@ New-PodeLogApiMethod -Url '<url>' -Headers $headers -Compress -BodyScriptBlock {
 
     $events = @(foreach $logItem in $logItems) {
         @{
-            message = $logItem.Data
-            level   = $logItem.Event.Level
+            message   = $logItem.Data
+            level     = $logItem.Event.Level
             timestamp = $item.Event.Timestamp.ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
         }
     }
@@ -61,6 +61,68 @@ New-PodeLogApiMethod ... -HeadersScriptBlock {
     return @{
         Timestamp = [datetime]::UtcNow.ToString('yyyy-MM-ddTHH:mm:ssZ')
     }
+}
+```
+
+## Override
+
+You can use [`New-PodeLogApiOverride`](../../../../Functions/Logging/New-PodeLogApiOverride) to override certain properties of an API Log Method, when calling either [`Write-PodeErrorLog`](../../../../Functions/Logging/Write-PodeErrorLog) or [`Write-PodeLog`](../../../../Functions/Logging/Write-PodeLog).
+
+You can specify a hashtable of custom properties via `-Data`, as well as specify `-Ignore`, which allows you to specify that certain log items will not be logged via the API.
+
+If you don't specify an `-Id` then the override will apply to all API Log Methods configured for a Log Type.
+
+```powershell
+# supply custom override properties for an API Log Method
+$_ | Write-PodeErrorLog -Override @(
+    New-PodeLogApiOverride -Data @{
+        Key1 = 'Value1'
+        Key2 = 'Value2'
+    }
+)
+
+# if you have an error log method configured with API and terminal logging,
+# the below will only log the error to the terminal and ignore logging via API
+$_ | Write-PodeErrorLog -Override @(
+    New-PodeLogApiOverride -Ignore
+)
+```
+
+Within your `-BodyScriptBlock` for your API Log Method, you can retrieve the override data for a Log Event using [`Get-PodeLogOverride`](../../../../Functions/Logging/Get-PodeLogOverride):
+
+```powershell
+# setup the method
+$headers = @{
+    Authorization = "Bearer $($your_token)"
+}
+
+New-PodeLogApiMethod -Url '<url>' -Headers $headers -Compress -BodyScriptBlock {
+    param($logItems)
+
+    $events = @(foreach $logItem in $logItems) {
+        # get override data
+        $override = Get-PodeLogOverride -LogEvent $logItem.Event
+
+        # define the event item, using a service override if available
+        @{
+            message   = $logItem.Data
+            level     = $logItem.Event.Level
+            timestamp = $item.Event.Timestamp.ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+            service   = Protect-PodeValue -Value $override.Data.Service -Default 'Website'
+        }
+    }
+
+    return $events | ConvertTo-Json -Compress -Depth 10
+} | Enable-PodeLogErrorType
+
+# log to it
+try {
+    # ...
+}
+catch {
+    $_ | Write-PodeErrorLog -Override @(
+        New-PodeLogApiOverride -Data @{ Service = 'Portal' }
+    )
 }
 ```
 

--- a/docs/Tutorials/Logging/Methods/AWS.md
+++ b/docs/Tutorials/Logging/Methods/AWS.md
@@ -20,6 +20,27 @@ The default source for your logs sent by Pode is the [Server's App Name](../../.
 
 The default index supplied by Pode is empty, which usually equates to the main index in AWS. However, if you wish to supply an explicit index you can do so via the `-Index` parameter.
 
+## Override
+
+You can use [`New-PodeLogAwsOverride`](../../../../Functions/Logging/New-PodeLogAwsOverride) to override certain properties of the AWS Log Method, when calling either [`Write-PodeErrorLog`](../../../../Functions/Logging/Write-PodeErrorLog) or [`Write-PodeLog`](../../../../Functions/Logging/Write-PodeLog).
+
+You can override the `-Source`, `-SourceType`, and `-Index`, as well as specify `-Ignore`, which allows you to specify that certain log items will not be logged to AWS.
+
+If you don't specify an `-Id` then the override will apply to all AWS Log Methods configured for a Log Type.
+
+```powershell
+# override the Index when logging to AWS
+$_ | Write-PodeErrorLog -Override @(
+    New-PodeLogAwsOverride -Index 'custom_index'
+)
+
+# if you have an error log method configured with AWS and terminal logging,
+# the below will only log the error to the terminal and ignore logging to AWS
+$_ | Write-PodeErrorLog -Override @(
+    New-PodeLogAwsOverride -Ignore
+)
+```
+
 ## Examples
 
 ### Send Request Logs

--- a/docs/Tutorials/Logging/Methods/Azure.md
+++ b/docs/Tutorials/Logging/Methods/Azure.md
@@ -42,6 +42,27 @@ When sending logs via Data Collection, you can expect the top-level format of th
 
 The default source for your logs sent by Pode is the [Server's App Name](../../../../Basic#app-name). If you wish to supply an explicit source different from the server's, then you can do so via the `-Source` parameter.
 
+## Override
+
+You can use [`New-PodeLogAzureOverride`](../../../../Functions/Logging/New-PodeLogAzureOverride) to override certain properties of the Azure Log Method, when calling either [`Write-PodeErrorLog`](../../../../Functions/Logging/Write-PodeErrorLog) or [`Write-PodeLog`](../../../../Functions/Logging/Write-PodeLog).
+
+You can override the `-Source`, as well as specify `-Ignore`, which allows you to specify that certain log items will not be logged to Azure.
+
+If you don't specify an `-Id` then the override will apply to all Azure Log Methods configured for a Log Type.
+
+```powershell
+# override the Source when logging to Azure
+$_ | Write-PodeErrorLog -Override @(
+    New-PodeLogAzureOverride -Source 'custom_source'
+)
+
+# if you have an error log method configured with azure and terminal logging,
+# the below will only log the error to the terminal and ignore logging to azure
+$_ | Write-PodeErrorLog -Override @(
+    New-PodeLogAzureOverride -Ignore
+)
+```
+
 ## Examples
 
 ### Workspace

--- a/docs/Tutorials/Logging/Methods/Custom.md
+++ b/docs/Tutorials/Logging/Methods/Custom.md
@@ -22,6 +22,64 @@ The scriptblock you provide will be supplied with the following parameters, depe
 1. A list of [Log Items](../../Objects#log-item).
 2. The arguments that were supplied from [`New-PodeLogCustomMethod`](../../../../Functions/Logging/New-PodeLogCustomMethod)'s `-ArgumentList` parameter.
 
+## Override
+
+You can use [`New-PodeLogCustomOverride`](../../../../Functions/Logging/New-PodeLogCustomOverride) to override certain properties of a Custom Log Method, when calling either [`Write-PodeErrorLog`](../../../../Functions/Logging/Write-PodeErrorLog) or [`Write-PodeLog`](../../../../Functions/Logging/Write-PodeLog).
+
+You can specify a hashtable of custom properties via `-Data`, as well as specify `-Ignore`, which allows you to specify that certain log items will not be logged to Custom Log Method.
+
+If you don't specify an `-Id` then the override will apply to all Custom Log Methods configured for a Log Type.
+
+```powershell
+# supply custom override properties for a Custom Log Method
+$_ | Write-PodeErrorLog -Override @(
+    New-PodeLogCustomOverride -Data @{
+        Key1 = 'Value1'
+        Key2 = 'Value2'
+    }
+)
+
+# if you have an error log method configured with custom and terminal logging,
+# the below will only log the error to the terminal and ignore logging to custom
+$_ | Write-PodeErrorLog -Override @(
+    New-PodeLogCustomOverride -Ignore
+)
+```
+
+Within your `-ScriptBlock` for your Custom Log Method, you can retrieve the override data for a Log Event using [`Get-PodeLogOverride`](../../../../Functions/Logging/Get-PodeLogOverride):
+
+```powershell
+# setup the method
+$method - New-PodeLogCustomType -ArgumentList @{ Key1 = 'Value1' } -Version 2 -ScriptBlock {
+    param($logItems, $opts)
+
+    foreach ($logItem in $logItems) {
+        # get override data
+        $override = Get-PodeLogOverride -LogEvent $logItem.Event
+
+        # check overrides
+        $key1 = Protect-PodeValue -Value $override.Data.Key1 -Default $opts.Key1
+
+        # log your item
+        $item = @{
+            Key1    = $key1
+            Message = $logItem.ToString()
+        }
+        $item | Out-Default
+    }
+} | Enable-PodeLogErrorType
+
+# log to it
+try {
+    # ...
+}
+catch {
+    $_ | Write-PodeErrorLog -Override @(
+        New-PodeLogCustomOverride -Data @{ Key1 = 'Value1000' }
+    )
+}
+```
+
 ## Examples
 
 ### Send to S3 Bucket
@@ -35,13 +93,15 @@ $s3_options = @{
 }
 
 $s3_logging = New-PodeLogCustomType -ArgumentList $s3_options -Version 2 -ScriptBlock {
-    param($logItem, $s3_opts)
+    param($logItems, $s3_opts)
 
-    Write-S3Object `
-        -BucketName '<name>' `
-        -Content $logItem.ToString() `
-        -AccessKey $s3_opts.AccessKey `
-        -SecretKey $s3_opts.SecretKey
+    foreach ($logItem in $logItems) {
+        Write-S3Object `
+            -BucketName '<name>' `
+            -Content $logItem.ToString() `
+            -AccessKey $s3_opts.AccessKey `
+            -SecretKey $s3_opts.SecretKey
+    }
 }
 
 $s3_logging | Enable-PodeLogRequestType

--- a/docs/Tutorials/Logging/Methods/Datadog.md
+++ b/docs/Tutorials/Logging/Methods/Datadog.md
@@ -22,6 +22,38 @@ The default source type sent by Pode is empty, if you wish to supply a source yo
 
 The default tags supplied by Pode is empty, if you wish to supply any tags you can do so via the `-Tags` parameter as a hashtable.
 
+## Override
+
+You can use [`New-PodeLogDatadogOverride`](../../../../Functions/Logging/New-PodeLogDatadogOverride) to override certain properties of the Datadog Log Method, when calling either [`Write-PodeErrorLog`](../../../../Functions/Logging/Write-PodeErrorLog) or [`Write-PodeLog`](../../../../Functions/Logging/Write-PodeLog).
+
+You can override the `-Source`, `-Service`, and `-Tags`, as well as specify `-Ignore`, which allows you to specify that certain log items will not be logged to Datadog.
+
+If you don't specify an `-Id` then the override will apply to all Datadog Log Methods configured for a Log Type.
+
+```powershell
+# override the Service when logging to Datadog
+$_ | Write-PodeErrorLog -Override @(
+    New-PodeLogDatadogOverride -Service 'custom_service'
+)
+
+# if you have an error log method configured with datadog and terminal logging,
+# the below will only log the error to the terminal and ignore logging to datadog
+$_ | Write-PodeErrorLog -Override @(
+    New-PodeLogDatadogOverride -Ignore
+)
+```
+
+For Tags, you can specify a `-TagsAction` to define how the override tags are used. The default is `Merge`, which will combine the two sets of tags together, with the override's taking precedence during conflicts. The other option is `Replace`, which will use the override's tags completely in place of the Log Method's.
+
+```powershell
+$_ | Write-PodeErrorLog -Override @(
+    New-PodeLogDatadogOverride -Tags @{
+        Key1 = 'Value1'
+        Key2 = 'Value2'
+    }
+)
+```
+
 ## Examples
 
 ### Send Request Logs

--- a/docs/Tutorials/Logging/Methods/EventViewer.md
+++ b/docs/Tutorials/Logging/Methods/EventViewer.md
@@ -46,3 +46,24 @@ To log using a different source, other than Pode, you can specify the source via
 ```powershell
 New-PodeLogEventViewerMethod -Source WebsiteName | Enable-PodeLogErrorType
 ```
+
+## Override
+
+You can use [`New-PodeLogEventViewerOverride`](../../../../Functions/Logging/New-PodeLogEventViewerOverride) to override certain properties of the Event Viewer Log Method, when calling either [`Write-PodeErrorLog`](../../../../Functions/Logging/Write-PodeErrorLog) or [`Write-PodeLog`](../../../../Functions/Logging/Write-PodeLog).
+
+You can override the `-EventID`, as well as specify `-Ignore`, which allows you to specify that certain log items will not be logged to Event Viewer.
+
+If you don't specify an `-Id` then the override will apply to all Event Viewer Log Methods configured for a Log Type.
+
+```powershell
+# override the Event ID when logging to Event Viewer
+$_ | Write-PodeErrorLog -Override @(
+    New-PodeLogEventViewerOverride -EventId 1337
+)
+
+# if you have an error log method configured with event viewer and terminal logging,
+# the below will only log the error to the terminal and ignore logging to event viewer
+$_ | Write-PodeErrorLog -Override @(
+    New-PodeLogEventViewerOverride -Ignore
+)
+```

--- a/docs/Tutorials/Logging/Methods/File.md
+++ b/docs/Tutorials/Logging/Methods/File.md
@@ -10,6 +10,22 @@ You can log items to a file using Pode's inbuilt file Log Method, via [`New-Pode
 
 By default, Pode will store all log files in a `./logs` directory at the root of your server. Each log file will be stored by day, eg: `<name>_2019-08-02_001.log`. The last `001` number specifies the log number for that day - if files are be limited by size.
 
+## Override
+
+You can use [`New-PodeLogFileOverride`](../../../../Functions/Logging/New-PodeLogFileOverride) to override certain properties of the File Log Method, when calling either [`Write-PodeErrorLog`](../../../../Functions/Logging/Write-PodeErrorLog) or [`Write-PodeLog`](../../../../Functions/Logging/Write-PodeLog).
+
+The only option available for File is `-Ignore`, which allows you to specify that certain log items will not be logged via to File.
+
+If you don't specify an `-Id` then the override will apply to all File Log Methods configured for a Log Type.
+
+```powershell
+# if you have an error log method configured with file and terminal logging,
+# the below will only log the error to the terminal and ignore logging to file
+$_ | Write-PodeErrorLog -Override @(
+    New-PodeLogFileOverride -Ignore
+)
+```
+
 ## Examples
 
 ### Basic

--- a/docs/Tutorials/Logging/Methods/Network.md
+++ b/docs/Tutorials/Logging/Methods/Network.md
@@ -10,6 +10,22 @@ The default transport is UDP, and the default port is 514 (ie, syslog).
 
 If you wish to ignore any certificate checks, in the case of TLS, you may supply `-SkipCertificateCheck`.
 
+## Override
+
+You can use [`New-PodeLogNetworkOverride`](../../../../Functions/Logging/New-PodeLogNetworkOverride) to override certain properties of the Network Log Method, when calling either [`Write-PodeErrorLog`](../../../../Functions/Logging/Write-PodeErrorLog) or [`Write-PodeLog`](../../../../Functions/Logging/Write-PodeLog).
+
+The only option available for Network is `-Ignore`, which allows you to specify that certain log items will not be logged over a Network connection.
+
+If you don't specify an `-Id` then the override will apply to all Network Log Methods configured for a Log Type.
+
+```powershell
+# if you have an error log method configured with network and terminal logging,
+# the below will only log the error to the terminal and ignore logging to a network connection
+$_ | Write-PodeErrorLog -Override @(
+    New-PodeLogNetworkOverride -Ignore
+)
+```
+
 ## Examples
 
 ### Send via UDP

--- a/docs/Tutorials/Logging/Methods/Splunk.md
+++ b/docs/Tutorials/Logging/Methods/Splunk.md
@@ -22,6 +22,27 @@ The default source for your logs sent by Pode is the [Server's App Name](../../.
 
 The default index supplied by Pode is empty, which usually equates to the main index in Splunk. However, if you wish to supply an explicit index you can do so via the `-Index` parameter.
 
+## Override
+
+You can use [`New-PodeLogSplunkOverride`](../../../../Functions/Logging/New-PodeLogSplunkOverride) to override certain properties of the Splunk Log Method, when calling either [`Write-PodeErrorLog`](../../../../Functions/Logging/Write-PodeErrorLog) or [`Write-PodeLog`](../../../../Functions/Logging/Write-PodeLog).
+
+You can override the `-Source`, `-SourceType`, and `-Index`, as well as specify `-Ignore`, which allows you to specify that certain log items will not be logged to Splunk.
+
+If you don't specify an `-Id` then the override will apply to all Splunk Log Methods configured for a Log Type.
+
+```powershell
+# override the Index when logging to Splunk
+$_ | Write-PodeErrorLog -Override @(
+    New-PodeLogSplunkOverride -Index 'custom_index'
+)
+
+# if you have an error log method configured with splunk and terminal logging,
+# the below will only log the error to the terminal and ignore logging to splunk
+$_ | Write-PodeErrorLog -Override @(
+    New-PodeLogSplunkOverride -Ignore
+)
+```
+
 ## Examples
 
 ### Send Request Logs

--- a/docs/Tutorials/Logging/Methods/Terminal.md
+++ b/docs/Tutorials/Logging/Methods/Terminal.md
@@ -8,6 +8,22 @@ You can log items to the terminal using Pode's inbuilt terminal Method, via [`Ne
 !!! important
     The `New-PodeLoggingMethod` function is now deprecated, please use [`New-PodeLogTerminalMethod`](../../../../Functions/Logging/New-PodeLogTerminalMethod) instead.
 
+## Override
+
+You can use [`New-PodeLogTerminalOverride`](../../../../Functions/Logging/New-PodeLogTerminalOverride) to override certain properties of the Terminal Log Method, when calling either [`Write-PodeErrorLog`](../../../../Functions/Logging/Write-PodeErrorLog) or [`Write-PodeLog`](../../../../Functions/Logging/Write-PodeLog).
+
+The only option available for Terminal is `-Ignore`, which allows you to specify that certain log items will not be logged via the Terminal.
+
+If you don't specify an `-Id` then the override will apply to all Terminal Log Methods configured for a Log Type.
+
+```powershell
+# if you have an error log method configured with file and terminal logging,
+# the below will only log the error to file and ignore the terminal
+$_ | Write-PodeErrorLog -Override @(
+    New-PodeLogTerminalOverride -Ignore
+)
+```
+
 ## Examples
 
 ### Basic

--- a/docs/Tutorials/Logging/Objects.md
+++ b/docs/Tutorials/Logging/Objects.md
@@ -6,13 +6,15 @@ This page describes the various .NET objects that will be supplied to Log Type a
 
 This is typically supplied to custom Log Type scriptblocks. It will be an `IPodeLogEvent` object with the following properties.
 
-| Name      | Type           | Description                                         |
-| --------- | -------------- | --------------------------------------------------- |
-| Data      | `object`       | The raw log data from, for example, `Write-PodeLog` |
-| Name      | `string`       | The name of the Log Type this event is for          |
-| Level     | `PodeLogLevel` | The log level of this event                         |
-| Metadata  | `hashtable`    | Any optionally supplied metadata                    |
-| Timestamp | `datetime`     | The timestamp of this event                         |
+| Name          | Type           | Description                                           |
+| ------------- | -------------- | ----------------------------------------------------- |
+| Data          | `object`       | The raw log data from, for example, `Write-PodeLog`   |
+| Level         | `PodeLogLevel` | The log level of this event                           |
+| Metadata      | `hashtable`    | Any optionally supplied metadata                      |
+| Name          | `string`       | The name of the Log Type this event is for            |
+| Overrides     | `hashtable`    | Any optionally supplied Log Method property overrides |
+| Timestamp     | `datetime`     | The timestamp of this event                           |
+| GetOverride() | `method`       | A utility method for returning Log Method overrides   |
 
 ## Log Item
 

--- a/docs/Tutorials/Logging/Overview.md
+++ b/docs/Tutorials/Logging/Overview.md
@@ -5,28 +5,28 @@ There are two aspects to logging in Pode: Types and Methods.
 * **Types** define how log items are transformed, serialised, and/or formatted, and what should be supplied to the Method, such as Error or Request.
 * **Methods** define how the transformed log items should be recorded, such as to a file, terminal, or event viewer.
 
-Think of it like the phases of an ETL data pipeline:
+Think of it like the phases of an ETL data pipeline, but more defined as "Event", "Transform", and "Log":
 
 ```mermaid
 graph LR
-    Extract("`**Log Item**
-    (Extract)`")
+    Event("`**Log Item**
+    (Event)`")
 
     Transform("`**Type**
     (Transform)`")
 
-    Load("`**Method**
-    (Load)`")
+    Log("`**Method**
+    (Log)`")
 
-    Extract --> Transform
-    Transform --> Load
+    Event --> Transform
+    Transform --> Log
 ```
 
 | Phase     | Description                                                                    |
 | --------- | ------------------------------------------------------------------------------ |
-| Extract   | The originating log item, for example from `Write-PodeErrorLog`                |
+| Event     | The originating log item, for example from `Write-PodeErrorLog`                |
 | Transform | The log item is transformed by the Log Type, for example serialisation         |
-| Load      | The resultant log message is outputted via a Log Method, for example to a file |
+| Log       | The resultant log message is outputted via a Log Method, for example to a file |
 
 For example when you supply an Exception to [`Write-PodeErrorLog`](../../../Functions/Logging/Write-PodeErrorLog), the Exception is passed to Pode's inbuilt Error Log Type which transforms it into a string; which is then passed to a Log Method - like a File or Terminal - to be outputted/recorded.
 
@@ -36,6 +36,12 @@ Pode has several built-in Log Methods for you to use:
 * [File](../Methods/File)
 * [Event Viewer](../Methods/EventViewer)
 * [Custom](../Methods/Custom)
+* [API](../Methods/API)
+* [Splunk](../Methods/Splunk)
+* [Datadog](../Methods/Datadog)
+* [Azure](../Methods/Azure)
+* [AWS](../Methods/AWS)
+* [Network](../Methods/Network)
 
 As well as some built-in Log Types:
 

--- a/docs/Tutorials/Logging/Types/Custom.md
+++ b/docs/Tutorials/Logging/Types/Custom.md
@@ -46,6 +46,40 @@ You can alter the log level by supplying `-Levels` to [`Add-PodeLogType`](../../
 
 You can control the log level of custom log items being written, by supplying `-Level` to [`Write-PodeLog`](../../../../Functions/Logging/Write-PodeLog) - Informational being the default.
 
+## Override Methods
+
+[`Write-PodeLog`](../../../../Functions/Logging/Write-PodeLog) has an `-Override` parameter, which allows you to override certain properties of certain Log Methods - or to ignore certain Log Methods from logging items if required (if you have multiple Log Methods configured for Custom logging).
+
+For more information, refer to the "Override" sections of the specific Log Methods.
+
+An example would be Event Viewer; normally when you configure the Event Viewer Log Method you supply an Event ID, and every log item sent to Event Viewer using that Log Method uses the same Event ID. But there could be times you require different Event IDs, in which case you would use [`New-PodeLogEventViewerOverride`](../../../../Functions/Logging/New-PodeLogEventViewerOverride) and supply the result the [`Write-PodeLog`](../../../../Functions/Logging/Write-PodeLog).
+
+```powershell
+# setup main Event Viewer method for Custom logging
+# all logs will be given an Event ID of 1000
+New-PodeLogEventViewerMethod -EventID 1000 | Add-PodeLogType -Name 'Main' -Version 2 -SerialiseFormat Json -ScriptBlock {
+    param($logEvent)
+    return [ordered]@{
+        Level     = $logEvent.Level
+        Key1      = $logEvent.Data.Key1
+        MergedKey = "$($logEvent.Data.Key2) & $($logEvent.Data.Key3)"
+    }
+}
+
+# ...
+
+# log an item with a custom Event ID of 1337 instead
+$item = @{
+    Key1 = 'Value1'
+    Key2 = 'Value2'
+    Key3 = 'Value3'
+}
+
+Write-PodeLog -Name 'Main' -InputObject $item -Override @(
+    New-PodeLogEventViewerOverride -EventId 1337
+)
+```
+
 ## Examples
 
 ### Log to File

--- a/docs/Tutorials/Logging/Types/Errors.md
+++ b/docs/Tutorials/Logging/Types/Errors.md
@@ -104,6 +104,32 @@ Or, a raw string message:
 'Some error message' | Write-PodeErrorLog -Level Warning
 ```
 
+## Override Methods
+
+[`Write-PodeErrorLog`](../../../../Functions/Logging/Write-PodeErrorLog) has an `-Override` parameter, which allows you to override certain properties of certain Log Methods - or to ignore certain Log Methods from logging errors if required (if you have multiple Log Methods configured for Error logging).
+
+For more information, refer to the "Override" sections of the specific Log Methods.
+
+An example would be Event Viewer; normally when you configure the Event Viewer Log Method you supply an Event ID, and every error log sent to Event Viewer using that Log Method uses the same Event ID. But there could be times you require different Event IDs, in which case you would use [`New-PodeLogEventViewerOverride`](../../../../Functions/Logging/New-PodeLogEventViewerOverride) and supply the result the [`Write-PodeErrorLog`](../../../../Functions/Logging/Write-PodeErrorLog).
+
+```powershell
+# setup main Event Viewer method for Error logging
+# all errors will be given an Event ID of 1000
+New-PodeLogEventViewerMethod -EventID 1000 | Enable-PodeLogErrorType
+
+# ...
+
+# log an error with a custom Event ID of 1337 instead
+try {
+    # ...
+}
+catch {
+    $_ | Write-PodeErrorLog -Override @(
+        New-PodeLogEventViewerOverride -EventId 1337
+    )
+}
+```
+
 ## Internal Logging
 
 When error logging is enabled, you'll also see internal logging from Pode. Pode at present has internal Error logging, as well as Debug and Verbose logging from its various Adapters.

--- a/pode.build.ps1
+++ b/pode.build.ps1
@@ -155,7 +155,7 @@ param(
 
 # Dependency Versions
 $Versions = @{
-    Pester      = '6.0.0'
+    Pester      = '6.0.1'
     MkDocs      = '1.6.1'
     DotNet      = $SdkVersion
     MkDocsTheme = '9.7.7'
@@ -1354,7 +1354,7 @@ Add-BuildTask ChocoDeploy -If (Test-PodeBuildIsWindows) {
         $chocoVer = "$($Version)-$($PreRelease)"
     }
 
-    exec { choco push "./deliverable/pode.$($chocoVer).nupkg" --source https://push.chocolatey.org/ --api-key $ApiKey }
+    exec { choco push "./deliverable/pode.$($chocoVer).nupkg" --source https://push.chocolatey.org/ --api-key $ApiPassword }
 }
 
 # Synopsis: Package up the Module
@@ -1366,7 +1366,7 @@ Add-BuildTask PowershellPack {
 Add-BuildTask PowershellDeploy {
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
     $Name = 'Pode'
-    Publish-Module -Path "./$($Name)" -Repository 'PSGallery' -NuGetApiKey $ApiKey
+    Publish-Module -Path "./$($Name)" -Repository 'PSGallery' -NuGetApiKey $ApiPassword
 }
 
 # Synopsis: Create docker tags
@@ -1415,7 +1415,7 @@ Add-BuildTask DockerDeploy {
 
     try {
         # Try to login to docker
-        docker login -u $ApiUsername -p $ApiKey
+        docker login -u $ApiUsername -p $ApiPassword
     }
     catch {
         # If Docker is not available, exit the task

--- a/src/Listener/Utilities/Logging/IPodeLogEvent.cs
+++ b/src/Listener/Utilities/Logging/IPodeLogEvent.cs
@@ -9,6 +9,9 @@ namespace Pode.Utilities.Logging
         PodeLogLevel Level { get; }
         DateTime Timestamp { get; }
         Hashtable Metadata { get; }
+        Hashtable Overrides { get; }
         object Data { get; }
+
+        Hashtable GetOverride(string id, string type);
     }
 }

--- a/src/Listener/Utilities/Logging/IPodeLogger.cs
+++ b/src/Listener/Utilities/Logging/IPodeLogger.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Threading;
 using Pode.Protocols.Common.Requests;
 
@@ -20,10 +21,10 @@ namespace Pode.Utilities.Logging
         void RegisterType(IPodeLogType logType);
         void UnregisterType(string name);
 
-        void Add(string logTypeName, PodeLogLevel level, object data, Hashtable metadata = null);
-        void AddException(Exception exception, string contextId, PodeLogLevel level, Hashtable metadata = null, int threadId = 0);
-        void AddException(string message, string contextId, PodeLogLevel level, PodeRequestExceptionKind kind = PodeRequestExceptionKind.Server, Hashtable metadata = null, int threadId = 0);
-        void AddException(string category, string message, string stackTrace, string contextId, PodeLogLevel level, PodeRequestExceptionKind kind = PodeRequestExceptionKind.Server, Hashtable metadata = null, int threadId = 0);
+        void Add(string logTypeName, PodeLogLevel level, object data, Hashtable metadata = null, List<Hashtable> overrides = null);
+        void AddException(Exception exception, string contextId, PodeLogLevel level, Hashtable metadata = null, List<Hashtable> overrides = null, int threadId = 0);
+        void AddException(string message, string contextId, PodeLogLevel level, PodeRequestExceptionKind kind = PodeRequestExceptionKind.Server, Hashtable metadata = null, List<Hashtable> overrides = null, int threadId = 0);
+        void AddException(string category, string message, string stackTrace, string contextId, PodeLogLevel level, PodeRequestExceptionKind kind = PodeRequestExceptionKind.Server, Hashtable metadata = null, List<Hashtable> overrides = null, int threadId = 0);
         bool TryTake(out IPodeLogEvent logEvent, CancellationToken cancellationToken);
         void Reset();
     }

--- a/src/Listener/Utilities/Logging/PodeLogEvent.cs
+++ b/src/Listener/Utilities/Logging/PodeLogEvent.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using System.Collections.Generic;
 
 namespace Pode.Utilities.Logging
 {
@@ -9,15 +10,56 @@ namespace Pode.Utilities.Logging
         public PodeLogLevel Level { get; private set; }
         public DateTime Timestamp { get; private set; }
         public Hashtable Metadata { get; private set; }
+        public Hashtable Overrides { get; private set; }
         public object Data { get; private set; }
 
-        public PodeLogEvent(IPodeLogType type, PodeLogLevel level, object data, Hashtable metadata = null)
+        public PodeLogEvent(IPodeLogType type, PodeLogLevel level, object data, Hashtable metadata = null, List<Hashtable> overrides = null)
         {
             Type = type ?? throw new ArgumentNullException(nameof(type), "Log item type cannot be null.");
             Level = level;
             Data = data;
             Metadata = metadata ?? new Hashtable(StringComparer.InvariantCultureIgnoreCase);
             Timestamp = type.GetTimestamp();
+            SetOverrides(overrides);
+        }
+
+        private void SetOverrides(List<Hashtable> overrides)
+        {
+            Overrides = new Hashtable(StringComparer.InvariantCultureIgnoreCase);
+            if (overrides == default)
+            {
+                return;
+            }
+
+            foreach (var item in overrides)
+            {
+                if (item == null || !item.ContainsKey("Id"))
+                {
+                    continue;
+                }
+
+                Overrides[item["Id"]] = item;
+            }
+        }
+
+        public Hashtable GetOverride(string id, string type)
+        {
+            if (string.IsNullOrEmpty(id) && string.IsNullOrEmpty(type))
+            {
+                return null;
+            }
+
+            if (Overrides.ContainsKey(id))
+            {
+                return Overrides[id] as Hashtable;
+            }
+
+            if (Overrides.ContainsKey(type))
+            {
+                return Overrides[type] as Hashtable;
+            }
+
+            return null;
         }
     }
 }

--- a/src/Listener/Utilities/Logging/PodeLogger.cs
+++ b/src/Listener/Utilities/Logging/PodeLogger.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Net;
 using System.Threading;
 using Pode.Protocols.Common.Requests;
@@ -73,7 +74,7 @@ namespace Pode.Utilities.Logging
             RequestLogTypeNames.TryRemove(name, out _);
         }
 
-        public void Add(string logTypeName, PodeLogLevel level, object data, Hashtable metadata = null)
+        public void Add(string logTypeName, PodeLogLevel level, object data, Hashtable metadata = null, List<Hashtable> overrides = null)
         {
             if (IsDisposed || !IsEnabled)
             {
@@ -93,10 +94,10 @@ namespace Pode.Utilities.Logging
             }
 
             // add the log event to the queue
-            Queue.Add(new PodeLogEvent(logType, level, data, metadata));
+            Queue.Add(new PodeLogEvent(logType, level, data, metadata, overrides));
         }
 
-        public void AddException(Exception exception, string contextId, PodeLogLevel level, Hashtable metadata = null, int threadId = 0)
+        public void AddException(Exception exception, string contextId, PodeLogLevel level, Hashtable metadata = null, List<Hashtable> overrides = null, int threadId = 0)
         {
             if (exception == null)
             {
@@ -107,15 +108,15 @@ namespace Pode.Utilities.Logging
                 ? podeRequestException.Kind
                 : PodeRequestExceptionKind.Server;
 
-            AddException(exception.Source, exception.Message, exception.StackTrace, contextId, level, kind, metadata, threadId);
+            AddException(exception.Source, exception.Message, exception.StackTrace, contextId, level, kind, metadata, overrides, threadId);
         }
 
-        public void AddException(string message, string contextId, PodeLogLevel level, PodeRequestExceptionKind kind = PodeRequestExceptionKind.Server, Hashtable metadata = null, int threadId = 0)
+        public void AddException(string message, string contextId, PodeLogLevel level, PodeRequestExceptionKind kind = PodeRequestExceptionKind.Server, Hashtable metadata = null, List<Hashtable> overrides = null, int threadId = 0)
         {
-            AddException(string.Empty, message, string.Empty, contextId, level, kind, metadata, threadId);
+            AddException(string.Empty, message, string.Empty, contextId, level, kind, metadata, overrides, threadId);
         }
 
-        public void AddException(string category, string message, string stackTrace, string contextId, PodeLogLevel level, PodeRequestExceptionKind kind = PodeRequestExceptionKind.Server, Hashtable metadata = null, int threadId = 0)
+        public void AddException(string category, string message, string stackTrace, string contextId, PodeLogLevel level, PodeRequestExceptionKind kind = PodeRequestExceptionKind.Server, Hashtable metadata = null, List<Hashtable> overrides = null, int threadId = 0)
         {
             if (IsDisposed || !IsEnabled || !IsErrorLoggingEnabled)
             {
@@ -183,7 +184,7 @@ namespace Pode.Utilities.Logging
                 };
 
                 // add the log event to the queue
-                Queue.Add(new PodeLogEvent(logType, level, item, metadata));
+                Queue.Add(new PodeLogEvent(logType, level, item, metadata, overrides));
             }
         }
 

--- a/src/Pode.psd1
+++ b/src/Pode.psd1
@@ -365,6 +365,17 @@
         'New-PodeLogW3CInfo',
         'Add-PodeLogW3CField',
         'Add-PodeLogW3CCustomField',
+        'New-PodeLogTerminalOverride',
+        'New-PodeLogEventViewerOverride',
+        'New-PodeLogFileOverride',
+        'New-PodeLogApiOverride',
+        'New-PodeLogAwsOverride',
+        'New-PodeLogAzureOverride',
+        'New-PodeLogDatadogOverride',
+        'New-PodeLogNetworkOverride',
+        'New-PodeLogSplunkOverride',
+        'New-PodeLogCustomOverride',
+        'Get-PodeLogOverride',
 
         # core
         'Start-PodeServer',

--- a/src/Private/Logging.ps1
+++ b/src/Private/Logging.ps1
@@ -6,7 +6,11 @@ function Get-PodeLoggingTerminalMethod {
         param(
             [Parameter(Mandatory = $true)]
             [string]
-            $MethodId
+            $MethodId,
+
+            [Parameter(Mandatory = $true)]
+            [string]
+            $MethodType
         )
 
         if ($PodeContext.Server.Quiet) {
@@ -62,7 +66,11 @@ function Get-PodeLoggingFileMethod {
         param(
             [Parameter(Mandatory = $true)]
             [string]
-            $MethodId
+            $MethodId,
+
+            [Parameter(Mandatory = $true)]
+            [string]
+            $MethodType
         )
 
         # wait for the server to fully start
@@ -155,7 +163,11 @@ function Get-PodeLoggingEventViewerMethod {
         param(
             [Parameter(Mandatory = $true)]
             [string]
-            $MethodId
+            $MethodId,
+
+            [Parameter(Mandatory = $true)]
+            [string]
+            $MethodType
         )
 
         # wait for the server to fully start
@@ -178,11 +190,19 @@ function Get-PodeLoggingEventViewerMethod {
                     }
 
                     foreach ($item in $logCol.Items) {
+                        # get any overrides for this method
+                        $override = Get-PodeLogOverride -LogEvent $item.Event
+
                         # convert log level - info if no level present
                         $entryType = ConvertTo-PodeEventViewerLevel -Level $item.Event.Level
 
                         # create log instance
-                        $entryInstance = [System.Diagnostics.EventInstance]::new($method.Arguments.ID, 0, $entryType)
+                        $eventId = [int]$override.EventId
+                        if ($eventId -eq 0) {
+                            $eventId = $method.Arguments.ID
+                        }
+
+                        $entryInstance = [System.Diagnostics.EventInstance]::new($eventId, 0, $entryType)
 
                         # create event log
                         $entryLog = [System.Diagnostics.EventLog]::new()
@@ -226,7 +246,11 @@ function Get-PodeLoggingCustomMethod {
         param(
             [Parameter(Mandatory = $true)]
             [string]
-            $MethodId
+            $MethodId,
+
+            [Parameter(Mandatory = $true)]
+            [string]
+            $MethodType
         )
 
         # wait for the server to fully start
@@ -293,7 +317,11 @@ function Get-PodeLoggingApiMethod {
         param(
             [Parameter(Mandatory = $true)]
             [string]
-            $MethodId
+            $MethodId,
+
+            [Parameter(Mandatory = $true)]
+            [string]
+            $MethodType
         )
 
         # wait for the server to fully start
@@ -397,7 +425,11 @@ function Get-PodeLoggingNetworkMethod {
         param(
             [Parameter(Mandatory = $true)]
             [string]
-            $MethodId
+            $MethodId,
+
+            [Parameter(Mandatory = $true)]
+            [string]
+            $MethodType
         )
 
         # wait for the server to fully start
@@ -506,8 +538,11 @@ function New-PodeLogAzureWorkspaceMethod {
                     Timestamp = $item.Event.Timestamp.ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
                 }
 
+                # get any overrides for this method
+                $override = Get-PodeLogOverride -LogEvent $item.Event
+
                 # add source
-                $source = Protect-PodeValue -Value $item.Event.Metadata['Source'] -Default $options.Source
+                $source = Protect-PodeValue -Value $override.Source -Default $options.Source
                 if (![string]::IsNullOrEmpty($source)) {
                     $evt.Source = $source
                 }
@@ -541,7 +576,7 @@ function New-PodeLogAzureWorkspaceMethod {
         $hmacsha256.Key = $keyBytes
         $signatureBytes = $hmacsha256.ComputeHash($bytesToSign)
         $signature = [System.Convert]::ToBase64String($signatureBytes)
-        $authorizationHeader = "SharedKey $($workspaceId):$($signature)"
+        $authorizationHeader = "SharedKey $($options.WorkspaceId):$($signature)"
 
         return @{
             'Authorization' = $authorizationHeader
@@ -561,7 +596,8 @@ function New-PodeLogAzureWorkspaceMethod {
     }
 
     $headerArgs = @{
-        SharedKey = $SharedKey
+        SharedKey   = $SharedKey
+        WorkspaceId = $WorkspaceId
     }
 
     return New-PodeLogApiMethod `
@@ -634,8 +670,11 @@ function New-PodeLogAzureDataCollectionMethod {
                     TimeGenerated = $item.Event.Timestamp.ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
                 }
 
+                # get any overrides for this method
+                $override = Get-PodeLogOverride -LogEvent $item.Event
+
                 # add source
-                $source = Protect-PodeValue -Value $item.Event.Metadata['Source'] -Default $options.Source
+                $source = Protect-PodeValue -Value $override.Source -Default $options.Source
                 if (![string]::IsNullOrEmpty($source)) {
                     $evt.Source = $source
                 }
@@ -1338,7 +1377,19 @@ function Start-PodeLoggingRunspace {
 
     foreach ($methodId in $PodeContext.Server.Logging.Methods.Keys) {
         $method = Get-PodeLogMethod -Id $methodId
-        $method.Runspace = Add-PodeRunspace -Type Logs -Name "Method_$($method.Type)" -ScriptBlock $method.ScriptBlock -Parameters @{ MethodId = $methodId } -PassThru
+
+        $params = @{
+            Type        = 'Logs'
+            Name        = "Method_$($method.Type)"
+            ScriptBlock = $method.ScriptBlock
+            Parameters  = @{
+                MethodId   = $methodId
+                MethodType = $method.Type
+            }
+            PassThru    = $true
+        }
+
+        $method.Runspace = Add-PodeRunspace @params
     }
 
     # start the log dispatcher runspace
@@ -1412,10 +1463,17 @@ function Push-PodeLogItem {
     )
 
     foreach ($logMethodId in $LogType.Method) {
+        # get the log method we need to log to
         $logMethod = Get-PodeLogMethod -Id $logMethodId
-        $batch = $logMethod.Batch
+
+        # check if this event doesn't have an override that ignores this log method
+        $override = Get-PodeLogOverride -LogEvent $LogEvent -Id $logMethodId -Type $logMethod.Type
+        if (($null -ne $override) -and $override.Ignore) {
+            continue
+        }
 
         # add current item to batch
+        $batch = $logMethod.Batch
         $batch.Items.Add([Pode.Utilities.Logging.PodeLogItem]::new($Message, $LogEvent))
 
         # if the batch is full, send to Log Method and reset
@@ -1438,7 +1496,7 @@ function Add-PodeLogMethodInternal {
 
         [Parameter(Mandatory = $true)]
         [hashtable]
-        $Metadata
+        $Config
     )
 
     # generate an ID if not supplied
@@ -1453,21 +1511,33 @@ function Add-PodeLogMethodInternal {
     }
 
     # empty list of Log Types for later associations
-    $Metadata.Types = @()
+    $Config.Types = @()
 
     # add batching info to metadata
-    $Metadata.Batch = $BatchInfo | New-PodeLogBatchConfig
+    $Config.Batch = $BatchInfo | New-PodeLogBatchConfig
 
     # create queue for the method's log items
-    $Metadata.Queue = [Pode.Utilities.Logging.PodeLogQueue[Pode.Utilities.Logging.IPodeLogItemCollection]]::new()
+    $Config.Queue = [Pode.Utilities.Logging.PodeLogQueue[Pode.Utilities.Logging.IPodeLogItemCollection]]::new()
 
     # add method to server
-    $PodeContext.Server.Logging.Methods[$Id] = $Metadata
+    $PodeContext.Server.Logging.Methods[$Id] = $Config
 
     # extend runspace pool, and create runspace for the method - if logging is already running
     if ($PodeContext.Server.Logging.Running) {
         $null = $PodeContext.RunspacePools.Logs.Pool.SetMaxRunspaces($PodeContext.Server.Logging.Methods.Count + 1)
-        $Metadata.Runspace = Add-PodeRunspace -Type Logs -Name "Method_$($Metadata.Type)" -ScriptBlock $Metadata.ScriptBlock -Parameters @{ MethodId = $Id } -PassThru
+
+        $params = @{
+            Type        = 'Logs'
+            Name        = "Method_$($Config.Type)"
+            ScriptBlock = $Config.ScriptBlock
+            Parameters  = @{
+                MethodId   = $Id
+                MethodType = $Config.Type
+            }
+            PassThru    = $true
+        }
+
+        $Config.Runspace = Add-PodeRunspace @params
     }
 
     # return the method ID

--- a/src/Public/Logging.ps1
+++ b/src/Public/Logging.ps1
@@ -1086,6 +1086,10 @@ The Level of the error being logged. (Default: Error)
 .PARAMETER Metadata
 An optional hashtable of Metadata to include with the log item.
 
+.PARAMETER Override
+An optional array of override options, to override certain properties of log methods.
+Created using the New-PodeLogEventViewerOverride, etc. functions.
+
 .PARAMETER CheckInnerException
 If supplied, any exceptions are check for inner exceptions. If one is present, this is also logged.
 
@@ -1097,6 +1101,9 @@ try { /* logic */ } catch { $_ | Write-PodeErrorLog }
 
 .EXAMPLE
 Write-PodeErrorLog -Message 'error message' -Level 'Warning'
+
+.EXAMPLE
+Write-PodeErrorLog -Message 'error message' -Override @(New-PodeLogEventViewerOverride -EventId 1337)
 #>
 function Write-PodeErrorLog {
     [CmdletBinding()]
@@ -1122,6 +1129,10 @@ function Write-PodeErrorLog {
         [hashtable]
         $Metadata,
 
+        [Parameter()]
+        [hashtable[]]
+        $Override,
+
         [Parameter(ParameterSetName = 'Exception')]
         [switch]
         $CheckInnerException
@@ -1144,6 +1155,7 @@ function Write-PodeErrorLog {
                     $contextId,
                     $Level,
                     $Metadata,
+                    $Override,
                     [int]$ThreadId
                 )
             }
@@ -1157,6 +1169,7 @@ function Write-PodeErrorLog {
                     $Level,
                     [Pode.Protocols.Common.Requests.PodeRequestExceptionKind]::Server,
                     $Metadata,
+                    $Override,
                     [int]$ThreadId
                 )
             }
@@ -1171,6 +1184,7 @@ function Write-PodeErrorLog {
                     $Level,
                     [Pode.Protocols.Common.Requests.PodeRequestExceptionKind]::Server,
                     $Metadata,
+                    $Override,
                     [int]$ThreadId
                 )
             }
@@ -1178,7 +1192,7 @@ function Write-PodeErrorLog {
 
         # for exceptions, check the inner exception
         if ($CheckInnerException -and ($null -ne $Exception.InnerException) -and ![string]::IsNullOrWhiteSpace($Exception.InnerException.Message)) {
-            $Exception.InnerException | Write-PodeErrorLog
+            $Exception.InnerException | Write-PodeErrorLog -Level $Level -Metadata $Metadata -Override $Override
         }
     }
 }
@@ -1202,6 +1216,10 @@ The Object to write.
 .PARAMETER Metadata
 An optional hashtable of Metadata to include with the log item.
 
+.PARAMETER Override
+An optional array of override options, to override certain properties of log methods.
+Created using the New-PodeLogEventViewerOverride, etc. functions.
+
 .EXAMPLE
 $object | Write-PodeLog -Name 'LogTypeName'
 
@@ -1210,6 +1228,9 @@ $object | Write-PodeLog -Name 'LogTypeName1', 'LogTypeName2'
 
 .EXAMPLE
 $object | Write-PodeLog -Name 'LogTypeName' -Level 'Debug' -Metadata @{ Key = 'Value' }
+
+.EXAMPLE
+$object | Write-PodeLog -Name 'LogTypeName' -Override @(New-PodeLogEventViewerOverride -EventId 1337)
 #>
 function Write-PodeLog {
     [CmdletBinding()]
@@ -1229,12 +1250,16 @@ function Write-PodeLog {
 
         [Parameter()]
         [hashtable]
-        $Metadata
+        $Metadata,
+
+        [Parameter()]
+        [hashtable[]]
+        $Override
     )
 
     process {
         foreach ($n in $Name) {
-            $PodeContext.Server.Logging.Logger.Add($n, $Level, $InputObject, $Metadata)
+            $PodeContext.Server.Logging.Logger.Add($n, $Level, $InputObject, $Metadata, $Override)
         }
     }
 }
@@ -1402,10 +1427,49 @@ function New-PodeLogTerminalMethod {
     )
 
     # add method to server
-    return Add-PodeLogMethodInternal -Id $Id -Batch $BatchInfo -Metadata @{
+    return Add-PodeLogMethodInternal -Id $Id -Batch $BatchInfo -Config @{
         Type        = 'Terminal'
         ScriptBlock = Get-PodeLoggingTerminalMethod
         Arguments   = @{}
+    }
+}
+
+<#
+.SYNOPSIS
+Create new Override options for the Terminal Log Method.
+
+.DESCRIPTION
+Creates new set of override options for the Terminal Log Method.
+
+.PARAMETER Id
+The ID of the Terminal Log Method to override. (Default: 'Terminal')
+
+.PARAMETER Ignore
+Whether to ignore the Terminal Log Method when writing log items.
+
+.EXAMPLE
+$override = New-PodeLogTerminalOverride -Ignore
+
+.EXAMPLE
+$override = New-PodeLogTerminalOverride -Id 'TerminalMethod' -Ignore
+#>
+function New-PodeLogTerminalOverride {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter()]
+        [string]
+        $Id,
+
+        [switch]
+        $Ignore
+    )
+
+    $Id = Protect-PodeValue -Value $Id -Default 'Terminal'
+
+    return @{
+        Id     = $Id
+        Ignore = $Ignore.IsPresent
     }
 }
 
@@ -1480,7 +1544,7 @@ function New-PodeLogFileMethod {
     $null = New-Item -Path $Path -ItemType Directory -Force
 
     # add method to server
-    return Add-PodeLogMethodInternal -Id $Id -Batch $BatchInfo -Metadata @{
+    return Add-PodeLogMethodInternal -Id $Id -Batch $BatchInfo -Config @{
         Type        = 'File'
         ScriptBlock = Get-PodeLoggingFileMethod
         Arguments   = @{
@@ -1492,6 +1556,45 @@ function New-PodeLogFileMethod {
             Date          = $null
             NextClearDown = [datetime]::Now.Date
         }
+    }
+}
+
+<#
+.SYNOPSIS
+Create new Override options for the File Log Method.
+
+.DESCRIPTION
+Creates a new set of override options for the File Log Method.
+
+.PARAMETER Id
+The ID of the File Log Method to override. (Default: 'File')
+
+.PARAMETER Ignore
+Whether to ignore the File Log Method when writing log items.
+
+.EXAMPLE
+$override = New-PodeLogFileOverride -Ignore
+
+.EXAMPLE
+$override = New-PodeLogFileOverride -Id 'FileMethod' -Ignore
+#>
+function New-PodeLogFileOverride {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter()]
+        [string]
+        $Id,
+
+        [switch]
+        $Ignore
+    )
+
+    $Id = Protect-PodeValue -Value $Id -Default 'File'
+
+    return @{
+        Id     = $Id
+        Ignore = $Ignore.IsPresent
     }
 }
 
@@ -1563,7 +1666,7 @@ function New-PodeLogEventViewerMethod {
     }
 
     # add method to server
-    return Add-PodeLogMethodInternal -Id $Id -Batch $BatchInfo -Metadata @{
+    return Add-PodeLogMethodInternal -Id $Id -Batch $BatchInfo -Config @{
         Type        = 'EventViewer'
         ScriptBlock = Get-PodeLoggingEventViewerMethod
         Arguments   = @{
@@ -1571,6 +1674,56 @@ function New-PodeLogEventViewerMethod {
             Source  = $Source
             ID      = $EventID
         }
+    }
+}
+
+<#
+.SYNOPSIS
+Create new Override options for the Event Viewer Log Method.
+
+.DESCRIPTION
+Creates a new set of override options for the Event Viewer Log Method.
+
+.PARAMETER Id
+The ID of the Event Viewer Log Method to override. (Default: 'EventViewer')
+
+.PARAMETER EventID
+An optional EventID to override the EventID of the Event Viewer Log Method.
+
+.PARAMETER Ignore
+Whether to ignore the Event Viewer Log Method when writing log items.
+
+.EXAMPLE
+$override = New-PodeLogEventViewerOverride -Ignore
+
+.EXAMPLE
+$override = New-PodeLogEventViewerOverride -EventID 1337
+
+.EXAMPLE
+$override = New-PodeLogEventViewerOverride -Id 'EventViewerMethod' -EventID 1337
+#>
+function New-PodeLogEventViewerOverride {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter()]
+        [string]
+        $Id,
+
+        [Parameter()]
+        [int]
+        $EventID,
+
+        [switch]
+        $Ignore
+    )
+
+    $Id = Protect-PodeValue -Value $Id -Default 'EventViewer'
+
+    return @{
+        Id      = $Id
+        EventID = $EventID
+        Ignore  = $Ignore.IsPresent
     }
 }
 
@@ -1653,7 +1806,7 @@ function New-PodeLogCustomMethod {
     $ScriptBlock, $usingVars = Convert-PodeScopedVariables -ScriptBlock $ScriptBlock -PSSession $PSCmdlet.SessionState
 
     # add method to server
-    return Add-PodeLogMethodInternal -Id $Id -Batch $BatchInfo -Metadata @{
+    return Add-PodeLogMethodInternal -Id $Id -Batch $BatchInfo -Config @{
         Type        = 'Custom'
         ScriptBlock = Get-PodeLoggingCustomMethod
         Custom      = @{
@@ -1662,6 +1815,57 @@ function New-PodeLogCustomMethod {
         }
         Arguments   = $ArgumentList
         Version     = $Version
+    }
+}
+
+<#
+.SYNOPSIS
+Creates a new set of override options for the Custom Log Method.
+
+.DESCRIPTION
+Creates a new set of override options for the Custom Log Method.
+This allows you to specify custom data for Custom Log Methods, and can be retrieved via Get-PodeLogOverride per Log Event.
+
+.PARAMETER Id
+An optional ID to assign to the Log Method to override. (Default: 'Custom')
+
+.PARAMETER Data
+A hashtable of custom data to associate with the Custom Log Method override.
+
+.PARAMETER Ignore
+Whether to ignore the Custom Log Method when writing log items.
+
+.EXAMPLE
+$override = New-PodeLogCustomOverride -Data @{ Key = 'Value' }
+
+.EXAMPLE
+$override = New-PodeLogCustomOverride -Id 'CustomMethod' -Data @{ Key = 'Value' }
+
+.EXAMPLE
+$override = New-PodeLogCustomOverride -Ignore
+#>
+function New-PodeLogCustomOverride {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter()]
+        [string]
+        $Id,
+
+        [Parameter()]
+        [hashtable]
+        $Data,
+
+        [switch]
+        $Ignore
+    )
+
+    $Id = Protect-PodeValue -Value $Id -Default 'Custom'
+
+    return @{
+        Id     = $Id
+        Data   = $Data
+        Ignore = $Ignore.IsPresent
     }
 }
 
@@ -1779,9 +1983,7 @@ function New-PodeLogApiMethod {
     )
 
     # default type
-    if ([string]::IsNullOrWhiteSpace($Type)) {
-        $Type = 'API'
-    }
+    $Type = Protect-PodeValue -Value $Type -Default 'API'
 
     # default headers
     if ($null -eq $Headers) {
@@ -1803,7 +2005,7 @@ function New-PodeLogApiMethod {
     }
 
     # add method to server
-    return Add-PodeLogMethodInternal -Id $Id -Batch $BatchInfo -Metadata @{
+    return Add-PodeLogMethodInternal -Id $Id -Batch $BatchInfo -Config @{
         Type        = $Type
         ScriptBlock = Get-PodeLoggingApiMethod
         Arguments   = @{
@@ -1824,6 +2026,68 @@ function New-PodeLogApiMethod {
             }
             SkipCertificateCheck = $SkipCertificateCheck.IsPresent
         }
+    }
+}
+
+<#
+.SYNOPSIS
+Creates a new set of override options for the API Log Method.
+
+.DESCRIPTION
+Creates a new set of override options for the API Log Method.
+This allows you to specify custom data for API Log Methods, and can be retrieved via Get-PodeLogOverride per Log Event.
+
+.PARAMETER Id
+An optional ID to assign to the Log Method to override. (Default: 'API')
+
+.PARAMETER Type
+An optional Type to assign to the Log Method to override. (Default: API)
+
+.PARAMETER Data
+A hashtable of custom data to associate with the API Log Method override.
+
+.PARAMETER Ignore
+Whether to ignore the API Log Method when writing log items.
+
+.EXAMPLE
+$override = New-PodeLogApiOverride -Data @{ Key = 'Value' }
+
+.EXAMPLE
+$override = New-PodeLogApiOverride -Id 'ApiMethod' -Data @{ Key = 'Value' }
+
+.EXAMPLE
+$override = New-PodeLogApiOverride -Ignore
+
+.EXAMPLE
+$override = New-PodeLogApiOverride -Type 'NewRelic' -Data @{ Key = 'Value' }
+#>
+function New-PodeLogApiOverride {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter()]
+        [string]
+        $Id,
+
+        [Parameter()]
+        [string]
+        $Type,
+
+        [Parameter()]
+        [hashtable]
+        $Data,
+
+        [switch]
+        $Ignore
+    )
+
+    $Type = Protect-PodeValue -Value $Type -Default 'API'
+    $Id = Protect-PodeValue -Value $Id -Default $Type
+
+    return @{
+        Id     = $Id
+        Data   = $Data
+        Ignore = $Ignore.IsPresent
     }
 }
 
@@ -1924,20 +2188,23 @@ function New-PodeLogSplunkMethod {
                     }
                 }
 
+                # get any overrides for this method
+                $override = Get-PodeLogOverride -LogEvent $item.Event
+
                 # add source type
-                $sourceType = Protect-PodeValue -Value $item.Event.Metadata['SourceType'] -Default $options.SourceType
+                $sourceType = Protect-PodeValue -Value $override.SourceType -Default $options.SourceType
                 if (![string]::IsNullOrEmpty($sourceType)) {
                     $evt.sourcetype = $sourceType
                 }
 
                 # add source
-                $source = Protect-PodeValue -Value $item.Event.Metadata['Source'] -Default $options.Source
+                $source = Protect-PodeValue -Value $override.Source -Default $options.Source
                 if (![string]::IsNullOrEmpty($source)) {
                     $evt.source = $source
                 }
 
                 # add index
-                $index = Protect-PodeValue -Value $item.Event.Metadata['Index'] -Default $options.Index
+                $index = Protect-PodeValue -Value $override.Index -Default $options.Index
                 if (![string]::IsNullOrEmpty($index)) {
                     $evt.index = $index
                 }
@@ -1971,6 +2238,69 @@ function New-PodeLogSplunkMethod {
         -BodyArguments $bodyArgs `
         -SkipCertificateCheck:$SkipCertificateCheck.IsPresent `
         -Compress
+}
+
+<#
+.SYNOPSIS
+Creates a new set of override options for the Splunk Log Method.
+
+.DESCRIPTION
+Creates a new set of override options for the Splunk Log Method.
+
+.PARAMETER Id
+The ID of the Splunk Log Method to override. (Default: 'Splunk')
+
+.PARAMETER Source
+An optional source to override the source of the Splunk Log Method.
+
+.PARAMETER SourceType
+An optional source type to override the source type of the Splunk Log Method.
+
+.PARAMETER Index
+An optional index to override the index of the Splunk Log Method.
+
+.PARAMETER Ignore
+Whether to ignore the Splunk Log Method when writing log items.
+
+.EXAMPLE
+$override = New-PodeLogSplunkOverride -Source 'my_source' -SourceType 'syslog' -Index 'main'
+
+.EXAMPLE
+$override = New-PodeLogSplunkOverride -Id 'SplunkMethod' -Ignore
+#>
+function New-PodeLogSplunkOverride {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter()]
+        [string]
+        $Id,
+
+        [Parameter()]
+        [string]
+        $Source,
+
+        [Parameter()]
+        [string]
+        $SourceType,
+
+        [Parameter()]
+        [string]
+        $Index,
+
+        [switch]
+        $Ignore
+    )
+
+    $Id = Protect-PodeValue -Value $Id -Default 'Splunk'
+
+    return @{
+        Id         = $Id
+        Source     = $Source
+        SourceType = $SourceType
+        Index      = $Index
+        Ignore     = $Ignore.IsPresent
+    }
 }
 
 <#
@@ -2068,21 +2398,40 @@ function New-PodeLogDatadogMethod {
                     timestamp = $item.Event.Timestamp.ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
                 }
 
+                # get any overrides for this method
+                $override = Get-PodeLogOverride -LogEvent $item.Event
+
                 # add service
-                $service = Protect-PodeValue -Value $item.Event.Metadata['Service'] -Default $options.Service
+                $service = Protect-PodeValue -Value $override.Service -Default $options.Service
                 if (![string]::IsNullOrEmpty($service)) {
                     $evt.service = $service
                 }
 
                 # add source
-                $source = Protect-PodeValue -Value $item.Event.Metadata['Source'] -Default $options.Source
+                $source = Protect-PodeValue -Value $override.Source -Default $options.Source
                 if (![string]::IsNullOrEmpty($source)) {
                     $evt.ddsource = $source
                 }
 
                 # add tags
+                $_tags = @{}
                 if ($options.Tags.Count -gt 0) {
-                    $evt.ddtags = @(foreach ($key in $options.Tags.Keys) { "$($key):$($options.Tags[$key])" }) -join ','
+                    $_tags = $options.Tags
+                }
+
+                if (($null -ne $override.Tags) -and ($override.Tags.Count -gt 0)) {
+                    switch ($override.TagsAction) {
+                        'replace' { $_tags = $override.Tags }
+                        'merge' {
+                            foreach ($key in $override.Tags.Keys) {
+                                $_tags[$key] = $override.Tags[$key]
+                            }
+                        }
+                    }
+                }
+
+                if ($_tags.Count -gt 0) {
+                    $evt.ddtags = @(foreach ($key in $_tags.Keys) { "$($key):$($_tags[$key])" }) -join ','
                 }
 
                 $evt
@@ -2119,6 +2468,78 @@ function New-PodeLogDatadogMethod {
         -BodyArguments $bodyArgs `
         -SkipCertificateCheck:$SkipCertificateCheck.IsPresent `
         -Compress
+}
+
+<#
+.SYNOPSIS
+Creates a new set of override options for the Datadog Log Method.
+
+.DESCRIPTION
+Creates a new set of override options for the Datadog Log Method.
+
+.PARAMETER Id
+An optional ID to assign to the Log Method to override. (Default: 'Datadog')
+
+.PARAMETER Service
+An optional service name to override the service of the Datadog Log Method.
+
+.PARAMETER Source
+An optional source name to override the source of the Datadog Log Method.
+
+.PARAMETER Tags
+An optional hashtable of tags to override the tags of the Datadog Log Method.
+
+.PARAMETER TagsAction
+An optional action to determine how to handle the tags of the Datadog Log Method. (Default: 'Merge')
+
+.PARAMETER Ignore
+Whether to ignore the Datadog Log Method when writing log items.
+
+.EXAMPLE
+$override = New-PodeLogDatadogOverride -Service 'my_service' -Source 'my_source' -Tags @{ env = 'prod' } -TagsAction 'Append'
+
+.EXAMPLE
+$override = New-PodeLogDatadogOverride -Id 'DatadogMethod' -Ignore
+#>
+function New-PodeLogDatadogOverride {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter()]
+        [string]
+        $Id,
+
+        [Parameter()]
+        [string]
+        $Service,
+
+        [Parameter()]
+        [string]
+        $Source,
+
+        [Parameter()]
+        [hashtable]
+        $Tags,
+
+        [Parameter()]
+        [ValidateSet('Merge', 'Replace')]
+        [string]
+        $TagsAction = 'Merge',
+
+        [switch]
+        $Ignore
+    )
+
+    $Id = Protect-PodeValue -Value $Id -Default 'Datadog'
+
+    return @{
+        Id         = $Id
+        Service    = $Service
+        Source     = $Source
+        Tags       = $Tags
+        TagsAction = $TagsAction.ToLowerInvariant()
+        Ignore     = $Ignore.IsPresent
+    }
 }
 
 <#
@@ -2266,6 +2687,53 @@ function New-PodeLogAzureMethod {
 
 <#
 .SYNOPSIS
+Creates a new set of override options for the Azure Log Method.
+
+.DESCRIPTION
+Creates a new set of override options for the Azure Log Method.
+
+.PARAMETER Id
+An optional ID to assign to the Log Method to override. (Default: 'Azure')
+
+.PARAMETER Source
+An optional source to override the source of the Azure Log Method.
+
+.PARAMETER Ignore
+Whether to ignore the Azure Log Method when writing log items.
+
+.EXAMPLE
+$override = New-PodeLogAzureOverride -Source 'my_source'
+
+.EXAMPLE
+$override = New-PodeLogAzureOverride -Id 'AzureMethod' -Ignore
+#>
+function New-PodeLogAzureOverride {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter()]
+        [string]
+        $Id,
+
+        [Parameter()]
+        [string]
+        $Source,
+
+        [switch]
+        $Ignore
+    )
+
+    $Id = Protect-PodeValue -Value $Id -Default 'Azure'
+
+    return @{
+        Id     = $Id
+        Source = $Source
+        Ignore = $Ignore.IsPresent
+    }
+}
+
+<#
+.SYNOPSIS
 Creates a new AWS CloudWatch Log Method.
 
 .DESCRIPTION
@@ -2370,20 +2838,23 @@ function New-PodeLogAwsMethod {
                     severity = ConvertTo-PodeSplunkLevel -Level $item.Event.Level
                 }
 
+                # get any overrides for this method
+                $override = Get-PodeLogOverride -LogEvent $item.Event
+
                 # add source type
-                $sourceType = Protect-PodeValue -Value $item.Event.Metadata['SourceType'] -Default $options.SourceType
+                $sourceType = Protect-PodeValue -Value $override.SourceType -Default $options.SourceType
                 if (![string]::IsNullOrEmpty($sourceType)) {
                     $evt.sourcetype = $sourceType
                 }
 
                 # add source
-                $source = Protect-PodeValue -Value $item.Event.Metadata['Source'] -Default $options.Source
+                $source = Protect-PodeValue -Value $override.Source -Default $options.Source
                 if (![string]::IsNullOrEmpty($source)) {
                     $evt.source = $source
                 }
 
                 # add index
-                $index = Protect-PodeValue -Value $item.Event.Metadata['Index'] -Default $options.Index
+                $index = Protect-PodeValue -Value $override.Index -Default $options.Index
                 if (![string]::IsNullOrEmpty($index)) {
                     $evt.index = $index
                 }
@@ -2417,6 +2888,69 @@ function New-PodeLogAwsMethod {
         -BodyArguments $bodyArgs `
         -SkipCertificateCheck:$SkipCertificateCheck.IsPresent `
         -Compress
+}
+
+<#
+.SYNOPSIS
+Creates a new set of override options for the AWS Log Method.
+
+.DESCRIPTION
+Creates a new set of override options for the AWS Log Method.
+
+.PARAMETER Id
+An optional ID to assign to the Log Method to override. (Default: 'AWS')
+
+.PARAMETER Source
+An optional source to override the source of the AWS Log Method.
+
+.PARAMETER SourceType
+An optional source type to override the source type of the AWS Log Method.
+
+.PARAMETER Index
+An optional index to override the index of the AWS Log Method.
+
+.PARAMETER Ignore
+Whether to ignore the AWS Log Method when writing log items.
+
+.EXAMPLE
+$override = New-PodeLogAwsOverride -Source 'my_source' -SourceType 'syslog' -Index 'main'
+
+.EXAMPLE
+$override = New-PodeLogAwsOverride -Id 'AwsMethod' -Ignore
+#>
+function New-PodeLogAwsOverride {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter()]
+        [string]
+        $Id,
+
+        [Parameter()]
+        [string]
+        $Source,
+
+        [Parameter()]
+        [string]
+        $SourceType,
+
+        [Parameter()]
+        [string]
+        $Index,
+
+        [switch]
+        $Ignore
+    )
+
+    $Id = Protect-PodeValue -Value $Id -Default 'AWS'
+
+    return @{
+        Id         = $Id
+        Source     = $Source
+        SourceType = $SourceType
+        Index      = $Index
+        Ignore     = $Ignore.IsPresent
+    }
 }
 
 <#
@@ -2486,7 +3020,7 @@ function New-PodeLogNetworkMethod {
     )
 
     # add method to server
-    return Add-PodeLogMethodInternal -Id $Id -Batch $BatchInfo -Metadata @{
+    return Add-PodeLogMethodInternal -Id $Id -Batch $BatchInfo -Config @{
         Type        = 'Network'
         ScriptBlock = Get-PodeLoggingNetworkMethod
         Arguments   = @{
@@ -2495,6 +3029,45 @@ function New-PodeLogNetworkMethod {
             Port                 = $Port
             SkipCertificateCheck = $SkipCertificateCheck.IsPresent
         }
+    }
+}
+
+<#
+.SYNOPSIS
+Creates a new set of override options for the Network Log Method.
+
+.DESCRIPTION
+Creates a new set of override options for the Network Log Method.
+
+.PARAMETER Id
+An optional ID to assign to the Log Method to override. (Default: 'Network')
+
+.PARAMETER Ignore
+Whether to ignore the Network Log Method when writing log items.
+
+.EXAMPLE
+$override = New-PodeLogNetworkOverride -Ignore
+
+.EXAMPLE
+$override = New-PodeLogNetworkOverride -Id 'NetworkMethod' -Ignore
+#>
+function New-PodeLogNetworkOverride {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter()]
+        [string]
+        $Id,
+
+        [switch]
+        $Ignore
+    )
+
+    $Id = Protect-PodeValue -Value $Id -Default 'Network'
+
+    return @{
+        Id     = $Id
+        Ignore = $Ignore.IsPresent
     }
 }
 
@@ -2985,4 +3558,50 @@ function Add-PodeLogW3CCustomField {
         Name      = $Name
         FieldName = $fieldName
     }
+}
+
+<#
+.SYNOPSIS
+Gets the override options for a Pode Log event, for a Log Method.
+
+.DESCRIPTION
+Gets the override options for a Pode Log event, for a specific Log Method.
+
+.PARAMETER LogEvent
+The Pode Log Event object to retrieve the override options for.
+
+.PARAMETER Id
+The ID of the Log Method to retrieve the override options for. (Default: $MethodId)
+The Default value is the ID of the Log Method that is currently being processed.
+
+.PARAMETER Type
+The type of the Log Method to retrieve the override options for. (Default: $MethodType)
+The Default value is the type of the Log Method that is currently being processed.
+
+.EXAMPLE
+$override = Get-PodeLogOverride -LogEvent $logEvent
+
+.EXAMPLE
+$override = Get-PodeLogOverride -LogEvent $logEvent -Id 'DatadogMethod' -Type 'Datadog'
+#>
+function Get-PodeLogOverride {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [Pode.Utilities.Logging.IPodeLogEvent]
+        $LogEvent,
+
+        [Parameter()]
+        [string]
+        $Id,
+
+        [Parameter()]
+        [string]
+        $Type
+    )
+
+    $Id = Protect-PodeValue -Value $Id -Default $MethodId
+    $Type = Protect-PodeValue -Value $Type -Default $MethodType
+    return $LogEvent.GetOverride($Id, $Type)
 }


### PR DESCRIPTION
### Description of the Change
This adds support for being able to override certain properties of Log Methods during `Write-PodeLog` and `Write-PodeErrorLog` calls, via a new `-Override` parameter on both.

There are new override functions, per Log Method, which allow to customise select properties. 

* New-PodeLogTerminalOverride
* New-PodeLogFileOverride
* New-PodeLogEventViewerOverride
* New-PodeLogCustomOverride
* New-PodeLogApiOverride
* New-PodeLogSplunkOverride
* New-PodeLogDatadogOverride
* New-PodeLogAzureOverride
* New-PodeLogAwsOverride
* New-PodeLogNetworkOverride

For example, you might have Event Viewer with a default Event ID of 1000, but then then on select Write calls override that to to be 1337 instead:

```powershell
# setup main Event Viewer method for Error logging
# all errors will be given an Event ID of 1000
New-PodeLogEventViewerMethod -EventID 1000 | Enable-PodeLogErrorType

# ...

# log an error with a custom Event ID of 1337 instead
try {
    # ...
}
catch {
    $_ | Write-PodeErrorLog -Override @(
        New-PodeLogEventViewerOverride -EventId 1337
    )
}
```

