### PR TITLE
Fix to accept repeated HTTP request header fields

### DIFF
--- a/src/Listener/Protocols/Http/PodeHttpRequestStrategy.cs
+++ b/src/Listener/Protocols/Http/PodeHttpRequestStrategy.cs
@@ -309,7 +309,14 @@ namespace Pode.Protocols.Http
                 {
                     h_name = h_line.Substring(0, h_index).Trim();
                     h_value = h_line.Substring(h_index + 1).Trim();
-                    Headers.Add(h_name, h_value);
+                    if (Headers.ContainsKey(h_name))
+                    {
+                        Headers[h_name] = $"{Headers[h_name]}, {h_value}";
+                    }
+                    else
+                    {
+                        Headers.Add(h_name, h_value);
+                    }
                 }
             }
 

--- a/tests/integration/RestApi.Tests.ps1
+++ b/tests/integration/RestApi.Tests.ps1
@@ -27,6 +27,12 @@ Describe 'REST API Requests' {
                     Write-PodeJsonResponse -Value @{ Result = 'Pong' }
                 }
 
+                Add-PodeRoute -Method Get -Path '/headers' -ScriptBlock {
+                    Write-PodeJsonResponse -Value @{
+                        AcceptEncoding = Get-PodeHeader -Name 'Accept-Encoding'
+                    }
+                }
+
                 function Write-InnerImportedResponse {
                     Write-PodeJsonResponse -Value @{ Message = 'Inner Hello' }
                 }
@@ -122,6 +128,38 @@ Describe 'REST API Requests' {
     It 'responds back with pong' {
         $result = Invoke-RestMethod -Uri "$($Endpoint)/ping" -Method Get
         $result.Result | Should -Be 'Pong'
+    }
+
+    It 'combines duplicate request header values' {
+        $client = [System.Net.Sockets.TcpClient]::new('127.0.0.1', $Port)
+        try {
+            $stream = $client.GetStream()
+            $request = @(
+                'GET /headers HTTP/1.1'
+                "Host: localhost:$($Port)"
+                'Accept-Encoding: gzip, deflate'
+                'Accept-Encoding: UTF-8'
+                'Connection: close'
+                ''
+                ''
+            ) -join "`r`n"
+
+            $requestBytes = [System.Text.Encoding]::ASCII.GetBytes($request)
+            $stream.Write($requestBytes, 0, $requestBytes.Length)
+            $stream.Flush()
+
+            $reader = [System.IO.StreamReader]::new($stream)
+            $response = $reader.ReadToEnd()
+        }
+        finally {
+            $client.Dispose()
+        }
+
+        $responseParts = $response -split "`r`n`r`n", 2
+        $responseParts[0] | Should -Match '^HTTP/1.1 200'
+
+        $body = $responseParts[1] | ConvertFrom-Json
+        $body.AcceptEncoding | Should -Be 'gzip, deflate, UTF-8'
     }
 
     It 'responds back with 404 for invalid route' {


### PR DESCRIPTION
### Description of the Change
HTTP request header parsing now accepts repeated field lines with the same name. When a header name already exists, Pode appends the new value with a comma instead of calling `Hashtable.Add`, which previously threw and returned HTTP 400 before any route or middleware ran.

This matches common list-based header behavior and unblocks clients such as RingCentral webhooks that send:

```http
Accept-Encoding: gzip, deflate
Accept-Encoding: UTF-8
```

### Related Issue
Closes https://github.com/Badgerati/Pode/issues/1764

### Examples
Before this change, a request with two `Accept-Encoding` lines returned HTTP 400 and never reached the route.

After this change:

```powershell
Start-PodeServer {
    Add-PodeEndpoint -Address localhost -Port 8080 -Protocol Http
    Add-PodeRoute -Method Get -Path '/headers' -ScriptBlock {
        Write-PodeJsonResponse -Value @{
            AcceptEncoding = Get-PodeHeader -Name 'Accept-Encoding'
        }
    }
}
```

A raw request with both `Accept-Encoding` lines returns HTTP 200 and:

```json
{ "AcceptEncoding": "gzip, deflate, UTF-8" }
```

### Additional Context
- Change is in `src/Listener/Protocols/Http/PodeHttpRequestStrategy.cs` (`ParseHeaders`).
- Added an integration test in `tests/integration/RestApi.Tests.ps1` that sends two `Accept-Encoding` field lines over TCP and asserts HTTP 200 plus the combined header value.
- Integration tests were run locally against this change (`86` passed).
