### PR TITLE
Enables failed Task processes to be retained for a period, plus custom retention periods

### DIFF
--- a/docs/Tutorials/Tasks.md
+++ b/docs/Tutorials/Tasks.md
@@ -2,9 +2,9 @@
 
 A Task in Pode is a script that you can later invoke either asynchronously, or synchronously. They can be invoked many times, and they also support returning values from them for later use.
 
-Similar to [Schedules](../Schedules), Tasks also run in their own separate runspaces; meaning you can have long or short running tasks. By default up to a maximum of 2 tasks can run concurrently, but this can be changed by using [`Set-PodeTaskConcurrency`](../../Functions/Tasks/Set-PodeTaskConcurrency). When more tasks are invoked than can be run concurrently, tasks will be added to the task queue and will run once there is available resource in the thread pool.
+Tasks run in their own separate runspaces, meaning you can have long or short running tasks. By default up to a maximum of 2 tasks can run concurrently, but this can be changed by using [`Set-PodeTaskConcurrency`](../../Functions/Tasks/Set-PodeTaskConcurrency). When more tasks are invoked than can be run concurrently, tasks will be added to the task queue and will run once there is available resource in the thread pool.
 
-Behind the scenes there is a a Timer created that will automatically clean-up any completed tasks. Any task that has been completed for 1+ minutes will be disposed of to free up resources - there are functions which will let you clean-up tasks more quickly.
+Behind the scenes there is a Timer created that will automatically clean-up any completed, failed, or expired tasks. Any task that has been completed/failed for 1+ minutes will be disposed of to free up resources - there are functions which will let you clean-up tasks more quickly.
 
 ## Create a Task
 
@@ -101,6 +101,15 @@ Add-PodeRoute -Method Get -Path '/run-task' -ScriptBlock {
     Write-PodeJsonResponse -Value @{ User = $user }
 }
 ```
+
+#### Retention
+
+When running Tasks asynchronously, once the process has completed/failed they will be automatically clean-up after the default of 1 minute. You can customise this by using `-CompletedRetentionPeriod` and `FailedRetentionPeriod` on [`Add-PodeTask`](../../Functions/Tasks/Add-PodeTask), and supply a value in minutes.
+
+This is useful if you want to check/poll for Task process statuses using [`Get-PodeTaskProcess`](../../Functions/Tasks/Get-PodeTaskProcess).
+
+!!! note
+    Supplying a value of 0 implies immediate clean-up, no retention.
 
 ### Synchronously
 

--- a/examples/Tasks.ps1
+++ b/examples/Tasks.ps1
@@ -44,6 +44,13 @@ Start-PodeServer {
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http
     New-PodeLogTerminalMethod | Enable-PodeLogErrorType
 
+    Add-PodeTimer -Name 'GetTaskProcesses' -Interval 5 -ScriptBlock {
+        '----' | Out-Default
+        Get-PodeTaskProcess | ForEach-Object {
+            "Task: $($_.Task) | State: $($_.State) | Completed: $($_.CompletedTime)" | Out-Default
+        }
+    }
+
     Add-PodeTask -Name 'Test1' -ScriptBlock {
         'a string'
         4
@@ -62,6 +69,10 @@ Start-PodeServer {
         }
 
         'task completed' | Out-Default
+    }
+
+    Add-PodeTask -Name 'Fail' -FailedRetentionPeriod 2 -ScriptBlock {
+        throw 'this task has failed'
     }
 
     # create a new task via a route
@@ -83,5 +94,9 @@ Start-PodeServer {
 
     Add-PodeRoute -Method Get -Path '/api/task/intermittent' -ScriptBlock {
         Invoke-PodeTask -Name 'Intermittent'
+    }
+
+    Add-PodeRoute -Method Get -Path '/api/task/fail' -ScriptBlock {
+        Invoke-PodeTask -Name 'Fail'
     }
 }

--- a/src/Private/Tasks.ps1
+++ b/src/Private/Tasks.ps1
@@ -37,7 +37,7 @@ function Start-PodeTaskHousekeeper {
                     }
 
                     # if the process is completed, then close and remove
-                    if (($process.State -ieq 'Completed') -and ($process.CompletedTime.AddMinutes(1) -lt $now)) {
+                    if (($process.State -ieq 'Completed') -and ($process.CompletedTime.AddMinutes($task.Retention.Completed) -lt $now)) {
                         Close-PodeTaskInternal -Process $process
                         continue
                     }
@@ -46,7 +46,10 @@ function Start-PodeTaskHousekeeper {
                     if ($process.State -ieq 'Failed') {
                         # if we have hit the max retries, then close and remove
                         if ($process.Retry.Count -ge $task.Retry.Max) {
-                            Close-PodeTaskInternal -Process $process
+                            if ($process.CompletedTime.AddMinutes($task.Retention.Failed) -lt $now) {
+                                Close-PodeTaskInternal -Process $process
+                            }
+
                             continue
                         }
 

--- a/src/Public/Tasks.ps1
+++ b/src/Public/Tasks.ps1
@@ -29,6 +29,12 @@ The maximum number of retries to attempt if the Task fails. (Default: 0)
 .PARAMETER RetryDelay
 The delay, in minutes, between automatically retrying failed task processes. (Default: 0)
 
+.PARAMETER CompletedRetentionPeriod
+The number of minutes to retain completed task processes before automatically closing and removing them. (Default: 1)
+
+.PARAMETER FailedRetentionPeriod
+The number of minutes to retain failed task processes before automatically closing and removing them. (Default: 1)
+
 .PARAMETER AutoRetry
 If supplied, the Task will automatically retry processes if they fail.
 
@@ -79,6 +85,16 @@ function Add-PodeTask {
         [int]
         $RetryDelay = 0,
 
+        [Parameter()]
+        [ValidateRange(0, [int]::MaxValue)]
+        [int]
+        $CompletedRetentionPeriod = 1,
+
+        [Parameter()]
+        [ValidateRange(0, [int]::MaxValue)]
+        [int]
+        $FailedRetentionPeriod = 1,
+
         [switch]
         $AutoRetry
     )
@@ -115,6 +131,10 @@ function Add-PodeTask {
             Max       = $MaxRetries
             Delay     = $RetryDelay
             AutoRetry = $AutoRetry.IsPresent
+        }
+        Retention      = @{
+            Completed = $CompletedRetentionPeriod
+            Failed    = $FailedRetentionPeriod
         }
     }
 }
@@ -186,7 +206,7 @@ A Timeout, in seconds, to abort running the Task process. (Default: -1 [never ti
 Where to start the Timeout from, either 'Default', 'Create', or 'Start'. (Default: 'Default' - will use the value from Add-PodeTask)
 
 .PARAMETER Wait
-If supplied, Pode will wait until the Task process has finished executing, and then return any values.
+If supplied, Pode will wait until the Task process has finished executing, clean-up, and then return any values.
 
 .OUTPUTS
 The triggered Task process.
@@ -504,10 +524,10 @@ function Test-PodeTaskFailed {
 
 <#
 .SYNOPSIS
-Waits for a Task process to finish, and returns a result if there is one.
+Waits for a Task process to finish, cleans up, and returns a result if there is one.
 
 .DESCRIPTION
-Waits for a Task process to finish, and returns a result if there is one.
+Waits for a Task process to finish, cleans up, and returns a result if there is one.
 
 .PARAMETER Process
 The Task process to wait on. The process returned by either Invoke-PodeTask or Get-PodeTaskProcess.


### PR DESCRIPTION
### Description of the Change
When Task processes completed they would be retained for ~1 minute before clean-up. Failed processes however were cleaned-up immediately.

This sets failed processes to mirror completed - 1 minute retention. It also adds `-CompletedRetentionPeriod` and `-FailedRetentionPeriod` to `Add-PodeTask` so the retention periods can be customised.

### Related Issue
Resolves #1766 