### PR TITLE
Update deprecated CefSharp dependency reference to new package

### DIFF
--- a/docs/Tutorials/Misc/DesktopApp.md
+++ b/docs/Tutorials/Misc/DesktopApp.md
@@ -1,23 +1,21 @@
 # Desktop Application
 
-Normally in Pode you define a server and run it, however if you use the [`Show-PodeGui`](../../../Functions/Core/Show-PodeGui) function Pode will serve the server up as a desktop application.
+Normally in Pode you define a server and run it, however if you use [`Show-PodeGui`](../../../Functions/Core/Show-PodeGui) then Pode will display the server as a desktop application.
 
 !!! warning
-    Currently only supported in Windows PowerShell, and PowerShell 7 on Windows due to using WPF.
+    Currently only supported in Windows PowerShell, and PowerShell 7 on Windows due to requiring WPF.
 
-## Setting Server to run as Application
+## Server to run as Application
 
-To serve up you server as a desktop application you can just write you Pode server script as normal. The only difference is you can use the [`Show-PodeGui`](../../../Functions/Core/Show-PodeGui) function to display the application.
+To display your server as a desktop application you write you Pode server script as normal, the only difference is you use [`Show-PodeGui`](../../../Functions/Core/Show-PodeGui) to display the application - a `-Title` is required.
 
-The [`Show-PodeGui`](../../../Functions/Core/Show-PodeGui) function _must_ have a Title supplied - this is the title of the application's window.
-
-The following will create a basic web server with a single page, but when the server is run it will pop up as a desktop application:
+The following will create a basic web server with a single page, but when the server is run it will display as a desktop application:
 
 ```powershell
 Start-PodeServer {
     Add-PodeEndpoint -Address localhost -Port 8080 -Protocol Http
 
-    Show-PodeGui -Title 'Basic Server'
+    Show-PodeGui -Title 'Example Server'
 
     Add-PodeRoute -Method Get -Path '/' -ScriptBlock {
         Write-PodeViewResponse -Path 'index'
@@ -39,9 +37,9 @@ The page used is as follows:
 </html>
 ```
 
-## Simple script to load Application
+## Script to load Application
 
-When you run the server from your terminal, the application will open and the terminal will remain visible. However, you could have a script which opens PowerShell as hidden and launches the server.
+When you run the server from your terminal, the application will open and the terminal will remain visible. However, you use a script which opens PowerShell as hidden and launches the server.
 
 The following is a basic example of a `.bat` file which could be double-clicked to open the application, and then hide the terminal:
 
@@ -50,20 +48,17 @@ powershell.exe -noprofile -windowstyle hidden -command .\you-server-script.ps1
 exit
 ```
 
-## Using Chromium instead of Internet Explorer
+## Using Chromium
 
-The default WPF Browser Element used by Pode is based on the system internal Internet Explorer API, which is also bound to the same Javascript and Webbrowser Limitations as Internet Explorer itself.
+The default WPF Browser Element used by Pode is based on the system internal Internet Explorer API, which is also bound to the same JavaScript and web browser limitations as Internet Explorer itself.
 
-To utilize Chromium in WPF, Pode offers support for CefSharp which adds a Chromium Web Element to WPF.
-In order to switch to [`CefSharp`](http://cefsharp.github.io/), either compile or download its precompiled binaries.
+To utilise Chromium in WPF instead, Pode offers support for using [`CefSharp`](http://cefsharp.github.io/) which adds a Chromium Web Element to WPF. Pode will automatically switch to CefSharp if the binaries are loaded into the Powershell session before the Pode Module itself gets initialised.
 
-Pode will automatically switch to CefSharp, if the binaries are loaded into the Powershell Session before the Pode Module itself gets initialized.
+The following packages are required, and can be compiled from scratch or downloaded from NuGet:
 
-The required packages are the following and can be compiled from scratch or downloaded from the Nuget Repository:
-
-- [`cef.redist.x64`](https://www.nuget.org/packages/cef.redist.x64/)
-- [`cefsharp.common`](https://www.nuget.org/packages/cefsharp.common)
-- [`cefsharp.wpf`](https://www.nuget.org/packages/cefsharp.wpf)
+* [CefSharp.Wpf](https://www.nuget.org/packages/CefSharp.Wpf/)
+* [CefSharp.Common](https://www.nuget.org/packages/CefSharp.Common/)
+* [chromiumembeddedframework.runtime.win-x64](https://www.nuget.org/packages/chromiumembeddedframework.runtime.win-x64/)
 
 This example shows how to load them:
 


### PR DESCRIPTION
### Description of the Change
The `cef.redist.x64` dependency is now deprecated. This PR updates the reference in the docs to point to the new `chromiumembeddedframework.runtime.win-x64` instead.

### Related Issue
Resolves #1778 