### PR TITLE
Fix 404 First App link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Start-PodeServer -ScriptBlock {
 # then call "http://127.0.0.1:32005/ping"
 ```
 
-See [here](https://badgerati.github.io/Pode/Getting-Started/FirstApp) for building your first app! Don't know HTML, CSS, or JavaScript? No problem! [Pode.Web](https://github.com/Badgerati/Pode.Web) is currently a work in progress, and lets you build web pages using purely PowerShell!
+See [here](https://badgerati.github.io/Pode/latest/Getting-Started/FirstApp/) for building your first app! Don't know HTML, CSS, or JavaScript? No problem! [Pode.Web](https://github.com/Badgerati/Pode.Web) is currently a work in progress, and lets you build web pages using purely PowerShell!
 
 ## 📘 Documentation
 


### PR DESCRIPTION
## Problem

The README's *First App* link points to `https://badgerati.github.io/Pode/Getting-Started/FirstApp`, which returns a **404** (reported in #1787).

The documentation site is versioned with [mike](https://github.com/jimporter/mike), so pages live under a version segment (e.g. `/latest/`). The link is missing that segment and also the trailing slash.

## Change

Update the link to `https://badgerati.github.io/Pode/latest/Getting-Started/FirstApp/`, which returns **200**.

## Verification

- `https://badgerati.github.io/Pode/Getting-Started/FirstApp` → 404 (before)
- `https://badgerati.github.io/Pode/latest/Getting-Started/FirstApp/` → 200 (after)
- `git diff --check` clean; single-line change in `README.md`

Fixes #1787

## Notes

Scoped to exactly the link reported in the issue. A few other doc links in the README are also missing the version segment, but their target paths have changed too and don't have a straightforward working equivalent, so they are intentionally left out of this focused fix.