### PR TITLE
Enhances State management to be thread-safe; Enhances State management to Save and Restore true object types

### DIFF
--- a/docs/Tutorials/SharedState.md
+++ b/docs/Tutorials/SharedState.md
@@ -1,16 +1,13 @@
 # Shared State
 
-Most things in Pode run in isolated runspaces: routes, middleware, schedules - to name a few. This means you can't create a variable in a timer, and then access that variable in a route. To overcome this limitation you can use the Shared State feature within Pode, which allows you to set/get variables on a state shared between all runspaces. This lets you can create a variable in a timer and store it within the shared state; then you can retrieve the variable from the state in a route.
+Most things in Pode run in isolated runspaces: Routes, Middleware, Schedules - to name a few. This means you can't create a variable in a Timer, and then access that variable in a Route. To overcome this limitation you can use the Shared State feature within Pode, which allows you to set/get variables on a state shared between all runspaces. This lets you can create a variable in a Timer and store it within the shared state; then you can retrieve the variable from the state in a Route.
 
 You also have the option of saving the current state to a file, and then restoring the state back on server start. This way you won't lose state between server restarts.
 
 You can also use the State in combination with [`Lock-PodeObject`](../../Functions/Threading/Lock-PodeObject) to ensure thread safety - if needed.
 
 !!! tip
-    It's wise to use the State in conjunction with [`Lock-PodeObject`](../../Functions/Threading/Lock-PodeObject), to ensure thread safety between runspaces.
-
-!!! warning
-    If you omit the use of [`Lock-PodeObject`](../../Functions/Threading/Lock-PodeObject), you might run into errors due to multi-threading. Only omit if you are *absolutely confident* you do not need locking. (ie: you set in state once and then only ever retrieve, never updating the variable).
+    From Pode v2.14.0 the State is now a thread-safe Concurrent Dictionary, which means in the vast majority of cases you won't need to use [`Lock-PodeObject`](../../Functions/Threading/Lock-PodeObject) when setting and retrieving State values.
 
 ## Usage
 
@@ -25,21 +22,17 @@ An example of setting a hashtable variable in the state is as follows:
 ```powershell
 Start-PodeServer {
     Add-PodeTimer -Name 'do-something' -Interval 5 -ScriptBlock {
-        Lock-PodeObject -ScriptBlock {
-            Set-PodeState -Name 'data' -Value @{ 'Name' = 'Rick Sanchez' } | Out-Null
-        }
+        $value = Set-PodeState -Name 'data' -Value (New-PodeStateDictionary -Data @{ Name = 'Rick Sanchez' })
     }
 }
 ```
 
-Alternatively you could use the `$state:` variable scope to set a variable in state. This variable will be scopeless, so if you need scope then use [`Set-PodeState`](../../Functions/State/Set-PodeState). `$state:` can be used anywhere, but keep in mind that like `$session:` Pode can only remap the this in scriptblocks it's aware of; so using it in a function of a custom module won't work. Similar to the example above:
+Alternatively you could use the `$state:` variable scope to set a variable in state. This variable will be scope-less, so if you need scope then use [`Set-PodeState`](../../Functions/State/Set-PodeState). `$state:` can be used anywhere, but keep in mind that like `$session:` Pode can only remap the this in scriptblocks it's aware of; so using it in a function of a custom module won't work. Similar to the example above:
 
 ```powershell
 Start-PodeServer {
     Add-PodeTimer -Name 'do-something' -Interval 5 -ScriptBlock {
-        Lock-PodeObject -ScriptBlock {
-            $state:data = @{ 'Name' = 'Rick Sanchez' }
-        }
+        $state:data = New-PodeStateDictionary -Data @{ Name = 'Rick Sanchez' }
     }
 }
 ```
@@ -53,13 +46,7 @@ An example of retrieving a value from the state is as follows:
 ```powershell
 Start-PodeServer {
     Add-PodeTimer -Name 'do-something' -Interval 5 -ScriptBlock {
-        $value = $null
-
-        Lock-PodeObject -ScriptBlock {
-            $value = (Get-PodeState -Name 'data')
-        }
-
-        # do something with $value
+        $value = Get-PodeState -Name 'data'
     }
 }
 ```
@@ -69,13 +56,7 @@ Alternatively you could use the `$state:` variable scope to get a variable in st
 ```powershell
 Start-PodeServer {
     Add-PodeTimer -Name 'do-something' -Interval 5 -ScriptBlock {
-        $value = $null
-
-        Lock-PodeObject -ScriptBlock {
-            $value = $state:data
-        }
-
-        # do something with $value
+        $value = $state:data
     }
 }
 ```
@@ -89,9 +70,7 @@ An example of removing a variable from the state is as follows:
 ```powershell
 Start-PodeServer {
     Add-PodeTimer -Name 'do-something' -Interval 5 -ScriptBlock {
-        Lock-PodeObject -ScriptBlock {
-            Remove-PodeState -Name 'data' | Out-Null
-        }
+        Remove-PodeState -Name 'data' -NoPassThru
     }
 }
 ```
@@ -131,6 +110,25 @@ Start-PodeServer {
 ```
 
 By default, restoring from a state file will overwrite the current state. You can change this so the restored state is merged instead by using the `-Merge` switch. (Note: if you restore a key that already exists in state, this will still overwrite that key).
+
+## Thread Safety
+
+From Pode v2.14.0 State will be a Concurrent Dictionary for improved thread-safety, reducing the need to use [`Lock-PodeObject`](../../Functions/Threading/Lock-PodeObject). Before this version you will need to use [`Lock-PodeObject`](../../Functions/Threading/Lock-PodeObject) when setting/retrieving State values.
+
+Additionally, there are also 5 helper functions for creating thread-safe collections for use with State:
+
+| Function                           | Type                                              |
+| ---------------------------------- | ------------------------------------------------- |
+| [`New-PodeStateDictionary`](../../Functions/State/New-PodeStateDictionary)        | `ConcurrentDictionary[string, object]`            |
+| [`New-PodeStateOrderedDictionary`](../../Functions/State/New-PodeStateOrderedDictionary) | `PodeOrderedConcurrentDictionary[string, object]` |
+| [`New-PodeStateBag`](../../Functions/State/New-PodeStateBag)               | `ConcurrentBag[object]`                           |
+| [`New-PodeStateSet`](../../Functions/State/New-PodeStateSet)               | `PodeConcurrentSet[object]`                       |
+| [`New-PodeStateList`](../../Functions/State/New-PodeStateList)              | `PodeConcurrentList[object]`                      |
+
+Each of the above classes has the following methods:
+
+* `TryAdd(<item>)` - returns a boolean of whether the item was added
+* `TryRemove(<item>, [ref])` - returns a boolean of whether the item was removed, and a [ref] of the removed item
 
 ## Full Example
 

--- a/examples/Shared-State-Concurrent.ps1
+++ b/examples/Shared-State-Concurrent.ps1
@@ -3,17 +3,21 @@
     A sample PowerShell script to set up a Pode server with state management and logging.
 
 .DESCRIPTION
-    This script sets up a Pode server that listens on port 8081, logs requests and errors to the terminal, and manages state using timers and routes. The server initializes state from a JSON file, updates state periodically using timers, and provides routes to interact with the state.
+    This script sets up a Pode server that listens on port 8081, logs requests and errors to the terminal,
+    and manages state using timers and routes. The server initializes state from a JSON file, updates state
+    periodically using timers, and provides routes to interact with the state.
+
+    The state is setup using thread-safe collections.
 
 .EXAMPLE
-    To run the sample: ./Shared-State.ps1
+    To run the sample: ./Shared-State-Concurrent.ps1
 
     Invoke-RestMethod -Uri http://localhost:8081/array -Method Get
     Invoke-RestMethod -Uri http://localhost:8081/array3 -Method Get
     Invoke-RestMethod -Uri http://localhost:8081/array -Method Delete
 
 .LINK
-    https://github.com/Badgerati/Pode/blob/develop/examples/Shared-State.ps1
+    https://github.com/Badgerati/Pode/blob/develop/examples/Shared-State-Concurrent.ps1
 
 .NOTES
     Author: Pode Team
@@ -46,58 +50,47 @@ Start-PodeServer {
     New-PodeLogTerminalMethod | Enable-PodeLogErrorType
 
     # re-initialise the state
-    Restore-PodeState -Path './state.json'
+    Restore-PodeState -Path './state-concurrent.json'
 
     # initialise if there was no file
     if ($null -eq ($hash = (Get-PodeState -Name 'hash1'))) {
-        $hash = Set-PodeState -Name 'hash1' -Value @{} -Scope Scope0, Scope1
-        $hash['values'] = @()
+        $hash = Set-PodeState -Name 'hash1' -Value (New-PodeStateDictionary) -Scope Scope0, Scope1
+        $null = $hash.values = New-PodeStateList
     }
 
     if ($null -eq ($hash = (Get-PodeState -Name 'hash2'))) {
-        $hash = Set-PodeState -Name 'hash2' -Value @{} -Scope Scope0, Scope2
-        $hash['values'] = @()
+        $hash = Set-PodeState -Name 'hash2' -Value (New-PodeStateDictionary) -Scope Scope0, Scope2
+        $hash.values = New-PodeStateList
     }
 
     if ($null -eq $state:hash3) {
-        $state:hash3 = @{ values = @() }
+        $state:hash3 = (New-PodeStateDictionary)
+        $state:hash3.values = New-PodeStateList
     }
 
     # create timer to update a hashtable and make it globally accessible
     Add-PodeTimer -Name 'forever' -Interval 2 -ScriptBlock {
-        $hash = $null
+        $hash = Get-PodeState -Name 'hash1'
+        $null = $hash.values.TryAdd((Get-Random -Minimum 0 -Maximum 10))
+        Save-PodeState -Path './state-concurrent.json' -Scope Scope1
 
-        Lock-PodeObject -ScriptBlock {
-            $hash = (Get-PodeState -Name 'hash1')
-            $hash.values += (Get-Random -Minimum 0 -Maximum 10)
-            Save-PodeState -Path './state.json' -Scope Scope1 #-Exclude 'hash1'
-        }
-
-        Lock-PodeObject -ScriptBlock {
-            $state:hash3.values += (Get-Random -Minimum 0 -Maximum 10)
-        }
+        $null = $state:hash3.values.TryAdd((Get-Random -Minimum 0 -Maximum 10))
     }
 
     # route to retrieve and return the value of the hashtable from global state
     Add-PodeRoute -Method Get -Path '/array' -ScriptBlock {
-        Lock-PodeObject -ScriptBlock {
-            $hash = (Get-PodeState 'hash1')
-            Write-PodeJsonResponse -Value $hash
-        }
+        $hash = Get-PodeState 'hash1'
+        Write-PodeJsonResponse -Value $hash
     }
 
     Add-PodeRoute -Method Get -Path '/array3' -ScriptBlock {
-        Lock-PodeObject -ScriptBlock {
-            Write-PodeJsonResponse -Value $state:hash3
-        }
+        Write-PodeJsonResponse -Value $state:hash3
     }
 
     # route to remove the hashtable from global state
     Add-PodeRoute -Method Delete -Path '/array' -ScriptBlock {
-        Lock-PodeObject -ScriptBlock {
-            $hash = Set-PodeState -Name 'hash1' -Value @{} -Scope Scope0, Scope1
-            $hash.values = @()
-        }
+        $hash = Set-PodeState -Name 'hash1' -Value (New-PodeStateDictionary) -Scope Scope0, Scope1
+        $hash['values'] = New-PodeStateList
     }
 
 }

--- a/src/Pode.psd1
+++ b/src/Pode.psd1
@@ -66,6 +66,11 @@
         'Restore-PodeState',
         'Test-PodeState',
         'Get-PodeStateNames',
+        'New-PodeStateDictionary',
+        'New-PodeStateOrderedDictionary',
+        'New-PodeStateBag',
+        'New-PodeStateSet',
+        'New-PodeStateList',
 
         # response helpers
         'Set-PodeResponseAttachment',

--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -350,7 +350,7 @@ function New-PodeContext {
     $ctx.Server.InbuiltDrives = @{}
 
     # shared state between runspaces
-    $ctx.Server.State = @{}
+    $ctx.Server.State = New-PodeStateDictionary
 
     # setup caching
     $ctx.Server.Cache = @{

--- a/src/Private/ScopedVariables.ps1
+++ b/src/Private/ScopedVariables.ps1
@@ -76,7 +76,7 @@ function Add-PodeScopedVariableInbuiltSession {
 function Add-PodeScopedVariableInbuiltState {
     Add-PodeScopedVariable -Name 'state' `
         -SetReplace "Set-PodeState -Name '{{name}}' -Value " `
-        -GetReplace "`$PodeContext.Server.State.'{{name}}'.Value"
+        -GetReplace "`$PodeContext.Server.State['{{name}}'].Value"
 }
 
 function Add-PodeScopedVariableInbuiltUsing {

--- a/src/Private/State.ps1
+++ b/src/Private/State.ps1
@@ -1,0 +1,395 @@
+function ConvertTo-PodeStateData {
+    param(
+        [Parameter()]
+        [object]
+        $InputObject
+    )
+
+    # return null if no object
+    if ($null -eq $InputObject) {
+        return $null
+    }
+
+    # for date/times, return in ISO 8601 format
+    if ($InputObject -is [datetime]) {
+        return @{
+            Type  = 'DateTime'
+            Value = $InputObject.ToString('o')
+        }
+    }
+
+    # for time spans, return as ticks
+    if ($InputObject -is [timespan]) {
+        return @{
+            Type  = 'TimeSpan'
+            Value = $InputObject.Ticks
+        }
+    }
+
+    # for a guid, return as string
+    if ($InputObject -is [guid]) {
+        return @{
+            Type  = 'Guid'
+            Value = $InputObject.ToString()
+        }
+    }
+
+    # return raw object if it's a value type or string
+    if (($InputObject -is [valuetype]) -or ($InputObject -is [string])) {
+        return @{
+            Type  = $InputObject.GetType().Name
+            Value = $InputObject
+        }
+    }
+
+    # handle each key for hashtables, and dictionaries
+    if (
+        ($InputObject -is [hashtable]) -or
+        ($InputObject -is [System.Collections.Specialized.OrderedDictionary]) -or
+        ($InputObject -is [System.Collections.Generic.Dictionary[string, object]]) -or
+        ($InputObject -is [System.Collections.Concurrent.ConcurrentDictionary[string, object]]) -or
+        ($InputObject -is [Pode.Utilities.Structures.PodeConcurrentOrderedDictionary[string, object]])
+    ) {
+        $result = @{
+            Type  = ($InputObject.GetType().Name -split '`')[0]
+            Items = @()
+        }
+
+        foreach ($key in $InputObject.Keys) {
+            $result.Items += @{
+                Key   = $key
+                Value = ConvertTo-PodeStateData -InputObject $InputObject[$key]
+            }
+        }
+
+        return $result
+    }
+
+    # handle each item in lists, set, and bags
+    if (
+        ($InputObject -is [System.Collections.Generic.List[object]]) -or
+        ($InputObject -is [System.Collections.Generic.HashSet[object]]) -or
+        ($InputObject -is [System.Collections.Generic.SortedSet[object]]) -or
+        ($InputObject -is [System.Collections.Concurrent.ConcurrentBag[object]]) -or
+        ($InputObject -is [Pode.Utilities.Structures.PodeConcurrentList[object]]) -or
+        ($InputObject -is [Pode.Utilities.Structures.PodeConcurrentSet[object]])
+    ) {
+        $result = @{
+            Type  = ($InputObject.GetType().Name -split '`')[0]
+            Items = @()
+        }
+
+        foreach ($item in $InputObject) {
+            $result.Items += ConvertTo-PodeStateData -InputObject $item
+        }
+
+        return $result
+    }
+
+    # handle generic arrays / IEnumerable
+    if (($InputObject -is [array]) -or ($InputObject -is [System.Collections.IEnumerable])) {
+        if ($InputObject.Length -eq 0) {
+            return , @()
+        }
+
+        $items = @()
+        foreach ($item in $InputObject) {
+            $items += ConvertTo-PodeStateData -InputObject $item
+        }
+
+        return , $items
+    }
+
+    # handle PSCustomObject
+    if ($InputObject -is [PSCustomObject]) {
+        $result = @{
+            Type  = 'PSCustomObject'
+            Items = @()
+        }
+
+        foreach ($key in $InputObject.PSObject.Properties.Name) {
+            $result.Items += @{
+                Key   = $key
+                Value = ConvertTo-PodeStateData -InputObject $InputObject.$key
+            }
+        }
+
+        return $result
+    }
+
+    # return object as is
+    return $InputObject
+}
+
+function ConvertFrom-PodeStateJson {
+    param(
+        [Parameter()]
+        [pscustomobject]
+        $InputObject
+    )
+
+    # legacy version, convert to concurrent dictionary and return
+    if ($null -eq $InputObject.__pode_state_metadata__) {
+        $state = New-PodeStateDictionary
+
+        if ($InputObject -is [hashtable]) {
+            foreach ($key in $InputObject.Keys) {
+                $state[$key] = $InputObject[$key]
+            }
+        }
+        else {
+            foreach ($key in $InputObject.psobject.properties.name) {
+                $state[$key] = $InputObject.$key
+            }
+        }
+
+        return $state
+    }
+
+    # convert based on the version of the state file
+    switch ($InputObject.__pode_state_metadata__.Version) {
+        2 {
+            return ConvertFrom-PodeStateData -InputObject $InputObject.__pode_state_data__
+        }
+    }
+}
+
+function ConvertFrom-PodeStateData {
+    param(
+        [Parameter()]
+        [object]
+        $InputObject
+    )
+
+    # return null if no object
+    if ($null -eq $InputObject) {
+        return $null
+    }
+
+    # if it's not a pscustomobject, or doesn't contain a Type, handle raw types
+    if ([string]::IsNullOrEmpty($InputObject.Type) -or ($InputObject.Type.Count -gt 1)) {
+        # handle value types and strings
+        if (($InputObject -is [valuetype]) -or ($InputObject -is [string])) {
+            return $InputObject
+        }
+
+        # handle arrays
+        if (($InputObject -is [array]) -or ($InputObject -is [System.Collections.IEnumerable])) {
+            $items = @()
+
+            foreach ($item in $InputObject) {
+                $items += ConvertFrom-PodeStateData -InputObject $item
+            }
+
+            return , $items
+        }
+
+        # else return the object as is
+        return $InputObject
+    }
+
+    # convert based on the type of object
+    switch ($InputObject.Type) {
+        'DateTime' {
+            if ($InputObject.Value -is [datetime]) {
+                return $InputObject.Value
+            }
+            return [datetime]::Parse($InputObject.Value)
+        }
+
+        'TimeSpan' {
+            return [timespan]::FromTicks($InputObject.Value)
+        }
+
+        'Guid' {
+            return [guid]::Parse($InputObject.Value)
+        }
+
+        'Int32' {
+            return [int]$InputObject.Value
+        }
+
+        'Int64' {
+            return [long]$InputObject.Value
+        }
+
+        'Double' {
+            return [double]$InputObject.Value
+        }
+
+        'Decimal' {
+            return [decimal]$InputObject.Value
+        }
+
+        'Float' {
+            return [float]$InputObject.Value
+        }
+
+        'Boolean' {
+            return [bool]$InputObject.Value
+        }
+
+        'String' {
+            return [string]$InputObject.Value
+        }
+
+        'Char' {
+            return [char]$InputObject.Value
+        }
+
+        'Byte' {
+            return [byte]$InputObject.Value
+        }
+
+        'SByte' {
+            return [sbyte]$InputObject.Value
+        }
+
+        'UInt16' {
+            return [uint16]$InputObject.Value
+        }
+
+        'UInt32' {
+            return [uint32]$InputObject.Value
+        }
+
+        'UInt64' {
+            return [uint64]$InputObject.Value
+        }
+
+        'Single' {
+            return [single]$InputObject.Value
+        }
+
+        'Int16' {
+            return [int16]$InputObject.Value
+        }
+
+        'Hashtable' {
+            $result = @{}
+
+            foreach ($item in $InputObject.Items) {
+                $result[$item.Key] = ConvertFrom-PodeStateData -InputObject $item.Value
+            }
+
+            return $result
+        }
+
+        { $_ -iin @('OrderedDictionary', 'OrderedHashtable') } {
+            $result = [ordered]@{}
+
+            foreach ($item in $InputObject.Items) {
+                $result[$item.Key] = ConvertFrom-PodeStateData -InputObject $item.Value
+            }
+
+            return $result
+        }
+
+        'Dictionary' {
+            $result = [System.Collections.Generic.Dictionary[string, object]]::new()
+
+            foreach ($item in $InputObject.Items) {
+                $result[$item.Key] = ConvertFrom-PodeStateData -InputObject $item.Value
+            }
+
+            return $result
+        }
+
+        'ConcurrentDictionary' {
+            $result = [System.Collections.Concurrent.ConcurrentDictionary[string, object]]::new()
+
+            foreach ($item in $InputObject.Items) {
+                $result[$item.Key] = ConvertFrom-PodeStateData -InputObject $item.Value
+            }
+
+            return $result
+        }
+
+        'PodeConcurrentOrderedDictionary' {
+            $result = New-PodeStateDictionary
+
+            foreach ($item in $InputObject.Items) {
+                $result[$item.Key] = ConvertFrom-PodeStateData -InputObject $item.Value
+            }
+
+            return , $result
+        }
+
+        'List' {
+            $result = [System.Collections.Generic.List[object]]::new()
+
+            foreach ($item in $InputObject.Items) {
+                $null = $result.Add((ConvertFrom-PodeStateData -InputObject $item))
+            }
+
+            return , $result
+        }
+
+        'HashSet' {
+            $result = [System.Collections.Generic.HashSet[object]]::new()
+
+            foreach ($item in $InputObject.Items) {
+                $null = $result.Add((ConvertFrom-PodeStateData -InputObject $item))
+            }
+
+            return , $result
+        }
+
+        'SortedSet' {
+            $result = [System.Collections.Generic.SortedSet[object]]::new()
+
+            foreach ($item in $InputObject.Items) {
+                $null = $result.Add((ConvertFrom-PodeStateData -InputObject $item))
+            }
+
+            return , $result
+        }
+
+        'ConcurrentBag' {
+            $result = [System.Collections.Concurrent.ConcurrentBag[object]]::new()
+
+            foreach ($item in $InputObject.Items) {
+                $null = $result.TryAdd((ConvertFrom-PodeStateData -InputObject $item))
+            }
+
+            return , $result
+        }
+
+        'PodeConcurrentList' {
+            $result = New-PodeStateList
+
+            foreach ($item in $InputObject.Items) {
+                $null = $result.TryAdd((ConvertFrom-PodeStateData -InputObject $item))
+            }
+
+            return , $result
+        }
+
+        'PodeConcurrentSet' {
+            $result = New-PodeStateSet
+
+            foreach ($item in $InputObject.Items) {
+                $null = $result.TryAdd((ConvertFrom-PodeStateData -InputObject $item))
+            }
+
+            return , $result
+        }
+
+        'PSCustomObject' {
+            $result = [PSCustomObject]@{}
+
+            foreach ($item in $InputObject.Items) {
+                $null = $result | Add-Member -MemberType NoteProperty -Name $item.Key -Value (ConvertFrom-PodeStateData -InputObject $item.Value) -Force
+            }
+
+            return $result
+        }
+    }
+
+    # if we get here, return the object as is
+    if ($InputObject.Value) {
+        return $InputObject.Value
+    }
+
+    return $InputObject.Items
+}

--- a/src/Private/State.ps1
+++ b/src/Private/State.ps1
@@ -265,6 +265,16 @@ function ConvertFrom-PodeStateData {
             return [int16]$InputObject.Value
         }
 
+        'SyncHashtable' {
+            $result = [hashtable]::Synchronized(@{})
+
+            foreach ($item in $InputObject.Items) {
+                $result[$item.Key] = ConvertFrom-PodeStateData -InputObject $item.Value
+            }
+
+            return $result
+        }
+
         'Hashtable' {
             $result = @{}
 

--- a/src/Public/State.ps1
+++ b/src/Public/State.ps1
@@ -14,11 +14,17 @@ The value to set in the state.
 .PARAMETER Scope
 An optional Scope for the state object, used when saving the state.
 
-.EXAMPLE
-Set-PodeState -Name 'Data' -Value @{ 'Name' = 'Rick Sanchez' }
+.PARAMETER NoPassThru
+If supplied, the value that was set will not be returned.
 
 .EXAMPLE
-Set-PodeState -Name 'Users' -Value @('user1', 'user2') -Scope General, Users
+$value = Set-PodeState -Name 'Data' -Value @{ 'Name' = 'Rick Sanchez' }
+
+.EXAMPLE
+$value = Set-PodeState -Name 'Users' -Value @('user1', 'user2') -Scope General, Users
+
+.EXAMPLE
+Set-PodeState -Name 'Data' -Value @{ 'Name' = 'Rick Sanchez' } -NoPassThru
 #>
 function Set-PodeState {
     [CmdletBinding()]
@@ -34,7 +40,10 @@ function Set-PodeState {
 
         [Parameter()]
         [string[]]
-        $Scope
+        $Scope,
+
+        [switch]
+        $NoPassThru
     )
 
     begin {
@@ -62,12 +71,15 @@ function Set-PodeState {
             $Value = $pipelineValue
         }
 
-        $PodeContext.Server.State[$Name] = @{
-            Value = $Value
-            Scope = $Scope
-        }
+        # create state object
+        $PodeContext.Server.State[$Name] = New-PodeStateDictionary
+        $PodeContext.Server.State[$Name].Value = $Value
+        $PodeContext.Server.State[$Name].Scope = $Scope
 
-        return $Value
+        # return the value that was set
+        if (!$NoPassThru) {
+            return $Value
+        }
     }
 }
 
@@ -85,7 +97,7 @@ The name of the state object.
 If supplied, the state's value and scope will be returned as a hashtable.
 
 .EXAMPLE
-Get-PodeState -Name 'Data'
+$value = Get-PodeState -Name 'Data'
 #>
 function Get-PodeState {
     [CmdletBinding()]
@@ -106,9 +118,8 @@ function Get-PodeState {
     if ($WithScope) {
         return $PodeContext.Server.State[$Name]
     }
-    else {
-        return $PodeContext.Server.State[$Name].Value
-    }
+
+    return $PodeContext.Server.State[$Name].Value
 }
 
 <#
@@ -124,11 +135,20 @@ An optional regex Pattern to filter the state names.
 .PARAMETER Scope
 An optional Scope to filter the state names.
 
+.PARAMETER Exclude
+An optional array of state names to exclude from the result.
+
+.PARAMETER Include
+An optional array of state names to include in the result.
+
 .EXAMPLE
 $names = Get-PodeStateNames -Scope '<scope>'
 
 .EXAMPLE
 $names = Get-PodeStateNames -Pattern '^\w+[0-9]{0,2}$'
+
+.EXAMPLE
+$names = Get-PodeStateNames -Include 'Name1', 'Name2' -Exclude 'Name3'
 #>
 function Get-PodeStateNames {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '')]
@@ -140,7 +160,15 @@ function Get-PodeStateNames {
 
         [Parameter()]
         [string[]]
-        $Scope
+        $Scope,
+
+        [Parameter()]
+        [string[]]
+        $Exclude,
+
+        [Parameter()]
+        [string[]]
+        $Include
     )
 
     if ($null -eq $PodeContext.Server.State) {
@@ -152,17 +180,47 @@ function Get-PodeStateNames {
         $Scope = @()
     }
 
-    $tempState = $PodeContext.Server.State.Clone()
-    $keys = $tempState.Keys
+    # get the keys from the state
+    $keys = $PodeContext.Server.State.Keys
 
+    # filter by scope if supplied
     if ($Scope.Length -gt 0) {
         $keys = @(foreach ($key in $keys) {
-                if ($tempState[$key].Scope -iin $Scope) {
-                    $key
+                $value = $null
+                if ($PodeContext.Server.State.TryGetValue($key, [ref]$value)) {
+                    foreach ($_scope in $value.Scope) {
+                        if ($Scope -icontains $_scope) {
+                            $key
+                            break
+                        }
+                    }
                 }
             })
     }
 
+    # filter by include if supplied
+    if ($Include.Length -gt 0) {
+        $keys = @(foreach ($key in $keys) {
+                if ($Include -inotcontains $key) {
+                    continue
+                }
+
+                $key
+            })
+    }
+
+    # filter by exclude if supplied
+    if ($Exclude.Length -gt 0) {
+        $keys = @(foreach ($key in $keys) {
+                if ($Exclude -icontains $key) {
+                    continue
+                }
+
+                $key
+            })
+    }
+
+    # filter by pattern if supplied
     if (![string]::IsNullOrWhiteSpace($Pattern)) {
         $keys = @(foreach ($key in $keys) {
                 if ($key -imatch $Pattern) {
@@ -184,8 +242,14 @@ Removes some state object from the shared state. After removal, the original obj
 .PARAMETER Name
 The name of the state object.
 
+.PARAMETER NoPassThru
+If supplied, the removed state object will not be returned.
+
 .EXAMPLE
-Remove-PodeState -Name 'Data'
+$value = Remove-PodeState -Name 'Data'
+
+.EXAMPLE
+Remove-PodeState -Name 'Data' -NoPassThru
 #>
 function Remove-PodeState {
     [CmdletBinding()]
@@ -193,7 +257,10 @@ function Remove-PodeState {
     param(
         [Parameter(Mandatory = $true)]
         [string]
-        $Name
+        $Name,
+
+        [switch]
+        $NoPassThru
     )
 
     if ($null -eq $PodeContext.Server.State) {
@@ -201,9 +268,14 @@ function Remove-PodeState {
         throw ($PodeLocale.podeNotInitializedExceptionMessage)
     }
 
-    $value = $PodeContext.Server.State[$Name].Value
-    $null = $PodeContext.Server.State.Remove($Name)
-    return $value
+    $item = $null
+    if (!$PodeContext.Server.State.TryRemove($Name, [ref]$item)) {
+        return $null
+    }
+
+    if (!$NoPassThru) {
+        return $item.Value
+    }
 }
 
 <#
@@ -226,7 +298,7 @@ An optional array of state object names to exclude from being saved. (This has a
 An optional array of state object names to only include when being saved.
 
 .PARAMETER Depth
-Saved JSON maximum depth. Will be passed to ConvertTo-JSON's -Depth parameter. Default is 10.
+Saved JSON maximum depth. Will be passed to ConvertTo-JSON's -Depth parameter. Default is 20.
 
 .PARAMETER Compress
 If supplied, the saved JSON will be compressed.
@@ -261,7 +333,7 @@ function Save-PodeState {
 
         [Parameter()]
         [int16]
-        $Depth = 10,
+        $Depth = 20,
 
         [switch]
         $Compress
@@ -276,57 +348,32 @@ function Save-PodeState {
     # get the full path to save the state
     $Path = Get-PodeRelativePath -Path $Path -JoinRoot
 
-    # contruct the state to save (excludes, etc)
-    $state = $PodeContext.Server.State.Clone()
+    # which keys in the state do we need to save?
+    $keys = Get-PodeStateNames -Scope $Scope -Exclude $Exclude -Include $Include
 
-    # scopes
-    if (($null -ne $Scope) -and ($Scope.Length -gt 0)) {
-        foreach ($_key in $state.Clone().Keys) {
-            # remove if no scope
-            if (($null -eq $state[$_key].Scope) -or ($state[$_key].Scope.Length -eq 0)) {
-                $null = $state.Remove($_key)
-                continue
-            }
-
-            # check scopes (only remove if none match)
-            $found = $false
-
-            foreach ($_scope in $state[$_key].Scope) {
-                if ($Scope -icontains $_scope) {
-                    $found = $true
-                    break
-                }
-            }
-
-            if ($found) {
-                continue
-            }
-
-            # none matched, remove
-            $null = $state.Remove($_key)
-        }
-    }
-
-    # include keys
-    if (($null -ne $Include) -and ($Include.Length -gt 0)) {
-        foreach ($_key in $state.Clone().Keys) {
-            if ($Include -inotcontains $_key) {
-                $null = $state.Remove($_key)
-            }
-        }
-    }
-
-    # exclude keys
-    if (($null -ne $Exclude) -and ($Exclude.Length -gt 0)) {
-        foreach ($_key in $state.Clone().Keys) {
-            if ($Exclude -icontains $_key) {
-                $null = $state.Remove($_key)
-            }
+    # create a clone of the state, using only the keys we want to save
+    $state = New-PodeStateDictionary
+    foreach ($key in $keys) {
+        $value = $null
+        if ($PodeContext.Server.State.TryGetValue($key, [ref]$value)) {
+            $state[$key] = $value
         }
     }
 
     # save the state
-    $null = ConvertTo-Json -InputObject $state -Depth $Depth -Compress:$Compress | Out-File -FilePath $Path -Force
+    $result = @{
+        '__pode_state_metadata__' = @{
+            Version   = 2
+            Timestamp = [DateTime]::UtcNow.ToString('yyyy-MM-ddTHH:mm:ss.fffZ')
+        }
+        '__pode_state_data__'     = ConvertTo-PodeStateData -InputObject $state
+    }
+
+    $null = $result |
+        ConvertTo-Json -Depth $Depth -Compress:$Compress |
+        Out-File -FilePath $Path -Force
+
+    $state = $null
 }
 
 <#
@@ -343,7 +390,7 @@ The path to a JSON file that contains the state information.
 If supplied, the state loaded from the JSON file will be merged with the current state, instead of overwriting it.
 
 .PARAMETER Depth
-Saved JSON maximum depth. Will be passed to ConvertFrom-JSON's -Depth parameter (Powershell >=6). Default is 10.
+Saved JSON maximum depth. Will be passed to ConvertFrom-JSON's -Depth parameter (Powershell >=6). Default is 20.
 
 .EXAMPLE
 Restore-PodeState -Path './state.json'
@@ -359,7 +406,7 @@ function Restore-PodeState {
         $Merge,
 
         [int16]
-        $Depth = 10
+        $Depth = 20
     )
 
     # error if attempting to use outside of the pode server
@@ -374,45 +421,36 @@ function Restore-PodeState {
         return
     }
 
-    # restore the state from file
-    $state = @{}
-
+    # load the json state from file
+    $params = @{}
     if (Test-PodeIsPSCore) {
-        $state = (Get-Content $Path -Force | ConvertFrom-Json -AsHashtable -Depth $Depth)
+        $params['AsHashtable'] = $true
+        $params['Depth'] = $Depth
     }
-    else {
-        $props = (Get-Content $Path -Force | ConvertFrom-Json).psobject.properties
-        foreach ($prop in $props) {
-            $state[$prop.Name] = $prop.Value
-        }
+
+    $content = Get-Content -Path $Path -Force | ConvertFrom-Json @params
+    if ([string]::IsNullOrEmpty($content)) {
+        return
     }
+
+    # convert into a concurrent dictionary based on the version of the state file
+    $state = ConvertFrom-PodeStateJson -InputObject $content
 
     # check for no scopes, and add for backwards compat
-    $convert = $false
-    foreach ($_key in $state.Clone().Keys) {
+    foreach ($_key in $state.Keys) {
         if ($null -eq $state[$_key].Scope) {
-            $convert = $true
-            break
-        }
-    }
-
-    if ($convert) {
-        foreach ($_key in $state.Clone().Keys) {
-            $state[$_key] = @{
-                Value = $state[$_key]
-                Scope = @()
-            }
+            $state[$_key].Scope = @()
         }
     }
 
     # set the scope to the main context
     if ($Merge) {
-        foreach ($_key in $state.Clone().Keys) {
+        foreach ($_key in $state.Keys) {
             $PodeContext.Server.State[$_key] = $state[$_key]
         }
     }
     else {
-        $PodeContext.Server.State = $state.Clone()
+        $PodeContext.Server.State = $state
     }
 }
 
@@ -444,4 +482,205 @@ function Test-PodeState {
     }
 
     return $PodeContext.Server.State.ContainsKey($Name)
+}
+
+<#
+.SYNOPSIS
+Creates a new concurrent dictionary for use in the shared state.
+
+.DESCRIPTION
+Creates a new concurrent dictionary for use in the shared state. This is useful for storing key-value pairs in a thread-safe manner.
+
+.PARAMETER Data
+An optional hashtable of initial key-value pairs to populate the dictionary.
+
+.EXAMPLE
+Set-PodeState -Name 'MyDictionary' -Value (New-PodeStateDictionary)
+
+.EXAMPLE
+Set-PodeState -Name 'MyDictionary' -Value (New-PodeStateDictionary -Data @{ 'Key1' = 'Value1'; 'Key2' = 'Value2' })
+#>
+function New-PodeStateDictionary {
+    [CmdletBinding()]
+    [OutputType([System.Collections.Concurrent.ConcurrentDictionary[string, object]])]
+    param(
+        [Parameter()]
+        [hashtable]
+        $Data
+    )
+
+    $dict = [System.Collections.Concurrent.ConcurrentDictionary[string, object]]::new([StringComparer]::InvariantCultureIgnoreCase)
+    if (($null -eq $Data) -or ($Data.Count -eq 0)) {
+        return $dict
+    }
+
+    foreach ($key in $Data.Keys) {
+        $dict[$key] = $Data[$key]
+    }
+
+    return $dict
+}
+
+<#
+.SYNOPSIS
+Creates a new concurrent ordered dictionary for use in the shared state.
+
+.DESCRIPTION
+Creates a new concurrent ordered dictionary for use in the shared state. This is useful for storing key-value pairs in a thread-safe manner while maintaining the order of insertion.
+
+.PARAMETER Data
+An optional hashtable of initial key-value pairs to populate the ordered dictionary.
+
+.EXAMPLE
+Set-PodeState -Name 'MyOrderedDictionary' -Value (New-PodeStateOrderedDictionary)
+
+.EXAMPLE
+Set-PodeState -Name 'MyOrderedDictionary' -Value (New-PodeStateOrderedDictionary -Data @{ 'Key1' = 'Value1'; 'Key2' = 'Value2' })
+
+.NOTES
+This uses a custom concurrent ordered dictionary implementation to ensure thread safety and maintain order of insertion.
+The PodeConcurrentOrderedDictionary class is defined in the Pode.Utilities.Structures namespace.
+#>
+function New-PodeStateOrderedDictionary {
+    [CmdletBinding()]
+    [OutputType([Pode.Utilities.Structures.PodeConcurrentOrderedDictionary[string, object]])]
+    [OutputType([System.Object[]])]
+    param(
+        [Parameter()]
+        [hashtable]
+        $Data
+    )
+
+    $dict = [Pode.Utilities.Structures.PodeConcurrentOrderedDictionary[string, object]]::new()
+    if (($null -eq $Data) -or ($Data.Count -eq 0)) {
+        return , $dict
+    }
+
+    foreach ($key in $Data.Keys) {
+        $dict[$key] = $Data[$key]
+    }
+
+    return , $dict
+}
+
+<#
+.SYNOPSIS
+Creates a new concurrent bag for use in the shared state.
+
+.DESCRIPTION
+Creates a new concurrent bag for use in the shared state. This is useful for storing a collection of objects in a thread-safe manner.
+
+.PARAMETER Data
+An optional array of initial objects to populate the bag.
+
+.EXAMPLE
+Set-PodeState -Name 'MyBag' -Value (New-PodeStateBag)
+
+.EXAMPLE
+Set-PodeState -Name 'MyBag' -Value (New-PodeStateBag -Data @(1, 2, 3))
+#>
+function New-PodeStateBag {
+    [CmdletBinding()]
+    [OutputType([System.Collections.Concurrent.ConcurrentBag[object]])]
+    [OutputType([System.Object[]])]
+    param(
+        [Parameter()]
+        [object[]]
+        $Data
+    )
+
+    $bag = [System.Collections.Concurrent.ConcurrentBag[object]]::new()
+    if (($null -eq $Data) -or ($Data.Count -eq 0)) {
+        return , $bag
+    }
+
+    foreach ($item in $Data) {
+        $null = $bag.Add($item)
+    }
+
+    return , $bag
+}
+
+<#
+.SYNOPSIS
+Creates a new concurrent hash set for use in the shared state.
+
+.DESCRIPTION
+Creates a new concurrent hash set for use in the shared state. This is useful for storing a collection of unique objects in a thread-safe manner.
+
+.PARAMETER Data
+An optional array of initial objects to populate the hash set.
+
+.EXAMPLE
+Set-PodeState -Name 'MySet' -Value (New-PodeStateSet)
+
+.EXAMPLE
+Set-PodeState -Name 'MySet' -Value (New-PodeStateSet -Data @('Item1', 'Item2', 'Item3'))
+
+.NOTES
+This uses a custom concurrent set implementation to ensure thread safety and uniqueness of items.
+The PodeConcurrentSet class is defined in the Pode.Utilities.Structures namespace.
+#>
+function New-PodeStateSet {
+    [CmdletBinding()]
+    [OutputType([Pode.Utilities.Structures.PodeConcurrentSet[object]])]
+    [OutputType([System.Object[]])]
+    param(
+        [Parameter()]
+        [object[]]
+        $Data
+    )
+
+    $set = [Pode.Utilities.Structures.PodeConcurrentSet[object]]::new()
+    if (($null -eq $Data) -or ($Data.Count -eq 0)) {
+        return , $set
+    }
+
+    foreach ($item in $Data) {
+        $null = $set.TryAdd($item)
+    }
+
+    return , $set
+}
+
+<#
+.SYNOPSIS
+Creates a new concurrent list for use in the shared state.
+
+.DESCRIPTION
+Creates a new concurrent list for use in the shared state. This is useful for storing a collection of objects in a thread-safe manner while maintaining the order of insertion.
+
+.PARAMETER Data
+An optional array of initial objects to populate the list.
+
+.EXAMPLE
+Set-PodeState -Name 'MyList' -Value (New-PodeStateList)
+
+.EXAMPLE
+Set-PodeState -Name 'MyList' -Value (New-PodeStateList -Data @('Item1', 'Item2'))
+
+.NOTES
+This uses a custom concurrent list implementation to ensure thread safety and maintain order of insertion.
+The PodeConcurrentList class is defined in the Pode.Utilities.Structures namespace.
+#>
+function New-PodeStateList {
+    [CmdletBinding()]
+    [OutputType([Pode.Utilities.Structures.PodeConcurrentList[object]])]
+    [OutputType([System.Object[]])]
+    param(
+        [Parameter()]
+        [object[]]
+        $Data
+    )
+
+    $list = [Pode.Utilities.Structures.PodeConcurrentList[object]]::new()
+    if (($null -eq $Data) -or ($Data.Count -eq 0)) {
+        return , $list
+    }
+
+    foreach ($item in $Data) {
+        $null = $list.Add($item)
+    }
+
+    return , $list
 }

--- a/src/Public/State.ps1
+++ b/src/Public/State.ps1
@@ -439,7 +439,10 @@ function Restore-PodeState {
     # check for no scopes, and add for backwards compat
     foreach ($_key in $state.Keys) {
         if ($null -eq $state[$_key].Scope) {
-            $state[$_key].Scope = @()
+            $state[$_key] = @{
+                Value = $state[$_key]
+                Scope = @()
+            }
         }
     }
 

--- a/src/Public/State.ps1
+++ b/src/Public/State.ps1
@@ -72,9 +72,10 @@ function Set-PodeState {
         }
 
         # create state object
-        $PodeContext.Server.State[$Name] = New-PodeStateDictionary
-        $PodeContext.Server.State[$Name].Value = $Value
-        $PodeContext.Server.State[$Name].Scope = $Scope
+        $PodeContext.Server.State[$Name] = New-PodeStateDictionary -Data @{
+            Value = $Value
+            Scope = $Scope
+        }
 
         # return the value that was set
         if (!$NoPassThru) {

--- a/tests/unit/State.Tests.ps1
+++ b/tests/unit/State.Tests.ps1
@@ -13,7 +13,10 @@ InModuleScope -ModuleName 'Pode' {
         }
 
         It 'Sets and returns an object' {
-            $PodeContext.Server = @{ 'State' = @{} }
+            $PodeContext.Server = @{
+                State = [System.Collections.Concurrent.ConcurrentDictionary[string, object]]::new([StringComparer]::InvariantCultureIgnoreCase)
+            }
+
             $result = Set-PodeState -Name 'test' -Value 7
 
             $result | Should -Be 7
@@ -22,7 +25,10 @@ InModuleScope -ModuleName 'Pode' {
         }
 
         It 'Sets by pipe and returns an object array' {
-            $PodeContext.Server = @{ 'State' = @{} }
+            $PodeContext.Server = @{
+                State = [System.Collections.Concurrent.ConcurrentDictionary[string, object]]::new([StringComparer]::InvariantCultureIgnoreCase)
+            }
+
             $result = @(7, 3, 4) | Set-PodeState -Name 'test'
 
             $result | Should -Be @(7, 3, 4)
@@ -38,7 +44,10 @@ InModuleScope -ModuleName 'Pode' {
         }
 
         It 'Gets an object from the state' {
-            $PodeContext.Server = @{ 'State' = @{} }
+            $PodeContext.Server = @{
+                State = [System.Collections.Concurrent.ConcurrentDictionary[string, object]]::new([StringComparer]::InvariantCultureIgnoreCase)
+            }
+
             Set-PodeState -Name 'test' -Value 8
             Get-PodeState -Name 'test' | Should -Be 8
         }
@@ -51,7 +60,10 @@ InModuleScope -ModuleName 'Pode' {
         }
 
         It 'Removes an object from the state' {
-            $PodeContext.Server = @{ 'State' = @{} }
+            $PodeContext.Server = @{
+                State = [System.Collections.Concurrent.ConcurrentDictionary[string, object]]::new([StringComparer]::InvariantCultureIgnoreCase)
+            }
+
             Set-PodeState -Name 'test' -Value 8
             Remove-PodeState -Name 'test' | Should -Be 8
             $PodeContext.Server.State['test'] | Should -Be $null
@@ -68,7 +80,10 @@ InModuleScope -ModuleName 'Pode' {
             Mock Get-PodeRelativePath { return $Path }
             Mock Out-File {}
 
-            $PodeContext.Server = @{ 'State' = @{} }
+            $PodeContext.Server = @{
+                State = [System.Collections.Concurrent.ConcurrentDictionary[string, object]]::new([StringComparer]::InvariantCultureIgnoreCase)
+            }
+
             Set-PodeState -Name 'test' -Value 8
             Save-PodeState -Path './state.json'
 
@@ -79,7 +94,10 @@ InModuleScope -ModuleName 'Pode' {
             Mock Get-PodeRelativePath { return $Path }
             Mock Out-File {}
 
-            $PodeContext.Server = @{ 'State' = @{} }
+            $PodeContext.Server = @{
+                State = [System.Collections.Concurrent.ConcurrentDictionary[string, object]]::new([StringComparer]::InvariantCultureIgnoreCase)
+            }
+
             Set-PodeState -Name 'test' -Value 8
             Save-PodeState -Path './state.json' -Include 'test'
 
@@ -90,7 +108,10 @@ InModuleScope -ModuleName 'Pode' {
             Mock Get-PodeRelativePath { return $Path }
             Mock Out-File {}
 
-            $PodeContext.Server = @{ 'State' = @{} }
+            $PodeContext.Server = @{
+                State = [System.Collections.Concurrent.ConcurrentDictionary[string, object]]::new([StringComparer]::InvariantCultureIgnoreCase)
+            }
+
             Set-PodeState -Name 'test' -Value 8
             Save-PodeState -Path './state.json' -Exclude 'test'
 
@@ -107,9 +128,12 @@ InModuleScope -ModuleName 'Pode' {
         It 'Restores the state from file' {
             Mock Get-PodeRelativePath { return $Path }
             Mock Test-Path { return $true }
-            Mock Get-Content { return '{ "Name": "Morty" }' }
+            Mock Get-Content { return @{ Name = @{ Value = 'Morty' } } | ConvertTo-Json -Compress }
 
-            $PodeContext.Server = @{ 'State' = @{} }
+            $PodeContext.Server = @{
+                State = [System.Collections.Concurrent.ConcurrentDictionary[string, object]]::new([StringComparer]::InvariantCultureIgnoreCase)
+            }
+
             Restore-PodeState -Path './state.json'
             Get-PodeState -Name 'Name' | Should -Be 'Morty'
         }
@@ -122,13 +146,19 @@ InModuleScope -ModuleName 'Pode' {
         }
 
         It 'Returns true for an object being in the state' {
-            $PodeContext.Server = @{ 'State' = @{} }
+            $PodeContext.Server = @{
+                State = [System.Collections.Concurrent.ConcurrentDictionary[string, object]]::new([StringComparer]::InvariantCultureIgnoreCase)
+            }
+
             Set-PodeState -Name 'test' -Value 8
             Test-PodeState -Name 'test' | Should -Be $true
         }
 
         It 'Returns false for an object not being in the state' {
-            $PodeContext.Server = @{ 'State' = @{} }
+            $PodeContext.Server = @{
+                State = [System.Collections.Concurrent.ConcurrentDictionary[string, object]]::new([StringComparer]::InvariantCultureIgnoreCase)
+            }
+
             Set-PodeState -Name 'test' -Value 8
             Test-PodeState -Name 'tests' | Should -Be $false
         }

--- a/tests/unit/State.Tests.ps1
+++ b/tests/unit/State.Tests.ps1
@@ -128,7 +128,7 @@ InModuleScope -ModuleName 'Pode' {
         It 'Restores the state from file' {
             Mock Get-PodeRelativePath { return $Path }
             Mock Test-Path { return $true }
-            Mock Get-Content { return @{ Name = @{ Value = 'Morty' } } | ConvertTo-Json -Compress }
+            Mock Get-Content { return @{ Name = 'Morty' } | ConvertTo-Json -Compress }
 
             $PodeContext.Server = @{
                 State = [System.Collections.Concurrent.ConcurrentDictionary[string, object]]::new([StringComparer]::InvariantCultureIgnoreCase)


### PR DESCRIPTION
### Description of the Change
State management has always been a standard Hashtable, which isn't thread-safe - and it's recommended to use `Lock-PodeObject`.

This PR converts the State to a ConcurrentDictionary, and adds helper functions for creating other concurrent/thread-safe data structures; such as lists, bags, set, etc.

Set, Get, Save, and Restore are all now more thread-safe - reducing the need for `Lock-PodeObject`. Furthermore, any prior states restored will be automatically converted into a ConcurrentDictionary.

The State's saved JSON object has been expired, to save the actual type being saved - so the true type is restored.