### PR TITLE
Fixes the Routes collection to be thread-safe

### DIFF
--- a/src/Listener/Adapters/Consumers/PodeConsumer.cs
+++ b/src/Listener/Adapters/Consumers/PodeConsumer.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Pode.Utilities;
 using Pode.Protocols.WebSockets;
 using Pode.Utilities.Logging;
+using Pode.Utilities.Structures;
 
 namespace Pode.Adapters.Consumers
 {

--- a/src/Listener/Adapters/Listeners/IPodeListener.cs
+++ b/src/Listener/Adapters/Listeners/IPodeListener.cs
@@ -1,7 +1,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Pode.Transport.Sockets;
-using Pode.Utilities;
+using Pode.Utilities.Structures;
 using Pode.Protocols.Common.Contexts;
 
 namespace Pode.Adapters.Listeners

--- a/src/Listener/Adapters/Listeners/PodeListener.cs
+++ b/src/Listener/Adapters/Listeners/PodeListener.cs
@@ -6,6 +6,7 @@ using Pode.Transport.Sockets;
 using Pode.Utilities;
 using Pode.Protocols.Common.Contexts;
 using Pode.Utilities.Logging;
+using Pode.Utilities.Structures;
 
 namespace Pode.Adapters.Listeners
 {

--- a/src/Listener/Adapters/Watchers/PodeWatcher.cs
+++ b/src/Listener/Adapters/Watchers/PodeWatcher.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Pode.Utilities;
 using Pode.Protocols.File;
 using Pode.Utilities.Logging;
+using Pode.Utilities.Structures;
 
 namespace Pode.Adapters.Watchers
 {

--- a/src/Listener/Protocols/File/BufferingFileSystemWatcher.cs
+++ b/src/Listener/Protocols/File/BufferingFileSystemWatcher.cs
@@ -5,7 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Pode.Utilities;
+using Pode.Utilities.Structures;
 
 // A tweaked version of the FileSystemWatcher from https://github.com/petermeinl/LeanWork.IO.FileSystem.Watcher
 namespace Pode.Protocols.File

--- a/src/Listener/Protocols/Http/Client/PodeClientConnectionNestedMap.cs
+++ b/src/Listener/Protocols/Http/Client/PodeClientConnectionNestedMap.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using System.IO;
 using Pode.Utilities;
 using Pode.Utilities.Logging;
+using Pode.Utilities.Structures;
 
 namespace Pode.Protocols.Http.Client
 {

--- a/src/Listener/Protocols/Http/PodeHttpListener.cs
+++ b/src/Listener/Protocols/Http/PodeHttpListener.cs
@@ -7,6 +7,7 @@ using Pode.Protocols.Http.Client.Sse;
 using Pode.Protocols.Http.Client.Signals;
 using Pode.Adapters;
 using Pode.Utilities.Logging;
+using Pode.Utilities.Structures;
 
 namespace Pode.Protocols.Http
 {

--- a/src/Listener/Utilities/Logging/IPodeLogger.cs
+++ b/src/Listener/Utilities/Logging/IPodeLogger.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Threading;
 using Pode.Protocols.Common.Requests;
+using Pode.Utilities.Structures;
 
 namespace Pode.Utilities.Logging
 {

--- a/src/Listener/Utilities/Logging/PodeLogger.cs
+++ b/src/Listener/Utilities/Logging/PodeLogger.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Threading;
 using Pode.Protocols.Common.Requests;
+using Pode.Utilities.Structures;
 
 namespace Pode.Utilities.Logging
 {

--- a/src/Listener/Utilities/Structures/PodeConcurrentList.cs
+++ b/src/Listener/Utilities/Structures/PodeConcurrentList.cs
@@ -1,0 +1,170 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Pode.Utilities.Structures
+{
+    public class PodeConcurrentList<T> : IEnumerable<T>
+    {
+        private readonly List<T> Items = new List<T>();
+        private readonly object Lock = new object();
+
+        public PodeConcurrentList() { }
+
+        public int Count
+        {
+            get
+            {
+                lock (Lock)
+                {
+                    return Items.Count;
+                }
+            }
+        }
+
+        public T this[int index]
+        {
+            get
+            {
+                lock (Lock)
+                {
+                    return Items[index];
+                }
+            }
+            set
+            {
+                lock (Lock)
+                {
+                    Items[index] = value;
+                }
+            }
+        }
+
+        public bool TryAdd(T item, bool unique = false)
+        {
+            lock (Lock)
+            {
+                if (unique && Items.Contains(item))
+                {
+                    return false;
+                }
+
+                Items.Add(item);
+                return true;
+            }
+        }
+
+        public bool TryInsert(int index, T item, bool unique = false)
+        {
+            lock (Lock)
+            {
+                if (unique && Items.Contains(item))
+                {
+                    return false;
+                }
+
+                if (index < 0 || index > Items.Count)
+                {
+                    return false;
+                }
+
+                Items.Insert(index, item);
+                return true;
+            }
+        }
+
+        public bool TryRemove(T item, out T removedItem)
+        {
+            lock (Lock)
+            {
+                var removed = Items.Remove(item);
+                removedItem = removed ? item : default;
+                return removed;
+            }
+        }
+
+        public bool TryRemoveAt(int index, out T removedItem)
+        {
+            lock (Lock)
+            {
+                if (index < 0 || index >= Items.Count)
+                {
+                    removedItem = default;
+                    return false;
+                }
+
+                removedItem = Items[index];
+                Items.RemoveAt(index);
+                return true;
+            }
+        }
+
+        public bool Contains(T item)
+        {
+            lock (Lock)
+            {
+                return Items.Contains(item);
+            }
+        }
+
+        public void Clear()
+        {
+            lock (Lock)
+            {
+                Items.Clear();
+            }
+        }
+
+        public T[] ToArray()
+        {
+            lock (Lock)
+            {
+                return Items.ToArray();
+            }
+        }
+
+        public int IndexOf(T item)
+        {
+            lock (Lock)
+            {
+                return Items.IndexOf(item);
+            }
+        }
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            lock (Lock)
+            {
+                return ((IReadOnlyList<T>)Items.ToArray()).GetEnumerator();
+            }
+        }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        public override int GetHashCode()
+        {
+            lock (Lock)
+            {
+                return Items.GetHashCode();
+            }
+        }
+
+        public override bool Equals(object obj)
+        {
+            lock (Lock)
+            {
+                return obj is PodeConcurrentList<T> other && Items.SequenceEqual(other.Items);
+            }
+        }
+
+        public override string ToString()
+        {
+            lock (Lock)
+            {
+                return Items.ToString();
+            }
+        }
+    }
+}

--- a/src/Listener/Utilities/Structures/PodeConcurrentOrderedDictionary.cs
+++ b/src/Listener/Utilities/Structures/PodeConcurrentOrderedDictionary.cs
@@ -1,0 +1,176 @@
+using System;
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Linq;
+
+namespace Pode.Utilities.Structures
+{
+    public class PodeConcurrentOrderedDictionary<K, V> : IEnumerable<KeyValuePair<K, V>>
+    {
+        private readonly ConcurrentDictionary<K, V> Items = new ConcurrentDictionary<K, V>(
+            typeof(K) == typeof(string) ? (IEqualityComparer<K>)StringComparer.InvariantCultureIgnoreCase : EqualityComparer<K>.Default
+        );
+
+        private readonly OrderedDictionary OrderedKeys = new OrderedDictionary(
+            typeof(K) == typeof(string) ? (IEqualityComparer)StringComparer.InvariantCultureIgnoreCase : EqualityComparer<K>.Default
+        );
+
+        private volatile K[] OrderedKeysCache = Array.Empty<K>();
+        private volatile bool IsDirty = false;
+
+        private readonly object Lock = new object();
+
+        public PodeConcurrentOrderedDictionary() { }
+
+        public int Count
+        {
+            get
+            {
+                return Items.Count;
+            }
+        }
+
+        public K[] Keys => GetOrderedKeys();
+
+        public V[] Values
+        {
+            get
+            {
+                return GetOrderedKeys().Select(k => Items.TryGetValue(k, out var value) ? value : default).ToArray();
+            }
+        }
+
+        public V this[K key]
+        {
+            get
+            {
+                if (Items.TryGetValue(key, out var value))
+                {
+                    return value;
+                }
+
+                return default;
+            }
+            set
+            {
+                lock (Lock)
+                {
+                    if (Items.TryAdd(key, value))
+                    {
+                        OrderedKeys.Add(key, true);
+                    }
+                    else
+                    {
+                        Items[key] = value;
+                    }
+
+                    IsDirty = true;
+                }
+            }
+        }
+
+        public bool TryAdd(K key, V value)
+        {
+            lock (Lock)
+            {
+                if (!Items.TryAdd(key, value))
+                {
+                    return false;
+                }
+
+                OrderedKeys.Add(key, true);
+                IsDirty = true;
+                return true;
+            }
+        }
+
+        public bool TryRemove(K key, out V removedValue)
+        {
+            lock (Lock)
+            {
+                var removed = Items.TryRemove(key, out var value);
+                if (!removed)
+                {
+                    removedValue = default;
+                    return removed;
+                }
+
+                removedValue = value;
+                OrderedKeys.Remove(key);
+                IsDirty = true;
+                return removed;
+            }
+        }
+
+        public bool Contains(K key)
+        {
+            return Items.ContainsKey(key);
+        }
+
+        public void Clear()
+        {
+            lock (Lock)
+            {
+                Items.Clear();
+                OrderedKeys.Clear();
+                IsDirty = true;
+            }
+        }
+
+        public KeyValuePair<K, V>[] ToArray()
+        {
+            return GetOrderedKeys().Select(k => new KeyValuePair<K, V>(k, Items.TryGetValue(k, out var value) ? value : default)).ToArray();
+        }
+
+        public IEnumerator<KeyValuePair<K, V>> GetEnumerator()
+        {
+            return ((IReadOnlyList<KeyValuePair<K, V>>)ToArray()).GetEnumerator();
+        }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        public override int GetHashCode()
+        {
+            return Items.GetHashCode();
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is PodeConcurrentOrderedDictionary<K, V> other && Items.SequenceEqual(other.Items);
+        }
+
+        public override string ToString()
+        {
+            return Items.ToString();
+        }
+
+        private K[] GetOrderedKeys()
+        {
+            // return the cached ordered keys if not dirty
+            if (!IsDirty)
+            {
+                return OrderedKeysCache;
+            }
+
+            // otherwise, rebuild the ordered keys cache
+            lock (Lock)
+            {
+                // ensure still dirty, else return
+                if (!IsDirty)
+                {
+                    return OrderedKeysCache;
+                }
+
+                OrderedKeysCache = OrderedKeys.Keys.Cast<K>().ToArray();
+                IsDirty = false;
+            }
+
+            return OrderedKeysCache;
+        }
+    }
+}

--- a/src/Listener/Utilities/Structures/PodeConcurrentSet.cs
+++ b/src/Listener/Utilities/Structures/PodeConcurrentSet.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Pode.Utilities
+namespace Pode.Utilities.Structures
 {
     public class PodeConcurrentSet<T> : IEnumerable<T>
     {
@@ -74,6 +74,30 @@ namespace Pode.Utilities
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
         {
             return GetEnumerator();
+        }
+
+        public override int GetHashCode()
+        {
+            lock (Lock)
+            {
+                return Items.GetHashCode();
+            }
+        }
+
+        public override bool Equals(object obj)
+        {
+            lock (Lock)
+            {
+                return obj is PodeConcurrentSet<T> other && Items.SetEquals(other.Items);
+            }
+        }
+
+        public override string ToString()
+        {
+            lock (Lock)
+            {
+                return Items.ToString();
+            }
         }
     }
 }

--- a/src/Listener/Utilities/Structures/PodeItemNestedMap.cs
+++ b/src/Listener/Utilities/Structures/PodeItemNestedMap.cs
@@ -2,7 +2,7 @@ using System;
 using System.Linq;
 using System.Collections.Concurrent;
 
-namespace Pode.Utilities
+namespace Pode.Utilities.Structures
 {
     public class PodeItemNestedMap<T>
     {

--- a/src/Listener/Utilities/Structures/PodeItemQueue.cs
+++ b/src/Listener/Utilities/Structures/PodeItemQueue.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Pode.Utilities
+namespace Pode.Utilities.Structures
 {
     public class PodeItemQueue<T> : IDisposable
     {

--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -1,5 +1,6 @@
 using namespace Pode.Utilities
 using namespace Pode.Utilities.Logging
+using namespace Pode.Utilities.Structures
 
 function New-PodeContext {
     [CmdletBinding()]
@@ -381,22 +382,11 @@ function New-PodeContext {
     }
 
     # routes for pages and api
-    $ctx.Server.Routes = [ordered]@{
-        # common methods
-        'get'     = [ordered]@{}
-        'post'    = [ordered]@{}
-        'put'     = [ordered]@{}
-        'patch'   = [ordered]@{}
-        'delete'  = [ordered]@{}
-        # other methods
-        'connect' = [ordered]@{}
-        'head'    = [ordered]@{}
-        'merge'   = [ordered]@{}
-        'options' = [ordered]@{}
-        'trace'   = [ordered]@{}
-        'static'  = [ordered]@{}
-        'signal'  = [ordered]@{}
-        '*'       = [ordered]@{}
+    $ctx.Server.Routes = [PodeConcurrentOrderedDictionary[string, [PodeConcurrentOrderedDictionary[string, object]]]]::new()
+
+    $methods = @('get', 'post', 'put', 'patch', 'delete', 'connect', 'head', 'merge', 'options', 'trace', 'static', 'signal', '*')
+    foreach ($method in $methods) {
+        $null = $ctx.Server.Routes.TryAdd($method, [PodeConcurrentOrderedDictionary[string, object]]::new())
     }
 
     # verbs for tcp

--- a/src/Private/Server.ps1
+++ b/src/Private/Server.ps1
@@ -247,7 +247,10 @@ function Restart-PodeInternalServer {
         $PodeContext.Server.Modules.Clear()
 
         # clear up timers, schedules and loggers
-        Clear-PodeHashtableInnerKey -InputObject $PodeContext.Server.Routes
+        $PodeContext.Server.Routes.Keys | ForEach-Object {
+            $PodeContext.Server.Routes[$_].Clear()
+        }
+
         Clear-PodeHashtableInnerKey -InputObject $PodeContext.Server.Handlers
         Clear-PodeHashtableInnerKey -InputObject $PodeContext.Server.Events
 

--- a/src/Public/Routes.ps1
+++ b/src/Public/Routes.ps1
@@ -1724,7 +1724,7 @@ function Remove-PodeRoute {
 
     # if the route has no more logic, just remove it
     if ((Get-PodeCount $PodeContext.Server.Routes[$Method][$Path]) -eq 0) {
-        $null = $PodeContext.Server.Routes[$Method].Remove($Path)
+        $null = $PodeContext.Server.Routes[$Method].TryRemove($Path, [ref]$null)
     }
 }
 
@@ -1773,7 +1773,7 @@ function Remove-PodeStaticRoute {
 
     # if the route has no more logic, just remove it
     if ((Get-PodeCount $PodeContext.Server.Routes[$Method][$Path]) -eq 0) {
-        $null = $PodeContext.Server.Routes[$Method].Remove($Path)
+        $null = $PodeContext.Server.Routes[$Method].TryRemove($Path, [ref]$null)
     }
 }
 
@@ -1822,7 +1822,7 @@ function Remove-PodeSignalRoute {
 
     # if the route has no more logic, just remove it
     if ((Get-PodeCount $PodeContext.Server.Routes[$Method][$Path]) -eq 0) {
-        $null = $PodeContext.Server.Routes[$Method].Remove($Path)
+        $null = $PodeContext.Server.Routes[$Method].TryRemove($Path, [ref]$null)
     }
 }
 
@@ -1854,11 +1854,11 @@ function Clear-PodeRoutes {
 
     if (![string]::IsNullOrWhiteSpace($Method)) {
         $PodeContext.Server.Routes[$Method].Clear()
+        return
     }
-    else {
-        $PodeContext.Server.Routes.Keys.Clone() | ForEach-Object {
-            $PodeContext.Server.Routes[$_].Clear()
-        }
+
+    $PodeContext.Server.Routes.Keys | ForEach-Object {
+        $PodeContext.Server.Routes[$_].Clear()
     }
 }
 

--- a/src/Public/Routes.ps1
+++ b/src/Public/Routes.ps1
@@ -2409,36 +2409,37 @@ function Get-PodeRoute {
         $EndpointName
     )
 
-    # start off with every route
-    $routes = @()
-    foreach ($route in $PodeContext.Server.Routes.Values.Values) {
-        $routes += $route
-    }
-
-    # if we have a method, filter
-    if (![string]::IsNullOrWhiteSpace($Method)) {
-        $routes = @(foreach ($route in $routes) {
-                if ($route.Method -ine $Method) {
-                    continue
-                }
-
-                $route
-            })
-    }
-
-    # if we have a path, filter
-    if (![string]::IsNullOrWhiteSpace($Path)) {
+    # if we have a path, ensure it's parsed and escaped
+    if (![string]::IsNullOrEmpty($Path)) {
         $Path = Split-PodeRouteQuery -Path $Path
         $Path = Update-PodeRouteSlash -Path $Path
         $Path = Resolve-PodePlaceholder -Path $Path
+    }
 
-        $routes = @(foreach ($route in $routes) {
-                if ($route.Path -ine $Path) {
-                    continue
-                }
+    # select the routes based on the method and path
+    $routes = $null
 
-                $route
-            })
+    if (![string]::IsNullOrEmpty($Method) -and ![string]::IsNullOrEmpty($Path)) {
+        $routes = $PodeContext.Server.Routes[$Method][$Path]
+    }
+    elseif (![string]::IsNullOrEmpty($Method)) {
+        foreach ($route in $PodeContext.Server.Routes[$Method].Values) {
+            $routes += $route
+        }
+    }
+    elseif (![string]::IsNullOrEmpty($Path)) {
+        foreach ($method in $PodeContext.Server.Routes.Keys) {
+            if ($PodeContext.Server.Routes[$method].Contains($Path)) {
+                $routes += $PodeContext.Server.Routes[$method][$Path]
+            }
+        }
+    }
+    else {
+        foreach ($method in $PodeContext.Server.Routes.Keys) {
+            foreach ($route in $PodeContext.Server.Routes[$method].Values) {
+                $routes += $route
+            }
+        }
     }
 
     # further filter by endpoint names
@@ -2717,9 +2718,9 @@ function Test-PodeRoute {
     $endpoint = @(Find-PodeEndpoint -EndpointName $EndpointName)[0]
 
     # check for routes
-    $found = (Test-PodeRouteInternal -Method $Method -Path $Path -Protocol $endpoint.Protocol -Address $endpoint.Address)
+    $found = Test-PodeRouteInternal -Method $Method -Path $Path -Protocol $endpoint.Protocol -Address $endpoint.Address
     if (!$found -and $CheckWildcard) {
-        $found = (Test-PodeRouteInternal -Method '*' -Path $Path -Protocol $endpoint.Protocol -Address $endpoint.Address)
+        $found = Test-PodeRouteInternal -Method '*' -Path $Path -Protocol $endpoint.Protocol -Address $endpoint.Address
     }
 
     return $found

--- a/tests/unit/Routes.Tests.ps1
+++ b/tests/unit/Routes.Tests.ps1
@@ -889,19 +889,29 @@ InModuleScope -ModuleName 'Pode' {
     Describe 'Get-PodeRoute' {
         BeforeAll {
             Mock Test-PodeIPAddress { return $true }
-            Mock Test-PodeIsAdminUser { return $true } }
+            Mock Test-PodeIsAdminUser { return $true }
+        }
+
         BeforeEach {
-            $PodeContext.Server = @{ 'Routes' = @{ 'GET' = @{}; 'POST' = @{}; }; 'FindEndpoints' = @{}; 'Endpoints' = @{}; 'EndpointsMap' = @{}; 'Type' = $null
-                'OpenAPI' = @{
+            $PodeContext.Server = @{
+                Routes        = [Pode.Utilities.Structures.PodeConcurrentOrderedDictionary[string, object]]::new()
+                FindEndpoints = @{}
+                Endpoints     = @{}
+                EndpointsMap  = @{}
+                Type          = $null
+                OpenAPI       = @{
                     SelectedDefinitionTag = 'default'
                     Definitions           = @{
                         default = Get-PodeOABaseObject
                     }
                 }
             }
+
+            $PodeContext.Server.Routes['GET'] = [Pode.Utilities.Structures.PodeConcurrentOrderedDictionary[string, object]]::new()
+            $PodeContext.Server.Routes['POST'] = [Pode.Utilities.Structures.PodeConcurrentOrderedDictionary[string, object]]::new()
         }
 
-        It 'Returns both routes whe nothing supplied' {
+        It 'Returns all routes when nothing supplied' {
             Add-PodeRoute -Method Get -Path '/users' -ScriptBlock { Write-Host 'hello' }
             Add-PodeRoute -Method Get -Path '/about' -ScriptBlock { Write-Host 'hello' }
             Add-PodeRoute -Method Post -Path '/users' -ScriptBlock { Write-Host 'hello' }
@@ -937,6 +947,15 @@ InModuleScope -ModuleName 'Pode' {
             $routes.Length | Should -Be 2
         }
 
+        It 'Returns route for placeholder path' {
+            Add-PodeRoute -Method Get -Path '/users/:userId' -ScriptBlock { Write-Host 'hello' }
+            Add-PodeRoute -Method Get -Path '/about' -ScriptBlock { Write-Host 'hello' }
+            Add-PodeRoute -Method Post -Path '/users' -ScriptBlock { Write-Host 'hello' }
+
+            $routes = Get-PodeRoute -Path '/users/:userId'
+            $routes.Length | Should -Be 1
+        }
+
         It 'Returns one route for users path and GET method' {
             Add-PodeRoute -Method Get -Path '/users' -ScriptBlock { Write-Host 'hello' }
             Add-PodeRoute -Method Get -Path '/about' -ScriptBlock { Write-Host 'hello' }
@@ -947,7 +966,6 @@ InModuleScope -ModuleName 'Pode' {
         }
 
         It 'Returns one route for users path and endpoint name user' {
-
             Add-PodeEndpoint -Address '127.0.0.1' -Port 8080 -Protocol Http -Name user
             Add-PodeEndpoint -Address '127.0.0.1' -Port 8081 -Protocol Http -Name admin
 
@@ -961,7 +979,6 @@ InModuleScope -ModuleName 'Pode' {
         }
 
         It 'Returns both routes for users path and endpoint names' {
-
             Add-PodeEndpoint -Address '127.0.0.1' -Port 8080 -Protocol Http -Name user
             Add-PodeEndpoint -Address '127.0.0.1' -Port 8081 -Protocol Http -Name admin
 
@@ -973,7 +990,6 @@ InModuleScope -ModuleName 'Pode' {
         }
 
         It 'Returns both routes for user endpoint name' {
-
             Add-PodeEndpoint -Address '127.0.0.1' -Port 8080 -Protocol Http -Name user
             Add-PodeEndpoint -Address '127.0.0.1' -Port 8081 -Protocol Http -Name admin
 

--- a/tests/unit/Routes.Tests.ps1
+++ b/tests/unit/Routes.Tests.ps1
@@ -107,28 +107,35 @@ InModuleScope -ModuleName 'Pode' {
 
     Describe 'Remove-PodeRoute' {
         BeforeEach {
-            $PodeContext.Server = @{ 'Routes' = @{ 'GET' = @{}; }; 'FindEndpoints' = @{}; 'Endpoints' = @{}; 'EndpointsMap' = @{}
-                'OpenAPI' = @{
+            $PodeContext.Server = @{
+                Routes        = [Pode.Utilities.Structures.PodeConcurrentOrderedDictionary[string, object]]::new()
+                FindEndpoints = @{}
+                Endpoints     = @{}
+                EndpointsMap  = @{}
+                OpenAPI       = @{
                     SelectedDefinitionTag = 'default'
                     Definitions           = @{
                         default = Get-PodeOABaseObject
                     }
                 }
             }
+
+            $PodeContext.Server.Routes['get'] = [Pode.Utilities.Structures.PodeConcurrentOrderedDictionary[string, object]]::new()
         }
+
         It 'Adds route with simple url, and then removes it' {
             Add-PodeRoute -Method Get -Path '/users' -ScriptBlock { Write-Host 'hello' }
 
             $routes = $PodeContext.Server.Routes['get']
             $routes | Should -Not -Be $null
-            $routes.ContainsKey('/users') | Should -Be $true
+            $routes.Contains('/users') | Should -Be $true
             $routes['/users'].Length | Should -Be 1
 
             Remove-PodeRoute -Method Get -Path '/users'
 
             $routes = $PodeContext.Server.Routes['get']
-            $routes | Should -Not -Be $null
-            $routes.ContainsKey('/users') | Should -Be $false
+            $routes.Count | Should -Be 0
+            $routes.Contains('/users') | Should -Be $false
         }
 
         It 'Adds two routes with simple url, and then removes one' {
@@ -140,14 +147,14 @@ InModuleScope -ModuleName 'Pode' {
 
             $routes = $PodeContext.Server.Routes['get']
             $routes | Should -Not -Be $null
-            $routes.ContainsKey('/users') | Should -Be $true
+            $routes.Contains('/users') | Should -Be $true
             $routes['/users'].Length | Should -Be 2
 
             Remove-PodeRoute -Method Get -Path '/users'
 
             $routes = $PodeContext.Server.Routes['get']
-            $routes | Should -Not -Be $null
-            $routes.ContainsKey('/users') | Should -Be $true
+            $routes.Count | Should -Be 1
+            $routes.Contains('/users') | Should -Be $true
             $routes['/users'].Length | Should -Be 1
         }
 
@@ -156,14 +163,14 @@ InModuleScope -ModuleName 'Pode' {
 
             $routes = $PodeContext.Server.Routes['GET']
             $routes | Should -Not -Be $null
-            $routes.ContainsKey('/users') | Should -Be $true
+            $routes.Contains('/users') | Should -Be $true
             $routes['/users'].Length | Should -Be 1
 
             Remove-PodeRoute -Method Get -Path '/users'
 
             $routes = $PodeContext.Server.Routes['GET']
-            $routes | Should -Not -Be $null
-            $routes.ContainsKey('/users') | Should -Be $false
+            $routes.Count | Should -Be 0
+            $routes.Contains('/users') | Should -Be $false
             $PodeContext.Server.OpenAPI.Definitions.default.hiddenComponents.operationId | Should -Not -Contain 'getUsers'
         }
 
@@ -175,14 +182,14 @@ InModuleScope -ModuleName 'Pode' {
 
             $routes = $PodeContext.Server.Routes['GET']
             $routes | Should -Not -Be $null
-            $routes.ContainsKey('/users') | Should -Be $true
+            $routes.Contains('/users') | Should -Be $true
             $routes['/users'].Length | Should -Be 2
 
             Remove-PodeRoute -Method Get -Path '/users' -EndpointName 'user'
 
             $routes = $PodeContext.Server.Routes['GET']
             $routes | Should -Not -Be $null
-            $routes.ContainsKey('/users') | Should -Be $true
+            $routes.Contains('/users') | Should -Be $true
             $routes['/users'].Length | Should -Be 1
             $PodeContext.Server.OpenAPI.Definitions.default.hiddenComponents.operationId | Should -Not -Contain 'getUsers2'
         }
@@ -193,33 +200,44 @@ InModuleScope -ModuleName 'Pode' {
             Mock Test-PodePath { return $true }
             Mock New-PodePSDrive { return './assets' }
 
-            $PodeContext.Server = @{ 'Routes' = @{ 'STATIC' = @{}; }; 'Root' = $pwd }
+            $PodeContext.Server = @{
+                Routes = [Pode.Utilities.Structures.PodeConcurrentOrderedDictionary[string, object]]::new()
+                Root   = $pwd
+            }
+            $PodeContext.Server.Routes['static'] = [Pode.Utilities.Structures.PodeConcurrentOrderedDictionary[string, object]]::new()
+
             Add-PodeStaticRoute -Path '/assets' -Source './assets'
 
             $routes = $PodeContext.Server.Routes['static']
             $routes | Should -Not -Be $null
-            $routes.ContainsKey('/assets[/]{0,1}(?<file>.*)') | Should -Be $true
+            $routes.Contains('/assets[/]{0,1}(?<file>.*)') | Should -Be $true
             $routes['/assets[/]{0,1}(?<file>.*)'].Source | Should -Be './assets'
 
             Remove-PodeStaticRoute -Path '/assets'
 
             $routes = $PodeContext.Server.Routes['static']
-            $routes | Should -Not -Be $null
-            $routes.ContainsKey('/assets[/]{0,1}(?<file>.*)') | Should -Be $false
+            $routes.Count | Should -Be 0
+            $routes.Contains('/assets[/]{0,1}(?<file>.*)') | Should -Be $false
         }
     }
 
     Describe 'Clear-PodeRoutes' {
         BeforeEach {
-            $PodeContext.Server = @{ 'Routes' = @{ 'GET' = @{}; 'POST' = @{} }
-                'FindEndpoints'               = @{}
-                'OpenAPI'                     = @{
+            $PodeContext.Server = @{
+                Routes          = @{
+                    'GET'  = @{}
+                    'POST' = @{}
+                }
+                'FindEndpoints' = @{}
+                'OpenAPI'       = @{
                     SelectedDefinitionTag = 'default'
                     Definitions           = @{
                         default = Get-PodeOABaseObject
                     }
                 }
-            } }
+            }
+        }
+
         It 'Adds routes for methods, and clears everything' {
             Add-PodeRoute -Method GET -Path '/users' -ScriptBlock { Write-Host 'hello1' }
             Add-PodeRoute -Method POST -Path '/messages' -ScriptBlock { Write-Host 'hello2' }


### PR DESCRIPTION
### Description of the Change
The Routes collection is currently an OrderedDictionary, which is not thread-safe. Normally this isn't an issue, but Pode.Web add routes during the running of the server which causes threading issues at times.

This PR converts the Routes collection to be a new `PodeConcurrentOrderedDictionary` object.

### Related Issue
Resolves #1669 
