### PR TITLE
Fixes Get-PodeRoute when called with no Method

### DIFF
--- a/src/Public/Routes.ps1
+++ b/src/Public/Routes.ps1
@@ -2428,15 +2428,15 @@ function Get-PodeRoute {
         }
     }
     elseif (![string]::IsNullOrEmpty($Path)) {
-        foreach ($method in $PodeContext.Server.Routes.Keys) {
-            if ($PodeContext.Server.Routes[$method].Contains($Path)) {
-                $routes += $PodeContext.Server.Routes[$method][$Path]
+        foreach ($_method in $PodeContext.Server.Routes.Keys) {
+            if ($PodeContext.Server.Routes[$_method].Contains($Path)) {
+                $routes += $PodeContext.Server.Routes[$_method][$Path]
             }
         }
     }
     else {
-        foreach ($method in $PodeContext.Server.Routes.Keys) {
-            foreach ($route in $PodeContext.Server.Routes[$method].Values) {
+        foreach ($_method in $PodeContext.Server.Routes.Keys) {
+            foreach ($route in $PodeContext.Server.Routes[$_method].Values) {
                 $routes += $route
             }
         }

--- a/tests/unit/Routes.Tests.ps1
+++ b/tests/unit/Routes.Tests.ps1
@@ -890,6 +890,8 @@ InModuleScope -ModuleName 'Pode' {
         BeforeAll {
             Mock Test-PodeIPAddress { return $true }
             Mock Test-PodeIsAdminUser { return $true }
+            Mock Test-PodePath { return $true }
+            Mock New-PodePSDrive { return './assets' }
         }
 
         BeforeEach {
@@ -909,15 +911,17 @@ InModuleScope -ModuleName 'Pode' {
 
             $PodeContext.Server.Routes['GET'] = [Pode.Utilities.Structures.PodeConcurrentOrderedDictionary[string, object]]::new()
             $PodeContext.Server.Routes['POST'] = [Pode.Utilities.Structures.PodeConcurrentOrderedDictionary[string, object]]::new()
+            $PodeContext.Server.Routes['STATIC'] = [Pode.Utilities.Structures.PodeConcurrentOrderedDictionary[string, object]]::new()
         }
 
         It 'Returns all routes when nothing supplied' {
             Add-PodeRoute -Method Get -Path '/users' -ScriptBlock { Write-Host 'hello' }
             Add-PodeRoute -Method Get -Path '/about' -ScriptBlock { Write-Host 'hello' }
             Add-PodeRoute -Method Post -Path '/users' -ScriptBlock { Write-Host 'hello' }
+            Add-PodeStaticRoute -Path '/assets' -Source './assets'
 
             $routes = Get-PodeRoute
-            $routes.Length | Should -Be 3
+            $routes.Length | Should -Be 4
         }
 
         It 'Returns both routes for GET method' {


### PR DESCRIPTION
### Description of the Change
When `Get-PodeRoute` was called with no `-Method`, the `$Method` parameter variable was being erroneously re-used in a foreach and an invalid value - causing the `ValidateSet` to error.

### Related Issue
Resolves #1773