### PR TITLE
Fixes collection modified errors when cleaning up Tasks and Schedules

### DIFF
--- a/examples/Schedules.ps1
+++ b/examples/Schedules.ps1
@@ -44,6 +44,9 @@ Start-PodeServer {
     # listen on localhost:8081
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http
 
+    # log errors to the terminal
+    New-PodeLogTerminalMethod | Enable-PodeLogErrorType
+
     # schedule minutely using predefined cron
     $message = 'Hello, world!'
     Add-PodeSchedule -Name 'predefined' -Cron '@minutely' -Limit 2 -ScriptBlock {

--- a/examples/Tasks.ps1
+++ b/examples/Tasks.ps1
@@ -64,7 +64,7 @@ Start-PodeServer {
         'task completed' | Out-Default
     }
 
-    # create a new timer via a route
+    # create a new task via a route
     Add-PodeRoute -Method Get -Path '/api/task/sync' -ScriptBlock {
         $result = Invoke-PodeTask -Name 'Test1' -Wait
         Write-PodeJsonResponse -Value @{ Result = $result }

--- a/src/Private/Schedules.ps1
+++ b/src/Private/Schedules.ps1
@@ -26,7 +26,7 @@ function Start-PodeScheduleRunspace {
 
             $now = [datetime]::UtcNow
 
-            foreach ($key in $PodeContext.Schedules.Processes.Keys) {
+            foreach ($key in $PodeContext.Schedules.Processes.Keys.Clone()) {
                 try {
                     $process = $PodeContext.Schedules.Processes[$key]
                     if ($null -eq $process) {

--- a/src/Private/Tasks.ps1
+++ b/src/Private/Tasks.ps1
@@ -18,7 +18,7 @@ function Start-PodeTaskHousekeeper {
             $now = [datetime]::UtcNow
 
             # loop through each process
-            foreach ($key in $PodeContext.Tasks.Processes.Keys) {
+            foreach ($key in $PodeContext.Tasks.Processes.Keys.Clone()) {
                 try {
                     # get the process
                     $process = $PodeContext.Tasks.Processes[$key]


### PR DESCRIPTION
### Description of the Change
`.Clone()` was removed erroneously during the thread-safety improvements, causing collection modified errors in the Tasks/Schedules clean-up housekeepers.

### Related Issue
Resolves #1780 