### PR TITLE
Enhances the following to be more thread-safe: Sessions, Tasks, Schedules, and Cache

### DIFF
--- a/src/Private/Caching.ps1
+++ b/src/Private/Caching.ps1
@@ -44,11 +44,11 @@ function Set-PodeCacheInternal {
     )
 
     # crete (or update) value value
-    $PodeContext.Server.Cache.Items[$Key] = @{
-        Value  = $InputObject
-        Ttl    = $Ttl
-        Expiry = [datetime]::UtcNow.AddSeconds($Ttl)
-    }
+    $PodeContext.Server.Cache.Items[$Key] = [hashtable]::Synchronized(@{
+            Value  = $InputObject
+            Ttl    = $Ttl
+            Expiry = [datetime]::UtcNow.AddSeconds($Ttl)
+        })
 }
 
 function Test-PodeCacheInternal {
@@ -83,15 +83,11 @@ function Remove-PodeCacheInternal {
         $Key
     )
 
-    Lock-PodeObject -Object $PodeContext.Threading.Lockables.Cache -ScriptBlock {
-        $null = $PodeContext.Server.Cache.Items.Remove($Key)
-    }
+    $null = $PodeContext.Server.Cache.Items.Remove($Key)
 }
 
 function Clear-PodeCacheInternal {
-    Lock-PodeObject -Object $PodeContext.Threading.Lockables.Cache -ScriptBlock {
-        $null = $PodeContext.Server.Cache.Items.Clear()
-    }
+    $null = $PodeContext.Server.Cache.Items.Clear()
 }
 
 function Start-PodeCacheHousekeeper {
@@ -101,14 +97,7 @@ function Start-PodeCacheHousekeeper {
     }
 
     Add-PodeTimer -Name '__pode_cache_housekeeper__' -Interval 10 -ScriptBlock {
-        $keys = Lock-PodeObject -Object $PodeContext.Threading.Lockables.Cache -Return -ScriptBlock {
-            if ($PodeContext.Server.Cache.Items.Count -eq 0) {
-                return
-            }
-
-            return $PodeContext.Server.Cache.Items.Keys.Clone()
-        }
-
+        $keys = $PodeContext.Server.Cache.Items.Keys
         if (Test-PodeIsEmpty $keys) {
             return
         }

--- a/src/Private/Context.ps1
+++ b/src/Private/Context.ps1
@@ -125,14 +125,14 @@ function New-PodeContext {
 
     $ctx.Schedules = @{
         Enabled   = ($EnablePool -icontains 'schedules')
-        Items     = @{}
-        Processes = @{}
+        Items     = [hashtable]::Synchronized(@{})
+        Processes = [hashtable]::Synchronized(@{})
     }
 
     $ctx.Tasks = @{
         Enabled   = ($EnablePool -icontains 'tasks')
-        Items     = @{}
-        Processes = @{}
+        Items     = [hashtable]::Synchronized(@{})
+        Processes = [hashtable]::Synchronized(@{})
     }
 
     $ctx.Fim = @{
@@ -354,7 +354,7 @@ function New-PodeContext {
 
     # setup caching
     $ctx.Server.Cache = @{
-        Items          = @{}
+        Items          = [hashtable]::Synchronized(@{})
         Storage        = @{}
         DefaultStorage = $null
         DefaultTtl     = 3600 # 1hr
@@ -506,11 +506,11 @@ function New-PodeContext {
     $ctx.Threading.Lockables = @{
         Global = [hashtable]::Synchronized(@{})
         Cache  = [hashtable]::Synchronized(@{})
-        Custom = @{}
+        Custom = [hashtable]::Synchronized(@{})
     }
 
-    $ctx.Threading.Mutexes = @{}
-    $ctx.Threading.Semaphores = @{}
+    $ctx.Threading.Mutexes = [hashtable]::Synchronized(@{})
+    $ctx.Threading.Semaphores = [hashtable]::Synchronized(@{})
 
     # setup runspaces
     $ctx.Runspaces = @()

--- a/src/Private/Limit.ps1
+++ b/src/Private/Limit.ps1
@@ -21,7 +21,7 @@ function Add-PodeLimitRateTimer {
                     continue
                 }
 
-                foreach ($key in $rule.Active.Keys.Clone()) {
+                foreach ($key in $rule.Active.Keys) {
                     try {
                         $item = $rule.Active[$key]
 

--- a/src/Private/Schedules.ps1
+++ b/src/Private/Schedules.ps1
@@ -26,9 +26,12 @@ function Start-PodeScheduleRunspace {
 
             $now = [datetime]::UtcNow
 
-            foreach ($key in $PodeContext.Schedules.Processes.Keys.Clone()) {
+            foreach ($key in $PodeContext.Schedules.Processes.Keys) {
                 try {
                     $process = $PodeContext.Schedules.Processes[$key]
+                    if ($null -eq $process) {
+                        continue
+                    }
 
                     # if it's completed or expired, dispose and remove
                     if ($process.Runspace.Handler.IsCompleted -or ($process.ExpireTime -lt $now)) {

--- a/src/Private/Sessions.ps1
+++ b/src/Private/Sessions.ps1
@@ -16,7 +16,7 @@ function New-PodeSession {
         FullId    = (Get-PodeSessionFullId -SessionId $sessionId -TabId $tabId)
         Extend    = $PodeContext.Server.Sessions.Info.Extend
         TimeStamp = [datetime]::UtcNow
-        Data      = @{}
+        Data      = [hashtable]::Synchronized(@{})
     }
 }
 
@@ -117,7 +117,7 @@ function Get-PodeSession {
         FullId    = (Get-PodeSessionFullId -SessionId $sessionId -TabId $tabId)
         Extend    = $PodeContext.Server.Sessions.Info.Extend
         TimeStamp = $null
-        Data      = @{}
+        Data      = [hashtable]::Synchronized(@{})
     }
 }
 
@@ -143,10 +143,10 @@ function Set-PodeSessionDataHash {
     }
 
     if (($null -eq $WebEvent.Session.Data) -or ($WebEvent.Session.Data.Count -eq 0)) {
-        $WebEvent.Session.Data = @{}
+        $WebEvent.Session.Data = [hashtable]::Synchronized(@{})
     }
 
-    $WebEvent.Session.DataHash = (Invoke-PodeSHA256Hash -Value (ConvertTo-Json -InputObject $WebEvent.Session.Data.Clone() -Depth 10 -Compress))
+    $WebEvent.Session.DataHash = Invoke-PodeSHA256Hash -Value (ConvertTo-Json -InputObject $WebEvent.Session.Data -Depth 10 -Compress)
 }
 
 function Test-PodeSessionDataHash {
@@ -159,11 +159,11 @@ function Test-PodeSessionDataHash {
     }
 
     if (($null -eq $WebEvent.Session.Data) -or ($WebEvent.Session.Data.Count -eq 0)) {
-        $WebEvent.Session.Data = @{}
+        $WebEvent.Session.Data = [hashtable]::Synchronized(@{})
     }
 
-    $hash = (Invoke-PodeSHA256Hash -Value (ConvertTo-Json -InputObject $WebEvent.Session.Data -Depth 10 -Compress))
-    return ($WebEvent.Session.DataHash -eq $hash)
+    $hash = Invoke-PodeSHA256Hash -Value (ConvertTo-Json -InputObject $WebEvent.Session.Data -Depth 10 -Compress)
+    return $WebEvent.Session.DataHash -eq $hash
 }
 
 function Save-PodeSessionInternal {
@@ -186,26 +186,26 @@ function Save-PodeSessionInternal {
     $expiry = Get-PodeSessionExpiry
 
     # the data to save - which will be the data, and some extra metadata like timestamp
-    $data = @{
-        Version  = 3
-        Metadata = @{
-            TimeStamp = $WebEvent.Session.TimeStamp
-        }
-        Data     = $WebEvent.Session.Data
-    }
-
-    # save base session data to store
-    if (!$PodeContext.Server.Sessions.Info.Scope.IsBrowser -and $WebEvent.Session.TabId) {
-        $authData = @{
+    $data = [hashtable]::Synchronized(@{
             Version  = 3
             Metadata = @{
                 TimeStamp = $WebEvent.Session.TimeStamp
-                Tabbed    = $true
             }
-            Data     = @{
-                Auth = $WebEvent.Session.Data.Auth
-            }
-        }
+            Data     = $WebEvent.Session.Data
+        })
+
+    # save base session data to store
+    if (!$PodeContext.Server.Sessions.Info.Scope.IsBrowser -and $WebEvent.Session.TabId) {
+        $authData = [hashtable]::Synchronized(@{
+                Version  = 3
+                Metadata = @{
+                    TimeStamp = $WebEvent.Session.TimeStamp
+                    Tabbed    = $true
+                }
+                Data     = @{
+                    Auth = $WebEvent.Session.Data.Auth
+                }
+            })
 
         $null = Invoke-PodeScriptBlock -ScriptBlock $PodeContext.Server.Sessions.Store.Set -Arguments @($WebEvent.Session.Id, $authData, $expiry) -Splat
         $data.Metadata['Parent'] = $WebEvent.Session.Id
@@ -235,7 +235,7 @@ function Get-PodeSessionInMemStore {
     $store = [psobject]::new()
 
     # add in-mem storage
-    $store | Add-Member -MemberType NoteProperty -Name Memory -Value @{}
+    $store | Add-Member -MemberType NoteProperty -Name Memory -Value ([hashtable]::Synchronized(@{}))
 
     # delete a sessionId and data
     $store | Add-Member -MemberType NoteProperty -Name Delete -Value {
@@ -265,10 +265,10 @@ function Get-PodeSessionInMemStore {
     $store | Add-Member -MemberType NoteProperty -Name Set -Value {
         param($sessionId, $data, $expiry)
 
-        $PodeContext.Server.Sessions.Store.Memory[$sessionId] = @{
-            Data   = $data
-            Expiry = $expiry
-        }
+        $PodeContext.Server.Sessions.Store.Memory[$sessionId] = [hashtable]::Synchronized(@{
+                Data   = $data
+                Expiry = $expiry
+            })
     }
 
     return $store
@@ -290,7 +290,7 @@ function Set-PodeSessionInMemClearDown {
 
         # remove sessions that have expired, or where the parent is gone
         $now = [DateTime]::UtcNow
-        foreach ($key in $store.Memory.Keys.Clone()) {
+        foreach ($key in $store.Memory.Keys) {
             # expired
             if ($store.Memory[$key].Expiry -lt $now) {
                 $null = $store.Memory.Remove($key)

--- a/src/Private/Tasks.ps1
+++ b/src/Private/Tasks.ps1
@@ -18,10 +18,15 @@ function Start-PodeTaskHousekeeper {
             $now = [datetime]::UtcNow
 
             # loop through each process
-            foreach ($key in $PodeContext.Tasks.Processes.Keys.Clone()) {
+            foreach ($key in $PodeContext.Tasks.Processes.Keys) {
                 try {
-                    # get the process and the task
+                    # get the process
                     $process = $PodeContext.Tasks.Processes[$key]
+                    if ($null -eq $process) {
+                        continue
+                    }
+
+                    # get the task
                     $task = $PodeContext.Tasks.Items[$process.Task]
 
                     # if completed, and no completed time set, then set one and continue

--- a/src/Public/Threading.ps1
+++ b/src/Public/Threading.ps1
@@ -384,7 +384,7 @@ function Clear-PodeLockables {
         return
     }
 
-    foreach ($name in $PodeContext.Threading.Lockables.Custom.Keys.Clone()) {
+    foreach ($name in $PodeContext.Threading.Lockables.Custom.Keys) {
         Remove-PodeLockable -Name $name
     }
 }
@@ -676,7 +676,7 @@ function Clear-PodeMutexes {
         return
     }
 
-    foreach ($name in $PodeContext.Threading.Mutexes.Keys.Clone()) {
+    foreach ($name in $PodeContext.Threading.Mutexes.Keys) {
         Remove-PodeMutex -Name $name
     }
 }
@@ -990,7 +990,7 @@ function Clear-PodeSemaphores {
         return
     }
 
-    foreach ($name in $PodeContext.Threading.Semaphores.Keys.Clone()) {
+    foreach ($name in $PodeContext.Threading.Semaphores.Keys) {
         Remove-PodeSemaphore -Name $name
     }
 }


### PR DESCRIPTION
### Description of the Change
This changes the following features to use `[hashtable]::Synchronized(@{})`, instead of an ordinary hashtable, so they are more thread-safe:

* Sessions
* Tasks
* Schedules
* Cache

Also tweaked are threading features such as: Mutexes, Semaphores, and Lockables.

Due to this, I've been able to remove some of the internal `Lock-PodeObject` and `.Clone()` calls.

### Related Issue
Resolves #1657 
