### PR TITLE
v2.14.1

### DIFF
--- a/.github/workflows/PSScriptAnalyzer.yml
+++ b/.github/workflows/PSScriptAnalyzer.yml
@@ -54,6 +54,6 @@ jobs:
           output: results.sarif
 
       - name: Upload SARIF results file
-        uses: github/codeql-action/upload-sarif@v4.37.7
+        uses: github/codeql-action/upload-sarif@v4.37.8
         with:
           sarif_file: results.sarif

--- a/.github/workflows/PSScriptAnalyzer.yml
+++ b/.github/workflows/PSScriptAnalyzer.yml
@@ -54,6 +54,6 @@ jobs:
           output: results.sarif
 
       - name: Upload SARIF results file
-        uses: github/codeql-action/upload-sarif@v4.37.6
+        uses: github/codeql-action/upload-sarif@v4.37.7
         with:
           sarif_file: results.sarif

--- a/docs/Tutorials/Misc/DesktopApp.md
+++ b/docs/Tutorials/Misc/DesktopApp.md
@@ -1,23 +1,21 @@
 # Desktop Application
 
-Normally in Pode you define a server and run it, however if you use the [`Show-PodeGui`](../../../Functions/Core/Show-PodeGui) function Pode will serve the server up as a desktop application.
+Normally in Pode you define a server and run it, however if you use [`Show-PodeGui`](../../../Functions/Core/Show-PodeGui) then Pode will display the server as a desktop application.
 
 !!! warning
-    Currently only supported in Windows PowerShell, and PowerShell 7 on Windows due to using WPF.
+    Currently only supported in Windows PowerShell, and PowerShell 7 on Windows due to requiring WPF.
 
-## Setting Server to run as Application
+## Server to run as Application
 
-To serve up you server as a desktop application you can just write you Pode server script as normal. The only difference is you can use the [`Show-PodeGui`](../../../Functions/Core/Show-PodeGui) function to display the application.
+To display your server as a desktop application you write you Pode server script as normal, the only difference is you use [`Show-PodeGui`](../../../Functions/Core/Show-PodeGui) to display the application - a `-Title` is required.
 
-The [`Show-PodeGui`](../../../Functions/Core/Show-PodeGui) function _must_ have a Title supplied - this is the title of the application's window.
-
-The following will create a basic web server with a single page, but when the server is run it will pop up as a desktop application:
+The following will create a basic web server with a single page, but when the server is run it will display as a desktop application:
 
 ```powershell
 Start-PodeServer {
     Add-PodeEndpoint -Address localhost -Port 8080 -Protocol Http
 
-    Show-PodeGui -Title 'Basic Server'
+    Show-PodeGui -Title 'Example Server'
 
     Add-PodeRoute -Method Get -Path '/' -ScriptBlock {
         Write-PodeViewResponse -Path 'index'
@@ -39,9 +37,9 @@ The page used is as follows:
 </html>
 ```
 
-## Simple script to load Application
+## Script to load Application
 
-When you run the server from your terminal, the application will open and the terminal will remain visible. However, you could have a script which opens PowerShell as hidden and launches the server.
+When you run the server from your terminal, the application will open and the terminal will remain visible. However, you use a script which opens PowerShell as hidden and launches the server.
 
 The following is a basic example of a `.bat` file which could be double-clicked to open the application, and then hide the terminal:
 
@@ -50,20 +48,17 @@ powershell.exe -noprofile -windowstyle hidden -command .\you-server-script.ps1
 exit
 ```
 
-## Using Chromium instead of Internet Explorer
+## Using Chromium
 
-The default WPF Browser Element used by Pode is based on the system internal Internet Explorer API, which is also bound to the same Javascript and Webbrowser Limitations as Internet Explorer itself.
+The default WPF Browser Element used by Pode is based on the system internal Internet Explorer API, which is also bound to the same JavaScript and web browser limitations as Internet Explorer itself.
 
-To utilize Chromium in WPF, Pode offers support for CefSharp which adds a Chromium Web Element to WPF.
-In order to switch to [`CefSharp`](http://cefsharp.github.io/), either compile or download its precompiled binaries.
+To utilise Chromium in WPF instead, Pode offers support for using [`CefSharp`](http://cefsharp.github.io/) which adds a Chromium Web Element to WPF. Pode will automatically switch to CefSharp if the binaries are loaded into the Powershell session before the Pode Module itself gets initialised.
 
-Pode will automatically switch to CefSharp, if the binaries are loaded into the Powershell Session before the Pode Module itself gets initialized.
+The following packages are required, and can be compiled from scratch or downloaded from NuGet:
 
-The required packages are the following and can be compiled from scratch or downloaded from the Nuget Repository:
-
-- [`cef.redist.x64`](https://www.nuget.org/packages/cef.redist.x64/)
-- [`cefsharp.common`](https://www.nuget.org/packages/cefsharp.common)
-- [`cefsharp.wpf`](https://www.nuget.org/packages/cefsharp.wpf)
+* [CefSharp.Wpf](https://www.nuget.org/packages/CefSharp.Wpf/)
+* [CefSharp.Common](https://www.nuget.org/packages/CefSharp.Common/)
+* [chromiumembeddedframework.runtime.win-x64](https://www.nuget.org/packages/chromiumembeddedframework.runtime.win-x64/)
 
 This example shows how to load them:
 

--- a/docs/Tutorials/Tasks.md
+++ b/docs/Tutorials/Tasks.md
@@ -2,9 +2,9 @@
 
 A Task in Pode is a script that you can later invoke either asynchronously, or synchronously. They can be invoked many times, and they also support returning values from them for later use.
 
-Similar to [Schedules](../Schedules), Tasks also run in their own separate runspaces; meaning you can have long or short running tasks. By default up to a maximum of 2 tasks can run concurrently, but this can be changed by using [`Set-PodeTaskConcurrency`](../../Functions/Tasks/Set-PodeTaskConcurrency). When more tasks are invoked than can be run concurrently, tasks will be added to the task queue and will run once there is available resource in the thread pool.
+Tasks run in their own separate runspaces, meaning you can have long or short running tasks. By default up to a maximum of 2 tasks can run concurrently, but this can be changed by using [`Set-PodeTaskConcurrency`](../../Functions/Tasks/Set-PodeTaskConcurrency). When more tasks are invoked than can be run concurrently, tasks will be added to the task queue and will run once there is available resource in the thread pool.
 
-Behind the scenes there is a a Timer created that will automatically clean-up any completed tasks. Any task that has been completed for 1+ minutes will be disposed of to free up resources - there are functions which will let you clean-up tasks more quickly.
+Behind the scenes there is a Timer created that will automatically clean-up any completed, failed, or expired tasks. Any task that has been completed/failed for 1+ minutes will be disposed of to free up resources - there are functions which will let you clean-up tasks more quickly.
 
 ## Create a Task
 
@@ -101,6 +101,15 @@ Add-PodeRoute -Method Get -Path '/run-task' -ScriptBlock {
     Write-PodeJsonResponse -Value @{ User = $user }
 }
 ```
+
+#### Retention
+
+When running Tasks asynchronously, once the process has completed/failed they will be automatically clean-up after the default of 1 minute. You can customise this by using `-CompletedRetentionPeriod` and `FailedRetentionPeriod` on [`Add-PodeTask`](../../Functions/Tasks/Add-PodeTask), and supply a value in minutes.
+
+This is useful if you want to check/poll for Task process statuses using [`Get-PodeTaskProcess`](../../Functions/Tasks/Get-PodeTaskProcess).
+
+!!! note
+    Supplying a value of 0 implies immediate clean-up, no retention.
 
 ### Synchronously
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,28 @@
 # Release Notes
 
+# v2.14.1
+
+Date: 29th August 2026
+
+```plain
+### Enhancements
+* #1783: Enables failed Task processes to be retained for a period, plus custom retention periods
+
+### Bugs
+* #1765: Fix to accept repeated HTTP request header fields (thanks @SsSonic3!)
+* #1775: Fixes Get-PodeRoute when called with no Method
+* #1781: Sanitize the file name during multipart/form-data requests
+* #1782: Fixes collection modified errors when cleaning up Tasks and Schedules
+
+### Documentation
+* #1779: Update deprecated CefSharp dependency reference to new package
+
+### Packaging
+* #1771: Bump @highlightjs/cdn-assets from 11.11.1 to 11.12.0
+* #1774: Bump swagger-ui-dist from 5.32.12 to 5.32.14
+* #1777: Bump github/codeql-action from 4.37.6 to 4.37.8
+```
+
 # v2.14.0
 
 Date: 13th August 2026

--- a/examples/Schedules.ps1
+++ b/examples/Schedules.ps1
@@ -44,6 +44,9 @@ Start-PodeServer {
     # listen on localhost:8081
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http
 
+    # log errors to the terminal
+    New-PodeLogTerminalMethod | Enable-PodeLogErrorType
+
     # schedule minutely using predefined cron
     $message = 'Hello, world!'
     Add-PodeSchedule -Name 'predefined' -Cron '@minutely' -Limit 2 -ScriptBlock {

--- a/examples/Tasks.ps1
+++ b/examples/Tasks.ps1
@@ -44,6 +44,13 @@ Start-PodeServer {
     Add-PodeEndpoint -Address localhost -Port 8081 -Protocol Http
     New-PodeLogTerminalMethod | Enable-PodeLogErrorType
 
+    Add-PodeTimer -Name 'GetTaskProcesses' -Interval 5 -ScriptBlock {
+        '----' | Out-Default
+        Get-PodeTaskProcess | ForEach-Object {
+            "Task: $($_.Task) | State: $($_.State) | Completed: $($_.CompletedTime)" | Out-Default
+        }
+    }
+
     Add-PodeTask -Name 'Test1' -ScriptBlock {
         'a string'
         4
@@ -62,6 +69,10 @@ Start-PodeServer {
         }
 
         'task completed' | Out-Default
+    }
+
+    Add-PodeTask -Name 'Fail' -FailedRetentionPeriod 2 -ScriptBlock {
+        throw 'this task has failed'
     }
 
     # create a new task via a route
@@ -83,5 +94,9 @@ Start-PodeServer {
 
     Add-PodeRoute -Method Get -Path '/api/task/intermittent' -ScriptBlock {
         Invoke-PodeTask -Name 'Intermittent'
+    }
+
+    Add-PodeRoute -Method Get -Path '/api/task/fail' -ScriptBlock {
+        Invoke-PodeTask -Name 'Fail'
     }
 }

--- a/examples/Tasks.ps1
+++ b/examples/Tasks.ps1
@@ -64,7 +64,7 @@ Start-PodeServer {
         'task completed' | Out-Default
     }
 
-    # create a new timer via a route
+    # create a new task via a route
     Add-PodeRoute -Method Get -Path '/api/task/sync' -ScriptBlock {
         $result = Invoke-PodeTask -Name 'Test1' -Wait
         Write-PodeJsonResponse -Value @{ Result = $result }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Matthew Kelly <badgerati42@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "@highlightjs/cdn-assets": "11.11.1",
+    "@highlightjs/cdn-assets": "11.12.0",
     "@stoplight/elements": "9.0.24",
     "bootstrap": "5.3.8",
     "openapi-explorer": "2.4.820",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,6 @@
     "rapipdf": "2.2.1",
     "redoc": "2.5.3",
     "swagger-editor-dist": "4.14.8",
-    "swagger-ui-dist": "5.32.12"
+    "swagger-ui-dist": "5.32.13"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,6 @@
     "rapipdf": "2.2.1",
     "redoc": "2.5.3",
     "swagger-editor-dist": "4.14.8",
-    "swagger-ui-dist": "5.32.13"
+    "swagger-ui-dist": "5.32.14"
   }
 }

--- a/src/Listener/Protocols/Common/Forms/PodeForm.cs
+++ b/src/Listener/Protocols/Common/Forms/PodeForm.cs
@@ -115,7 +115,6 @@ namespace Pode.Protocols.Common.Forms
                     throw new Exception("No Content-Disposition found in multipart/form-data");
                 }
 
-                // foreach (var line in disposition.Split(';'))
                 foreach (var line in contentDispHeader.Split(';'))
                 {
                     var atoms = line.Split('=');
@@ -126,7 +125,7 @@ namespace Pode.Protocols.Common.Forms
                 }
 
                 // is this just a regular data field?
-                if (!fields.TryGetValue("filename", out string filenameField))
+                if (!fields.TryGetValue("filename", out string filenameField) || string.IsNullOrWhiteSpace(filenameField))
                 {
                     // add the data item as name=value
                     form.Data.Add(new PodeFormData(fields["name"], GetLineString(lines[currentLineIndex], contentEncoding)));
@@ -135,6 +134,9 @@ namespace Pode.Protocols.Common.Forms
                 // otherwise it's a file field
                 else
                 {
+                    // sanitise the filename field, and remove any path information
+                    filenameField = Path.GetFileName(filenameField);
+
                     // add a data item for mapping name=filename
                     var currentData = form.Data.FirstOrDefault(x => x.Key == fields["name"]);
                     if (currentData == default(PodeFormData))
@@ -144,12 +146,6 @@ namespace Pode.Protocols.Common.Forms
                     else
                     {
                         currentData.AddValue(filenameField);
-                    }
-
-                    // do we actually have a filename?
-                    if (string.IsNullOrWhiteSpace(filenameField))
-                    {
-                        continue;
                     }
 
                     // parse the file contents, and create a stream for the payload

--- a/src/Listener/Protocols/Http/PodeHttpRequestStrategy.cs
+++ b/src/Listener/Protocols/Http/PodeHttpRequestStrategy.cs
@@ -309,7 +309,14 @@ namespace Pode.Protocols.Http
                 {
                     h_name = h_line.Substring(0, h_index).Trim();
                     h_value = h_line.Substring(h_index + 1).Trim();
-                    Headers.Add(h_name, h_value);
+                    if (Headers.ContainsKey(h_name))
+                    {
+                        Headers[h_name] = $"{Headers[h_name]}, {h_value}";
+                    }
+                    else
+                    {
+                        Headers.Add(h_name, h_value);
+                    }
                 }
             }
 

--- a/src/Private/Schedules.ps1
+++ b/src/Private/Schedules.ps1
@@ -26,7 +26,7 @@ function Start-PodeScheduleRunspace {
 
             $now = [datetime]::UtcNow
 
-            foreach ($key in $PodeContext.Schedules.Processes.Keys) {
+            foreach ($key in $PodeContext.Schedules.Processes.Keys.Clone()) {
                 try {
                     $process = $PodeContext.Schedules.Processes[$key]
                     if ($null -eq $process) {

--- a/src/Private/Tasks.ps1
+++ b/src/Private/Tasks.ps1
@@ -18,7 +18,7 @@ function Start-PodeTaskHousekeeper {
             $now = [datetime]::UtcNow
 
             # loop through each process
-            foreach ($key in $PodeContext.Tasks.Processes.Keys) {
+            foreach ($key in $PodeContext.Tasks.Processes.Keys.Clone()) {
                 try {
                     # get the process
                     $process = $PodeContext.Tasks.Processes[$key]

--- a/src/Private/Tasks.ps1
+++ b/src/Private/Tasks.ps1
@@ -37,7 +37,7 @@ function Start-PodeTaskHousekeeper {
                     }
 
                     # if the process is completed, then close and remove
-                    if (($process.State -ieq 'Completed') -and ($process.CompletedTime.AddMinutes(1) -lt $now)) {
+                    if (($process.State -ieq 'Completed') -and ($process.CompletedTime.AddMinutes($task.Retention.Completed) -lt $now)) {
                         Close-PodeTaskInternal -Process $process
                         continue
                     }
@@ -46,7 +46,10 @@ function Start-PodeTaskHousekeeper {
                     if ($process.State -ieq 'Failed') {
                         # if we have hit the max retries, then close and remove
                         if ($process.Retry.Count -ge $task.Retry.Max) {
-                            Close-PodeTaskInternal -Process $process
+                            if ($process.CompletedTime.AddMinutes($task.Retention.Failed) -lt $now) {
+                                Close-PodeTaskInternal -Process $process
+                            }
+
                             continue
                         }
 

--- a/src/Public/Routes.ps1
+++ b/src/Public/Routes.ps1
@@ -2428,15 +2428,15 @@ function Get-PodeRoute {
         }
     }
     elseif (![string]::IsNullOrEmpty($Path)) {
-        foreach ($method in $PodeContext.Server.Routes.Keys) {
-            if ($PodeContext.Server.Routes[$method].Contains($Path)) {
-                $routes += $PodeContext.Server.Routes[$method][$Path]
+        foreach ($_method in $PodeContext.Server.Routes.Keys) {
+            if ($PodeContext.Server.Routes[$_method].Contains($Path)) {
+                $routes += $PodeContext.Server.Routes[$_method][$Path]
             }
         }
     }
     else {
-        foreach ($method in $PodeContext.Server.Routes.Keys) {
-            foreach ($route in $PodeContext.Server.Routes[$method].Values) {
+        foreach ($_method in $PodeContext.Server.Routes.Keys) {
+            foreach ($route in $PodeContext.Server.Routes[$_method].Values) {
                 $routes += $route
             }
         }

--- a/src/Public/Tasks.ps1
+++ b/src/Public/Tasks.ps1
@@ -29,6 +29,12 @@ The maximum number of retries to attempt if the Task fails. (Default: 0)
 .PARAMETER RetryDelay
 The delay, in minutes, between automatically retrying failed task processes. (Default: 0)
 
+.PARAMETER CompletedRetentionPeriod
+The number of minutes to retain completed task processes before automatically closing and removing them. (Default: 1)
+
+.PARAMETER FailedRetentionPeriod
+The number of minutes to retain failed task processes before automatically closing and removing them. (Default: 1)
+
 .PARAMETER AutoRetry
 If supplied, the Task will automatically retry processes if they fail.
 
@@ -79,6 +85,16 @@ function Add-PodeTask {
         [int]
         $RetryDelay = 0,
 
+        [Parameter()]
+        [ValidateRange(0, [int]::MaxValue)]
+        [int]
+        $CompletedRetentionPeriod = 1,
+
+        [Parameter()]
+        [ValidateRange(0, [int]::MaxValue)]
+        [int]
+        $FailedRetentionPeriod = 1,
+
         [switch]
         $AutoRetry
     )
@@ -115,6 +131,10 @@ function Add-PodeTask {
             Max       = $MaxRetries
             Delay     = $RetryDelay
             AutoRetry = $AutoRetry.IsPresent
+        }
+        Retention      = @{
+            Completed = $CompletedRetentionPeriod
+            Failed    = $FailedRetentionPeriod
         }
     }
 }
@@ -186,7 +206,7 @@ A Timeout, in seconds, to abort running the Task process. (Default: -1 [never ti
 Where to start the Timeout from, either 'Default', 'Create', or 'Start'. (Default: 'Default' - will use the value from Add-PodeTask)
 
 .PARAMETER Wait
-If supplied, Pode will wait until the Task process has finished executing, and then return any values.
+If supplied, Pode will wait until the Task process has finished executing, clean-up, and then return any values.
 
 .OUTPUTS
 The triggered Task process.
@@ -504,10 +524,10 @@ function Test-PodeTaskFailed {
 
 <#
 .SYNOPSIS
-Waits for a Task process to finish, and returns a result if there is one.
+Waits for a Task process to finish, cleans up, and returns a result if there is one.
 
 .DESCRIPTION
-Waits for a Task process to finish, and returns a result if there is one.
+Waits for a Task process to finish, cleans up, and returns a result if there is one.
 
 .PARAMETER Process
 The Task process to wait on. The process returned by either Invoke-PodeTask or Get-PodeTaskProcess.

--- a/tests/integration/RestApi.Tests.ps1
+++ b/tests/integration/RestApi.Tests.ps1
@@ -27,6 +27,12 @@ Describe 'REST API Requests' {
                     Write-PodeJsonResponse -Value @{ Result = 'Pong' }
                 }
 
+                Add-PodeRoute -Method Get -Path '/headers' -ScriptBlock {
+                    Write-PodeJsonResponse -Value @{
+                        AcceptEncoding = Get-PodeHeader -Name 'Accept-Encoding'
+                    }
+                }
+
                 function Write-InnerImportedResponse {
                     Write-PodeJsonResponse -Value @{ Message = 'Inner Hello' }
                 }
@@ -122,6 +128,38 @@ Describe 'REST API Requests' {
     It 'responds back with pong' {
         $result = Invoke-RestMethod -Uri "$($Endpoint)/ping" -Method Get
         $result.Result | Should -Be 'Pong'
+    }
+
+    It 'combines duplicate request header values' {
+        $client = [System.Net.Sockets.TcpClient]::new('127.0.0.1', $Port)
+        try {
+            $stream = $client.GetStream()
+            $request = @(
+                'GET /headers HTTP/1.1'
+                "Host: localhost:$($Port)"
+                'Accept-Encoding: gzip, deflate'
+                'Accept-Encoding: UTF-8'
+                'Connection: close'
+                ''
+                ''
+            ) -join "`r`n"
+
+            $requestBytes = [System.Text.Encoding]::ASCII.GetBytes($request)
+            $stream.Write($requestBytes, 0, $requestBytes.Length)
+            $stream.Flush()
+
+            $reader = [System.IO.StreamReader]::new($stream)
+            $response = $reader.ReadToEnd()
+        }
+        finally {
+            $client.Dispose()
+        }
+
+        $responseParts = $response -split "`r`n`r`n", 2
+        $responseParts[0] | Should -Match '^HTTP/1.1 200'
+
+        $body = $responseParts[1] | ConvertFrom-Json
+        $body.AcceptEncoding | Should -Be 'gzip, deflate, UTF-8'
     }
 
     It 'responds back with 404 for invalid route' {

--- a/tests/unit/Routes.Tests.ps1
+++ b/tests/unit/Routes.Tests.ps1
@@ -890,6 +890,8 @@ InModuleScope -ModuleName 'Pode' {
         BeforeAll {
             Mock Test-PodeIPAddress { return $true }
             Mock Test-PodeIsAdminUser { return $true }
+            Mock Test-PodePath { return $true }
+            Mock New-PodePSDrive { return './assets' }
         }
 
         BeforeEach {
@@ -909,15 +911,17 @@ InModuleScope -ModuleName 'Pode' {
 
             $PodeContext.Server.Routes['GET'] = [Pode.Utilities.Structures.PodeConcurrentOrderedDictionary[string, object]]::new()
             $PodeContext.Server.Routes['POST'] = [Pode.Utilities.Structures.PodeConcurrentOrderedDictionary[string, object]]::new()
+            $PodeContext.Server.Routes['STATIC'] = [Pode.Utilities.Structures.PodeConcurrentOrderedDictionary[string, object]]::new()
         }
 
         It 'Returns all routes when nothing supplied' {
             Add-PodeRoute -Method Get -Path '/users' -ScriptBlock { Write-Host 'hello' }
             Add-PodeRoute -Method Get -Path '/about' -ScriptBlock { Write-Host 'hello' }
             Add-PodeRoute -Method Post -Path '/users' -ScriptBlock { Write-Host 'hello' }
+            Add-PodeStaticRoute -Path '/assets' -Source './assets'
 
             $routes = Get-PodeRoute
-            $routes.Length | Should -Be 3
+            $routes.Length | Should -Be 4
         }
 
         It 'Returns both routes for GET method' {


### PR DESCRIPTION
### Enhancements
* #1783: Enables failed Task processes to be retained for a period, plus custom retention periods

### Bugs
* #1765: Fix to accept repeated HTTP request header fields (thanks @SsSonic3!)
* #1775: Fixes Get-PodeRoute when called with no Method
* #1781: Sanitize the file name during multipart/form-data requests
* #1782: Fixes collection modified errors when cleaning up Tasks and Schedules

### Documentation
* #1779: Update deprecated CefSharp dependency reference to new package

### Packaging
* #1771: Bump @highlightjs/cdn-assets from 11.11.1 to 11.12.0
* #1774: Bump swagger-ui-dist from 5.32.12 to 5.32.14
* #1777: Bump github/codeql-action from 4.37.6 to 4.37.8